### PR TITLE
Use pwndbg.stdio for all pdb function calls

### DIFF
--- a/pwndbg/__init__.py
+++ b/pwndbg/__init__.py
@@ -60,6 +60,7 @@ import pwndbg.heap
 import pwndbg.inthook
 import pwndbg.memory
 import pwndbg.net
+import pwndbg.pdb
 import pwndbg.proc
 import pwndbg.prompt
 import pwndbg.regs

--- a/pwndbg/pdb.py
+++ b/pwndbg/pdb.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+This module serves as utility for the developers to get pdb debugging session right, whenever standard:
+    import pdb; pdb.set_trace()
+Can't do its job properly (that happens often as gdb does some magic with stdout/stderr).
+
+Thanks to Dmoreno: http://stackoverflow.com/questions/17074177/how-to-debug-python-cli-that-takes-stdin
+
+Usage:
+    import pwndbg.pdb
+
+Importing the module will print out pretty message on what to do next.
+"""
+import functools
+import pdb
+import os
+
+import pwndbg.stdio
+
+for name, value in list(pdb.__dict__.items()):
+	if not callable(value):
+		continue
+
+	@functools.wraps(value)
+	def wrapper(*a, **kw):
+		with pwndbg.stdio.stdio:
+			return value(*a, **kw)
+
+	setattr(pdb, name, value)

--- a/pwndbg/stdio.py
+++ b/pwndbg/stdio.py
@@ -20,16 +20,7 @@ import pwndbg.compat
 
 
 def get(fd, mode):
-    if pwndbg.compat.python3:
-        file = io.open(fd, mode=mode, buffering=0)
-
-        kw ={}
-        if pwndbg.compat.python3:
-            kw['write_through']=True
-
-        return io.TextIOWrapper(file, **kw)
-    else:
-        return codecs.open(fd, mode, 'utf-8')
+    return io.open(fd, mode + 'b', buffering=0)
 
 
 class Stdio(object):
@@ -37,11 +28,10 @@ class Stdio(object):
 
     def __enter__(self, *a, **kw):
         self.queue.append((sys.stdin, sys.stdout, sys.stderr))
-
         if pwndbg.compat.python3 or True:
-            sys.stdin  = get('/dev/stdin', 'rb')
-            sys.stdout = get('/dev/stdout', 'wb')
-            sys.stderr = get('/dev/stderr', 'wb')
+            sys.stdin  = get('/dev/stdin', 'r')
+            sys.stdout = get('/dev/stdout', 'w')
+            sys.stderr = get('/dev/stderr', 'w')
 
     def __exit__(self, *a, **kw):
         sys.stdin, sys.stdout, sys.stderr = self.queue.pop()


### PR DESCRIPTION
This is an example alternative to #247 which prevents stdio from being hooked by GDB when interacting with PDB