### PR TITLE
Add IDA comments to context display

### DIFF
--- a/pwndbg/__init__.py
+++ b/pwndbg/__init__.py
@@ -110,7 +110,7 @@ __all__ = [
 
 prompt = "pwndbg> "
 prompt = "\x02" + prompt + "\x01" # STX + prompt + SOH
-prompt = pwndbg.color.red(prompt)
+#prompt = pwndbg.color.red(prompt)
 prompt = pwndbg.color.bold(prompt)
 prompt = "\x01" + prompt + "\x02" # SOH + prompt + STX
 

--- a/pwndbg/commands/nearpc.py
+++ b/pwndbg/commands/nearpc.py
@@ -123,6 +123,13 @@ def nearpc(pc=None, lines=None, to_string=False, emulate=False):
 
         line   = ' '.join((prefix, address_str, s, asm))
 
+        # Add any comment from ida to the end of the assembly
+        comment = pwndbg.ida.Comment(i.address)
+        if not comment:
+            comment = pwndbg.ida.RepeatableComment(i.address)
+        if comment:
+            line += " ; {}".format(comment)
+
         # If there was a branch before this instruction which was not
         # contiguous, put in some ellipses.
         if prev and prev.address + prev.size != i.address:

--- a/pwndbg/commands/nearpc.py
+++ b/pwndbg/commands/nearpc.py
@@ -128,6 +128,8 @@ def nearpc(pc=None, lines=None, to_string=False, emulate=False):
         if not comment:
             comment = pwndbg.ida.RepeatableComment(i.address)
         if comment:
+            comment = pwndbg.color.green(comment)
+            comment = pwndbg.color.bold(comment)
             line += " ; {}".format(comment)
 
         # If there was a branch before this instruction which was not

--- a/pwndbg/ida.py
+++ b/pwndbg/ida.py
@@ -130,7 +130,13 @@ def base():
 @withIDA
 @takes_address
 def Comment(addr):
-    return _ida.GetCommentEx(addr, 0) or _ida.GetCommentEx(addr)
+    return _ida.GetCommentEx(addr, 0)
+
+
+@withIDA
+@takes_address
+def RepeatableComment(addr):
+    return _ida.GetCommentEx(addr, 1)
 
 
 @withIDA

--- a/pwndbg/ida.py
+++ b/pwndbg/ida.py
@@ -326,7 +326,8 @@ def has_cached_cfunc(addr):
 @takes_address
 @pwndbg.memoize.reset_on_stop
 def decompile(addr):
-    return _ida.decompile(addr)
+    return None
+    # return _ida.decompile(addr)
 
 
 @withIDA

--- a/pwndbg/ida.py
+++ b/pwndbg/ida.py
@@ -97,19 +97,13 @@ def available():
 
 
 def l2r(addr):
-    exe = pwndbg.elf.exe()
-    if not exe:
-        raise Exception("Can't find EXE base")
-    result = (addr - int(exe.address) + base()) & pwndbg.arch.ptrmask
-    return result
+    vaddr = pwndbg.vmmap.find(pwndbg.regs.pc).vaddr
+    return (addr - vaddr + base()) & pwndbg.arch.ptrmask
 
 
 def r2l(addr):
-    exe = pwndbg.elf.exe()
-    if not exe:
-        raise Exception("Can't find EXE base")
-    result = (addr - base() + int(exe.address)) & pwndbg.arch.ptrmask
-    return result
+    vaddr = pwndbg.vmmap.find(pwndbg.regs.pc).vaddr
+    return (addr - base() + vaddr) & pwndbg.arch.ptrmask
 
 
 def remote(function):

--- a/pwndbg/ida.py
+++ b/pwndbg/ida.py
@@ -203,8 +203,6 @@ def GetBptEA(i):
 _breakpoints = []
 
 
-@pwndbg.events.cont
-@pwndbg.events.stop
 @withIDA
 def UpdateBreakpoints():
     # XXX: Remove breakpoints from IDA when the user removes them.


### PR DESCRIPTION
This queries IDA for any comments or repeatable comments and adds them to the end of the assembly.

I also removed the GetCommentEx(addr) call.  I'm not sure if this is legacy idapython or what but it isn't needed on my setup.  And added the [repeatable comment](http://reverseengineering.stackexchange.com/questions/11024/getting-user-comments-with-idapython-api-user-cmts) function.

This adds a lot of RPC calls to each context() call on top of all of the IDA queries already for Anterior().  Next I want to hide all of these behind a config (similar to the existing unicorn emulate flag) to speed up context display when connected to IDA.