### PR TITLE
Fix parsed commands

### DIFF
--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -114,7 +114,7 @@ class ParsedCommand(Command):
 
     def split_args(self, argument):
         # sys.stdout.write(repr(argument) + '\n')
-        argv = super(ParsedCommand,self).split_args(argument)
+        argv, _ = super(ParsedCommand, self).split_args(argument)
         # sys.stdout.write(repr(argv) + '\n')
         return list(filter(lambda x: x is not None, map(self.fix, argv))), {}
 


### PR DESCRIPTION
The latest cleanup (https://github.com/pwndbg/pwndbg/pull/278) has broken `ParsedCommands` so we had `args = (real_args, kwargs)`. This also made so that the `fix` function got e.g. a tuple instead of string as an argument.

See below what happens to some of the commands before fix.

#### vmmap
```
pwndbg> set exception-debugger on
Set whether to debug exceptions raised in Pwndbg commands to True
pwndbg> vmmap
'vmmap': Print the virtal memory map, or the specific mapping for the
    provided address / module name.
Traceback (most recent call last):
  File "/home/dc/installed/pwndbg/pwndbg/commands/__init__.py", line 99, in __call__
    return self.function(*args, **kwargs)
  File "/home/dc/installed/pwndbg/pwndbg/commands/__init__.py", line 191, in _OnlyWhenRunning
    return function(*a, **kw)
TypeError: vmmap() takes from 0 to 1 positional arguments but 2 were given

> /home/dc/installed/pwndbg/pwndbg/commands/__init__.py(191)_OnlyWhenRunning()
    190         if pwndbg.proc.alive:
--> 191             return function(*a, **kw)
    192         else:

ipdb> p a, kw
(([], {}), {})
ipdb> up
> /home/dc/installed/pwndbg/pwndbg/commands/__init__.py(99)__call__()
     98         try:
---> 99             return self.function(*args, **kwargs)
    100         except TypeError as te:

ipdb> 
*** Oldest frame
```

#### distance
```
pwndbg> distance 1 2
expected string or bytes-like object
expected string or bytes-like object
'distance': Print the distance between the two arguments
Traceback (most recent call last):
  File "/home/dc/installed/pwndbg/pwndbg/commands/__init__.py", line 99, in __call__
    return self.function(*args, **kwargs)
TypeError: distance() missing 2 required positional arguments: 'a' and 'b'

> /home/dc/installed/pwndbg/pwndbg/commands/__init__.py(99)__call__()
     98         try:
---> 99             return self.function(*args, **kwargs)
    100         except TypeError as te:

ipdb> p args, kwargs
((), {})
```

#### argv, nearpc (pdisass, emulate), auxv, fsbase, gsbase
All of them show this when invoked:
```
expected string or bytes-like object
expected string or bytes-like object
```

---

... and maybe some more. I haven't checked all of the commands.