### PR TITLE
Enhance stack command to support offset argument

### DIFF
--- a/pwndbg/commands/telescope.py
+++ b/pwndbg/commands/telescope.py
@@ -8,6 +8,7 @@ Generally used to print out the stack or register values.
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import argparse
 import collections
 
 import pwndbg.arch
@@ -98,11 +99,16 @@ def telescope(address=None, count=telescope_lines, to_string=False):
     return result
 
 
-
-@pwndbg.commands.ParsedCommand
+parser = argparse.ArgumentParser(description='dereferences on stack data with specified count and offset')
+parser.add_argument('count', nargs='?', default=8, type=int,
+                    help='number of element to dump')
+parser.add_argument('offset', nargs='?', default=0, type=int,
+                    help='Element offset from $sp (support negative offset)')
+@pwndbg.commands.ArgparsedCommand(parser)
 @pwndbg.commands.OnlyWhenRunning
-def stack(*a):
+def stack(count, offset):
     """
     Recursively dereferences pointers on the stack
     """
-    telescope(*a)
+    ptrsize = pwndbg.typeinfo.ptrsize
+    telescope(address=pwndbg.regs.sp + offset * ptrsize, count=count)


### PR DESCRIPTION
Sometimes I want to show the stack frame which is already pop, I can only use something like `telescope $sp-0x10`.
I add an argument `offset` of command of `stack` and use `argparse` instead of the origin argument parser. This will be useful. At most of times, I don't want to calculate the actually offset by myself.

```
pwndbg> stack 5 -2
00:0000|      0x7fffffffdc60 <-- 0x13ed
01:0008|      0x7fffffffdc68 --> 0x7ffff7a7d2c8 <-- add    byte ptr [rdi + 0x5f], bl
02:0010| rsp  0x7fffffffdc70 --> 0x7ffff7ff74d0 --> 0x7ffff7a55000 <-- jg     0x7ffff7a55047
03:0018|      0x7fffffffdc78 --> 0x7fffffffdd18 --> 0x4004bf <-- pop    rdi /* '__cxa_atexit' */
04:0020|      0x7fffffffdc80 --> 0x7fffffffdd14 <-- 0x4004bf00000000
```

I put the `count` argument at the first since some people will use `stack 10` to show 10 elements on the stack (original behavior).
 
However, the address offset indicator is strange now. I may want something like
```
pwndbg> stack 5 -2
-02:-010|      0x7fffffffdc60 <-- 0x13ed
-01:-008|      0x7fffffffdc68 --> 0x7ffff7a7d2c8 <-- add    byte ptr [rdi + 0x5f], bl
 00: 000| rsp  0x7fffffffdc70 --> 0x7ffff7ff74d0 --> 0x7ffff7a55000 <-- jg     0x7ffff7a55047
 03: 008|      0x7fffffffdc78 --> 0x7fffffffdd18 --> 0x4004bf <-- pop    rdi /* '__cxa_atexit' */
 04: 010|      0x7fffffffdc80 --> 0x7fffffffdd14 <-- 0x4004bf00000000
```
but don't have a good idea to implement this (The UI is also ugly if I implement like this example).
Because the offset indicator is done by `telescope()`, but it didn't know the offset now.
