### PR TITLE
make metaclass syntax in inthook.py compatible with Python 3

### DIFF
--- a/pwndbg/inthook.py
+++ b/pwndbg/inthook.py
@@ -13,6 +13,7 @@ from __future__ import unicode_literals
 import sys
 
 import gdb
+from future.utils import with_metaclass
 
 import pwndbg.typeinfo
 
@@ -28,8 +29,7 @@ class IsAnInt(type):
     def __instancecheck__(self, other):
         return isinstance(other, _int)
 
-class xint(builtins.int):
-    __metaclass__ = IsAnInt
+class xint(with_metaclass(IsAnInt, builtins.int)):
     def __new__(cls, value, *a, **kw):
         if isinstance(value, gdb.Value):
             if pwndbg.typeinfo.is_pointer(value):
@@ -44,4 +44,3 @@ globals()['int'] = xint
 if sys.version_info >= (3,0):
     builtins.long = xint
     globals()['long'] = xint
-


### PR DESCRIPTION
As I mentioned in #126, I use the future package to make metaclass syntax compatible with both Python 2 and 3. 