### PR TITLE
avoid searching 0-length in memory

### DIFF
--- a/pwndbg/search.py
+++ b/pwndbg/search.py
@@ -49,7 +49,11 @@ def search(searchfor, mapping=None, start=None, end=None,
             if not pwndbg.memory.peek(start):
                 break
 
-            start = i.search_memory(start, end - start, searchfor)
+            length = end - start
+            if length <= 0:
+                break
+
+            start = i.search_memory(start, length, searchfor)
 
             if start is None:
                 break


### PR DESCRIPTION
This will result in an internal exception and make pwndbg stop
searching. Just avoid and exit this search block if the current
search length equals zero.