### PR TITLE
Fix commands without file loaded in gdb

### DIFF
--- a/pwndbg/commands/checksec.py
+++ b/pwndbg/commands/checksec.py
@@ -5,26 +5,20 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import os
 import subprocess
-
-import gdb
 
 import pwndbg.commands
 import pwndbg.which
 
 
 @pwndbg.commands.Command
+@pwndbg.commands.OnlyWithFile
 def checksec(file=None):
     '''
     Prints out the binary security settings. Attempts to call the binjitsu
     checksec first, and then falls back to checksec.sh.
     '''
     local_path = file or pwndbg.file.get_file(pwndbg.proc.exe)
-
-    if not local_path:
-        print('No file is selected')
-        return
 
     for program in ['checksec', 'checksec.sh']:
         program = pwndbg.which.which(program)

--- a/pwndbg/commands/elf.py
+++ b/pwndbg/commands/elf.py
@@ -56,9 +56,6 @@ def plt():
 
 def get_section_bounds(section_name):
     local_path = pwndbg.file.get_file(pwndbg.proc.exe)
-    if not local_path:
-        print('No file is selected')
-        return None, None
 
     with open(local_path, 'rb') as f:
         elffile = ELFFile(f)
@@ -66,11 +63,11 @@ def get_section_bounds(section_name):
         section = elffile.get_section_by_name(section_name)
 
         if not section:
-            return None, None
+            return (None, None)
 
         start = section['sh_addr']
         size = section['sh_size']
-        return start, start + size
+        return (start, start + size)
 
 
 def print_symbols_in_section(section_name, filter_text=''):

--- a/pwndbg/commands/elf.py
+++ b/pwndbg/commands/elf.py
@@ -5,26 +5,21 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import gdb
 from elftools.elf.elffile import ELFFile
 
 import pwndbg.commands
 
 
 @pwndbg.commands.Command
+@pwndbg.commands.OnlyWithFile
 def elfheader():
     """
     Prints the section mappings contained in the ELF header.
     """
     local_path = pwndbg.file.get_file(pwndbg.proc.exe)
-    if not local_path:
-        print('No file is selected')
-        return
 
     with open(local_path, 'rb') as f:
         elffile = ELFFile(f)
-        load_segment = elffile.get_segment(3)
-        segment_base = load_segment['p_vaddr']
         sections = []
         for section in elffile.iter_sections():
             start = section['sh_addr']
@@ -40,25 +35,30 @@ def elfheader():
         for start, end, name in sections:
             print('%#x - %#x ' % (start, end), name)
 
+
 @pwndbg.commands.Command
+@pwndbg.commands.OnlyWithFile
 def gotplt():
     """
     Prints any symbols found in the .got.plt section if it exists.
     """
     print_symbols_in_section('.got.plt', '@got.plt')
 
+
 @pwndbg.commands.Command
+@pwndbg.commands.OnlyWithFile
 def plt():
     """
     Prints any symbols found in the .plt section if it exists.
     """
     print_symbols_in_section('.plt', '@plt')
 
+
 def get_section_bounds(section_name):
     local_path = pwndbg.file.get_file(pwndbg.proc.exe)
     if not local_path:
         print('No file is selected')
-        return (None, None)
+        return None, None
 
     with open(local_path, 'rb') as f:
         elffile = ELFFile(f)
@@ -66,21 +66,24 @@ def get_section_bounds(section_name):
         section = elffile.get_section_by_name(section_name)
 
         if not section:
-            return (None, None)
+            return None, None
 
         start = section['sh_addr']
         size = section['sh_size']
-        return (start, start + size)
+        return start, start + size
+
 
 def print_symbols_in_section(section_name, filter_text=''):
     start, end = get_section_bounds(section_name)
-    if start == None:
+
+    if start is None:
         print(pwndbg.color.red('Could not find section'))
         return
 
     symbols = get_symbols_in_region(start, end, filter_text)
     for symbol, addr in symbols:
         print(hex(int(addr)) + ': ' + symbol)
+
 
 def get_symbols_in_region(start, end, filter_text=''):
     symbols = []

--- a/pwndbg/commands/ida.py
+++ b/pwndbg/commands/ida.py
@@ -73,44 +73,46 @@ if pwndbg.ida.available():
         j()
 
 
-@pwndbg.commands.Command
-def save_ida():
-    if not pwndbg.ida.available():
-        return
+    @pwndbg.commands.Command
+    def save_ida():
+        if not pwndbg.ida.available():
+            return
 
-    path = pwndbg.ida.GetIdbPath()
+        path = pwndbg.ida.GetIdbPath()
 
-    # Need to handle emulated paths for Wine
-    if path.startswith('Z:'):
-        path = path[2:].replace('\\', '/')
-        pwndbg.ida.SaveBase(path)
+        # Need to handle emulated paths for Wine
+        if path.startswith('Z:'):
+            path = path[2:].replace('\\', '/')
+            pwndbg.ida.SaveBase(path)
 
-    basename = os.path.basename(path)
-    dirname = os.path.dirname(path)
-    backups = os.path.join(dirname, 'ida-backup')
+        basename = os.path.basename(path)
+        dirname = os.path.dirname(path)
+        backups = os.path.join(dirname, 'ida-backup')
 
-    if not os.path.isdir(backups):
-        os.mkdir(backups)
+        if not os.path.isdir(backups):
+            os.mkdir(backups)
 
-    basename, ext = os.path.splitext(basename)
-    basename += '-%s' % datetime.datetime.now().isoformat()
-    basename += ext
+        basename, ext = os.path.splitext(basename)
+        basename += '-%s' % datetime.datetime.now().isoformat()
+        basename += ext
 
-    # Windows doesn't like colons in paths
-    basename = basename.replace(':', '_')
+        # Windows doesn't like colons in paths
+        basename = basename.replace(':', '_')
 
-    full_path = os.path.join(backups, basename)
+        full_path = os.path.join(backups, basename)
 
-    pwndbg.ida.SaveBase(full_path)
+        pwndbg.ida.SaveBase(full_path)
 
-    data = open(full_path, 'rb').read()
+        data = open(full_path, 'rb').read()
 
-    # Compress!
-    full_path_compressed = full_path + '.bz2'
-    bz2.BZ2File(full_path_compressed, 'w').write(data)
+        # Compress!
+        full_path_compressed = full_path + '.bz2'
+        bz2.BZ2File(full_path_compressed, 'w').write(data)
 
-    # Remove old version
-    os.unlink(full_path)
+        # Remove old version
+        os.unlink(full_path)
+
+    save_ida()
 
 
 class ida(gdb.Function):
@@ -131,4 +133,3 @@ class ida(gdb.Function):
 
 
 ida()
-save_ida()

--- a/pwndbg/commands/misc.py
+++ b/pwndbg/commands/misc.py
@@ -7,9 +7,6 @@ from __future__ import unicode_literals
 
 import argparse
 import errno as _errno
-import struct
-
-import gdb
 
 import pwndbg as _pwndbg
 import pwndbg.arch as _arch
@@ -25,7 +22,9 @@ Converts errno (or argument) to its string representation.
 ''')
 parser.add_argument('err', type=int, nargs='?', default=None, help='Errno; if not passed, it is retrieved from __errno_location')
 
+
 @_pwndbg.commands.ArgparsedCommand(parser)
+@pwndbg.commands.OnlyWhenRunning
 def errno(err):
     if err is None:
         # Dont ask.
@@ -48,6 +47,7 @@ Prints out a list of all pwndbg commands. The list can be optionally filtered if
 ''')
 parser.add_argument('filter_pattern', type=str, nargs='?', default=None, help='Filter to apply to commands names/docs')
 
+
 @_pwndbg.commands.ArgparsedCommand(parser)
 def pwndbg(filter_pattern):
     sorted_commands = list(_pwndbg.commands._Command.commands)
@@ -66,6 +66,7 @@ def pwndbg(filter_pattern):
         if not filter_pattern or filter_pattern in name.lower() or (docs and filter_pattern in docs.lower()):
             print("%-20s %s" % (name, docs))
 
+
 @_pwndbg.commands.ParsedCommand
 def distance(a, b):
     '''Print the distance between the two arguments'''
@@ -75,6 +76,7 @@ def distance(a, b):
     distance = (b-a)
 
     print("%#x->%#x is %#x bytes (%#x words)" % (a, b, distance, distance // _arch.ptrsize))
+
 
 @_pwndbg.commands.Command
 @_pwndbg.commands.OnlyWhenRunning

--- a/pwndbg/commands/radare2.py
+++ b/pwndbg/commands/radare2.py
@@ -17,13 +17,11 @@ parser.add_argument('--no-seek', action='store_true',
 parser.add_argument('arguments', nargs='*', type=str,
                     help='Arguments to pass to radare')
 
+
 @pwndbg.commands.ArgparsedCommand(parser)
+@pwndbg.commands.OnlyWithFile
 def r2(arguments, no_seek=False):
     filename = pwndbg.file.get_file(pwndbg.proc.exe)
-
-    if not filename:
-        print('No file is selected')
-        return
 
     # Build up the command line to run
     cmd = ['radare2', filename]

--- a/pwndbg/commands/rop.py
+++ b/pwndbg/commands/rop.py
@@ -22,7 +22,9 @@ parser.add_argument('--grep', type=str,
 parser.add_argument('argument', nargs='*', type=str,
                     help='Arguments to pass to ROPgadget')
 
+
 @pwndbg.commands.ArgparsedCommand(parser)
+@pwndbg.commands.OnlyWithFile
 def rop(grep, argument):
     with tempfile.NamedTemporaryFile() as corefile:
 
@@ -32,11 +34,6 @@ def rop(grep, argument):
             gdb.execute('gcore %s' % filename)
         else:
             filename = pwndbg.proc.exe
-
-        # If no binary was specified, we can't do anything
-        if not filename:
-            print("No file to get gadgets from")
-            return
 
         # Build up the command line to run
         cmd = ['ROPgadget',

--- a/pwndbg/commands/ropper.py
+++ b/pwndbg/commands/ropper.py
@@ -6,7 +6,6 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import argparse
-import re
 import subprocess
 import tempfile
 
@@ -20,7 +19,9 @@ parser = argparse.ArgumentParser(description="ROP gadget search with ropper.",
 parser.add_argument('argument', nargs='*', type=str,
                     help='Arguments to pass to ropper')
 
+
 @pwndbg.commands.ArgparsedCommand(parser)
+@pwndbg.commands.OnlyWithFile
 def ropper(argument):
     with tempfile.NamedTemporaryFile() as corefile:
 
@@ -30,11 +31,6 @@ def ropper(argument):
             gdb.execute('gcore %s' % filename)
         else:
             filename = pwndbg.proc.exe
-
-        # If no binary was specified, we can't do anything
-        if not filename:
-            print("No file to get gadgets from")
-            return
 
         # Build up the command line to run
         cmd = ['ropper',

--- a/pwndbg/commands/start.py
+++ b/pwndbg/commands/start.py
@@ -18,6 +18,7 @@ import pwndbg.symbol
 
 break_on_first_instruction = False
 
+
 @pwndbg.events.start
 def on_start():
     global break_on_first_instruction
@@ -25,6 +26,7 @@ def on_start():
         spec = "*%#x" % (int(pwndbg.elf.entry()))
         gdb.Breakpoint(spec, temporary=True)
         break_on_first_instruction = False
+
 
 @pwndbg.commands.Command
 def start(*a):
@@ -56,6 +58,7 @@ def start(*a):
 
 
 @pwndbg.commands.Command
+@pwndbg.commands.OnlyWithFile
 def entry(*a):
     """
     Set a breakpoint at the first instruction executed in


### PR DESCRIPTION
Introduces `pwndbg.commands.OnlyWithFile` decorator and decorates commands:
* `entry`, `start` - both of them hang pwndbg when there was no file loaded in gdb: https://asciinema.org/a/d5tyb7ombf18ppb3zwomcwjo9
* `rop`, `ropp`, `ropper`
* `elfheader`, `elf`, `gotplt`, `plt`
* `r2`
* `errno`

Also removes redundant imports and refactors the files a little bit (mainly newlines).