### PR TITLE
Fix submodule pull bug

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -11,7 +11,8 @@ if uname | grep -i Linux &>/dev/null; then
 fi
 
 # Update all submodules
-git submodule update --init --recursive
+#git submodule update --init --recursive
+git submodule foreach git pull
 
 # Find the Python version used by GDB.
 PYVER=$(gdb -batch -q --nx -ex 'pi import platform; print(".".join(platform.python_version_tuple()[:2]))')


### PR DESCRIPTION
The following submodule command no longer works on Ubuntu

```
# git submodule update --init --recursive
fatal: Needed a single revision
Unable to find current revision in submodule path 'capstone'
```

Changing to `git submodule foreach git pull`