### PR TITLE
Remove the sudos in setup.py

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -19,7 +19,7 @@ PYTHON="${PYTHON}${PYVER}"
 SITE_PACKAGES=$(gdb -batch -q --nx -ex 'pi import site; print(site.getsitepackages()[0])')
 
 # Install Python dependencies
-sudo ${PYTHON} -m pip install --target ${SITE_PACKAGES} -Ur requirements.txt
+${PYTHON} -m pip install --target ${SITE_PACKAGES} -Ur requirements.txt
 
 # Find the path to the Python2 interpreter needed by the Unicorn install process.
 export UNICORN_QEMU_FLAGS="--python=$(which python2)"
@@ -27,9 +27,9 @@ export UNICORN_QEMU_FLAGS="--python=$(which python2)"
 # Install both Unicorn and Capstone
 for directory in capstone unicorn; do
     pushd $directory
-    sudo ./make.sh install
+    ./make.sh install
     cd bindings/python
-    sudo ${PYTHON} -m pip install --target ${SITE_PACKAGES} .
+    ${PYTHON} -m pip install --target ${SITE_PACKAGES} .
     popd
 done
 


### PR DESCRIPTION
sudo resets the environment variables causing the UNICORN_QEMU_FLAGS to be worthless and the installation to fail on non-Python 2 systems.

They were also not needed since we were already running in sudo.