### PR TITLE
don't override gdb internal 'find' command via shell cmds

### DIFF
--- a/pwndbg/commands/shell.py
+++ b/pwndbg/commands/shell.py
@@ -31,7 +31,7 @@ shellcmds = [
     "diff",
     "disasm", # pwntools
     "egrep",
-    "find",
+    # "find", don't expose find as its an internal gdb command
     "grep",
     "htop",
     "id",


### PR DESCRIPTION
We keep 'find' inside but comment it out so future editors are
aware of why it is missing instead of assuming it was missing
by accident.