### PR TITLE
Fix resolving the return address on non-PC RET always get 0

### DIFF
--- a/pwndbg/disasm/x86.py
+++ b/pwndbg/disasm/x86.py
@@ -108,7 +108,7 @@ class DisassemblyAssistant(pwndbg.disasm.arch.DisassemblyAssistant):
 
         # Stop disassembling at RET if we won't know where it goes to
         if instruction.address != pwndbg.regs.pc:
-            return 0
+            return None
 
         # Otherwise, resolve the return on the stack
         pop = 0


### PR DESCRIPTION
Set the target value to `None` for RET instruction which is not PC pointed to.

This fix the disassembly display from:
```
ret     <0>
```
to
```
ret
```
