### PR TITLE
Ehdr phdr commands

### DIFF
--- a/pwndbg/commands/elf.py
+++ b/pwndbg/commands/elf.py
@@ -37,6 +37,25 @@ def elfheader():
 
 
 @pwndbg.commands.Command
+@pwndbg.commands.OnlyWhenRunning
+def ehdr():
+    """
+    Prints ELF header structure.
+    """
+    print(pwndbg.elf.exe())
+
+
+@pwndbg.commands.Command
+@pwndbg.commands.OnlyWhenRunning
+def phdr():
+    """
+    Prints ELF Program Headers structures.
+    """
+    for phdr in pwndbg.elf.iter_phdrs(pwndbg.elf.exe()):
+        print(phdr)
+
+
+@pwndbg.commands.Command
 @pwndbg.commands.OnlyWithFile
 def gotplt():
     """

--- a/pwndbg/elftypes.py
+++ b/pwndbg/elftypes.py
@@ -35,11 +35,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import ctypes
-import sys
 
-import six
-
-import pwndbg.arch
 import pwndbg.ctypes
 import pwndbg.events
 
@@ -390,12 +386,15 @@ def print_struct(obj, extra='', fields_constants=None):
     for field, _ in obj._fields_:
         value = getattr(obj, field)
 
+        if isinstance(value, ctypes.Array):
+            value = repr(''.join(map(chr, value)))
+
         value_str = hex(value) if isinstance(value, int) else str(value)
 
         if field in fields_constants:
-            value = '{} ({})'.format(fields_constants.get(value, '<unknown-const>'), value_str)
+            value = '{} ({})'.format(fields_constants[field].get(value, '<unknown-const>'), value_str)
 
-        s += '{field:>20}: {value}\n'.format(field=green(field), value=value)
+        s += '{field:>24}: {value}\n'.format(field=green(field), value=value)
 
     return s
 

--- a/pwndbg/elftypes.py
+++ b/pwndbg/elftypes.py
@@ -95,6 +95,7 @@ AT_CONSTANTS = {
     37: 'AT_L3_CACHESHAPE',
 }
 
+
 class constants:
     EI_MAG0                 = 0
     EI_MAG1                 = 1
@@ -263,8 +264,9 @@ class constants:
     AT_L2_CACHESHAPE        = 36
     AT_L3_CACHESHAPE        = 37
 
+
 class Elf32_Ehdr(pwndbg.ctypes.Structure):
-    _fields_ = [("e_ident", (ctypes.c_ubyte * 16)),
+    _fields_ = (("e_ident", (ctypes.c_ubyte * 16)),
                 ("e_type", Elf32_Half),
                 ("e_machine", Elf32_Half),
                 ("e_version", Elf32_Word),
@@ -277,10 +279,11 @@ class Elf32_Ehdr(pwndbg.ctypes.Structure):
                 ("e_phnum", Elf32_Half),
                 ("e_shentsize", Elf32_Half),
                 ("e_shnum", Elf32_Half),
-                ("e_shstrndx", Elf32_Half),]
+                ("e_shstrndx", Elf32_Half))
+
 
 class Elf64_Ehdr(pwndbg.ctypes.Structure):
-    _fields_ = [("e_ident", (ctypes.c_ubyte * 16)),
+    _fields_ = (("e_ident", (ctypes.c_ubyte * 16)),
                 ("e_type", Elf64_Half),
                 ("e_machine", Elf64_Half),
                 ("e_version", Elf64_Word),
@@ -293,24 +296,25 @@ class Elf64_Ehdr(pwndbg.ctypes.Structure):
                 ("e_phnum", Elf64_Half),
                 ("e_shentsize", Elf64_Half),
                 ("e_shnum", Elf64_Half),
-                ("e_shstrndx", Elf64_Half),]
+                ("e_shstrndx", Elf64_Half))
+
 
 class Elf32_Phdr(pwndbg.ctypes.Structure):
-    _fields_ = [("p_type", Elf32_Word),
+    _fields_ = (("p_type", Elf32_Word),
                 ("p_offset", Elf32_Off),
                 ("p_vaddr", Elf32_Addr),
                 ("p_paddr", Elf32_Addr),
                 ("p_filesz", Elf32_Word),
                 ("p_memsz", Elf32_Word),
                 ("p_flags", Elf32_Word),
-                ("p_align", Elf32_Word),]
+                ("p_align", Elf32_Word))
 
 class Elf64_Phdr(pwndbg.ctypes.Structure):
-    _fields_ = [("p_type", Elf64_Word),
+    _fields_ = (("p_type", Elf64_Word),
                 ("p_flags", Elf64_Word),
                 ("p_offset", Elf64_Off),
                 ("p_vaddr", Elf64_Addr),
                 ("p_paddr", Elf64_Addr),
                 ("p_filesz", Elf64_Xword),
                 ("p_memsz", Elf64_Xword),
-                ("p_align", Elf64_Xword),]
+                ("p_align", Elf64_Xword))


### PR DESCRIPTION
1. Adds `ehdr` and `phdr` commands and `__str__` for `ElfXX_Ehdr` and `ElfXX_Phdr`

Those might be handy for debugging issues with endianness (https://github.com/pwndbg/pwndbg/issues/156 or https://github.com/pwndbg/pwndbg/pull/239) or for debugging new commands that would have to use ehdr/phdr.

![image](https://cloud.githubusercontent.com/assets/10009354/25814381/9c37bcee-341d-11e7-8eed-24d0a1204881.png)

If the constant is not found:
![image](https://cloud.githubusercontent.com/assets/10009354/25814438/bfdd7bc0-341d-11e7-8941-bfebd6b9c931.png)

2. Adds `Elf32_Dyn` and `Elf64_Dyn` structures and `elftypes.print_struct` function (which might be extended in the future to pretty print other ctypes fields).

This will be needed in the future for a command to dump process into Elf (e.g. `dumpelf`).

3. Refactors elftypes a bit