### PR TITLE
extend next_call to take optional symbol/target to break on

### DIFF
--- a/pwndbg/commands/next.py
+++ b/pwndbg/commands/next.py
@@ -31,7 +31,7 @@ def nextjump(*args):
 @pwndbg.commands.OnlyWhenRunning
 def nextcall(*args):
     """Breaks at the next call instruction"""
-    if pwndbg.next.break_next_call():
+    if pwndbg.next.break_next_call(*args):
         pwndbg.commands.context.context()
 
 @pwndbg.commands.Command


### PR DESCRIPTION
Regex is choosen to provide a more sophisticated control over targets to match on. By default it does an exact match, so providing `printf` will exactly match on `printf`. If a match on `snprintf` is also desired, one should pass something like `.*printf`. This approach provides more user control on what should be beaked on.

Additionally the target can be matched too, this is especially handy for stripped down binaries. The specific reason to the regex approach at this is also more sophisticated control when there is one big stripped static binary and we want to break on the next call to something like `0x42fd.*`. This way we provide a more feature rich way to match the target/symbol with no downsides.