### PR TITLE
Added checksec command

### DIFF
--- a/pwndbg/__init__.py
+++ b/pwndbg/__init__.py
@@ -62,6 +62,7 @@ import pwndbg.commands.peda
 import pwndbg.commands.gdbinit
 import pwndbg.commands.defcon
 import pwndbg.commands.elfheader
+import pwndbg.commands.checksec
 
 
 

--- a/pwndbg/commands/checksec.py
+++ b/pwndbg/commands/checksec.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import gdb
+import pwndbg.commands
+
+import subprocess
+
+@pwndbg.commands.Command
+def checksec():
+    '''
+    Prints out the binary security settings. Attempts to call the binjitsu
+    checksec first, and then falls back to checksec.sh.
+    '''
+    #local_path = pwndbg.file.get_file(pwndbg.proc.exe)
+    local_path = pwndbg.proc.exe
+    try:
+        subprocess.call(['checksec', local_path])
+    except:
+        try:
+            subprocess.call(['checksec.sh', '--file', local_path])
+        except:
+            print(pwndbg.color.red(
+                'An error occurred when calling checksec. ' \
+                'Make sure the checksec binary is in your PATH.'
+            ))


### PR DESCRIPTION
Don't merge until the GOT/PLT PR is merged, as that provides the `pwndbg.file.get_file` command.

We first try to call the binjitsu checksec command (which is named `checksec`), and if it doesn't exist (indicated by an exception being thrown), we attempt to call `checksec.sh`. Using an exception isn't the cleanest way to check for the existence of a file, so if you want me to do a proper check, let me know.