### PR TITLE
Made elfheader run `info files`

### DIFF
--- a/pwndbg/__init__.py
+++ b/pwndbg/__init__.py
@@ -61,6 +61,7 @@ import pwndbg.commands.xor
 import pwndbg.commands.peda
 import pwndbg.commands.gdbinit
 import pwndbg.commands.defcon
+import pwndbg.commands.elfheader
 
 
 

--- a/pwndbg/commands/elfheader.py
+++ b/pwndbg/commands/elfheader.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import gdb
+import pwndbg.commands
+
+@pwndbg.commands.Command
+def elfheader():
+    """
+    Prints the section mappings contained in the ELF header
+    """
+    gdb.execute('info files')

--- a/pwndbg/commands/vmmap.py
+++ b/pwndbg/commands/vmmap.py
@@ -36,11 +36,3 @@ def vmmap(map=None):
             continue
 
         print(pwndbg.color.get(page.vaddr, text=str(page)))
-
-@pwndbg.commands.OnlyWhenRunning
-@pwndbg.commands.QuietSloppyParsedCommand
-def elfheader(map=None):
-    """
-    Provides PEDA compatibility.  See vmmap command.
-    """
-    return vmmap(map)


### PR DESCRIPTION
PEDA prints out something similar to `info files` when running elfheader. vmmap is completely different.