### PR TITLE
Fix Python 2 inthook (and so entry/start commands #234)

### DIFF
--- a/pwndbg/inthook.py
+++ b/pwndbg/inthook.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
-This hook is necessary for compatibility with Python2.7 versions of GDB
+This hook is necessary for compatibility with Python 2.7 versions of GDB
 since they cannot directly cast to integer a gdb.Value object that is
 not already an integer type.
 """
@@ -17,14 +17,18 @@ import gdb
 import six
 from future.utils import with_metaclass
 
+import pwndbg.compat
 import pwndbg.typeinfo
 
-if sys.version_info < (3, 0):
+if pwndbg.compat.python2:
     import __builtin__ as builtins
 else:
     import builtins
+    long = int
 
 _int = builtins.int
+
+types_default_int_new = six.string_types + (long, )
 
 
 # We need this class to get isinstance(7, xint) to return True
@@ -47,7 +51,7 @@ class xint(with_metaclass(IsAnInt, builtins.int)):
             if symbol.is_function:
                 value = value.cast(pwndbg.typeinfo.ulong)
 
-        elif not isinstance(value, six.string_types):
+        elif not isinstance(value, types_default_int_new):
             return _int.__new__(cls, value, *a, **kw)
 
         return _int(_int(value, *a, **kw))


### PR DESCRIPTION
This fixes #234, at least the bug reported by me.

Tested and works on:
```
Gdb: GNU gdb (Debian 7.7.1+dfsg-5) 7.7.1
Python: 2.7.9 (default, Jun 29 2016, 13:11:10)  [GCC 4.9.2]
Pwndbg: 1.0.0 build: 52abfa95
```

And (here also tested the synchronization with IDA Pro and it works):
```
Gdb: GNU gdb (GDB) 7.12
Python: 3.6.0 (default, Jan 16 2017, 12:12:55)  [GCC 6.3.1 20170109]
Pwndbg: 1.0.0 build: 52abfa95
```