### PR TITLE
Show "x" when the condition instruction will not be taken

### DIFF
--- a/pwndbg/disasm/arch.py
+++ b/pwndbg/disasm/arch.py
@@ -72,7 +72,7 @@ class DisassemblyAssistant(object):
         instruction.condition = c
 
     def condition(self, instruction):
-        return False
+        return None
 
     def enhance_next(self, instruction):
         """

--- a/pwndbg/disasm/arch.py
+++ b/pwndbg/disasm/arch.py
@@ -244,7 +244,7 @@ class DisassemblyAssistant(object):
 
         for i, op in enumerate(ins.operands):
             rv.append('   operands[%i] = %s' % (i, ops.get(op.type, op.type)))
-            rv.append('       access   = %s' % (access.get(op.access, op.access)))
+            #rv.append('       access   = %s' % (access.get(op.access, op.access)))
 
             if op.int is not None:
                 rv.append('            int = %#x' % (op.int))

--- a/pwndbg/disasm/arm.py
+++ b/pwndbg/disasm/arm.py
@@ -42,7 +42,7 @@ class DisassemblyAssistant(pwndbg.disasm.arch.DisassemblyAssistant):
             return None
 
         if instruction.address != pwndbg.regs.pc:
-            return False
+            return None
 
         cpsr = pwndbg.regs.cpsr
 

--- a/pwndbg/disasm/color.py
+++ b/pwndbg/disasm/color.py
@@ -57,11 +57,11 @@ def instruction(ins):
         asm = asm.replace(ins.mnemonic, pwndbg.color.bold(ins.mnemonic))
 
     # If we know the conditional is taken, mark it as green.
-    if ins.condition is True:
-        asm = pwndbg.color.green(u'✔ ') + asm
-    elif ins.condition is False:
-        asm = pwndbg.color.red(u'✘ ') + asm
-    else: # ins.codition is None
+    if ins.codition is None:
         asm = '  ' + asm
+    elif ins.condition:
+        asm = pwndbg.color.green(u'✔ ') + asm
+    else:
+        asm = pwndbg.color.red(u'✘ ') + asm
 
     return asm

--- a/pwndbg/disasm/color.py
+++ b/pwndbg/disasm/color.py
@@ -57,9 +57,11 @@ def instruction(ins):
         asm = asm.replace(ins.mnemonic, pwndbg.color.bold(ins.mnemonic))
 
     # If we know the conditional is taken, mark it as green.
-    if ins.condition:
+    if ins.condition is True:
         asm = pwndbg.color.green(u'✔ ') + asm
-    else:
+    elif ins.condition is False:
+        asm = pwndbg.color.red(u'✘ ') + asm
+    else: # ins.codition is None
         asm = '  ' + asm
 
     return asm

--- a/pwndbg/disasm/x86.py
+++ b/pwndbg/disasm/x86.py
@@ -129,7 +129,7 @@ class DisassemblyAssistant(pwndbg.disasm.arch.DisassemblyAssistant):
 
         # We can't reason about anything except the current instruction
         if instruction.address != pwndbg.regs.pc:
-            return False
+            return None
 
         efl = pwndbg.regs.eflags
 


### PR DESCRIPTION
As my understanding, `None` is mean "unconditional" and `False` is mean "it is conditional, but will not be taken". So I change the default value of `ins.condition` from `False` to `None` and set the `condition` attribute to `None` for all instructions whose address does not matched PC.

Then we can use `ins.condition` to know whether this condition instruction will be taken or not.

It is useful to show something when a condition instruction will not be taken because there is some instruction like `cmove` which is not a branch instruction. We can't know this instruction will be done or not by the origin UI.

![screen shot 2016-06-12 at 11 29 06 pm](https://cloud.githubusercontent.com/assets/2252236/15992056/7b22b54e-30f5-11e6-98ea-8c3b4ed2695d.png)
