### PR TITLE
fix checksec regression under certain circumstances and version

### DIFF
--- a/pwndbg/commands/checksec.py
+++ b/pwndbg/commands/checksec.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-import gdb
 import pwndbg.commands
 
 import subprocess

--- a/pwndbg/commands/checksec.py
+++ b/pwndbg/commands/checksec.py
@@ -13,12 +13,15 @@ def checksec():
     '''
     local_path = pwndbg.file.get_file(pwndbg.proc.exe)
     try:
-        subprocess.call(['checksec', local_path])
+        print(subprocess.check_output(['checksec', local_path]).decode(), end='')
     except:
         try:
-            subprocess.call(['checksec.sh', '--file', local_path])
+            print(subprocess.check_output(['checksec.sh', '--file', local_path]).decode(), end='')
         except:
-            print(pwndbg.color.red(
-                'An error occurred when calling checksec. ' \
-                'Make sure the checksec binary is in your PATH.'
-            ))
+            try:
+                print(subprocess.check_output(['checksec', '--file', local_path]).decode(), end='')
+            except:
+                print(pwndbg.color.red(
+                    'An error occurred when calling checksec. ' \
+                    'Make sure the checksec binary is in your PATH.'
+                ))


### PR DESCRIPTION
This resolves that a failing checksec command may output something when
falling back to the next version that will be tried. Additionally this
introduces a last option to try to call checksec before failing as some
distributions (like Arch Linix) package checksec under /usr/bin/checksec
and expect --file as command line option.
The returned output is decoded to ensure converting the bytes() object
to a proper string representation needed for python3, under python2 this
should simply be a no-op.
The line ending of the print command is stripped as the check_output
already returns a newline when not failing.