### PR TITLE
fixed condition label expression leading to always be None

### DIFF
--- a/pwndbg/disasm/color.py
+++ b/pwndbg/disasm/color.py
@@ -59,7 +59,7 @@ def instruction(ins):
         asm = asm.replace(ins.mnemonic, pwndbg.color.bold(ins.mnemonic))
 
     # If we know the conditional is taken, mark it as green.
-    if ins.codition is None:
+    if ins.condition is None:
         asm = '  ' + asm
     elif ins.condition:
         asm = pwndbg.color.green(u'✔ ') + asm


### PR DESCRIPTION
Show "x" when the condition instruction will not be taken (#74) in commit 6c04e5368e4d48472e10b5fbbb8cbf2a305fe187 introduced a regression because of a typo leading to always show nothing on conditional instructions.
