### PR TITLE
Better exception when calling events

### DIFF
--- a/pwndbg/events.py
+++ b/pwndbg/events.py
@@ -16,8 +16,10 @@ import traceback
 
 import gdb
 
+import pwndbg.color
 import pwndbg.config
 import pwndbg.stdio
+
 
 debug = pwndbg.config.Parameter('debug-events', False, 'display internal event debugging info')
 pause = 0
@@ -119,6 +121,9 @@ def connect(func, event_handler, name=''):
             try:
                 func()
             except Exception as e:
+                msg = "Exception during func={}.{} {!r}".format(func.__module__, func.__name__, a)
+                msg = pwndbg.color.red(msg)
+                print(msg, file=sys.stderr)
                 traceback.print_exc()
                 raise e
 


### PR DESCRIPTION
Added this during debugging mips issue (https://github.com/pwndbg/pwndbg/issues/156).
(note: I've got `set debug-events on`).

```
[dc@dc:challenge]$ gdb ./bender_safe
GNU gdb (GDB) 7.12
Copyright (C) 2016 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.  Type "show copying"
and "show warranty" for details.
This GDB was configured as "x86_64-pc-linux-gnu".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<http://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
<http://www.gnu.org/software/gdb/documentation/>.
For help, type "help".
Type "apropos word" to search for commands related to "word"...
Loaded 105 commands.  Type pwndbg [filter] for a list.
Set display internal event debugging info to True
Reading symbols from ./bender_safe...(no debugging symbols found)...done.
objfile: '/home/dc/ctfs/ctf2017/insomniahack_teaser/re50_bender_safe/challenge/bender_safe'
No shared libraries loaded at this time.
'obj' pwndbg.events._start_newobjfile (<gdb.NewObjFileEvent object at 0x7f6680aa2468>,)
'obj' pwndbg.memoize.__reset_on_objfile (<gdb.NewObjFileEvent object at 0x7f6680aa2468>,)
'obj' pwndbg.ctypes.update (<gdb.NewObjFileEvent object at 0x7f6680aa2468>,)
'obj' pwndbg.elf.update (<gdb.NewObjFileEvent object at 0x7f6680aa2468>,)
'obj' pwndbg.vmmap.get (<gdb.NewObjFileEvent object at 0x7f6680aa2468>,)
'obj' pwndbg.vmmap.check_aslr (<gdb.NewObjFileEvent object at 0x7f6680aa2468>,)
'obj' pwndbg.symbol.autofetch (<gdb.NewObjFileEvent object at 0x7f6680aa2468>,)
'obj' pwndbg.heap.update (<gdb.NewObjFileEvent object at 0x7f6680aa2468>,)
pwndbg> set arch mips
The target architecture is assumed to be mips
pwndbg> target remote localhost:1234
Remote debugging using localhost:1234
'stop' pwndbg.events._start_stop (<gdb.StopEvent object at 0x7f6680aa2468>,)
'start' pwndbg.memoize.__reset_on_start
'start' pwndbg.memoize.__reset_on_start ()
'start' pwndbg.memoize.__start_caching
'start' pwndbg.memoize.__start_caching ()
'start' pwndbg.qemu.root
'start' pwndbg.qemu.root ()
'start' pwndbg.android.sysroot
'start' pwndbg.android.sysroot ()
'start' pwndbg.typeinfo.update
'start' pwndbg.typeinfo.update ()
'start' pwndbg.arch.update
'start' pwndbg.arch.update ()
'start' pwndbg.memory.update_min_addr
'start' pwndbg.memory.update_min_addr ()
'start' pwndbg.ctypes.update
'start' pwndbg.ctypes.update ()
'start' pwndbg.elf.update
'start' pwndbg.elf.update ()
'start' pwndbg.argv.update
'start' pwndbg.argv.update ()
'start' pwndbg.commands.start.on_start
'start' pwndbg.commands.start.on_start ()
'stop' pwndbg.memoize.__reset_on_stop (<gdb.StopEvent object at 0x7f6680aa2468>,)
'stop' pwndbg.memoize.__reset_on_start (<gdb.StopEvent object at 0x7f6680aa2468>,)
'stop' pwndbg.typeinfo.update (<gdb.StopEvent object at 0x7f6680aa2468>,)
'stop' pwndbg.arch.update (<gdb.StopEvent object at 0x7f6680aa2468>,)
'stop' pwndbg.stack.update (<gdb.StopEvent object at 0x7f6680aa2468>,)
Exception during func=pwndbg.stack.update (<gdb.StopEvent object at 0x7f6680aa2468>,)
Traceback (most recent call last):
  File "/home/dc/installed/pwndbg/pwndbg/events.py", line 121, in caller
    func()
  File "/home/dc/installed/pwndbg/pwndbg/memoize.py", line 47, in __call__
    value = self.func(*args, **kwargs)
  File "/home/dc/installed/pwndbg/pwndbg/stack.py", line 79, in update
    page  = pwndbg.memory.Page(start, stop-start, 6 if not is_executable() else 7, 0, '[stack]')
  File "/home/dc/installed/pwndbg/pwndbg/memoize.py", line 47, in __call__
    value = self.func(*args, **kwargs)
  File "/home/dc/installed/pwndbg/pwndbg/stack.py", line 127, in is_executable
    for phdr in pwndbg.elf.iter_phdrs(ehdr):
  File "/home/dc/installed/pwndbg/pwndbg/elf.py", line 176, in iter_phdrs
    phnum, phentsize, phdr = get_phdrs(ehdr.address)
  File "/home/dc/installed/pwndbg/pwndbg/elf.py", line 169, in get_phdrs
    x = (phnum, phentsize, read(Phdr, Elfhdr.address + phoff))
  File "/home/dc/installed/pwndbg/pwndbg/elf.py", line 59, in read
    data = pwndbg.memory.read(address, size)
  File "/home/dc/installed/pwndbg/pwndbg/memory.py", line 44, in read
    result = gdb.selected_inferior().read_memory(addr, count)
gdb.MemoryError: Cannot access memory at address 0x34400000
Python Exception <class 'gdb.MemoryError'> Cannot access memory at address 0x34400000: 
'stop' pwndbg.stack.is_executable (<gdb.StopEvent object at 0x7f6680aa2468>,)
Exception during func=pwndbg.stack.is_executable (<gdb.StopEvent object at 0x7f6680aa2468>,)
Traceback (most recent call last):
  File "/home/dc/installed/pwndbg/pwndbg/events.py", line 121, in caller
    func()
  File "/home/dc/installed/pwndbg/pwndbg/memoize.py", line 47, in __call__
    value = self.func(*args, **kwargs)
  File "/home/dc/installed/pwndbg/pwndbg/stack.py", line 127, in is_executable
    for phdr in pwndbg.elf.iter_phdrs(ehdr):
  File "/home/dc/installed/pwndbg/pwndbg/elf.py", line 176, in iter_phdrs
    phnum, phentsize, phdr = get_phdrs(ehdr.address)
  File "/home/dc/installed/pwndbg/pwndbg/elf.py", line 169, in get_phdrs
    x = (phnum, phentsize, read(Phdr, Elfhdr.address + phoff))
  File "/home/dc/installed/pwndbg/pwndbg/elf.py", line 59, in read
    data = pwndbg.memory.read(address, size)
  File "/home/dc/installed/pwndbg/pwndbg/memory.py", line 44, in read
    result = gdb.selected_inferior().read_memory(addr, count)
gdb.MemoryError: Cannot access memory at address 0x34400000
Python Exception <class 'gdb.MemoryError'> Cannot access memory at address 0x34400000: 
'stop' pwndbg.ida.UpdateBreakpoints (<gdb.StopEvent object at 0x7f6680aa2468>,)
'stop' pwndbg.ida.Auto_Color_PC (<gdb.StopEvent object at 0x7f6680aa2468>,)
'stop' pwndbg.vmmap.explore_registers (<gdb.StopEvent object at 0x7f6680aa2468>,)
Exception during func=pwndbg.vmmap.explore_registers (<gdb.StopEvent object at 0x7f6680aa2468>,)
Traceback (most recent call last):
  File "/home/dc/installed/pwndbg/pwndbg/events.py", line 121, in caller
    func()
  File "/home/dc/installed/pwndbg/pwndbg/vmmap.py", line 107, in explore_registers
    find(pwndbg.regs[regname])
  File "/home/dc/installed/pwndbg/pwndbg/memoize.py", line 47, in __call__
    value = self.func(*args, **kwargs)
  File "/home/dc/installed/pwndbg/pwndbg/vmmap.py", line 63, in find
    for page in get():
  File "/home/dc/installed/pwndbg/pwndbg/memoize.py", line 47, in __call__
    value = self.func(*args, **kwargs)
  File "/home/dc/installed/pwndbg/pwndbg/vmmap.py", line 44, in get
    pages.extend(info_auxv())
  File "/home/dc/installed/pwndbg/pwndbg/memoize.py", line 47, in __call__
    value = self.func(*args, **kwargs)
  File "/home/dc/installed/pwndbg/pwndbg/vmmap.py", line 321, in info_auxv
    pages.extend(pwndbg.elf.map(entry or phdr, exe_name))
  File "/home/dc/installed/pwndbg/pwndbg/elf.py", line 210, in map
    return map_inner(ei_class, ehdr, objfile)
  File "/home/dc/installed/pwndbg/pwndbg/elf.py", line 226, in map_inner
    for phdr in iter_phdrs(ehdr):
  File "/home/dc/installed/pwndbg/pwndbg/elf.py", line 176, in iter_phdrs
    phnum, phentsize, phdr = get_phdrs(ehdr.address)
  File "/home/dc/installed/pwndbg/pwndbg/elf.py", line 169, in get_phdrs
    x = (phnum, phentsize, read(Phdr, Elfhdr.address + phoff))
  File "/home/dc/installed/pwndbg/pwndbg/elf.py", line 59, in read
    data = pwndbg.memory.read(address, size)
  File "/home/dc/installed/pwndbg/pwndbg/memory.py", line 44, in read
    result = gdb.selected_inferior().read_memory(addr, count)
gdb.MemoryError: Cannot access memory at address 0x34400000
Python Exception <class 'gdb.MemoryError'> Cannot access memory at address 0x34400000: 
'stop' pwndbg.symbol.add_main_exe_to_symbols (<gdb.StopEvent object at 0x7f6680aa2468>,)
Exception during func=pwndbg.symbol.add_main_exe_to_symbols (<gdb.StopEvent object at 0x7f6680aa2468>,)
Traceback (most recent call last):
  File "/home/dc/installed/pwndbg/pwndbg/events.py", line 121, in caller
    func()
  File "/home/dc/installed/pwndbg/pwndbg/memoize.py", line 47, in __call__
    value = self.func(*args, **kwargs)
  File "/home/dc/installed/pwndbg/pwndbg/symbol.py", line 244, in add_main_exe_to_symbols
    mmap = pwndbg.vmmap.find(addr)
  File "/home/dc/installed/pwndbg/pwndbg/memoize.py", line 47, in __call__
    value = self.func(*args, **kwargs)
  File "/home/dc/installed/pwndbg/pwndbg/vmmap.py", line 63, in find
    for page in get():
  File "/home/dc/installed/pwndbg/pwndbg/memoize.py", line 47, in __call__
    value = self.func(*args, **kwargs)
  File "/home/dc/installed/pwndbg/pwndbg/vmmap.py", line 44, in get
    pages.extend(info_auxv())
  File "/home/dc/installed/pwndbg/pwndbg/memoize.py", line 47, in __call__
    value = self.func(*args, **kwargs)
  File "/home/dc/installed/pwndbg/pwndbg/vmmap.py", line 321, in info_auxv
    pages.extend(pwndbg.elf.map(entry or phdr, exe_name))
  File "/home/dc/installed/pwndbg/pwndbg/elf.py", line 210, in map
    return map_inner(ei_class, ehdr, objfile)
  File "/home/dc/installed/pwndbg/pwndbg/elf.py", line 226, in map_inner
    for phdr in iter_phdrs(ehdr):
  File "/home/dc/installed/pwndbg/pwndbg/elf.py", line 176, in iter_phdrs
    phnum, phentsize, phdr = get_phdrs(ehdr.address)
  File "/home/dc/installed/pwndbg/pwndbg/elf.py", line 169, in get_phdrs
    x = (phnum, phentsize, read(Phdr, Elfhdr.address + phoff))
  File "/home/dc/installed/pwndbg/pwndbg/elf.py", line 59, in read
    data = pwndbg.memory.read(address, size)
  File "/home/dc/installed/pwndbg/pwndbg/memory.py", line 44, in read
    result = gdb.selected_inferior().read_memory(addr, count)
gdb.MemoryError: Cannot access memory at address 0x34400000
Python Exception <class 'gdb.MemoryError'> Cannot access memory at address 0x34400000: 
'stop' pwndbg.strings.update_length (<gdb.StopEvent object at 0x7f6680aa2468>,)
'stop' pwndbg.commands.ida.j (<gdb.StopEvent object at 0x7f6680aa2468>,)
0x00401160 in __start ()
'stop' pwndbg.events._start_stop ()
'stop' pwndbg.memoize.__reset_on_stop ()
'stop' pwndbg.memoize.__reset_on_start ()
'stop' pwndbg.typeinfo.update ()
'stop' pwndbg.arch.update ()
'stop' pwndbg.stack.update ()
Exception during func=pwndbg.stack.update ()
Traceback (most recent call last):
  File "/home/dc/installed/pwndbg/pwndbg/events.py", line 121, in caller
    func()
  File "/home/dc/installed/pwndbg/pwndbg/memoize.py", line 47, in __call__
    value = self.func(*args, **kwargs)
  File "/home/dc/installed/pwndbg/pwndbg/stack.py", line 79, in update
    page  = pwndbg.memory.Page(start, stop-start, 6 if not is_executable() else 7, 0, '[stack]')
  File "/home/dc/installed/pwndbg/pwndbg/memoize.py", line 47, in __call__
    value = self.func(*args, **kwargs)
  File "/home/dc/installed/pwndbg/pwndbg/stack.py", line 127, in is_executable
    for phdr in pwndbg.elf.iter_phdrs(ehdr):
  File "/home/dc/installed/pwndbg/pwndbg/elf.py", line 176, in iter_phdrs
    phnum, phentsize, phdr = get_phdrs(ehdr.address)
  File "/home/dc/installed/pwndbg/pwndbg/elf.py", line 169, in get_phdrs
    x = (phnum, phentsize, read(Phdr, Elfhdr.address + phoff))
  File "/home/dc/installed/pwndbg/pwndbg/elf.py", line 59, in read
    data = pwndbg.memory.read(address, size)
  File "/home/dc/installed/pwndbg/pwndbg/memory.py", line 44, in read
    result = gdb.selected_inferior().read_memory(addr, count)
gdb.MemoryError: Cannot access memory at address 0x34400000
Python Exception <class 'gdb.MemoryError'> Cannot access memory at address 0x34400000: 
```