### PR TITLE
Fix the length calculation of UTF-8 nearpc_prefix

### DIFF
--- a/pwndbg/commands/nearpc.py
+++ b/pwndbg/commands/nearpc.py
@@ -104,7 +104,7 @@ def nearpc(pc=None, lines=None, to_string=False, emulate=False):
     # Print out each instruction
     for address_str, s, i in zip(addresses, symbols, instructions):
         asm    = D.instruction(i)
-        prefix = ' %s' % (pwndbg.config.nearpc_prefix if i.address == pc else ' ' * len(pwndbg.config.nearpc_prefix.value))
+        prefix = ' %s' % (pwndbg.config.nearpc_prefix if i.address == pc else ' ' * len(pwndbg.config.nearpc_prefix.value.decode('utf-8')))
         prefix = N.prefix(prefix)
         if pwndbg.config.highlight_pc:
             prefix = C.highlight(prefix)


### PR DESCRIPTION
The ```len(pwndbg.config.nearpc_prefix.value)``` returns ```3```, instead of ```1``` (at
least with Python 2.7), which causes misalignment of the output.

Here's an example how the alignment breaks:

![pwndbg-5-2](https://user-images.githubusercontent.com/1058704/27254119-6ae94ea0-538a-11e7-81d5-93ca63730f31.png)

When you set the nearpc-prefix to ```=>``` it aligns properly:

![pwndbg-4-2](https://user-images.githubusercontent.com/1058704/27254123-80ca3d4c-538a-11e7-8b82-bc365172f43b.png)

I added ```decode('utf-8')``` to the ```len()``` calculation to fix this.