### PR TITLE
Fix rop, ropgadget: return when not $PATH

### DIFF
--- a/pwndbg/commands/rop.py
+++ b/pwndbg/commands/rop.py
@@ -45,6 +45,7 @@ def rop(grep, argument):
             io = subprocess.Popen(cmd, stdout=subprocess.PIPE)
         except Exception:
             print("Could not run ROPgadget.  Please ensure it's installed and in $PATH.")
+            return
 
         (stdout, stderr) = io.communicate()
 


### PR DESCRIPTION
Before the fix:
```
$ gdb /bin/ls
Defined pretty print function (pp) and libc (CDLL)
Loaded 108 commands. Type pwndbg [filter] for a list.
Set whether to print a full stacktracefor exceptions raised in Pwndbg commands to True
Reading symbols from /bin/ls...(no debugging symbols found)...done.
pwndbg> rop
Could not run ROPgadget.  Please ensure it's installed and in $PATH.
Traceback (most recent call last):
  File "/home/dc/installed/pwndbg/pwndbg/commands/__init__.py", line 99, in __call__
    return self.function(*args, **kwargs)
  File "/home/dc/installed/pwndbg/pwndbg/commands/__init__.py", line 180, in _OnlyWithFile
    return function(*a, **kw)
  File "/home/dc/installed/pwndbg/pwndbg/commands/rop.py", line 49, in rop
    (stdout, stderr) = io.communicate()
UnboundLocalError: local variable 'io' referenced before assignment
```