### PR TITLE
Don't encode section name as ascii in elf commands

### DIFF
--- a/pwndbg/commands/elf.py
+++ b/pwndbg/commands/elf.py
@@ -48,7 +48,6 @@ def plt():
     print_symbols_in_section('.plt', '@plt')
 
 def get_section_bounds(section_name):
-    section_name = section_name.encode('ascii')
     with open(pwndbg.proc.exe, 'rb') as f:
         elffile = ELFFile(f)
 


### PR DESCRIPTION
Without this, we can't get any of the sections found by elfheader. This works with python3, but someone should test this with python2 first (I'm wondering if I wrote it like this initially because I was using python2 when I made original PR).