### PR TITLE
bash != python

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -39,8 +39,8 @@ git submodule update --init --recursive
 
 # Find the Python version used by GDB.
 PYVER=$(gdb -batch -q --nx -ex 'pi import platform; print(".".join(platform.python_version_tuple()[:2]))')
-PYTHON+=$(gdb -batch -q --nx -ex 'pi import sys; print(sys.executable)')
-PYTHON+="${PYVER}"
+PYTHON=$(gdb -batch -q --nx -ex 'pi import sys; print(sys.executable)')
+PYTHON="${PYTHON}${PYVER}"
 
 # Find the Python site-packages that we need to use so that
 # GDB can find the files once we've installed them.


### PR DESCRIPTION
This patch reverts 8ee0208cb7a0f528517f283301fd26afae4e9e0e which breaks the install:

```
+ hash gdb
+ git submodule update --init --recursive
+ gdb -batch -q --nx -ex pi import platform; print(".".join(platform.python_version_tuple()[:2]))
+ PYVER=3.5
+ gdb -batch -q --nx -ex pi import sys; print(sys.executable)
+ PYTHON+=/usr/bin/python
setup.sh: 42: setup.sh: PYTHON+=/usr/bin/python: not found
```
