### PR TITLE
Fixed fastbin sizes

### DIFF
--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -107,13 +107,14 @@ def bins(addr=None):
     bins = main_arena['bins']
 
     size_t_size = pwndbg.typeinfo.load('size_t').sizeof
-    num_fastbins = int(fastbins.type.sizeof / fastbins.type.target().sizeof)
+    num_fastbins = 7
     num_bins = int(bins.type.sizeof / bins.type.target().sizeof)
     fd_field_offset = 2 * size_t_size
 
     print(underline(yellow('fastbins')))
+    size = 2 * size_t_size
     for i in range(num_fastbins):
-        size = 2 * size_t_size * (i + 1)
+        size += 2 * size_t_size
         chain = pwndbg.chain.format(int(fastbins[i]), offset=fd_field_offset)
         print((bold(size) + ': ').ljust(13) + chain)
 


### PR DESCRIPTION
The previous sizes of the fastbins were off by `2 * size_t_size`. This commit fixes that.

I also hardcoded the number of fastbins to 7. On Ubuntu 14.04, this is always true for both 32 bit and 64 bit binaries. I haven't tested on 16.04, but I'd guess it's true there as well. The reason for this change is for some reason, the size of the `fastbinsY` array in glibc is larger than the number of fastbins actually used. Thus, you can allocate and free a chunk of a size you'd expect to see in the fastbin array but you wouldn't see it, which is confusing. Limiting to 7 fastbins prevents this problem. If you think it's better to leave the full number of fastbins even if they're not used, I don't mind taking this out.