### PR TITLE
Use inthook only in gdb with Python 2

### DIFF
--- a/pwndbg/inthook.py
+++ b/pwndbg/inthook.py
@@ -18,37 +18,35 @@ from future.utils import with_metaclass
 
 import pwndbg.typeinfo
 
-if sys.version_info < (3,0):
+if sys.version_info < (3, 0):
     import __builtin__ as builtins
-else:
-    import builtins
 
-_int = builtins.int
+    _int = builtins.int
 
-# We need this class to get isinstance(7, xint) to return True
-class IsAnInt(type):
-    def __instancecheck__(self, other):
-        return isinstance(other, _int)
+    # We need this class to get isinstance(7, xint) to return True
+    class IsAnInt(type):
+        def __instancecheck__(self, other):
+            return isinstance(other, _int)
 
-class xint(with_metaclass(IsAnInt, builtins.int)):
-    def __new__(cls, value, *a, **kw):
-        if isinstance(value, gdb.Value):
-            if pwndbg.typeinfo.is_pointer(value):
-                value = value.cast(pwndbg.typeinfo.ulong)
-            else:
-                value = value.cast(pwndbg.typeinfo.long)
-        if isinstance(value, gdb.Symbol):
-            symbol = value
-            value  = symbol.value()
-            if symbol.is_function:
-                value = value.cast(pwndbg.typeinfo.ulong)
-        return _int(_int(value, *a, **kw))
+    class xint(with_metaclass(IsAnInt, builtins.int)):
+        def __new__(cls, value, *a, **kw):
+            if isinstance(value, gdb.Value):
+                if pwndbg.typeinfo.is_pointer(value):
+                    value = value.cast(pwndbg.typeinfo.ulong)
+                else:
+                    value = value.cast(pwndbg.typeinfo.long)
+            if isinstance(value, gdb.Symbol):
+                symbol = value
+                value  = symbol.value()
+                if symbol.is_function:
+                    value = value.cast(pwndbg.typeinfo.ulong)
+            return _int(_int(value, *a, **kw))
 
-# Do not hook 'int' if we are just generating documentation
-if os.environ.get('SPHINX', None) is None:
-    builtins.int = xint
-    globals()['int'] = xint
+    # Do not hook 'int' if we are just generating documentation
+    if os.environ.get('SPHINX', None) is None:
+        builtins.int = xint
+        globals()['int'] = xint
 
-    if sys.version_info >= (3,0):
-        builtins.long = xint
-        globals()['long'] = xint
+        if sys.version_info >= (3, 0):
+            builtins.long = xint
+            globals()['long'] = xint


### PR DESCRIPTION
Because of the inthook one can't use OR operation with Python 3 enums:

```
pwndbg> py import re; re.DOTALL | re.MULTILINE
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/usr/lib/python3.6/enum.py", line 794, in __or__
    result = self.__class__(self._value_ | self.__class__(other)._value_)
  File "/usr/lib/python3.6/enum.py", line 291, in __call__
    return cls.__new__(cls, value)
  File "/usr/lib/python3.6/enum.py", line 533, in __new__
    return cls._missing_(value)
  File "/usr/lib/python3.6/enum.py", line 760, in _missing_
    new_member = cls._create_pseudo_member_(value)
  File "/usr/lib/python3.6/enum.py", line 786, in _create_pseudo_member_
    pseudo_member._name_ = None
AttributeError: 'int' object has no attribute '_name_'
Error while executing Python code.
```