### PR TITLE
fix calling value() on NoneType

### DIFF
--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -26,7 +26,9 @@ def value_from_type(type_name, addr):
 
 def get_main_arena(addr=None):
     if addr == None:
-        main_arena = gdb.lookup_symbol('main_arena')[0].value()
+        main_arena = gdb.lookup_symbol('main_arena')[0]
+        if main_arena is not None:
+            main_arena = main_arena.value()
     else:
         main_arena = value_from_type('struct malloc_state', addr)
 


### PR DESCRIPTION
Before:

```
pwndbg> heap
Traceback (most recent call last):
  File "/opt/pwndbg/pwndbg/commands/__init__.py", line 57, in __call__
    return self.function(*args, **kwargs)
  File "/opt/pwndbg/pwndbg/commands/__init__.py", line 115, in _OnlyWhenRunning
    return function(*a, **kw)
  File "/opt/pwndbg/pwndbg/commands/heap.py", line 58, in heap
    main_arena = get_main_arena(addr)
  File "/opt/pwndbg/pwndbg/commands/heap.py", line 29, in get_main_arena
    main_arena = gdb.lookup_symbol('main_arena')[0].value()
AttributeError: 'NoneType' object has no attribute 'value'
```

After:

```
pwndbg> heap
Symbol 'main_arena' not found. Try installing libc debugging symbols or specifying the main arena address and try again
```
