### PR TITLE
Fix search string as bytes

### DIFF
--- a/pwndbg/commands/search.py
+++ b/pwndbg/commands/search.py
@@ -97,7 +97,7 @@ def search(type, hex, string, executable, writable, value, mapping):
     
     # Null-terminate strings
     elif type == 'string':
-        value += '\x00'
+        value += b'\x00'
 
     # Perform the search
     print_search(value, mapping=mapping, executable=executable, writable=writable)


### PR DESCRIPTION
I think `search -t string` behavior was broken by `unicode_literals`. So I fixed to use `b'\x00'` instead of `'\x00'`.

before:
```
pwndbg> search -t string ed
libc-2.19.so    0x7ffff789700c add    byte ptr gs:[rax], al /* u'e' */
libstdc++.so.6.0.19 0x7ffff7b96fc8 add    byte ptr gs:[rax], al /* u'e' */
pwndbg> hexdump 0x7ffff789700c
+0000 0x7ffff789700c  65 00 00 00  64 00 00 00  00 00 00 00  54 00 00 00  |e...|d...|....|T...|
+0010 0x7ffff789701c  68 00 00 00  75 00 00 00  00 00 00 00  46 00 00 00  |h...|u...|....|F...|
+0020 0x7ffff789702c  72 00 00 00  69 00 00 00  00 00 00 00  53 00 00 00  |r...|i...|....|S...|
+0030 0x7ffff789703c  61 00 00 00  74 00 00 00  00 00 00 00  53 00 00 00  |a...|t...|....|S...|
+0040 0x7ffff789704c
```

after:
```
pwndbg> search -t string ed
libc-2.19.so    0x7ffff7721ea8 add    byte ptr fs:[rdi + 0x5f], bl /* u'ed' */
...
```