### PR TITLE
Clean up some unnecessary closures in pwndbg.commands

### DIFF
--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -179,7 +179,7 @@ def OnlyWithFile(function):
         if pwndbg.proc.exe:
             return function(*a, **kw)
         else:
-            print("There is no file loaded.")
+            print("%s: There is no file loaded." % function.__name__)
 
     return _OnlyWithFile
 
@@ -190,7 +190,7 @@ def OnlyWhenRunning(function):
         if pwndbg.proc.alive:
             return function(*a, **kw)
         else:
-            print("The program is not being run.")
+            print("%s: The program is not being run." % function.__name__)
     return _OnlyWhenRunning
 
 

--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -40,13 +40,18 @@ class Command(gdb.Command):
         return gdb.string_to_argv(argument), {}
 
     def invoke(self, argument, from_tty):
-        args, kwargs = self.split_args(argument)
         try:
-            self.repeat = self.check_repeated(argument, from_tty)
-            return self(*args, **kwargs)
+            args, kwargs = self.split_args(argument)
+        except SystemExit:
+            # Raised when the usage is printed by an ArgparsedCommand
+            return
         except TypeError:
             pwndbg.exception.handle()
             raise
+
+        try:
+            self.repeat = self.check_repeated(argument, from_tty)
+            return self(*args, **kwargs)
         finally:
             self.repeat = False
 
@@ -89,9 +94,6 @@ class Command(gdb.Command):
             print('%r: %s' % (self.function.__name__.strip(),
                               self.function.__doc__.strip()))
             pwndbg.exception.handle()
-        except SystemExit:
-            # Raised when the usage is printed by an ArgparsedCommand
-            pass
         except Exception:
             pwndbg.exception.handle()
 

--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -40,7 +40,7 @@ class Command(gdb.Command):
         """Split a command-line string from the user into arguments.
 
         Returns:
-            A tuple / dict, in the form of ``*args, **args``.
+            A ``(tuple, dict)``, in the form of ``*args, **kwargs``.
             The contents of the tuple/dict are undefined.
         """
         return gdb.string_to_argv(argument), {}

--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -37,9 +37,16 @@ class Command(gdb.Command):
         self.__doc__ = function.__doc__
 
     def split_args(self, argument):
+        """Split a command-line string from the user into arguments.
+
+        Returns:
+            A tuple / dict, in the form of ``*args, **args``.
+            The contents of the tuple/dict are undefined.
+        """
         return gdb.string_to_argv(argument), {}
 
     def invoke(self, argument, from_tty):
+        """Invoke the command with an argument string"""
         try:
             args, kwargs = self.split_args(argument)
         except SystemExit:

--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -37,13 +37,13 @@ class Command(gdb.Command):
         self.__doc__ = function.__doc__
 
     def split_args(self, argument):
-        return gdb.string_to_argv(argument)
+        return gdb.string_to_argv(argument), {}
 
     def invoke(self, argument, from_tty):
-        argv = self.split_args(argument)
+        args, kwargs = self.split_args(argument)
         try:
             self.repeat = self.check_repeated(argument, from_tty)
-            return self(*argv)
+            return self(*args, **kwargs)
         except TypeError:
             pwndbg.exception.handle()
             raise
@@ -106,7 +106,7 @@ class ParsedCommand(Command):
         # sys.stdout.write(repr(argument) + '\n')
         argv = super(ParsedCommand,self).split_args(argument)
         # sys.stdout.write(repr(argv) + '\n')
-        return list(filter(lambda x: x is not None, map(self.fix, argv)))
+        return list(filter(lambda x: x is not None, map(self.fix, argv))), {}
 
     def fix(self, arg):
         return fix(arg, self.sloppy, self.quiet)
@@ -181,8 +181,8 @@ class _ArgparsedCommand(Command):
         super(_ArgparsedCommand, self).__init__(function, *a, **kw)
 
     def split_args(self, argument):
-        argv = super(_ArgparsedCommand, self).string_to_argv(argument)
-        return self.parser.parse_args(argv)
+        argv = gdb.string_to_argv(argument)
+        return tuple(), vars(self.parser.parse_args(argv))
 
 
 class ArgparsedCommand(object):

--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -47,8 +47,6 @@ class Command(gdb.Command):
         except TypeError:
             pwndbg.exception.handle()
             raise
-        except SystemExit:
-            pass
         finally:
             self.repeat = False
 
@@ -91,6 +89,9 @@ class Command(gdb.Command):
             print('%r: %s' % (self.function.__name__.strip(),
                               self.function.__doc__.strip()))
             pwndbg.exception.handle()
+        except SystemExit:
+            # Raised when the usage is printed by an ArgparsedCommand
+            pass
         except Exception:
             pwndbg.exception.handle()
 

--- a/pwndbg/commands/misc.py
+++ b/pwndbg/commands/misc.py
@@ -50,7 +50,7 @@ parser.add_argument('filter_pattern', type=str, nargs='?', default=None, help='F
 
 @_pwndbg.commands.ArgparsedCommand(parser)
 def pwndbg(filter_pattern):
-    sorted_commands = list(_pwndbg.commands._Command.commands)
+    sorted_commands = list(_pwndbg.commands.Command.commands)
     sorted_commands.sort(key=lambda x: x.__name__)
 
     if filter_pattern:

--- a/pwndbg/exception.py
+++ b/pwndbg/exception.py
@@ -43,8 +43,6 @@ def handle(name = 'Error'):
         with pwndbg.stdio.stdio:
             pdb.post_mortem()
 
-
-
 @functools.wraps(pdb.set_trace)
 def set_trace():
     """Enable sane debugging in Pwndbg by switching to the "real" stdio.

--- a/pwndbg/exception.py
+++ b/pwndbg/exception.py
@@ -23,7 +23,7 @@ except ImportError:
 verbose = pwndbg.config.Parameter('exception-verbose', False, 'whether to print a full stacktracefor exceptions raised in Pwndbg commands')
 debug = pwndbg.config.Parameter('exception-debugger', False, 'whether to debug exceptions raised in Pwndbg commands')
 
-def handle():
+def handle(name = 'Error'):
     """Displays an exception to the user, optionally displaying a full traceback
     and spawning an interactive post-moretem debugger.
 
@@ -36,7 +36,7 @@ def handle():
         print(traceback.format_exc())
     else:
         exc_type, exc_value, exc_traceback = sys.exc_info()
-        print(exc_type, exc_value)
+        print('{}: {} ({})'.format(name, exc_value, exc_type))
 
     # Break into the interactive debugger
     if debug:

--- a/pwndbg/prompt.py
+++ b/pwndbg/prompt.py
@@ -11,7 +11,7 @@ import pwndbg.events
 import pwndbg.memoize
 
 
-hint_msg = 'Loaded %i commands. Type pwndbg [filter] for a list.' % len(pwndbg.commands._Command.commands)
+hint_msg = 'Loaded %i commands. Type pwndbg [filter] for a list.' % len(pwndbg.commands.Command.commands)
 print(pwndbg.color.red(hint_msg))
 cur = (gdb.selected_inferior(), gdb.selected_thread())
 


### PR DESCRIPTION
There are a bunch of closures used for decorating, because I didn't have a good grasp on classes-as-decorators when I originally wrote this code.