### PR TITLE
remove re-introduced legacy import

### DIFF
--- a/pwndbg/__init__.py
+++ b/pwndbg/__init__.py
@@ -61,7 +61,6 @@ import pwndbg.commands.xor
 import pwndbg.commands.peda
 import pwndbg.commands.gdbinit
 import pwndbg.commands.defcon
-import pwndbg.commands.elfheader
 import pwndbg.commands.checksec
 
 


### PR DESCRIPTION
Seems the following commit: https://github.com/pwndbg/pwndbg/commit/1c6466d328a6fd53c39ec642f28aff1804aaaaa1#diff-6b7b09ae29c3f2feca1b2057a8b32da2 reintroduced the non existing elfheader command import, this break rinning pwndbg