### PR TITLE
Require isort and futurize to pass for tests

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -2,4 +2,4 @@
 indent='    '
 not_skip = __init__.py
 force_single_line = 1
-known_third_party=capstone,unicorn,six,psutil,pycparser
+known_third_party=capstone,unicorn,six,psutil,pycparser,gdb

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -2,3 +2,4 @@
 indent='    '
 not_skip = __init__.py
 force_single_line = 1
+known_third_party=capstone,unicorn,six,psutil,pycparser

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,10 @@ install:
   - lsb_release -a
   - pip install -r requirements.txt
   - sudo ./setup.sh
-before_script:
-  - isort --check-only --diff pwndbg
 script:
+  - isort --check-only --diff pwndbg
   - nosetests ./tests/
   - python2.7 -m py_compile ida_script.py $(git ls-files 'pwndbg/*.py')
   - python3   -m py_compile               $(git ls-files 'pwndbg/*.py')
+  - futurize --all-imports --stage1 --print-function --write --unicode-literals pwndbg
+  - git diff-index --quiet HEAD --

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
   - pip install -r requirements.txt
   - sudo ./setup.sh
 script:
-  - isort --check-only --diff pwndbg
+  - isort --check-only --diff --recursive pwndbg
   - nosetests ./tests/
   - python2.7 -m py_compile ida_script.py $(git ls-files 'pwndbg/*.py')
   - python3   -m py_compile               $(git ls-files 'pwndbg/*.py')

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,11 @@ install:
   - pip install -r requirements.txt
   - sudo ./setup.sh
 script:
+  - git status -sb
+  - futurize --all-imports --stage1 --print-function --write --unicode-literals pwndbg
+  - git diff-index --quiet HEAD --
+  - git status -sb
   - isort --check-only --diff --recursive pwndbg
   - nosetests ./tests/
   - python2.7 -m py_compile ida_script.py $(git ls-files 'pwndbg/*.py')
   - python3   -m py_compile               $(git ls-files 'pwndbg/*.py')
-  - futurize --all-imports --stage1 --print-function --write --unicode-literals pwndbg
-  - git diff-index --quiet HEAD --

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,8 @@ install:
   - pip install -r requirements.txt
   - sudo ./setup.sh
 script:
-  - git status -sb
   - futurize --all-imports --stage1 --print-function --write --unicode-literals pwndbg
-  - git diff-index --quiet HEAD --
-  - git status -sb
+  - git diff-index --quiet HEAD -- pwndbg
   - isort --check-only --diff --recursive pwndbg
   - nosetests ./tests/
   - python2.7 -m py_compile ida_script.py $(git ls-files 'pwndbg/*.py')

--- a/pwndbg/__init__.py
+++ b/pwndbg/__init__.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import sys
 

--- a/pwndbg/__init__.py
+++ b/pwndbg/__init__.py
@@ -8,6 +8,7 @@ from __future__ import unicode_literals
 import sys
 
 import gdb
+
 import pwndbg.android
 import pwndbg.arch
 import pwndbg.arguments

--- a/pwndbg/__init__.py
+++ b/pwndbg/__init__.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import sys
 

--- a/pwndbg/abi.py
+++ b/pwndbg/abi.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import pwndbg.arch
 

--- a/pwndbg/abi.py
+++ b/pwndbg/abi.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import pwndbg.arch
 

--- a/pwndbg/android.py
+++ b/pwndbg/android.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import gdb
 import pwndbg.color

--- a/pwndbg/android.py
+++ b/pwndbg/android.py
@@ -6,6 +6,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import gdb
+
 import pwndbg.color
 import pwndbg.events
 import pwndbg.file

--- a/pwndbg/android.py
+++ b/pwndbg/android.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import gdb
 import pwndbg.color

--- a/pwndbg/arch.py
+++ b/pwndbg/arch.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import collections
 import struct

--- a/pwndbg/arch.py
+++ b/pwndbg/arch.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import collections
 import struct

--- a/pwndbg/arch.py
+++ b/pwndbg/arch.py
@@ -9,9 +9,9 @@ import collections
 import struct
 import sys
 
+import gdb
 from capstone import *
 
-import gdb
 import pwndbg.events
 import pwndbg.memoize
 import pwndbg.regs

--- a/pwndbg/arguments.py
+++ b/pwndbg/arguments.py
@@ -4,10 +4,10 @@
 Allows describing functions, specifically enumerating arguments which
 may be passed in a combination of registers and stack values.
 """
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 from capstone import CS_GRP_CALL
 from capstone import CS_GRP_INT

--- a/pwndbg/arguments.py
+++ b/pwndbg/arguments.py
@@ -9,10 +9,10 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import gdb
 from capstone import CS_GRP_CALL
 from capstone import CS_GRP_INT
 
-import gdb
 import pwndbg.abi
 import pwndbg.arch
 import pwndbg.constants

--- a/pwndbg/arguments.py
+++ b/pwndbg/arguments.py
@@ -6,6 +6,8 @@ may be passed in a combination of registers and stack values.
 """
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 from capstone import CS_GRP_CALL
 from capstone import CS_GRP_INT

--- a/pwndbg/argv.py
+++ b/pwndbg/argv.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import gdb
 import pwndbg.arch

--- a/pwndbg/argv.py
+++ b/pwndbg/argv.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import gdb
 import pwndbg.arch

--- a/pwndbg/argv.py
+++ b/pwndbg/argv.py
@@ -6,6 +6,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import gdb
+
 import pwndbg.arch
 import pwndbg.events
 import pwndbg.memory

--- a/pwndbg/auxv.py
+++ b/pwndbg/auxv.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import os
 import re

--- a/pwndbg/auxv.py
+++ b/pwndbg/auxv.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import os
 import re

--- a/pwndbg/auxv.py
+++ b/pwndbg/auxv.py
@@ -10,6 +10,7 @@ import re
 import sys
 
 import gdb
+
 import pwndbg.arch
 import pwndbg.events
 import pwndbg.info

--- a/pwndbg/chain.py
+++ b/pwndbg/chain.py
@@ -6,6 +6,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import gdb
+
 import pwndbg.color.chain as C
 import pwndbg.color.memory as M
 import pwndbg.color.theme as theme
@@ -39,8 +40,8 @@ def get(address, limit=LIMIT, offset=0):
     return result
 
 
-config_arrow_left  = theme.Parameter('chain-arrow-left', u'◂—', 'left arrow of chain formatting')
-config_arrow_right = theme.Parameter('chain-arrow-right', u'—▸', 'right arrow of chain formatting')
+config_arrow_left  = theme.Parameter('chain-arrow-left', '◂—', 'left arrow of chain formatting')
+config_arrow_right = theme.Parameter('chain-arrow-right', '—▸', 'right arrow of chain formatting')
 config_contiguous  = theme.Parameter('chain-contiguous-marker', '...', 'contiguous marker of chain formatting')
 
 def format(value, limit=LIMIT, code=True, offset=0):

--- a/pwndbg/chain.py
+++ b/pwndbg/chain.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import gdb
 import pwndbg.color.chain as C

--- a/pwndbg/chain.py
+++ b/pwndbg/chain.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import gdb
 import pwndbg.color.chain as C

--- a/pwndbg/color/__init__.py
+++ b/pwndbg/color/__init__.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import re
 

--- a/pwndbg/color/__init__.py
+++ b/pwndbg/color/__init__.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import re
 

--- a/pwndbg/color/backtrace.py
+++ b/pwndbg/color/backtrace.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import print_function
-from __future__ import division
 from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
 from __future__ import unicode_literals
+
 import pwndbg.color.theme as theme
 import pwndbg.config as config
 from pwndbg.color import generateColorFunction

--- a/pwndbg/color/backtrace.py
+++ b/pwndbg/color/backtrace.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from __future__ import unicode_literals
 import pwndbg.color.theme as theme
 import pwndbg.config as config
 from pwndbg.color import generateColorFunction

--- a/pwndbg/color/chain.py
+++ b/pwndbg/color/chain.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import print_function
-from __future__ import division
 from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
 from __future__ import unicode_literals
+
 import pwndbg.color.theme as theme
 import pwndbg.config as config
 from pwndbg.color import generateColorFunction

--- a/pwndbg/color/chain.py
+++ b/pwndbg/color/chain.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from __future__ import unicode_literals
 import pwndbg.color.theme as theme
 import pwndbg.config as config
 from pwndbg.color import generateColorFunction

--- a/pwndbg/color/context.py
+++ b/pwndbg/color/context.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import print_function
-from __future__ import division
 from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
 from __future__ import unicode_literals
+
 import pwndbg.color.theme as theme
 import pwndbg.config as config
 from pwndbg.color import generateColorFunction

--- a/pwndbg/color/context.py
+++ b/pwndbg/color/context.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from __future__ import unicode_literals
 import pwndbg.color.theme as theme
 import pwndbg.config as config
 from pwndbg.color import generateColorFunction

--- a/pwndbg/color/disasm.py
+++ b/pwndbg/color/disasm.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import capstone
 

--- a/pwndbg/color/disasm.py
+++ b/pwndbg/color/disasm.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import capstone
 

--- a/pwndbg/color/enhance.py
+++ b/pwndbg/color/enhance.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import print_function
-from __future__ import division
 from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
 from __future__ import unicode_literals
+
 import pwndbg.color.theme as theme
 import pwndbg.config as config
 from pwndbg.color import generateColorFunction

--- a/pwndbg/color/enhance.py
+++ b/pwndbg/color/enhance.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from __future__ import unicode_literals
 import pwndbg.color.theme as theme
 import pwndbg.config as config
 from pwndbg.color import generateColorFunction

--- a/pwndbg/color/hexdump.py
+++ b/pwndbg/color/hexdump.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import print_function
-from __future__ import division
 from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
 from __future__ import unicode_literals
+
 import pwndbg.color.theme as theme
 import pwndbg.config as config
 from pwndbg.color import generateColorFunction

--- a/pwndbg/color/hexdump.py
+++ b/pwndbg/color/hexdump.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from __future__ import unicode_literals
 import pwndbg.color.theme as theme
 import pwndbg.config as config
 from pwndbg.color import generateColorFunction

--- a/pwndbg/color/memory.py
+++ b/pwndbg/color/memory.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from __future__ import unicode_literals
 import six
 
 import pwndbg.color.theme as theme

--- a/pwndbg/color/memory.py
+++ b/pwndbg/color/memory.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import print_function
-from __future__ import division
 from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
 from __future__ import unicode_literals
+
 import six
 
 import pwndbg.color.theme as theme

--- a/pwndbg/color/nearpc.py
+++ b/pwndbg/color/nearpc.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import print_function
-from __future__ import division
 from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
 from __future__ import unicode_literals
+
 import pwndbg.color.theme as theme
 import pwndbg.config as config
 from pwndbg.color import generateColorFunction

--- a/pwndbg/color/nearpc.py
+++ b/pwndbg/color/nearpc.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from __future__ import unicode_literals
 import pwndbg.color.theme as theme
 import pwndbg.config as config
 from pwndbg.color import generateColorFunction

--- a/pwndbg/color/telescope.py
+++ b/pwndbg/color/telescope.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import print_function
-from __future__ import division
 from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
 from __future__ import unicode_literals
+
 import pwndbg.color.theme as theme
 import pwndbg.config as config
 from pwndbg.color import generateColorFunction

--- a/pwndbg/color/telescope.py
+++ b/pwndbg/color/telescope.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from __future__ import unicode_literals
 import pwndbg.color.theme as theme
 import pwndbg.config as config
 from pwndbg.color import generateColorFunction

--- a/pwndbg/color/theme.py
+++ b/pwndbg/color/theme.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from __future__ import unicode_literals
 import pwndbg.config
 
 

--- a/pwndbg/color/theme.py
+++ b/pwndbg/color/theme.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import print_function
-from __future__ import division
 from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
 from __future__ import unicode_literals
+
 import pwndbg.config
 
 

--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -11,6 +11,7 @@ import sys
 import traceback
 
 import gdb
+
 import pwndbg.chain
 import pwndbg.color
 import pwndbg.enhance

--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import argparse
 import functools

--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import argparse
 import functools

--- a/pwndbg/commands/argv.py
+++ b/pwndbg/commands/argv.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import gdb
 import pwndbg.arch

--- a/pwndbg/commands/argv.py
+++ b/pwndbg/commands/argv.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import gdb
 import pwndbg.arch

--- a/pwndbg/commands/argv.py
+++ b/pwndbg/commands/argv.py
@@ -6,6 +6,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import gdb
+
 import pwndbg.arch
 import pwndbg.argv
 import pwndbg.commands

--- a/pwndbg/commands/aslr.py
+++ b/pwndbg/commands/aslr.py
@@ -8,6 +8,7 @@ from __future__ import unicode_literals
 import argparse
 
 import gdb
+
 import pwndbg.color
 import pwndbg.commands
 import pwndbg.proc

--- a/pwndbg/commands/aslr.py
+++ b/pwndbg/commands/aslr.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import argparse
 

--- a/pwndbg/commands/aslr.py
+++ b/pwndbg/commands/aslr.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import argparse
 

--- a/pwndbg/commands/asm.py
+++ b/pwndbg/commands/asm.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import subprocess
 

--- a/pwndbg/commands/asm.py
+++ b/pwndbg/commands/asm.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import subprocess
 

--- a/pwndbg/commands/auxv.py
+++ b/pwndbg/commands/auxv.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import six
 

--- a/pwndbg/commands/auxv.py
+++ b/pwndbg/commands/auxv.py
@@ -5,9 +5,9 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import gdb
 import six
 
-import gdb
 import pwndbg.auxv
 import pwndbg.chain
 import pwndbg.commands

--- a/pwndbg/commands/auxv.py
+++ b/pwndbg/commands/auxv.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import six
 

--- a/pwndbg/commands/checksec.py
+++ b/pwndbg/commands/checksec.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
 import os
 import subprocess

--- a/pwndbg/commands/checksec.py
+++ b/pwndbg/commands/checksec.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
 from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
 import os
 import subprocess

--- a/pwndbg/commands/checksec.py
+++ b/pwndbg/commands/checksec.py
@@ -9,6 +9,7 @@ import os
 import subprocess
 
 import gdb
+
 import pwndbg.commands
 import pwndbg.which
 

--- a/pwndbg/commands/config.py
+++ b/pwndbg/commands/config.py
@@ -4,6 +4,9 @@
 Dumps all pwndbg-specific configuration points.
 """
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
 import pwndbg.commands
 import pwndbg.config

--- a/pwndbg/commands/config.py
+++ b/pwndbg/commands/config.py
@@ -3,10 +3,10 @@
 """
 Dumps all pwndbg-specific configuration points.
 """
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
 from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
 import pwndbg.commands
 import pwndbg.config

--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -8,6 +8,7 @@ from __future__ import unicode_literals
 import sys
 
 import gdb
+
 import pwndbg.arguments
 import pwndbg.chain
 import pwndbg.color

--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import sys
 

--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import sys
 

--- a/pwndbg/commands/cpsr.py
+++ b/pwndbg/commands/cpsr.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import gdb
 import pwndbg.arch

--- a/pwndbg/commands/cpsr.py
+++ b/pwndbg/commands/cpsr.py
@@ -6,6 +6,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import gdb
+
 import pwndbg.arch
 import pwndbg.color
 import pwndbg.commands

--- a/pwndbg/commands/cpsr.py
+++ b/pwndbg/commands/cpsr.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import gdb
 import pwndbg.arch

--- a/pwndbg/commands/defcon.py
+++ b/pwndbg/commands/defcon.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import gdb
 import pwndbg.commands

--- a/pwndbg/commands/defcon.py
+++ b/pwndbg/commands/defcon.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import gdb
 import pwndbg.commands

--- a/pwndbg/commands/defcon.py
+++ b/pwndbg/commands/defcon.py
@@ -6,6 +6,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import gdb
+
 import pwndbg.commands
 import pwndbg.memory
 import pwndbg.symbol

--- a/pwndbg/commands/dt.py
+++ b/pwndbg/commands/dt.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import gdb
 import pwndbg.color

--- a/pwndbg/commands/dt.py
+++ b/pwndbg/commands/dt.py
@@ -6,6 +6,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import gdb
+
 import pwndbg.color
 import pwndbg.commands
 import pwndbg.dt

--- a/pwndbg/commands/dt.py
+++ b/pwndbg/commands/dt.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import gdb
 import pwndbg.color

--- a/pwndbg/commands/dumpargs.py
+++ b/pwndbg/commands/dumpargs.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import pwndbg.arguments
 import pwndbg.commands

--- a/pwndbg/commands/dumpargs.py
+++ b/pwndbg/commands/dumpargs.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import pwndbg.arguments
 import pwndbg.commands

--- a/pwndbg/commands/elf.py
+++ b/pwndbg/commands/elf.py
@@ -5,9 +5,9 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import gdb
 from elftools.elf.elffile import ELFFile
 
-import gdb
 import pwndbg.commands
 
 

--- a/pwndbg/commands/elf.py
+++ b/pwndbg/commands/elf.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
 from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
 from elftools.elf.elffile import ELFFile
 

--- a/pwndbg/commands/elf.py
+++ b/pwndbg/commands/elf.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
 from elftools.elf.elffile import ELFFile
 

--- a/pwndbg/commands/elf.py
+++ b/pwndbg/commands/elf.py
@@ -51,8 +51,8 @@ def plt():
     print_symbols_in_section('.plt', '@plt')
 
 def get_section_bounds(section_name):
-    section_name = section_name.encode('ascii')
-    with open(pwndbg.proc.exe, 'rb') as f:
+    local_path = pwndbg.file.get_file(pwndbg.proc.exe)
+    with open(local_path, 'rb') as f:
         elffile = ELFFile(f)
 
         section = elffile.get_section_by_name(section_name)

--- a/pwndbg/commands/gdbinit.py
+++ b/pwndbg/commands/gdbinit.py
@@ -7,6 +7,8 @@ https://github.com/gdbinit/Gdbinit/blob/master/gdbinit
 """
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import gdb
 import pwndbg.commands

--- a/pwndbg/commands/gdbinit.py
+++ b/pwndbg/commands/gdbinit.py
@@ -11,6 +11,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import gdb
+
 import pwndbg.commands
 
 

--- a/pwndbg/commands/gdbinit.py
+++ b/pwndbg/commands/gdbinit.py
@@ -5,10 +5,10 @@ Compatibility functionality for GDBINIT users.
 
 https://github.com/gdbinit/Gdbinit/blob/master/gdbinit
 """
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import gdb
 import pwndbg.commands

--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #!/usr/bin/env python
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import six
 

--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -6,9 +6,9 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import gdb
 import six
 
-import gdb
 import pwndbg.color.memory as M
 import pwndbg.commands
 from pwndbg.color import bold

--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -3,6 +3,8 @@
 #!/usr/bin/env python
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import six
 

--- a/pwndbg/commands/hexdump.py
+++ b/pwndbg/commands/hexdump.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import argparse
 

--- a/pwndbg/commands/hexdump.py
+++ b/pwndbg/commands/hexdump.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import argparse
 

--- a/pwndbg/commands/ida.py
+++ b/pwndbg/commands/ida.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import bz2
 import datetime

--- a/pwndbg/commands/ida.py
+++ b/pwndbg/commands/ida.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import bz2
 import datetime

--- a/pwndbg/commands/ida.py
+++ b/pwndbg/commands/ida.py
@@ -10,6 +10,7 @@ import datetime
 import os
 
 import gdb
+
 import pwndbg.commands
 import pwndbg.commands.context
 import pwndbg.ida

--- a/pwndbg/commands/misc.py
+++ b/pwndbg/commands/misc.py
@@ -10,6 +10,7 @@ import errno as _errno
 import struct
 
 import gdb
+
 import pwndbg as _pwndbg
 import pwndbg.arch as _arch
 import pwndbg.commands

--- a/pwndbg/commands/misc.py
+++ b/pwndbg/commands/misc.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import argparse
 import errno as _errno

--- a/pwndbg/commands/misc.py
+++ b/pwndbg/commands/misc.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import argparse
 import errno as _errno

--- a/pwndbg/commands/nearpc.py
+++ b/pwndbg/commands/nearpc.py
@@ -5,9 +5,9 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import gdb
 from capstone import *
 
-import gdb
 import pwndbg.arguments
 import pwndbg.color.context as C
 import pwndbg.color.disasm as D

--- a/pwndbg/commands/nearpc.py
+++ b/pwndbg/commands/nearpc.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 from capstone import *
 

--- a/pwndbg/commands/nearpc.py
+++ b/pwndbg/commands/nearpc.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 from capstone import *
 

--- a/pwndbg/commands/next.py
+++ b/pwndbg/commands/next.py
@@ -9,6 +9,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import gdb
+
 import pwndbg.commands
 import pwndbg.next
 

--- a/pwndbg/commands/next.py
+++ b/pwndbg/commands/next.py
@@ -3,10 +3,10 @@
 """
 Stepping until an event occurs
 """
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import gdb
 import pwndbg.commands

--- a/pwndbg/commands/next.py
+++ b/pwndbg/commands/next.py
@@ -5,6 +5,8 @@ Stepping until an event occurs
 """
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import gdb
 import pwndbg.commands

--- a/pwndbg/commands/peda.py
+++ b/pwndbg/commands/peda.py
@@ -8,6 +8,7 @@ from __future__ import unicode_literals
 import sys
 
 import gdb
+
 import pwndbg.auxv
 import pwndbg.commands
 import pwndbg.commands.context

--- a/pwndbg/commands/peda.py
+++ b/pwndbg/commands/peda.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import sys
 

--- a/pwndbg/commands/peda.py
+++ b/pwndbg/commands/peda.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import sys
 

--- a/pwndbg/commands/procinfo.py
+++ b/pwndbg/commands/procinfo.py
@@ -9,6 +9,7 @@ import os
 import string
 
 import gdb
+
 import pwndbg.auxv
 import pwndbg.commands
 import pwndbg.file

--- a/pwndbg/commands/procinfo.py
+++ b/pwndbg/commands/procinfo.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import os
 import string

--- a/pwndbg/commands/procinfo.py
+++ b/pwndbg/commands/procinfo.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import os
 import string

--- a/pwndbg/commands/reload.py
+++ b/pwndbg/commands/reload.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import imp
 import os

--- a/pwndbg/commands/reload.py
+++ b/pwndbg/commands/reload.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import imp
 import os

--- a/pwndbg/commands/reload.py
+++ b/pwndbg/commands/reload.py
@@ -11,6 +11,7 @@ import sys
 import types
 
 import gdb
+
 import pwndbg
 import pwndbg.commands
 import pwndbg.events

--- a/pwndbg/commands/rop.py
+++ b/pwndbg/commands/rop.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import argparse
 import re

--- a/pwndbg/commands/rop.py
+++ b/pwndbg/commands/rop.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import argparse
 import re

--- a/pwndbg/commands/rop.py
+++ b/pwndbg/commands/rop.py
@@ -11,6 +11,7 @@ import subprocess
 import tempfile
 
 import gdb
+
 import pwndbg.commands
 import pwndbg.vmmap
 

--- a/pwndbg/commands/ropper.py
+++ b/pwndbg/commands/ropper.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import argparse
 import re

--- a/pwndbg/commands/ropper.py
+++ b/pwndbg/commands/ropper.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import argparse
 import re

--- a/pwndbg/commands/ropper.py
+++ b/pwndbg/commands/ropper.py
@@ -11,6 +11,7 @@ import subprocess
 import tempfile
 
 import gdb
+
 import pwndbg.commands
 import pwndbg.vmmap
 

--- a/pwndbg/commands/search.py
+++ b/pwndbg/commands/search.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import argparse
 import codecs

--- a/pwndbg/commands/search.py
+++ b/pwndbg/commands/search.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import argparse
 import codecs

--- a/pwndbg/commands/search.py
+++ b/pwndbg/commands/search.py
@@ -11,6 +11,7 @@ import os
 import struct
 
 import gdb
+
 import pwndbg.color.memory as M
 import pwndbg.commands
 import pwndbg.config

--- a/pwndbg/commands/segments.py
+++ b/pwndbg/commands/segments.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import gdb
 import pwndbg.commands

--- a/pwndbg/commands/segments.py
+++ b/pwndbg/commands/segments.py
@@ -6,6 +6,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import gdb
+
 import pwndbg.commands
 import pwndbg.regs
 

--- a/pwndbg/commands/segments.py
+++ b/pwndbg/commands/segments.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import gdb
 import pwndbg.commands

--- a/pwndbg/commands/shell.py
+++ b/pwndbg/commands/shell.py
@@ -3,10 +3,10 @@
 """
 Wrapper for shell commands.
 """
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import os
 

--- a/pwndbg/commands/shell.py
+++ b/pwndbg/commands/shell.py
@@ -5,6 +5,8 @@ Wrapper for shell commands.
 """
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import os
 

--- a/pwndbg/commands/shell.py
+++ b/pwndbg/commands/shell.py
@@ -11,6 +11,7 @@ from __future__ import unicode_literals
 import os
 
 import gdb
+
 import pwndbg.commands
 import pwndbg.which
 

--- a/pwndbg/commands/start.py
+++ b/pwndbg/commands/start.py
@@ -6,6 +6,8 @@ entry point.
 """
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import gdb
 import pwndbg.commands

--- a/pwndbg/commands/start.py
+++ b/pwndbg/commands/start.py
@@ -4,10 +4,10 @@
 Launches the target process after setting a breakpoint at a convenient
 entry point.
 """
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import gdb
 import pwndbg.commands

--- a/pwndbg/commands/start.py
+++ b/pwndbg/commands/start.py
@@ -10,6 +10,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import gdb
+
 import pwndbg.commands
 import pwndbg.elf
 import pwndbg.events

--- a/pwndbg/commands/telescope.py
+++ b/pwndbg/commands/telescope.py
@@ -7,6 +7,8 @@ Generally used to print out the stack or register values.
 """
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import argparse
 import collections

--- a/pwndbg/commands/telescope.py
+++ b/pwndbg/commands/telescope.py
@@ -5,10 +5,10 @@ Prints out pointer chains starting at some address in memory.
 
 Generally used to print out the stack or register values.
 """
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import argparse
 import collections

--- a/pwndbg/commands/theme.py
+++ b/pwndbg/commands/theme.py
@@ -4,6 +4,9 @@
 Dumps all pwndbg-specific theme configuration points.
 """
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
 import pwndbg.color.theme
 import pwndbg.commands

--- a/pwndbg/commands/theme.py
+++ b/pwndbg/commands/theme.py
@@ -3,10 +3,10 @@
 """
 Dumps all pwndbg-specific theme configuration points.
 """
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
 from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
 import pwndbg.color.theme
 import pwndbg.commands

--- a/pwndbg/commands/vmmap.py
+++ b/pwndbg/commands/vmmap.py
@@ -3,10 +3,10 @@
 """
 Command to print the vitual memory map a la /proc/self/maps.
 """
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import six
 

--- a/pwndbg/commands/vmmap.py
+++ b/pwndbg/commands/vmmap.py
@@ -8,9 +8,9 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import gdb
 import six
 
-import gdb
 import pwndbg.color.memory as M
 import pwndbg.commands
 import pwndbg.compat

--- a/pwndbg/commands/vmmap.py
+++ b/pwndbg/commands/vmmap.py
@@ -5,6 +5,8 @@ Command to print the vitual memory map a la /proc/self/maps.
 """
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import six
 

--- a/pwndbg/commands/windbg.py
+++ b/pwndbg/commands/windbg.py
@@ -5,6 +5,8 @@ Compatibility functionality for Windbg users.
 """
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import codecs
 import math

--- a/pwndbg/commands/windbg.py
+++ b/pwndbg/commands/windbg.py
@@ -13,6 +13,7 @@ import math
 import sys
 
 import gdb
+
 import pwndbg.arch
 import pwndbg.commands
 import pwndbg.memory

--- a/pwndbg/commands/windbg.py
+++ b/pwndbg/commands/windbg.py
@@ -3,10 +3,10 @@
 """
 Compatibility functionality for Windbg users.
 """
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import codecs
 import math

--- a/pwndbg/commands/xor.py
+++ b/pwndbg/commands/xor.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import pwndbg.commands
 import pwndbg.memory

--- a/pwndbg/commands/xor.py
+++ b/pwndbg/commands/xor.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import pwndbg.commands
 import pwndbg.memory

--- a/pwndbg/compat.py
+++ b/pwndbg/compat.py
@@ -5,10 +5,10 @@ Compatibility functionality, for determining whether we are
 running under Python2 or Python3, and resolving any
 inconsistencies which arise from this.
 """
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import sys
 

--- a/pwndbg/compat.py
+++ b/pwndbg/compat.py
@@ -7,6 +7,8 @@ inconsistencies which arise from this.
 """
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import sys
 

--- a/pwndbg/config.py
+++ b/pwndbg/config.py
@@ -18,6 +18,9 @@ module, for example:
     7
 """
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
 import collections
 import sys

--- a/pwndbg/config.py
+++ b/pwndbg/config.py
@@ -26,9 +26,8 @@ import collections
 import sys
 import types
 
-import six
-
 import gdb
+import six
 
 TYPES = collections.OrderedDict()
 

--- a/pwndbg/config.py
+++ b/pwndbg/config.py
@@ -17,10 +17,10 @@ module, for example:
     >>> int(pwndbg.config.example_value)
     7
 """
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
 from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
 import collections
 import sys

--- a/pwndbg/constants/__init__.py
+++ b/pwndbg/constants/__init__.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import pwndbg.arch
 

--- a/pwndbg/constants/__init__.py
+++ b/pwndbg/constants/__init__.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import pwndbg.arch
 

--- a/pwndbg/constants/aarch64.py
+++ b/pwndbg/constants/aarch64.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
 from .constant import Constant
 

--- a/pwndbg/constants/aarch64.py
+++ b/pwndbg/constants/aarch64.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
 from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
 from .constant import Constant
 

--- a/pwndbg/constants/alpha.py
+++ b/pwndbg/constants/alpha.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
 from .constant import Constant
 

--- a/pwndbg/constants/alpha.py
+++ b/pwndbg/constants/alpha.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
 from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
 from .constant import Constant
 

--- a/pwndbg/constants/amd64.py
+++ b/pwndbg/constants/amd64.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
 from .constant import Constant
 

--- a/pwndbg/constants/amd64.py
+++ b/pwndbg/constants/amd64.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
 from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
 from .constant import Constant
 

--- a/pwndbg/constants/arm.py
+++ b/pwndbg/constants/arm.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
 from .constant import Constant
 

--- a/pwndbg/constants/arm.py
+++ b/pwndbg/constants/arm.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
 from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
 from .constant import Constant
 

--- a/pwndbg/constants/constant.py
+++ b/pwndbg/constants/constant.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
 from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
 
 class Constant(int):

--- a/pwndbg/constants/constant.py
+++ b/pwndbg/constants/constant.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
 
 class Constant(int):

--- a/pwndbg/constants/i386.py
+++ b/pwndbg/constants/i386.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
 from .constant import Constant
 

--- a/pwndbg/constants/i386.py
+++ b/pwndbg/constants/i386.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
 from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
 from .constant import Constant
 

--- a/pwndbg/constants/ia64.py
+++ b/pwndbg/constants/ia64.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
 from .constant import Constant
 

--- a/pwndbg/constants/ia64.py
+++ b/pwndbg/constants/ia64.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
 from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
 from .constant import Constant
 

--- a/pwndbg/constants/mips.py
+++ b/pwndbg/constants/mips.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
 from .constant import Constant
 

--- a/pwndbg/constants/mips.py
+++ b/pwndbg/constants/mips.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
 from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
 from .constant import Constant
 

--- a/pwndbg/constants/powerpc.py
+++ b/pwndbg/constants/powerpc.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
 from .constant import Constant
 

--- a/pwndbg/constants/powerpc.py
+++ b/pwndbg/constants/powerpc.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
 from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
 from .constant import Constant
 

--- a/pwndbg/constants/powerpc64.py
+++ b/pwndbg/constants/powerpc64.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
 from .constant import Constant
 

--- a/pwndbg/constants/powerpc64.py
+++ b/pwndbg/constants/powerpc64.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
 from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
 from .constant import Constant
 

--- a/pwndbg/constants/s390.py
+++ b/pwndbg/constants/s390.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
 from .constant import Constant
 

--- a/pwndbg/constants/s390.py
+++ b/pwndbg/constants/s390.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
 from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
 from .constant import Constant
 

--- a/pwndbg/constants/s390x.py
+++ b/pwndbg/constants/s390x.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
 from .constant import Constant
 

--- a/pwndbg/constants/s390x.py
+++ b/pwndbg/constants/s390x.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
 from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
 from .constant import Constant
 

--- a/pwndbg/constants/sparc.py
+++ b/pwndbg/constants/sparc.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
 from .constant import Constant
 

--- a/pwndbg/constants/sparc.py
+++ b/pwndbg/constants/sparc.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
 from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
 from .constant import Constant
 

--- a/pwndbg/constants/sparc64.py
+++ b/pwndbg/constants/sparc64.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
 from .constant import Constant
 

--- a/pwndbg/constants/sparc64.py
+++ b/pwndbg/constants/sparc64.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
 from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
 from .constant import Constant
 

--- a/pwndbg/constants/thumb.py
+++ b/pwndbg/constants/thumb.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
 from .constant import Constant
 

--- a/pwndbg/constants/thumb.py
+++ b/pwndbg/constants/thumb.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
 from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
 from .constant import Constant
 

--- a/pwndbg/disasm/__init__.py
+++ b/pwndbg/disasm/__init__.py
@@ -6,6 +6,8 @@ address +/- a few instructions.
 """
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import collections
 

--- a/pwndbg/disasm/__init__.py
+++ b/pwndbg/disasm/__init__.py
@@ -12,9 +12,9 @@ from __future__ import unicode_literals
 import collections
 
 import capstone
+import gdb
 from capstone import *
 
-import gdb
 import pwndbg.arch
 import pwndbg.disasm.arch
 import pwndbg.ida

--- a/pwndbg/disasm/__init__.py
+++ b/pwndbg/disasm/__init__.py
@@ -4,10 +4,10 @@
 Functionality for disassmebling code at an address, or at an
 address +/- a few instructions.
 """
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import collections
 

--- a/pwndbg/disasm/arch.py
+++ b/pwndbg/disasm/arch.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import collections
 

--- a/pwndbg/disasm/arch.py
+++ b/pwndbg/disasm/arch.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import collections
 

--- a/pwndbg/disasm/arm.py
+++ b/pwndbg/disasm/arm.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import collections
 

--- a/pwndbg/disasm/arm.py
+++ b/pwndbg/disasm/arm.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import collections
 

--- a/pwndbg/disasm/jump.py
+++ b/pwndbg/disasm/jump.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 from capstone import CS_GRP_JUMP
 

--- a/pwndbg/disasm/jump.py
+++ b/pwndbg/disasm/jump.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 from capstone import CS_GRP_JUMP
 

--- a/pwndbg/disasm/x86.py
+++ b/pwndbg/disasm/x86.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import collections
 

--- a/pwndbg/disasm/x86.py
+++ b/pwndbg/disasm/x86.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import collections
 

--- a/pwndbg/dt.py
+++ b/pwndbg/dt.py
@@ -5,6 +5,8 @@ Prints structures in a manner similar to Windbg's "dt" command.
 """
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import glob
 import os

--- a/pwndbg/dt.py
+++ b/pwndbg/dt.py
@@ -15,6 +15,7 @@ import subprocess
 import tempfile
 
 import gdb
+
 import pwndbg.memory
 import pwndbg.typeinfo
 

--- a/pwndbg/dt.py
+++ b/pwndbg/dt.py
@@ -3,10 +3,10 @@
 """
 Prints structures in a manner similar to Windbg's "dt" command.
 """
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import glob
 import os

--- a/pwndbg/elf.py
+++ b/pwndbg/elf.py
@@ -18,6 +18,7 @@ import subprocess
 import tempfile
 
 import gdb
+
 import pwndbg.auxv
 import pwndbg.events
 import pwndbg.info

--- a/pwndbg/elf.py
+++ b/pwndbg/elf.py
@@ -7,10 +7,10 @@ all of the address spaces and permissions of an ELF file in memory.
 This is necessary for when access to /proc is restricted, or when
 working on a BSD system which simply does not have /proc.
 """
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import os
 import re

--- a/pwndbg/elf.py
+++ b/pwndbg/elf.py
@@ -9,6 +9,8 @@ working on a BSD system which simply does not have /proc.
 """
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import os
 import re

--- a/pwndbg/elftypes.py
+++ b/pwndbg/elftypes.py
@@ -30,10 +30,10 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
 from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
 import ctypes
 

--- a/pwndbg/elftypes.py
+++ b/pwndbg/elftypes.py
@@ -31,6 +31,9 @@
 #
 
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
 import ctypes
 

--- a/pwndbg/emu/__init__.py
+++ b/pwndbg/emu/__init__.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import pwndbg.emu.x86

--- a/pwndbg/emu/__init__.py
+++ b/pwndbg/emu/__init__.py
@@ -2,5 +2,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import pwndbg.emu.x86

--- a/pwndbg/emu/emulator.py
+++ b/pwndbg/emu/emulator.py
@@ -5,6 +5,8 @@ Emulation assistance from Unicorn.
 """
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import binascii
 import inspect

--- a/pwndbg/emu/emulator.py
+++ b/pwndbg/emu/emulator.py
@@ -12,9 +12,9 @@ import binascii
 import inspect
 
 import capstone as C
+import gdb
 import unicorn as U
 
-import gdb
 import pwndbg.arch
 import pwndbg.disasm
 import pwndbg.emu.emulator

--- a/pwndbg/emu/emulator.py
+++ b/pwndbg/emu/emulator.py
@@ -3,16 +3,15 @@
 """
 Emulation assistance from Unicorn.
 """
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import binascii
 import inspect
 
 import capstone as C
-import unicorn as U
 
 import gdb
 import pwndbg.arch
@@ -20,6 +19,7 @@ import pwndbg.disasm
 import pwndbg.emu.emulator
 import pwndbg.memory
 import pwndbg.regs
+import unicorn as U
 
 # Map our internal architecture names onto Unicorn Engine's architecture types.
 arch_to_UC = {

--- a/pwndbg/emu/emulator.py
+++ b/pwndbg/emu/emulator.py
@@ -12,6 +12,7 @@ import binascii
 import inspect
 
 import capstone as C
+import unicorn as U
 
 import gdb
 import pwndbg.arch
@@ -19,7 +20,6 @@ import pwndbg.disasm
 import pwndbg.emu.emulator
 import pwndbg.memory
 import pwndbg.regs
-import unicorn as U
 
 # Map our internal architecture names onto Unicorn Engine's architecture types.
 arch_to_UC = {

--- a/pwndbg/emu/x86.py
+++ b/pwndbg/emu/x86.py
@@ -2,5 +2,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import pwndbg.emu.emulator

--- a/pwndbg/emu/x86.py
+++ b/pwndbg/emu/x86.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import pwndbg.emu.emulator

--- a/pwndbg/enhance.py
+++ b/pwndbg/enhance.py
@@ -10,6 +10,8 @@ supplemental information sources (e.g. active IDA Pro connection).
 """
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import string
 

--- a/pwndbg/enhance.py
+++ b/pwndbg/enhance.py
@@ -8,10 +8,10 @@ Currently prints out code, integers, or strings, in a best-effort manner
 dependent on page permissions, the contents of the data, and any
 supplemental information sources (e.g. active IDA Pro connection).
 """
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import string
 

--- a/pwndbg/enhance.py
+++ b/pwndbg/enhance.py
@@ -16,6 +16,7 @@ from __future__ import unicode_literals
 import string
 
 import gdb
+
 import pwndbg.arch
 import pwndbg.color as color
 import pwndbg.color.enhance as E

--- a/pwndbg/events.py
+++ b/pwndbg/events.py
@@ -15,6 +15,7 @@ import sys
 import traceback
 
 import gdb
+
 import pwndbg.config
 import pwndbg.stdio
 

--- a/pwndbg/events.py
+++ b/pwndbg/events.py
@@ -7,6 +7,8 @@ by using a decorator.
 """
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import functools
 import sys

--- a/pwndbg/events.py
+++ b/pwndbg/events.py
@@ -5,10 +5,10 @@ Enables callbacks into functions to be automatically invoked
 when various events occur to the debuggee (e.g. STOP on SIGINT)
 by using a decorator.
 """
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import functools
 import sys

--- a/pwndbg/file.py
+++ b/pwndbg/file.py
@@ -7,6 +7,8 @@ debugging a remote process over SSH or similar, where e.g.
 """
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import binascii
 import errno as _errno

--- a/pwndbg/file.py
+++ b/pwndbg/file.py
@@ -5,10 +5,10 @@ Retrieve files from the debuggee's filesystem.  Useful when
 debugging a remote process over SSH or similar, where e.g.
 /proc/FOO/maps is needed from the remote system.
 """
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import binascii
 import errno as _errno

--- a/pwndbg/file.py
+++ b/pwndbg/file.py
@@ -16,6 +16,7 @@ import os
 import tempfile
 
 import gdb
+
 import pwndbg.qemu
 import pwndbg.remote
 

--- a/pwndbg/funcparser.py
+++ b/pwndbg/funcparser.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import collections
 

--- a/pwndbg/funcparser.py
+++ b/pwndbg/funcparser.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import collections
 

--- a/pwndbg/functions.py
+++ b/pwndbg/functions.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
 from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
 import collections
 

--- a/pwndbg/functions.py
+++ b/pwndbg/functions.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
 import collections
 

--- a/pwndbg/gcc.py
+++ b/pwndbg/gcc.py
@@ -4,10 +4,10 @@
 Functions for determining the architecture-dependent path to
 GCC and any flags it should be executed with.
 """
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import collections
 import glob

--- a/pwndbg/gcc.py
+++ b/pwndbg/gcc.py
@@ -6,6 +6,8 @@ GCC and any flags it should be executed with.
 """
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import collections
 import glob

--- a/pwndbg/gcc.py
+++ b/pwndbg/gcc.py
@@ -15,6 +15,7 @@ import os
 import platform
 
 import gdb
+
 import pwndbg.arch
 
 

--- a/pwndbg/gitver.py
+++ b/pwndbg/gitver.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
 import os
 import subprocess

--- a/pwndbg/gitver.py
+++ b/pwndbg/gitver.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
 from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
 import os
 import subprocess

--- a/pwndbg/heap/__init__.py
+++ b/pwndbg/heap/__init__.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import pwndbg.heap.dlmalloc
 import pwndbg.heap.heap

--- a/pwndbg/heap/__init__.py
+++ b/pwndbg/heap/__init__.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import pwndbg.heap.dlmalloc
 import pwndbg.heap.heap

--- a/pwndbg/heap/dlmalloc.py
+++ b/pwndbg/heap/dlmalloc.py
@@ -6,6 +6,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import gdb
+
 import pwndbg.events
 import pwndbg.typeinfo
 

--- a/pwndbg/heap/dlmalloc.py
+++ b/pwndbg/heap/dlmalloc.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import gdb
 import pwndbg.events

--- a/pwndbg/heap/dlmalloc.py
+++ b/pwndbg/heap/dlmalloc.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import gdb
 import pwndbg.events

--- a/pwndbg/heap/heap.py
+++ b/pwndbg/heap/heap.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import pwndbg.events
 import pwndbg.symbol

--- a/pwndbg/heap/heap.py
+++ b/pwndbg/heap/heap.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import pwndbg.events
 import pwndbg.symbol

--- a/pwndbg/heap/libheap.py
+++ b/pwndbg/heap/libheap.py
@@ -23,10 +23,10 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import struct
 import sys

--- a/pwndbg/heap/libheap.py
+++ b/pwndbg/heap/libheap.py
@@ -25,6 +25,8 @@ SOFTWARE.
 """
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import struct
 import sys

--- a/pwndbg/heap/ptmalloc.py
+++ b/pwndbg/heap/ptmalloc.py
@@ -6,6 +6,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import gdb
+
 import pwndbg.events
 import pwndbg.typeinfo
 

--- a/pwndbg/heap/ptmalloc.py
+++ b/pwndbg/heap/ptmalloc.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import gdb
 import pwndbg.events

--- a/pwndbg/heap/ptmalloc.py
+++ b/pwndbg/heap/ptmalloc.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import gdb
 import pwndbg.events

--- a/pwndbg/hexdump.py
+++ b/pwndbg/hexdump.py
@@ -26,7 +26,7 @@ def groupby(array, count, fill=None):
         yield array[i:i+count]
 
 config_colorize_ascii = theme.Parameter('hexdump-colorize-ascii', True, 'whether to colorize the hexdump command ascii section')
-config_separator      = theme.Parameter('hexdump-ascii-block-separator', u'│', 'block separator char of the hexdump command')
+config_separator      = theme.Parameter('hexdump-ascii-block-separator', '│', 'block separator char of the hexdump command')
 
 @pwndbg.config.Trigger([H.config_normal, H.config_zero, H.config_special, H.config_printable, config_colorize_ascii])
 def load_color_scheme():

--- a/pwndbg/hexdump.py
+++ b/pwndbg/hexdump.py
@@ -3,10 +3,10 @@
 """
 Hexdump implementation, ~= stolen from pwntools.
 """
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import copy
 import string

--- a/pwndbg/hexdump.py
+++ b/pwndbg/hexdump.py
@@ -5,6 +5,8 @@ Hexdump implementation, ~= stolen from pwntools.
 """
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import copy
 import string

--- a/pwndbg/ida.py
+++ b/pwndbg/ida.py
@@ -19,6 +19,7 @@ import traceback
 from contextlib import closing
 
 import gdb
+
 import pwndbg.arch
 import pwndbg.compat
 import pwndbg.elf

--- a/pwndbg/ida.py
+++ b/pwndbg/ida.py
@@ -5,10 +5,10 @@ Talks to an XMLRPC server running inside of an active IDA Pro instance,
 in order to query it about the database.  Allows symbol resolution and
 interactive debugging.
 """
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import errno
 import functools

--- a/pwndbg/ida.py
+++ b/pwndbg/ida.py
@@ -7,6 +7,8 @@ interactive debugging.
 """
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import errno
 import functools

--- a/pwndbg/info.py
+++ b/pwndbg/info.py
@@ -11,6 +11,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import gdb
+
 import pwndbg.memoize
 
 

--- a/pwndbg/info.py
+++ b/pwndbg/info.py
@@ -5,10 +5,10 @@ Runs a few useful commands which are available under "info".
 
 We probably don't need this anymore.
 """
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import gdb
 import pwndbg.memoize

--- a/pwndbg/info.py
+++ b/pwndbg/info.py
@@ -7,6 +7,8 @@ We probably don't need this anymore.
 """
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import gdb
 import pwndbg.memoize

--- a/pwndbg/inthook.py
+++ b/pwndbg/inthook.py
@@ -7,6 +7,8 @@ not already an integer type.
 """
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import sys
 

--- a/pwndbg/inthook.py
+++ b/pwndbg/inthook.py
@@ -5,10 +5,10 @@ This hook is necessary for compatibility with Python2.7 versions of GDB
 since they cannot directly cast to integer a gdb.Value object that is
 not already an integer type.
 """
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import sys
 

--- a/pwndbg/inthook.py
+++ b/pwndbg/inthook.py
@@ -13,6 +13,7 @@ from __future__ import unicode_literals
 import sys
 
 import gdb
+
 import pwndbg.typeinfo
 
 if sys.version_info < (3,0):

--- a/pwndbg/inthook.py
+++ b/pwndbg/inthook.py
@@ -18,28 +18,30 @@ import pwndbg.typeinfo
 
 if sys.version_info < (3,0):
     import __builtin__ as builtins
-    _int = builtins.int
-
-    # We need this class to get isinstance(7, xint) to return True
-    class IsAnInt(type):
-        def __instancecheck__(self, other):
-            return isinstance(other, _int)
-
-    class xint(builtins.int):
-        __metaclass__ = IsAnInt
-        def __new__(cls, value, *a, **kw):
-            if isinstance(value, gdb.Value):
-                if pwndbg.typeinfo.is_pointer(value):
-                    value = value.cast(pwndbg.typeinfo.ulong)
-                else:
-                    value = value.cast(pwndbg.typeinfo.long)
-            return _int(_int(value, *a, **kw))
-
-    builtins.int = xint
-    globals()['int'] = xint
-
-    # Additionally, we need to compensate for Python2
 else:
     import builtins
-    builtins.long = int
-    globals()['long'] = int
+
+_int = builtins.int
+
+# We need this class to get isinstance(7, xint) to return True
+class IsAnInt(type):
+    def __instancecheck__(self, other):
+        return isinstance(other, _int)
+
+class xint(builtins.int):
+    __metaclass__ = IsAnInt
+    def __new__(cls, value, *a, **kw):
+        if isinstance(value, gdb.Value):
+            if pwndbg.typeinfo.is_pointer(value):
+                value = value.cast(pwndbg.typeinfo.ulong)
+            else:
+                value = value.cast(pwndbg.typeinfo.long)
+        return _int(_int(value, *a, **kw))
+
+builtins.int = xint
+globals()['int'] = xint
+
+if sys.version_info >= (3,0):
+    builtins.long = xint
+    globals()['long'] = xint
+

--- a/pwndbg/linkmap.py
+++ b/pwndbg/linkmap.py
@@ -5,10 +5,10 @@ Describes the standard Linux glibc/eglibc link_map, and
 allows enumeration of loaded modules under qemu-user where
 /proc/X/maps may lie or be unavialable.
 """
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import gdb
 import pwndbg.elf

--- a/pwndbg/linkmap.py
+++ b/pwndbg/linkmap.py
@@ -7,6 +7,8 @@ allows enumeration of loaded modules under qemu-user where
 """
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import gdb
 import pwndbg.elf

--- a/pwndbg/linkmap.py
+++ b/pwndbg/linkmap.py
@@ -11,6 +11,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import gdb
+
 import pwndbg.elf
 import pwndbg.events
 import pwndbg.memoize

--- a/pwndbg/malloc.py
+++ b/pwndbg/malloc.py
@@ -7,6 +7,8 @@ Work-in-progress.
 """
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import pwndbg.arch
 import pwndbg.events

--- a/pwndbg/malloc.py
+++ b/pwndbg/malloc.py
@@ -5,10 +5,10 @@ Describes the EGLIBC heap mechanisms.
 
 Work-in-progress.
 """
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import pwndbg.arch
 import pwndbg.events

--- a/pwndbg/memoize.py
+++ b/pwndbg/memoize.py
@@ -5,10 +5,10 @@ Caches return values until some event in the inferior happens,
 e.g. execution stops because of a SIGINT or breakpoint, or a
 new library/objfile are loaded, etc.
 """
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import collections
 import copy

--- a/pwndbg/memoize.py
+++ b/pwndbg/memoize.py
@@ -7,6 +7,8 @@ new library/objfile are loaded, etc.
 """
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import collections
 import copy

--- a/pwndbg/memoize.py
+++ b/pwndbg/memoize.py
@@ -16,6 +16,7 @@ import functools
 import sys
 
 import gdb
+
 import pwndbg.events
 
 debug = False

--- a/pwndbg/memory.py
+++ b/pwndbg/memory.py
@@ -3,10 +3,10 @@
 """
 Reading, writing, and describing memory.
 """
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import os
 import traceback

--- a/pwndbg/memory.py
+++ b/pwndbg/memory.py
@@ -12,6 +12,7 @@ import os
 import traceback
 
 import gdb
+
 import pwndbg.arch
 import pwndbg.compat
 import pwndbg.typeinfo

--- a/pwndbg/memory.py
+++ b/pwndbg/memory.py
@@ -5,6 +5,8 @@ Reading, writing, and describing memory.
 """
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import os
 import traceback

--- a/pwndbg/net.py
+++ b/pwndbg/net.py
@@ -6,6 +6,8 @@ remote debugging sessions.
 """
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import binascii
 import socket

--- a/pwndbg/net.py
+++ b/pwndbg/net.py
@@ -4,10 +4,10 @@
 Re-implements some psutil functionality to be able to get information from
 remote debugging sessions.
 """
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import binascii
 import socket

--- a/pwndbg/next.py
+++ b/pwndbg/next.py
@@ -6,6 +6,8 @@ instruction of some type (call, branch, etc.)
 """
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import capstone
 

--- a/pwndbg/next.py
+++ b/pwndbg/next.py
@@ -10,8 +10,8 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import capstone
-
 import gdb
+
 import pwndbg.disasm
 import pwndbg.regs
 

--- a/pwndbg/next.py
+++ b/pwndbg/next.py
@@ -4,10 +4,10 @@
 Commands for setting temporary breakpoints on the next
 instruction of some type (call, branch, etc.)
 """
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import capstone
 

--- a/pwndbg/proc.py
+++ b/pwndbg/proc.py
@@ -4,10 +4,10 @@
 Provides values which would be available from /proc which
 are not fulfilled by other modules.
 """
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import functools
 import sys

--- a/pwndbg/proc.py
+++ b/pwndbg/proc.py
@@ -14,6 +14,7 @@ import sys
 from types import ModuleType
 
 import gdb
+
 import pwndbg.memoize
 import pwndbg.qemu
 

--- a/pwndbg/proc.py
+++ b/pwndbg/proc.py
@@ -6,6 +6,8 @@ are not fulfilled by other modules.
 """
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import functools
 import sys

--- a/pwndbg/prompt.py
+++ b/pwndbg/prompt.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from __future__ import unicode_literals
 import gdb
 import pwndbg.events
 import pwndbg.memoize

--- a/pwndbg/prompt.py
+++ b/pwndbg/prompt.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import print_function
-from __future__ import division
 from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
 from __future__ import unicode_literals
+
 import gdb
 import pwndbg.events
 import pwndbg.memoize

--- a/pwndbg/prompt.py
+++ b/pwndbg/prompt.py
@@ -6,6 +6,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import gdb
+
 import pwndbg.events
 import pwndbg.memoize
 import pwndbg.stdio

--- a/pwndbg/qemu.py
+++ b/pwndbg/qemu.py
@@ -5,6 +5,8 @@ Determine whether the target is being run under QEMU.
 """
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import os
 

--- a/pwndbg/qemu.py
+++ b/pwndbg/qemu.py
@@ -10,9 +10,9 @@ from __future__ import unicode_literals
 
 import os
 
+import gdb
 import psutil
 
-import gdb
 import pwndbg.events
 import pwndbg.remote
 

--- a/pwndbg/qemu.py
+++ b/pwndbg/qemu.py
@@ -3,10 +3,10 @@
 """
 Determine whether the target is being run under QEMU.
 """
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import os
 

--- a/pwndbg/regs.py
+++ b/pwndbg/regs.py
@@ -15,9 +15,9 @@ import re
 import sys
 from types import ModuleType
 
+import gdb
 import six
 
-import gdb
 import pwndbg.arch
 import pwndbg.compat
 import pwndbg.events

--- a/pwndbg/regs.py
+++ b/pwndbg/regs.py
@@ -6,6 +6,8 @@ standardized interface to registers like "sp" and "pc".
 """
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import collections
 import ctypes

--- a/pwndbg/regs.py
+++ b/pwndbg/regs.py
@@ -4,10 +4,10 @@
 Reading register value from the inferior, and provides a
 standardized interface to registers like "sp" and "pc".
 """
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import collections
 import ctypes

--- a/pwndbg/remote.py
+++ b/pwndbg/remote.py
@@ -6,6 +6,8 @@ Information about whether the debuggee is local (under GDB) or remote
 """
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import gdb
 

--- a/pwndbg/remote.py
+++ b/pwndbg/remote.py
@@ -4,10 +4,10 @@
 Information about whether the debuggee is local (under GDB) or remote
 (under GDBSERVER or QEMU stub).
 """
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import gdb
 

--- a/pwndbg/search.py
+++ b/pwndbg/search.py
@@ -11,6 +11,7 @@ from __future__ import unicode_literals
 import struct
 
 import gdb
+
 import pwndbg.arch
 import pwndbg.memory
 import pwndbg.typeinfo

--- a/pwndbg/search.py
+++ b/pwndbg/search.py
@@ -5,6 +5,8 @@ Search the address space for byte patterns.
 """
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import struct
 

--- a/pwndbg/search.py
+++ b/pwndbg/search.py
@@ -3,10 +3,10 @@
 """
 Search the address space for byte patterns.
 """
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import struct
 

--- a/pwndbg/stack.py
+++ b/pwndbg/stack.py
@@ -13,6 +13,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import gdb
+
 import pwndbg.events
 import pwndbg.memoize
 import pwndbg.memory

--- a/pwndbg/stack.py
+++ b/pwndbg/stack.py
@@ -7,10 +7,10 @@ a stack.
 Generally not needed, except under qemu-user and for when
 binaries do things to remap the stack (e.g. pwnies' postit).
 """
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import gdb
 import pwndbg.events

--- a/pwndbg/stack.py
+++ b/pwndbg/stack.py
@@ -9,6 +9,8 @@ binaries do things to remap the stack (e.g. pwnies' postit).
 """
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import gdb
 import pwndbg.events

--- a/pwndbg/stdio.py
+++ b/pwndbg/stdio.py
@@ -4,10 +4,10 @@
 Provides functionality to circumvent GDB's hooks on sys.stdin and sys.stdout
 which prevent output from appearing on-screen inside of certain event handlers.
 """
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import codecs
 import io

--- a/pwndbg/stdio.py
+++ b/pwndbg/stdio.py
@@ -6,6 +6,8 @@ which prevent output from appearing on-screen inside of certain event handlers.
 """
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import codecs
 import io

--- a/pwndbg/stdio.py
+++ b/pwndbg/stdio.py
@@ -15,6 +15,7 @@ import os
 import sys
 
 import gdb
+
 import pwndbg.compat
 
 

--- a/pwndbg/strings.py
+++ b/pwndbg/strings.py
@@ -12,6 +12,7 @@ from __future__ import unicode_literals
 import string
 
 import gdb
+
 import pwndbg.events
 import pwndbg.memory
 import pwndbg.typeinfo

--- a/pwndbg/strings.py
+++ b/pwndbg/strings.py
@@ -6,6 +6,8 @@ the debuggee's address space.
 """
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import string
 

--- a/pwndbg/strings.py
+++ b/pwndbg/strings.py
@@ -4,10 +4,10 @@
 Functionality for resolving ASCII printable strings within
 the debuggee's address space.
 """
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import string
 

--- a/pwndbg/symbol.py
+++ b/pwndbg/symbol.py
@@ -9,6 +9,8 @@ information available.
 """
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import os
 import re

--- a/pwndbg/symbol.py
+++ b/pwndbg/symbol.py
@@ -7,10 +7,10 @@ vice-versa.
 Uses IDA when available if there isn't sufficient symbol
 information available.
 """
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import os
 import re

--- a/pwndbg/symbol.py
+++ b/pwndbg/symbol.py
@@ -20,9 +20,9 @@ import elftools.common.exceptions
 import elftools.elf.constants
 import elftools.elf.elffile
 import elftools.elf.segments
+import gdb
 import six
 
-import gdb
 import pwndbg.elf
 import pwndbg.events
 import pwndbg.file

--- a/pwndbg/typeinfo.py
+++ b/pwndbg/typeinfo.py
@@ -4,10 +4,10 @@
 Common types, and routines for manually loading types from file
 via GCC.
 """
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import glob
 import os

--- a/pwndbg/typeinfo.py
+++ b/pwndbg/typeinfo.py
@@ -15,9 +15,9 @@ import subprocess
 import sys
 import tempfile
 
+import gdb
 import six
 
-import gdb
 import pwndbg.events
 import pwndbg.gcc
 import pwndbg.memoize

--- a/pwndbg/typeinfo.py
+++ b/pwndbg/typeinfo.py
@@ -6,6 +6,8 @@ via GCC.
 """
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import glob
 import os

--- a/pwndbg/ui.py
+++ b/pwndbg/ui.py
@@ -5,6 +5,8 @@ A few helpers for making things print pretty-like.
 """
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import fcntl
 import struct

--- a/pwndbg/ui.py
+++ b/pwndbg/ui.py
@@ -18,7 +18,7 @@ import pwndbg.color.context as C
 import pwndbg.color.theme as theme
 import pwndbg.config as config
 
-theme.Parameter('banner-separator', u'─', 'repeated banner separator character')
+theme.Parameter('banner-separator', '─', 'repeated banner separator character')
 
 def banner(title):
     title = title.upper()

--- a/pwndbg/ui.py
+++ b/pwndbg/ui.py
@@ -3,10 +3,10 @@
 """
 A few helpers for making things print pretty-like.
 """
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import fcntl
 import struct

--- a/pwndbg/vmmap.py
+++ b/pwndbg/vmmap.py
@@ -7,10 +7,10 @@ address ranges with various ELF files and permissions.
 The reason that we need robustness is that not every operating
 system has /proc/$$/maps, which backs 'info proc mapping'.
 """
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 import os
 import sys

--- a/pwndbg/vmmap.py
+++ b/pwndbg/vmmap.py
@@ -9,6 +9,8 @@ system has /proc/$$/maps, which backs 'info proc mapping'.
 """
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
 import os
 import sys

--- a/pwndbg/vmmap.py
+++ b/pwndbg/vmmap.py
@@ -16,6 +16,7 @@ import os
 import sys
 
 import gdb
+
 import pwndbg.compat
 import pwndbg.elf
 import pwndbg.events

--- a/pwndbg/which.py
+++ b/pwndbg/which.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
 from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
 # This license covers everything within this project, except for a few pieces
 # of code that we either did not write ourselves or which we derived from code

--- a/pwndbg/which.py
+++ b/pwndbg/which.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
 # This license covers everything within this project, except for a few pieces
 # of code that we either did not write ourselves or which we derived from code

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ python-ptrace>=0.8
 pyelftools
 isort
 six
+future


### PR DESCRIPTION
This requires that `isort` and `futurize` do not have any complaints when performing CI.