### PR TITLE
Fix weird input issue

### DIFF
--- a/pwndbg/__init__.py
+++ b/pwndbg/__init__.py
@@ -121,6 +121,7 @@ pre_commands = """
 set confirm off
 set verbose off
 set prompt %s
+set pagination off
 set height 0
 set history expansion on
 set history save on


### PR DESCRIPTION
Reverts two lines from previous version. This fixes an issue that happens on my setup when gdb is launched through pwntools, e.g.:
```bash
$ pwn debug --exe /bin/ls
```

The problem is that when I resize gdb to fullscreen or as "half of screen" (e.g. stick to left/right side), firing a command e.g. `ni` asks me for `return` or `q` like the output would be very long.

My setup:
```
$ cat ~/.pwn.conf 
[context]
terminal=['terminator', '-x']
```

Pwndbg (guess it doesn't matter):
```
pwndbg> version
Gdb: GNU gdb (GDB) 7.12.1
Python: 3.6.1 (default, Mar 27 2017, 00:27:06)  [GCC 6.3.1 20170306]
Pwndbg: 1.0.0 build: f7b2811
```

This is how it looked before this fix:
https://i.gyazo.com/e3e0e67d92be775ff9d45c54793da27e.png