### PR TITLE
Enhance setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -28,7 +28,9 @@ PYTHON="${PYTHON}${PYVER}"
 SITE_PACKAGES=$(gdb -batch -q --nx -ex 'pi import site; print(site.getsitepackages()[0])')
 
 # Make sure that pip is available
-sudo ${PYTHON} -m ensurepip --upgrade
+if ! python -m pip -V; then
+    sudo ${PYTHON} -m ensurepip --upgrade
+fi
 
 # Upgrade pip itself
 sudo ${PYHTON} -m pip install --upgrade pip

--- a/setup.sh
+++ b/setup.sh
@@ -3,7 +3,7 @@ set -ex
 
 if uname | grep -i Linux &>/dev/null; then
     sudo apt-get update || true
-    sudo apt-get -y install python-dev python3-dev python-pip python3-pip libglib2.0-dev libc6-dbg
+    sudo apt-get -y install gdb python-dev python3-dev python-pip python3-pip libglib2.0-dev libc6-dbg
 
     if uname -m | grep x86_64 > /dev/null; then
         sudo apt-get install libc6-dbg:i386 || true

--- a/setup.sh
+++ b/setup.sh
@@ -28,12 +28,12 @@ PYTHON="${PYTHON}${PYVER}"
 SITE_PACKAGES=$(gdb -batch -q --nx -ex 'pi import site; print(site.getsitepackages()[0])')
 
 # Make sure that pip is available
-if ! python -m pip -V; then
+if ! ${PYTHON} -m pip -V; then
     sudo ${PYTHON} -m ensurepip --upgrade
 fi
 
 # Upgrade pip itself
-sudo ${PYHTON} -m pip install --upgrade pip
+sudo ${PYTHON} -m pip install --upgrade pip
 
 # Install Python dependencies
 sudo ${PYTHON} -m pip install --target ${SITE_PACKAGES} -Ur requirements.txt

--- a/setup.sh
+++ b/setup.sh
@@ -23,6 +23,12 @@ PYVER=$(gdb -batch -q --nx -ex 'pi import platform; print(".".join(platform.pyth
 PYTHON=$(gdb -batch -q --nx -ex 'pi import sys; print(sys.executable)')
 PYTHON="${PYTHON}${PYVER}"
 
+# Find the Python site-packages that we need to use so that
+# GDB can find the files once we've installed them.
+SITE_PACKAGES=$(gdb -batch -q --nx -ex 'pi import site; print(site.getsitepackages()[0])')
+PREFIX=$(gdb -batch -q --nx -ex 'pi import sys; print(sys.prefix)')
+EXEC_PREFIX=$(gdb -batch -q --nx -ex 'pi import sys; print(sys.exec_prefix)')
+
 # Install Python dependencies
 sudo ${PYTHON} -m pip install --target ${SITE_PACKAGES} -Ur requirements.txt
 

--- a/setup.sh
+++ b/setup.sh
@@ -10,6 +10,11 @@ if uname | grep -i Linux &>/dev/null; then
     fi
 fi
 
+if ! hash gdb; then
+    echo 'Could not find gdb in $PATH'
+    exit
+fi
+
 # Update all submodules
 git submodule update --init --recursive
 

--- a/setup.sh
+++ b/setup.sh
@@ -24,7 +24,7 @@ PYTHON=$(gdb -batch -q --nx -ex 'pi import sys; print(sys.executable)')
 PYTHON="${PYTHON}${PYVER}"
 
 # Install Python dependencies
-sudo ${PYTHON} -m pip install -Ur requirements.txt
+sudo ${PYTHON} -m pip install --target ${SITE_PACKAGES} -Ur requirements.txt
 
 # Install both Unicorn and Capstone
 for directory in capstone unicorn; do

--- a/setup.sh
+++ b/setup.sh
@@ -30,6 +30,9 @@ SITE_PACKAGES=$(gdb -batch -q --nx -ex 'pi import site; print(site.getsitepackag
 # Make sure that pip is available
 sudo ${PYTHON} -m ensurepip --upgrade
 
+# Upgrade pip itself
+sudo ${PYHTON} -m pip install --upgrade pip
+
 # Install Python dependencies
 sudo ${PYTHON} -m pip install --target ${SITE_PACKAGES} -Ur requirements.txt
 

--- a/setup.sh
+++ b/setup.sh
@@ -27,6 +27,9 @@ PYTHON="${PYTHON}${PYVER}"
 # GDB can find the files once we've installed them.
 SITE_PACKAGES=$(gdb -batch -q --nx -ex 'pi import site; print(site.getsitepackages()[0])')
 
+# Make sure that pip is available
+sudo ${PYTHON} -m ensurepip --upgrade
+
 # Install Python dependencies
 sudo ${PYTHON} -m pip install --target ${SITE_PACKAGES} -Ur requirements.txt
 

--- a/setup.sh
+++ b/setup.sh
@@ -26,8 +26,6 @@ PYTHON="${PYTHON}${PYVER}"
 # Find the Python site-packages that we need to use so that
 # GDB can find the files once we've installed them.
 SITE_PACKAGES=$(gdb -batch -q --nx -ex 'pi import site; print(site.getsitepackages()[0])')
-PREFIX=$(gdb -batch -q --nx -ex 'pi import sys; print(sys.prefix)')
-EXEC_PREFIX=$(gdb -batch -q --nx -ex 'pi import sys; print(sys.exec_prefix)')
 
 # Install Python dependencies
 sudo ${PYTHON} -m pip install --target ${SITE_PACKAGES} -Ur requirements.txt


### PR DESCRIPTION
A few enhancements to setup.sh

- Install `gdb` via `apt-get`
- Ensure that `gdb` is in `$PATH` before attempting to invoke it
- Ensure that the Python has access to `pip` via `ensurepip`
- Upgrade `pip` itself before installing dependencies
- Install dependencies into the correct `site-packages`
  - This code was previously removed, but is actually necessary when GDB does not use the system Python

Supersedes #206 