### PR TITLE
Add RPC-based tests

### DIFF
--- a/pwndbg/__init__.py
+++ b/pwndbg/__init__.py
@@ -63,6 +63,7 @@ import pwndbg.net
 import pwndbg.proc
 import pwndbg.prompt
 import pwndbg.regs
+import pwndbg.server
 import pwndbg.stack
 import pwndbg.stdio
 import pwndbg.typeinfo

--- a/pwndbg/server.py
+++ b/pwndbg/server.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+try:
+    import xmlrpc.client as xmlrpclib
+except:
+    import xmlrpclib
+

--- a/pwndbg/server.py
+++ b/pwndbg/server.py
@@ -5,8 +5,62 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-try:
-    import xmlrpc.client as xmlrpclib
-except:
-    import xmlrpclib
+import codecs
+import threading
+
+import gdb
+import pwndbg
+import pwndbg.xmlhacks
+
+pwndbg.xmlhacks.register_integer_type(gdb.Value)
+
+host = pwndbg.config.Parameter('rpc-host', '127.0.0.1', 'xmlrpc server address')
+port = pwndbg.config.Parameter('rpc-port', 8889, 'xmlrpc server port')
+
+def string_test():
+    return "String\x00Bar"
+
+def int_test():
+    return 17
+
+def long_test():
+    return 1 << 100
+
+def bytes_test():
+    return b'asdf'
+
+def bytearray_test():
+    return bytearray(b'asdfasdf')
+
+def string_test():
+    return "Hello"
+
+def string_with_null_test():
+    return "Hello\x00World"
+
+def unicode_test():
+    return "☠"
+
+def megatest():
+    return [int_test(),
+            long_test(),
+            bytes_test(),
+            bytearray_test(),
+            string_test(),
+            string_with_null_test(),
+            unicode_test()]
+
+def serve():
+    server = pwndbg.xmlhacks.SimpleXMLRPCServer((str(host), int(port)), logRequests=True, allow_none=True)
+    server.register_instance(gdb, allow_dotted_names=True)
+    server.register_instance(pwndbg, allow_dotted_names=True)
+    server.register_function(lambda a: eval(a, globals(), locals()), 'eval')
+    server.register_introspection_functions()
+
+    print("Starting server on %s:%s" % (host, port))
+
+    # thread = threading.Thread(target=server.serve_forever)
+    # thread.daemon = True
+    # thread.start()
+    server.serve_forever()
 

--- a/pwndbg/xmlhacks.py
+++ b/pwndbg/xmlhacks.py
@@ -37,6 +37,7 @@ def marshall_binary(self, value, write):
         return self.dump_string(value, write)
     template = "<value><binary>%s</binary></value>"
     value = codecs.encode(value, 'hex')
+    value = value.encode('latin-1')
     write(template % value)
 
 def unmarshall_int(self, data):

--- a/pwndbg/xmlhacks.py
+++ b/pwndbg/xmlhacks.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import codecs
+import string
+
+printable = set(string.printable)
+
+def isprint(x):
+    return set(x) < printable
+
+try:
+    import xmlrpc.client as xmlrpclib
+    from xmlrpc.server import SimpleXMLRPCServer
+except:
+    import xmlrpclib
+    from SimpleXMLRPCServer import SimpleXMLRPCServer
+
+# Disable use of the accelerated Unmarshaller, so that we
+# can add our own types.
+xmlrpclib.FastUnmarshaller = None
+
+# Declare code to marshal / unmarshal the only two types we really
+# care about: Integers and Binary data.  The built-in marshallers
+# are quite inferior.
+def marshall_int(self, value, write):
+    template = "<value><i8>%d</i8></value>"
+    value = int(value)
+    write(template % value)
+
+def marshall_binary(self, value, write):
+    if isprint(value):
+        return self.dump_string(value, write)
+    template = "<value><binary>%s</binary></value>"
+    value = codecs.encode(value, 'hex')
+    write(template % value)
+
+def unmarshall_int(self, data):
+    self.append(int(data))
+    self._value = 0
+
+def unmarshall_binary(self, data):
+    self.append(bytearray(codecs.decode(data, 'hex')))
+    self._value = 0
+
+# Registration routines
+def register_integer_type(t):
+    xmlrpclib.Marshaller.dispatch[t] = marshall_int
+
+def register_binary_type(t):
+    xmlrpclib.Marshaller.dispatch[t] = marshall_binary
+
+# We make some changes to the XMLRPC spec to support our needs
+register_integer_type(type(1))
+register_integer_type(type(1 << 100))
+
+register_binary_type(type(''))  # Unicode strings
+register_binary_type(type(b'')) # Byte strings
+register_binary_type(bytearray) # Byte arrays
+
+xmlrpclib.Unmarshaller.dispatch['binary'] = unmarshall_binary

--- a/tests/common.py
+++ b/tests/common.py
@@ -2,10 +2,15 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+import atexit
+import functools
 import subprocess
+import sys
 import tempfile
+import time
 import unittest
 
+from . import xmlhacks
 
 def pywrite(data):
     return write(data, suffix='.py')
@@ -15,7 +20,7 @@ def write(data, suffix=''):
     t.write(data.encode('utf-8'))
     return t
 
-def run_gdb_with_script(pybefore='', pyafter=''):
+def gdb_with_script(pybefore='', pyafter=''):
     command = ['gdb','--silent','--nx','--nh']
 
     if pybefore:
@@ -27,5 +32,17 @@ def run_gdb_with_script(pybefore='', pyafter=''):
         command += ['--command', pywrite(pyafter).name]
 
     command += ['--eval-command', 'quit']
+    return command
 
+def run_gdb_with_script(*a, **kw):
+    command = gdb_with_script(*a, **kw)
     return subprocess.check_output(command, stderr=subprocess.STDOUT)
+
+def run_with_server():
+    command = gdb_with_script(pyafter='import pwndbg;\npwndbg.server.serve()')
+    return subprocess.Popen(command, stdout=subprocess.PIPE)
+
+gdb_with_server = run_with_server()
+server = xmlhacks.xmlrpclib.ServerProxy('http://127.0.0.1:8889', verbose=1)
+
+atexit.register(lambda: gdb_with_server.kill())

--- a/tests/testLoadsWithoutCrashing.py
+++ b/tests/testLoadsWithoutCrashing.py
@@ -3,9 +3,8 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-from . import common
-
+from .common import run_gdb_with_script, server
 
 def test_loads_wivout_crashing_bruv():
-    output = common.run_gdb_with_script()
+    output = run_gdb_with_script()
     assert 'Type pwndbg [filter] for a list.' in output, output

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+from .common import run_gdb_with_script, server
+
+def test_eval():
+    assert server.eval('7') == 7
+
+def test_example():
+    assert server.gdb.parse_and_eval('7')
+
+def test_arch_pack():
+    result = server.pwndbg.arch.pack(0xdeadbeef)
+    assert result == bytearray(b'\xef\xbe\xad\xde')
+

--- a/tests/xmlhacks.py
+++ b/tests/xmlhacks.py
@@ -1,0 +1,1 @@
+../pwndbg/xmlhacks.py


### PR DESCRIPTION
Allow testing Pwndbg itself by embedding an XMLRPC server inside the GDB instance, which exposes both the `gdb` and `pwndbg` modules, as well as `eval`.

Since the default XMLRPC behavior is terrible and doesn't know how to marshall any of the following:

- `bytearray` object
- `bytes` object
- `str` or `unicode` with embedded `\x00`

We hack both the Marshaller and Unmarshaller to support a new datatype.