### PR TITLE
Only register memory_changed and register_changed events if they exist (fixes GDB 7.7)

### DIFF
--- a/pwndbg/events.py
+++ b/pwndbg/events.py
@@ -56,9 +56,14 @@ registered = {gdb.events.exited: [],
               gdb.events.cont: [],
               gdb.events.new_objfile: [],
               gdb.events.stop: [],
-              gdb.events.start: [],
-              gdb.events.memory_changed: [],
-              gdb.events.register_changed: []}
+              gdb.events.start: []}
+
+# These events don't exist on older version of GDB
+if hasattr(gdb.events, 'memory_changed'):
+    registered[gdb.events.memory_changed] = []
+
+if hasattr(gdb.events, 'register_changed'):
+    registered[gdb.events.register_changed] = []
 
 class Pause(object):
     def __enter__(self, *a, **kw):
@@ -111,12 +116,12 @@ def cont(func):        return connect(func, gdb.events.cont, 'cont')
 def new_objfile(func): return connect(func, gdb.events.new_objfile, 'obj')
 def stop(func):        return connect(func, gdb.events.stop, 'stop')
 def start(func):       return connect(func, gdb.events.start, 'start')
-def reg_changed(func): 
+def reg_changed(func):
     try:
         return connect(func, gdb.events.register_changed, 'reg_changed')
     except Exception:
         return func
-def mem_changed(func): 
+def mem_changed(func):
     try:
         return connect(func, gdb.events.memory_changed, 'mem_changed')
     except Exception:


### PR DESCRIPTION
An alternative solution would be to just check if the gdb version is 7.7 or less.