### PR TITLE
fixed potential wrong config param type resolution

### DIFF
--- a/pwndbg/config.py
+++ b/pwndbg/config.py
@@ -21,12 +21,17 @@ from __future__ import unicode_literals
 
 import sys
 import types
+import collections
 
 import six
 
 import gdb
 
-TYPES = {}
+TYPES = collections.OrderedDict()
+
+# The value is a plain boolean.
+# The Python boolean values, True and False are the only valid values.
+TYPES[bool] = gdb.PARAM_BOOLEAN
 
 # The value is an integer.
 # This is like PARAM_INTEGER, except 0 is interpreted as itself.
@@ -39,10 +44,6 @@ for type in six.integer_types:
 # corresponding characters and encoded into the current host charset.
 for type in six.string_types:
     TYPES[type] = gdb.PARAM_STRING
-
-# The value is a plain boolean.
-# The Python boolean values, True and False are the only valid values.
-TYPES[bool] = gdb.PARAM_BOOLEAN
 
 def getParam(value):
     for k,v in TYPES.items():


### PR DESCRIPTION
This fixes an issue that can potentially happen with unordered dicts
in python3. A boolean typed config parameter can be handles as
integer dependin on the order of iteration in getParam(value).

The reason for this is because True/False are both, bool and int
at the same time, however its not the other way around.

```
checking type <class 'bool'>
matched True against <class 'bool'>

checking type <class 'str'>
checking type <class 'int'>
matched True against <class 'int'>

In [1]: isinstance(True, bool)
Out[1]: True

In [3]: isinstance(True, int)
Out[3]: True

In [4]: isinstance(1, bool)
Out[4]: False
```