### PR TITLE
workaround for python2 unicode printing

### DIFF
--- a/pwndbg/__init__.py
+++ b/pwndbg/__init__.py
@@ -8,6 +8,7 @@ from __future__ import unicode_literals
 import sys
 
 import gdb
+import six
 
 import pwndbg.android
 import pwndbg.arch
@@ -72,6 +73,12 @@ try:
 except:
     pass
 
+# this is an unconventional workaround to
+# support unicode printing for python2
+# https://github.com/pwndbg/pwndbg/issues/117
+if six.PY2:
+    reload(sys)
+    sys.setdefaultencoding('utf-8')
 
 
 __all__ = [

--- a/pwndbg/color/disasm.py
+++ b/pwndbg/color/disasm.py
@@ -29,7 +29,7 @@ def branch(x):
     return generateColorFunction(config.disasm_branch_color)(x)
 
 def instruction(ins):
-    asm = u'%-06s %s' % (ins.mnemonic, ins.op_str)
+    asm = '%-06s %s' % (ins.mnemonic, ins.op_str)
     is_branch = set(ins.groups) & capstone_branch_groups
 
     # Highlight the current line if enabled
@@ -80,7 +80,7 @@ def instruction(ins):
     if ins.condition is None:
         asm = '  ' + asm
     elif ins.condition:
-        asm = green(u'✔ ') + asm
+        asm = green('✔ ') + asm
     else:
         asm = '  ' + asm
 

--- a/pwndbg/commands/nearpc.py
+++ b/pwndbg/commands/nearpc.py
@@ -28,10 +28,10 @@ def ljust_padding(lst):
     longest_len = max(map(len, lst)) if lst else 0
     return [s.ljust(longest_len) for s in lst]
 
-nearpc_branch_marker = pwndbg.color.theme.Parameter('nearpc-branch-marker', u'    ↓', 'branch marker line for nearpc command')
+nearpc_branch_marker = pwndbg.color.theme.Parameter('nearpc-branch-marker', '    ↓', 'branch marker line for nearpc command')
 nearpc_branch_marker_contiguous = pwndbg.color.theme.Parameter('nearpc-branch-marker-contiguous', ' ', 'contiguous branch marker line for nearpc command')
 pwndbg.color.theme.Parameter('highlight-pc', True, 'whether to highlight the current instruction')
-pwndbg.color.theme.Parameter('nearpc-prefix', u'►', 'prefix marker for nearpc command')
+pwndbg.color.theme.Parameter('nearpc-prefix', '►', 'prefix marker for nearpc command')
 pwndbg.config.Parameter('left-pad-disasm', True, 'whether to left-pad disassembly')
 
 @pwndbg.commands.ParsedCommand

--- a/pwndbg/commands/telescope.py
+++ b/pwndbg/commands/telescope.py
@@ -26,9 +26,9 @@ import pwndbg.typeinfo
 telescope_lines = pwndbg.config.Parameter('telescope-lines',
                                          8,
                                          'number of lines to printed by the telescope command')
-offset_separator = theme.Parameter('telescope-offset-separator', u'│', 'offset separator of the telescope command')
+offset_separator = theme.Parameter('telescope-offset-separator', '│', 'offset separator of the telescope command')
 offset_delimiter = theme.Parameter('telescope-offset-delimiter', ':', 'offset delimiter of the telescope command')
-repeating_maker  = theme.Parameter('telescope-repeating-marker', u'... ↓', 'repeating values marker of the telescope command')
+repeating_maker  = theme.Parameter('telescope-repeating-marker', '... ↓', 'repeating values marker of the telescope command')
 
 
 @pwndbg.commands.ParsedCommand

--- a/pwndbg/commands/theme.py
+++ b/pwndbg/commands/theme.py
@@ -22,14 +22,18 @@ def theme():
     values = [v for k, v in pwndbg.config.__dict__.items()
               if isinstance(v, pwndbg.config.Parameter) and v.scope == 'theme']
     longest_optname = max(map(len, [v.optname for v in values]))
-    longest_value = max(map(len, [extend_value_with_default(repr(v.value), repr(v.default)) for v in values]))
+    longest_value = max(map(len, [extend_value_with_default(str(v.value), str(v.default)) for v in values]))
 
     header = print_row('Name', 'Value', 'Def', 'Documentation', longest_optname, longest_value)
     print('-' * (len(header)))
     for v in sorted(values):
-        value = repr(v.value)
-        default = repr(v.default)
         if isinstance(v, pwndbg.color.theme.ColoredParameter):
-            value = generateColorFunction(v.value)(value)
-            default = generateColorFunction(v.default)(default)
+            value = generateColorFunction(v.value)(v.value)
+            default = generateColorFunction(v.default)(v.default)
+        elif isinstance(v.value, str):
+            value = "'%s'" % str(v.value)
+            default = str(v.default)
+        else:
+            value = repr(v.value)
+            default = repr(v.default)
         print_row(v.optname, value, default, v.docstring, longest_optname, longest_value)


### PR DESCRIPTION
repr() does not work well when printing unicode sequences (at least in python2)
therefor we add a small switch case in the theme command to properly print
the values depending on their types.

Remove u'' string prefxies as they are superseded by unicode_literals

Fixes #117