### PR TITLE
add option to show retaddr register to config

### DIFF
--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -71,11 +71,14 @@ def regs(*regs):
     print('\n'.join(get_regs(*regs)))
 
 pwndbg.config.Parameter('show-flags', False, 'whether to show flags registers')
+pwndbg.config.Parameter('show-retaddr-reg', False, 'whether to show return address register')
 
 def get_regs(*regs):
     result = []
 
-    if not regs:
+    if not regs and pwndbg.config.show_retaddr_reg:
+        regs = pwndbg.regs.gpr + (pwndbg.regs.frame, pwndbg.regs.current.stack) + pwndbg.regs.retaddr + (pwndbg.regs.current.pc,)
+    elif not regs:
         regs = pwndbg.regs.gpr + (pwndbg.regs.frame, pwndbg.regs.current.stack, pwndbg.regs.current.pc)
 
     if pwndbg.config.show_flags:

--- a/pwndbg/regs.py
+++ b/pwndbg/regs.py
@@ -91,7 +91,7 @@ class RegisterSet(object):
             if reg and reg not in self.common:
                 self.common.append(reg)
 
-        self.all = set(i for i in misc) | set(flags) | set(self.common)
+        self.all = set(i for i in misc) | set(flags) | set(self.retaddr) | set(self.common)
         self.all -= {None}
 
     def __iter__(self):
@@ -240,7 +240,6 @@ arch_to_regs = {
     'sparc': sparc,
     'arm': arm,
     'aarch64': aarch64,
-    'powerpc': powerpc,
     'powerpc': powerpc,
 }
 
@@ -426,3 +425,5 @@ sys.modules[__name__] = module(__name__, '')
 def update_last():
     M = sys.modules[__name__]
     M.last = {k:M[k] for k in M.common}
+    if pwndbg.config.show_retaddr_reg:
+        M.last.update({k:M[k] for k in M.retaddr})


### PR DESCRIPTION
Adds an option (show-retaddr-reg) to config to show return address registers like 'lr' on ARM. For #115 

```
show-retaddr-reg       False          whether to show return address register
```

Example:

```
*R0   0xf6fff23c —▸ 0xf66b6454 ◂— 0xe1a00005
*R1   0xf67937c4 —▸ 0x12000 ◂— 0x0
 R2   0x0
*R3   0xf6fff23c —▸ 0xf66b6454 ◂— 0xe1a00005
*R4   0x87ed (__libc_csu_init+1) ◂— 0x743f8e9
 R5   0x0
*R6   0x856d (_start+1) ◂— lsls   r0, r6, #3
*R7   0xf6fff238 ◂— 0x0
 R8   0x0
 R9   0x0
*R10  0xf67fdfb4 —▸ 0x2feec ◂— 0x0
 R11  0x0
*R12  0xb0
*SP   0xf6fff238 ◂— 0x0
*LR   0x87c9 (main+113) ◂— lsls   r6, r0, #1 /* u'F' */
*PC   0x86b2 (checkpassword+10) ◂— blx    #0x84c4

```