### PR TITLE
Add pwndbg commands list filtering

### DIFF
--- a/pwndbg/__init__.py
+++ b/pwndbg/__init__.py
@@ -130,7 +130,7 @@ handle SIGSEGV stop   print nopass
 for line in pre_commands.strip().splitlines():
     gdb.execute(line)
 
-msg = "Loaded %i commands.  Type pwndbg for a list." % len(pwndbg.commands._Command.commands)
+msg = "Loaded %i commands.  Type pwndbg [filter] for a list." % len(pwndbg.commands._Command.commands)
 print(pwndbg.color.red(msg))
 
 cur = (gdb.selected_inferior(), gdb.selected_thread())

--- a/pwndbg/commands/misc.py
+++ b/pwndbg/commands/misc.py
@@ -33,12 +33,16 @@ def errno(err=None):
     print("Errno %i: %s" % (err, msg))
 
 @_pwndbg.commands.Command
-def pwndbg():
+def pwndbg(filter_pattern=None):
     """
-    Prints out a list of all pwndbg commands.
+    Prints out a list of all pwndbg commands. The list can be optionally filtered if filter_pattern is passed.
     """
     sorted_commands = list(_pwndbg.commands._Command.commands)
     sorted_commands.sort(key=lambda x: x.__name__)
+
+    if filter_pattern:
+        filter_pattern = filter_pattern.lower()
+
     for c in sorted_commands:
         name = c.__name__
         docs = c.__doc__
@@ -46,7 +50,8 @@ def pwndbg():
         if docs: docs = docs.strip()
         if docs: docs = docs.splitlines()[0]
 
-        print("%-20s %s" % (name, docs))
+        if not filter_pattern or filter_pattern in name.lower() or (docs and filter_pattern in docs.lower()):
+            print("%-20s %s" % (name, docs))
 
 @_pwndbg.commands.ParsedCommand
 def distance(a, b):

--- a/pwndbg/commands/misc.py
+++ b/pwndbg/commands/misc.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import argparse
 import errno as _errno
 import struct
 
@@ -13,9 +14,13 @@ import pwndbg.symbol
 
 _errno.errorcode[0] = 'OK'
 
-@_pwndbg.commands.ParsedCommand
-def errno(err=None):
-    '''Converts errno (or argument) to its string representation'''
+parser = argparse.ArgumentParser(description='''
+Converts errno (or argument) to its string representation.
+''')
+parser.add_argument('err', type=int, nargs='?', default=None, help='Errno; if not passed, it is retrieved from __errno_location')
+
+@_pwndbg.commands.ArgparsedCommand(parser)
+def errno(err):
     if err is None:
         # Dont ask.
         errno_location = pwndbg.symbol.get('__errno_location')
@@ -32,11 +37,13 @@ def errno(err=None):
     msg = _errno.errorcode.get(int(err), "Unknown error code")
     print("Errno %i: %s" % (err, msg))
 
-@_pwndbg.commands.Command
-def pwndbg(filter_pattern=None):
-    """
-    Prints out a list of all pwndbg commands. The list can be optionally filtered if filter_pattern is passed.
-    """
+parser = argparse.ArgumentParser(description='''
+Prints out a list of all pwndbg commands. The list can be optionally filtered if filter_pattern is passed.
+''')
+parser.add_argument('filter_pattern', type=str, nargs='?', default=None, help='Filter to apply to commands names/docs')
+
+@_pwndbg.commands.ArgparsedCommand(parser)
+def pwndbg(filter_pattern):
     sorted_commands = list(_pwndbg.commands._Command.commands)
     sorted_commands.sort(key=lambda x: x.__name__)
 

--- a/tests/testLoadsWithoutCrashing.py
+++ b/tests/testLoadsWithoutCrashing.py
@@ -6,4 +6,4 @@ from . import common
 
 def test_loads_wivout_crashing_bruv():
     output = common.run_gdb_with_script()
-    assert 'Type pwndbg for a list' in output, output
+    assert 'Type pwndbg [filter] for a list.' in output, output


### PR DESCRIPTION
Hello,

I have added a possibility to filter the list of commands provided with `pwndbg`, simply by passing an argument to it:

```
pwndbg> pwndbg entry
entry                Set a breakpoint at the first instruction executed in
entry_point          GDBINIT compatibility alias to print the entry point.
pwndbg> 
```

Currently, this is done by simple lowercase string comparison. Imho we don't really need regexes here.