### PR TITLE
add config for amount of stack, code context and nearpc lines

### DIFF
--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -148,15 +148,16 @@ def get_regs(*regs):
 pwndbg.config.Parameter('emulate', True, '''
 Unicorn emulation of code near the current instruction
 ''')
+code_lines = pwndbg.config.Parameter('context-code-lines', 10, 'number of additional lines to print in the code context')
 
 def context_code():
     banner = [pwndbg.ui.banner("code")]
     emulate = bool(pwndbg.config.emulate)
-    result = pwndbg.commands.nearpc.nearpc(to_string=True, emulate=emulate)
+    result = pwndbg.commands.nearpc.nearpc(to_string=True, emulate=emulate, lines=int(code_lines) // 2)
 
     # If we didn't disassemble backward, try to make sure
     # that the amount of screen space taken is roughly constant.
-    while len(result) < 11:
+    while len(result) < int(code_lines) + 1:
         result.append('')
 
     return banner + result
@@ -212,10 +213,12 @@ def context_source():
 
     return []
 
+stack_lines = pwndbg.config.Parameter('context-stack-lines', 8, 'number of lines to print in the stack context')
+
 def context_stack():
     result = []
     result.append(pwndbg.ui.banner("stack"))
-    telescope = pwndbg.commands.telescope.telescope(pwndbg.regs.sp, to_string=True)
+    telescope = pwndbg.commands.telescope.telescope(pwndbg.regs.sp, to_string=True, count=int(stack_lines))
     if telescope:
         result.extend(telescope)
     return result

--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -153,11 +153,11 @@ code_lines = pwndbg.config.Parameter('context-code-lines', 10, 'number of additi
 def context_code():
     banner = [pwndbg.ui.banner("code")]
     emulate = bool(pwndbg.config.emulate)
-    result = pwndbg.commands.nearpc.nearpc(to_string=True, emulate=emulate, lines=int(code_lines) // 2)
+    result = pwndbg.commands.nearpc.nearpc(to_string=True, emulate=emulate, lines=code_lines // 2)
 
     # If we didn't disassemble backward, try to make sure
     # that the amount of screen space taken is roughly constant.
-    while len(result) < int(code_lines) + 1:
+    while len(result) < code_lines + 1:
         result.append('')
 
     return banner + result
@@ -218,7 +218,7 @@ stack_lines = pwndbg.config.Parameter('context-stack-lines', 8, 'number of lines
 def context_stack():
     result = []
     result.append(pwndbg.ui.banner("stack"))
-    telescope = pwndbg.commands.telescope.telescope(pwndbg.regs.sp, to_string=True, count=int(stack_lines))
+    telescope = pwndbg.commands.telescope.telescope(pwndbg.regs.sp, to_string=True, count=stack_lines)
     if telescope:
         result.extend(telescope)
     return result

--- a/pwndbg/commands/nearpc.py
+++ b/pwndbg/commands/nearpc.py
@@ -54,7 +54,7 @@ def nearpc(pc=None, lines=None, to_string=False, emulate=False):
         pc = pwndbg.regs.pc
 
     if lines is None:
-        lines = int(nearpc_lines) // 2
+        lines = nearpc_lines // 2
 
     pc    = int(pc)
     lines = int(lines)

--- a/pwndbg/commands/nearpc.py
+++ b/pwndbg/commands/nearpc.py
@@ -34,6 +34,7 @@ nearpc_branch_marker_contiguous = pwndbg.color.theme.Parameter('nearpc-branch-ma
 pwndbg.color.theme.Parameter('highlight-pc', True, 'whether to highlight the current instruction')
 pwndbg.color.theme.Parameter('nearpc-prefix', '►', 'prefix marker for nearpc command')
 pwndbg.config.Parameter('left-pad-disasm', True, 'whether to left-pad disassembly')
+nearpc_lines = pwndbg.config.Parameter('nearpc-lines', 10, 'number of additional lines to print for the nearpc command')
 
 @pwndbg.commands.ParsedCommand
 @pwndbg.commands.OnlyWhenRunning
@@ -53,7 +54,7 @@ def nearpc(pc=None, lines=None, to_string=False, emulate=False):
         pc = pwndbg.regs.pc
 
     if lines is None:
-        lines = 5
+        lines = int(nearpc_lines) // 2
 
     pc    = int(pc)
     lines = int(lines)

--- a/pwndbg/config.py
+++ b/pwndbg/config.py
@@ -135,6 +135,27 @@ class Parameter(gdb.Parameter):
     def __lt__(self, other):
         return self.optname <= other.optname
 
+    def __div__(self, other):
+        return self.value / other
+
+    def __floordiv__(self, other):
+        return self.value // other
+
+    def __mul__(self, other):
+        return self.value * other
+
+    def __sub__(self, other):
+        return self.value - other
+
+    def __add__(self, other):
+        return self.value + other
+
+    def __pow__(self, other):
+        return self.value ** other
+
+    def __mod__(self, other):
+        return self.value % other
+
     # Python2 compatibility
     __nonzero__ = __bool__
 


### PR DESCRIPTION
Adding options so all commands and context lines can be configured independently. For more human friendly behavior of the lines value, we internally divide it by 2 as it functions as a value for before+after current pc.