### PR TITLE
Avoid infinite loop on 0-sized chunks in heap command

### DIFF
--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -80,6 +80,8 @@ def heap(addr=None):
 
         # Clear the bottom 3 bits
         size &= ~7
+        if size == 0:
+            break
         addr += size
 
 @pwndbg.commands.ParsedCommand


### PR DESCRIPTION
During heap traversal, we'll enter an infinite loop if a 0-sized chunk is found (happens to me frequently while developing exploits), printing the same chunk forever. 