### PR TITLE
Fix missing import in pwndbg/exception.py

### DIFF
--- a/pwndbg/exception.py
+++ b/pwndbg/exception.py
@@ -13,6 +13,7 @@ import traceback
 import gdb
 
 import pwndbg.config
+import pwndbg.stdio
 
 try:
 	import ipdb as pdb


### PR DESCRIPTION
I was pretty sure I have tested this..:
```python
pwndbg> set exception-debugger on
Set whether to debug exceptions raised in Pwndbg commands to True
pwndbg> search -x -1 "0102"
'search': Search memory for byte sequences, strings, pointers, and integer values
Traceback (most recent call last):
  File "/home/dc/installed/pwndbg/pwndbg/commands/__init__.py", line 87, in __call__
    return self.function(*args, **kwargs)
  File "/home/dc/installed/pwndbg/pwndbg/commands/__init__.py", line 213, in _ArgparsedCommand
    return function(**vars(args))
  File "/home/dc/installed/pwndbg/pwndbg/commands/__init__.py", line 161, in _OnlyWhenRunning
    return function(*a, **kw)
  File "/home/dc/installed/pwndbg/pwndbg/commands/search.py", line 107, in search
    value = pwndbg.commands.fix_int(value)
  File "/home/dc/installed/pwndbg/pwndbg/commands/__init__.py", line 143, in fix_int
    return int(fix(*a,**kw))
  File "/home/dc/installed/pwndbg/pwndbg/inthook.py", line 51, in __new__
    return _int.__new__(cls, value, *a, **kw)
TypeError: int() argument must be a string, a bytes-like object or a number, not 'NoneType'

Traceback (most recent call last):
  File "/home/dc/installed/pwndbg/pwndbg/commands/__init__.py", line 87, in __call__
    return self.function(*args, **kwargs)
  File "/home/dc/installed/pwndbg/pwndbg/commands/__init__.py", line 213, in _ArgparsedCommand
    return function(**vars(args))
  File "/home/dc/installed/pwndbg/pwndbg/commands/__init__.py", line 161, in _OnlyWhenRunning
    return function(*a, **kw)
  File "/home/dc/installed/pwndbg/pwndbg/commands/search.py", line 107, in search
    value = pwndbg.commands.fix_int(value)
  File "/home/dc/installed/pwndbg/pwndbg/commands/__init__.py", line 143, in fix_int
    return int(fix(*a,**kw))
  File "/home/dc/installed/pwndbg/pwndbg/inthook.py", line 51, in __new__
    return _int.__new__(cls, value, *a, **kw)
TypeError: int() argument must be a string, a bytes-like object or a number, not 'NoneType'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/dc/installed/pwndbg/pwndbg/commands/__init__.py", line 46, in invoke
    return self(*argv)
  File "/home/dc/installed/pwndbg/pwndbg/commands/__init__.py", line 91, in __call__
    pwndbg.exception.handle()
  File "/home/dc/installed/pwndbg/pwndbg/exception.py", line 42, in handle
    with pwndbg.stdio.stdio:
AttributeError: module 'pwndbg' has no attribute 'stdio'

If you suspect this is an IPython bug, please report it at:
    https://github.com/ipython/ipython/issues
or send an email to the mailing list at ipython-dev@scipy.org

You can print a more detailed traceback right now with "%tb", or use "%debug"
to interactively debug it.

Extra-detailed tracebacks for bug-reporting purposes can be enabled via:
    %config Application.verbose_crash=True

Error occurred in Python command: module 'pwndbg' has no attribute 'stdio'
pwndbg>
```

After this change:
```python
pwndbg> set exception-debugger on
Set whether to debug exceptions raised in Pwndbg commands to True
pwndbg> search -x -1 "0102"
'search': Search memory for byte sequences, strings, pointers, and integer values
Traceback (most recent call last):
  File "/home/dc/installed/pwndbg/pwndbg/commands/__init__.py", line 87, in __call__
    return self.function(*args, **kwargs)
  File "/home/dc/installed/pwndbg/pwndbg/commands/__init__.py", line 213, in _ArgparsedCommand
    return function(**vars(args))
  File "/home/dc/installed/pwndbg/pwndbg/commands/__init__.py", line 161, in _OnlyWhenRunning
    return function(*a, **kw)
  File "/home/dc/installed/pwndbg/pwndbg/commands/search.py", line 107, in search
    value = pwndbg.commands.fix_int(value)
  File "/home/dc/installed/pwndbg/pwndbg/commands/__init__.py", line 143, in fix_int
    return int(fix(*a,**kw))
  File "/home/dc/installed/pwndbg/pwndbg/inthook.py", line 51, in __new__
    return _int.__new__(cls, value, *a, **kw)
TypeError: int() argument must be a string, a bytes-like object or a number, not 'NoneType'

> /home/dc/installed/pwndbg/pwndbg/inthook.py(51)__new__()
     50         elif not isinstance(value, six.string_types) and not isinstance(value, six.integer_types):
---> 51             return _int.__new__(cls, value, *a, **kw)
     52

ipdb>
```