### PR TITLE
remove seemingly obsolete pwndbg/events file

### DIFF
--- a/pwndbg/events
+++ b/pwndbg/events
@@ -1,2 +1,0 @@
-import gdb
-


### PR DESCRIPTION
looks like this file was an accident? Can't figure out why it should exist or where this could possibly be used... therefor proposing to delete it :fire: 