### PR TITLE
Move vmmap to ArgparsedCommand; add sloppy_gdb_parse

### DIFF
--- a/pwndbg/__init__.py
+++ b/pwndbg/__init__.py
@@ -163,4 +163,3 @@ signal.signal(signal.SIGWINCH, lambda signum, frame: gdb.execute("set width %i" 
 # After GDB gets the fix, we should disable this only for bugged GDB versions.
 if 1:
     gdb.execute('set remote search-memory-packet off')
-

--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -5,6 +5,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import argparse
 import functools
 
 import gdb
@@ -230,3 +231,19 @@ class ArgparsedCommand(object):
 
     def __call__(self, function):
         return _ArgparsedCommand(self.parser, function)
+
+
+def sloppy_gdb_parse(s):
+    """
+    This function should be used as ``argparse.ArgumentParser`` .add_argument method's `type` argument.
+
+    This makes the type being parsed as gdb value and if that parsing fails,
+    a string is returned.
+
+    :param s: String.
+    :return: Whatever gdb.parse_and_eval returns or string.
+    """
+    try:
+        return gdb.parse_and_eval(s)
+    except:
+        return s

--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -235,8 +235,8 @@ class ArgparsedCommand(object):
 
 def sloppy_gdb_parse(s):
     """
-    This function should be used as ``argparse.ArgumentParser`` .add_argument method's `type` argument.
-
+    This function should be used as ``argparse.ArgumentParser`` .add_argument method's `type` helper.
+    
     This makes the type being parsed as gdb value and if that parsing fails,
     a string is returned.
 
@@ -245,5 +245,5 @@ def sloppy_gdb_parse(s):
     """
     try:
         return gdb.parse_and_eval(s)
-    except:
+    except (TypeError, gdb.error):
         return s

--- a/pwndbg/commands/vmmap.py
+++ b/pwndbg/commands/vmmap.py
@@ -46,6 +46,10 @@ def vmmap(map=None):
 
     pages = list(filter(pages_filter, pwndbg.vmmap.get()))
 
+    if not pages:
+        print('There are no mappings for specified address or module.')
+        return
+
     print(M.legend())
     for page in pages:
         print(M.get(page.vaddr, text=str(page)))

--- a/pwndbg/commands/vmmap.py
+++ b/pwndbg/commands/vmmap.py
@@ -9,7 +9,6 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import argparse
-import functools
 
 import gdb
 import six
@@ -20,7 +19,7 @@ import pwndbg.compat
 import pwndbg.vmmap
 
 
-def map_type(s):
+def pages_filter(s):
     gdbval_or_str = pwndbg.commands.sloppy_gdb_parse(s)
 
     # returns a module filter
@@ -36,17 +35,17 @@ def map_type(s):
     else:
         raise argparse.ArgumentTypeError('Unknown vmmap argument type.')
 
+
 parser = argparse.ArgumentParser()
-parser.description = 'Print the virtual memory map, or the specific mapping for the provided address / module name.'
-parser.add_argument('map', type=map_type, nargs='?', default=None,
+parser.description = 'Print virtual memory map pages. Results can be filtered by providing address/module name.'
+parser.add_argument('pages_filter', type=pages_filter, nargs='?', default=None,
                     help='Address or module name.')
 
 
 @pwndbg.commands.ArgparsedCommand(parser)
 @pwndbg.commands.OnlyWhenRunning
-def vmmap(map=None):
-    print(map)
-    pages = list(filter(map, pwndbg.vmmap.get()))
+def vmmap(pages_filter=None):
+    pages = list(filter(pages_filter, pwndbg.vmmap.get()))
 
     if not pages:
         print('There are no mappings for specified address or module.')


### PR DESCRIPTION
This PR does three things:

* Adds `sloppy_gdb_parse` which can be used with `argparse.ArgumentParser`'s `.add_argument()` method's `type` argument
* Moves `vmmap` command to use `ArgparsedCommand` (https://github.com/pwndbg/pwndbg/issues/273)
* Adds a message when there are no mappings and leaving user with a WTF legend output