### PR TITLE
Fix git fatal msg display when pwndbg is installed w/o git

### DIFF
--- a/pwndbg/version.py
+++ b/pwndbg/version.py
@@ -15,12 +15,15 @@ def build_id():
     """
     try:
         git_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), '.git')
-        cmd = ['git', '--git-dir', git_path, 'rev-parse', 'HEAD']
+        cmd = ['git', '--git-dir', git_path, 'rev-parse', '--short', 'HEAD']
 
         commit_id = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
 
-        return 'build: %s' % commit_id[:8].decode('utf-8')
-    except:
+        return 'build: %s' % commit_id.decode('utf-8').strip('\n')
+
+    except (OSError, subprocess.CalledProcessError):
+        # OSError -> no git in $PATH
+        # CalledProcessError -> git return code != 0
         return ''
 
 __version__ = '1.0.0'
@@ -29,4 +32,3 @@ b_id = build_id()
 
 if b_id:
     __version__ += ' %s' % b_id
-

--- a/pwndbg/version.py
+++ b/pwndbg/version.py
@@ -15,10 +15,11 @@ def build_id():
     """
     try:
         git_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), '.git')
-        commit_id = subprocess.check_output(['git', '--git-dir', git_path, 'rev-parse', 'HEAD'])
-        commit_id = commit_id[:8].decode('utf-8')
+        cmd = ['git', '--git-dir', git_path, 'rev-parse', 'HEAD']
 
-        return 'build: %s' % commit_id
+        commit_id = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
+
+        return 'build: %s' % commit_id[:8].decode('utf-8')
     except:
         return ''
 


### PR DESCRIPTION
My bad. I haven't checked how pwndbg behaves without git when I added version command.

Before this commit:
```
$ gdb
Loaded 106 commands. Type pwndbg [filter] for a list.
fatal: Not a git repository: '/home/dc/installed/pwndbg/.git'
pwndbg> 
```

After this commit:
```
$ gdb
Loaded 106 commands. Type pwndbg [filter] for a list.
pwndbg> 
```