### PR TITLE
Fix windbg dX commands with explicit count

### DIFF
--- a/pwndbg/commands/windbg.py
+++ b/pwndbg/commands/windbg.py
@@ -78,6 +78,7 @@ def dX(size, address, count, to_string=False):
     values = []
     address = int(address) & pwndbg.arch.ptrmask
     type   = get_type(size)
+    count = int(count)
     for i in range(count):
         try:
             gval = pwndbg.memory.poi(type, address + i * size)


### PR DESCRIPTION
Tiny fix. Thanks for the tool!

```
pwndbg> dd 0 0
'gdb.Value' object cannot be interpreted as an integer
'dd': Starting at the specified address, dump N dwords
    (default 16).
```