### PR TITLE
correct branch coloring

### DIFF
--- a/pwndbg/color/disasm.py
+++ b/pwndbg/color/disasm.py
@@ -74,7 +74,7 @@ def instruction(ins):
 
     # Style the instruction mnemonic if it's a branch instruction.
     if is_branch:
-        asm = asm.replace(ins.mnemonic, branch(ins.mnemonic))
+        asm = asm.replace(ins.mnemonic, branch(ins.mnemonic), 1)
 
     # If we know the conditional is taken, mark it as green.
     if ins.condition is None:


### PR DESCRIPTION
If a function name contains the same substring as a branch instruction then those characters are colored as well.

Instead only color the first occurrence of the mnemonic string which should be the actual intended assembly.