### PR TITLE
Fix the x86/64 memory_sz name construct process

### DIFF
--- a/pwndbg/disasm/x86.py
+++ b/pwndbg/disasm/x86.py
@@ -90,8 +90,9 @@ class DisassemblyAssistant(pwndbg.disasm.arch.DisassemblyAssistant):
                 sz += ' - '
             elif arith and op.mem.disp >= 0:
                 sz += ' + '
+            sz += '%#x' % abs(op.mem.disp)
 
-        sz += ']'
+        sz = '[%s]' % sz
         return sz
 
 


### PR DESCRIPTION
I found something strange when I looking at the dump of in `DisassemblyAssistant`.

The following is a exmaple.
```asm
mov rax, qword ptr fs:[0x28]
           next = 0x400802
      condition = None
   operands[0] = CS_OP_REG
            str = rax
   operands[1] = CS_OP_MEM
            str = fs:]
```
You can see `fs:]` is strange, and I found out the `.str` attribute constructor `memory_sz` miss something.

After my patch will get:
```asm
            str = [fs:0x28]
```

Here's the other example:
before:
```asm
mov rdx, qword ptr [rbp - 8]
            str = rbp - ]
```
after:
```asm
            str = [rbp - 8]
```

I don't this patch whether break something because I didn't trace the code to find out who use use the `.str` attribute.

Also, I'm not sure the behavior of origin memory_sz is a design or a bug. If it is a design, please feel free to close this PR.
