### PR TITLE
Fix IDA synchronization marshalling xint issue

### DIFF
--- a/pwndbg/inthook.py
+++ b/pwndbg/inthook.py
@@ -14,6 +14,7 @@ import os
 import sys
 
 import gdb
+import six
 from future.utils import with_metaclass
 
 import pwndbg.typeinfo
@@ -46,7 +47,7 @@ class xint(with_metaclass(IsAnInt, builtins.int)):
             if symbol.is_function:
                 value = value.cast(pwndbg.typeinfo.ulong)
 
-        else:
+        elif not isinstance(value, six.string_types):
             return _int.__new__(cls, value, *a, **kw)
 
         return _int(_int(value, *a, **kw))


### PR DESCRIPTION
Because of recent changes, the IDA synchronization fails on marshalling a xint instance:
```
$ gdb -q ./babyuse
Pwndbg successfully connected to Ida Pro xmlrpc: http://127.0.0.1:8888
Loaded 108 commands.  Type pwndbg [filter] for a list.
Reading symbols from ./babyuse...(no debugging symbols found)...done.
pwndbg> entry
Temporary breakpoint 1 at 0x56555ca0
Exception during func=pwndbg.ida.Auto_Color_PC (<gdb.BreakpointEvent object at 0x7f1648274468>,)
Traceback (most recent call last):
  File "/usr/lib/python3.6/xmlrpc/client.py", line 510, in __dump
    f = self.dispatch[type(value)]
KeyError: <class 'pwndbg.inthook.xint'>

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/dc/installed/pwndbg/pwndbg/events.py", line 122, in caller
    func()
  File "/home/dc/installed/pwndbg/pwndbg/ida.py", line 74, in __call__
    return self.fn(*args, **kwargs)
  File "/home/dc/installed/pwndbg/pwndbg/ida.py", line 253, in Auto_Color_PC
    SetColor(colored_pc, 0x7f7fff)
  File "/home/dc/installed/pwndbg/pwndbg/ida.py", line 74, in __call__
    return self.fn(*args, **kwargs)
  File "/home/dc/installed/pwndbg/pwndbg/ida.py", line 87, in wrapper
    return function(l2r(address), *args, **kwargs)
  File "/home/dc/installed/pwndbg/pwndbg/ida.py", line 109, in l2r
    result = (addr - int(exe.address) + base()) & pwndbg.arch.ptrmask
  File "/home/dc/installed/pwndbg/pwndbg/memoize.py", line 47, in __call__
    value = self.func(*args, **kwargs)
  File "/home/dc/installed/pwndbg/pwndbg/ida.py", line 131, in base
    base = _ida.get_fileregion_offset(segaddr)
  File "/usr/lib/python3.6/xmlrpc/client.py", line 1112, in __call__
    return self.__send(self.__name, args)
  File "/usr/lib/python3.6/xmlrpc/client.py", line 1446, in __request
    allow_none=self.__allow_none).encode(self.__encoding, 'xmlcharrefreplace')
  File "/usr/lib/python3.6/xmlrpc/client.py", line 971, in dumps
    data = m.dumps(params)
  File "/usr/lib/python3.6/xmlrpc/client.py", line 502, in dumps
    dump(v, write)
  File "/usr/lib/python3.6/xmlrpc/client.py", line 520, in __dump
    raise TypeError("cannot marshal %s objects" % type(value))
TypeError: cannot marshal <class 'pwndbg.inthook.xint'> objects
Python Exception <class 'TypeError'> cannot marshal <class 'pwndbg.inthook.xint'> objects:

Temporary breakpoint 1, 0x56555ca0 in ?? ()
Exception during func=pwndbg.ida.Auto_Color_PC ()
Traceback (most recent call last):
  File "/usr/lib/python3.6/xmlrpc/client.py", line 510, in __dump
    f = self.dispatch[type(value)]
KeyError: <class 'pwndbg.inthook.xint'>

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/dc/installed/pwndbg/pwndbg/events.py", line 122, in caller
    func()
  File "/home/dc/installed/pwndbg/pwndbg/ida.py", line 74, in __call__
    return self.fn(*args, **kwargs)
  File "/home/dc/installed/pwndbg/pwndbg/ida.py", line 253, in Auto_Color_PC
    SetColor(colored_pc, 0x7f7fff)
  File "/home/dc/installed/pwndbg/pwndbg/ida.py", line 74, in __call__
    return self.fn(*args, **kwargs)
  File "/home/dc/installed/pwndbg/pwndbg/ida.py", line 87, in wrapper
    return function(l2r(address), *args, **kwargs)
  File "/home/dc/installed/pwndbg/pwndbg/ida.py", line 109, in l2r
    result = (addr - int(exe.address) + base()) & pwndbg.arch.ptrmask
  File "/home/dc/installed/pwndbg/pwndbg/memoize.py", line 47, in __call__
    value = self.func(*args, **kwargs)
  File "/home/dc/installed/pwndbg/pwndbg/ida.py", line 131, in base
    base = _ida.get_fileregion_offset(segaddr)
  File "/usr/lib/python3.6/xmlrpc/client.py", line 1112, in __call__
    return self.__send(self.__name, args)
  File "/usr/lib/python3.6/xmlrpc/client.py", line 1446, in __request
    allow_none=self.__allow_none).encode(self.__encoding, 'xmlcharrefreplace')
  File "/usr/lib/python3.6/xmlrpc/client.py", line 971, in dumps
    data = m.dumps(params)
  File "/usr/lib/python3.6/xmlrpc/client.py", line 502, in dumps
    dump(v, write)
  File "/usr/lib/python3.6/xmlrpc/client.py", line 520, in __dump
    raise TypeError("cannot marshal %s objects" % type(value))
TypeError: cannot marshal <class 'pwndbg.inthook.xint'> objects
Python Exception <class 'TypeError'> cannot marshal <class 'pwndbg.inthook.xint'> objects:
```

This patch fixes bug introduced in https://github.com/pwndbg/pwndbg/pull/222 (also discussed a bit in https://github.com/pwndbg/pwndbg/pull/221).