### PR TITLE
Use 4 space instead of tab

### DIFF
--- a/pwndbg/arch.py
+++ b/pwndbg/arch.py
@@ -66,7 +66,7 @@ def pack(integer):
     return struct.pack(fmt, integer & ptrmask)
 
 def unpack(data):
-	return struct.unpack(fmt, data)[0]
+    return struct.unpack(fmt, data)[0]
 
 def signed(integer):
     return unpack(pack(integer), signed=True)

--- a/pwndbg/malloc.py
+++ b/pwndbg/malloc.py
@@ -14,7 +14,7 @@ malloc_chunk  = None
 
 @pwndbg.events.new_objfile
 def load_malloc_chunk():
-	malloc_chunk = None
+    malloc_chunk = None
 
 
 def chunk2mem(p):

--- a/pwndbg/strings.py
+++ b/pwndbg/strings.py
@@ -42,6 +42,6 @@ def get(address, maxlen = None):
         return None
 
     if len(sz) < maxlen:
-    	return sz
+        return sz
 
     return sz[:maxlen] + '...'

--- a/pwndbg/ui.py
+++ b/pwndbg/ui.py
@@ -22,5 +22,5 @@ def banner(title):
     return ("[{:-^%ss}]" % width).format(title)
 
 def addrsz(address):
-	address = int(address) & pwndbg.arch.ptrmask
-	return "%{}x".format(2*pwndbg.arch.ptrsize) % address
+    address = int(address) & pwndbg.arch.ptrmask
+    return "%{}x".format(2*pwndbg.arch.ptrsize) % address


### PR DESCRIPTION
Minor fix.
I found some of codes contain tab characters. Just replace to 4 space to make coding style consistance.
