### PR TITLE
Better exception msg

### DIFF
--- a/pwndbg/elf.py
+++ b/pwndbg/elf.py
@@ -27,7 +27,6 @@ import pwndbg.memory
 import pwndbg.proc
 import pwndbg.stack
 
-
 # ELF constants
 PF_X, PF_W, PF_R = 1,2,4
 ET_EXEC, ET_DYN  = 2,3

--- a/pwndbg/events.py
+++ b/pwndbg/events.py
@@ -12,13 +12,10 @@ from __future__ import unicode_literals
 
 import functools
 import sys
-import traceback
 
 import gdb
 
-import pwndbg.color
 import pwndbg.config
-import pwndbg.exception
 
 debug = pwndbg.config.Parameter('debug-events', False, 'display internal event debugging info')
 pause = 0
@@ -121,6 +118,7 @@ def connect(func, event_handler, name=''):
         try:
             func()
         except Exception as e:
+            import pwndbg.exception
             pwndbg.exception.handle()
             raise e
 

--- a/pwndbg/exception.py
+++ b/pwndbg/exception.py
@@ -44,12 +44,6 @@ def handle(name = 'Error'):
               pwndbg.color.yellow('set exception-verbose on') +
               pwndbg.color.purple('` and rerun the command'))
 
-        print(pwndbg.color.purple(
-            'If that is an issue, you can report it on https://github.com/pwndbg/pwndbg/issues\n'
-            "(Please don't forget to search if it hasn't been reported before)\n"
-            "PS: Pull requests are welcome")
-        )
-
     # Break into the interactive debugger
     if debug:
         with pwndbg.stdio.stdio:

--- a/pwndbg/exception.py
+++ b/pwndbg/exception.py
@@ -14,17 +14,32 @@ import gdb
 
 import pwndbg.color
 import pwndbg.config
+import pwndbg.memoize
 import pwndbg.stdio
 
 try:
-	import ipdb as pdb
+    import ipdb as pdb
 except ImportError:
-	pass
+    pass
 
 verbose = pwndbg.config.Parameter('exception-verbose', False, 'whether to print a full stacktracefor exceptions raised in Pwndbg commands')
 debug = pwndbg.config.Parameter('exception-debugger', False, 'whether to debug exceptions raised in Pwndbg commands')
 
-def handle(name = 'Error'):
+
+@pwndbg.memoize.forever
+def inform_report_issue(exception_msg):
+    """
+    Informs user that he can report an issue.
+    The use of `memoize` makes it reporting only once for a given exception message.
+    """
+    print(pwndbg.color.purple(
+        'If that is an issue, you can report it on https://github.com/pwndbg/pwndbg/issues\n'
+        "(Please don't forget to search if it hasn't been reported before)\n"
+        "PS: Pull requests are welcome")
+    )
+
+
+def handle(name='Error'):
     """Displays an exception to the user, optionally displaying a full traceback
     and spawning an interactive post-moretem debugger.
 
@@ -34,12 +49,10 @@ def handle(name = 'Error'):
     """
     # Display the error
     if debug or verbose:
-        print(traceback.format_exc())
-        print(pwndbg.color.purple(
-            'If that is an issue, you can report it on https://github.com/pwndbg/pwndbg/issues\n'
-            "(Please don't forget to search if it hasn't been reported before)\n"
-            "PS: Pull requests are welcome")
-        )
+        exception_msg = traceback.format_exc()
+        print(exception_msg)
+        inform_report_issue(exception_msg)
+
     else:
         exc_type, exc_value, exc_traceback = sys.exc_info()
 
@@ -54,6 +67,7 @@ def handle(name = 'Error'):
         with pwndbg.stdio.stdio:
             pdb.post_mortem()
 
+
 @functools.wraps(pdb.set_trace)
 def set_trace():
     """Enable sane debugging in Pwndbg by switching to the "real" stdio.
@@ -64,6 +78,7 @@ def set_trace():
     debugger.set_trace()
 
 pdb.set_trace = set_trace
+
 
 @pwndbg.config.Trigger([verbose, debug])
 def update():

--- a/pwndbg/exception.py
+++ b/pwndbg/exception.py
@@ -35,6 +35,11 @@ def handle(name = 'Error'):
     # Display the error
     if debug or verbose:
         print(traceback.format_exc())
+        print(pwndbg.color.purple(
+            'If that is an issue, you can report it on https://github.com/pwndbg/pwndbg/issues\n'
+            "(Please don't forget to search if it hasn't been reported before)\n"
+            "PS: Pull requests are welcome")
+        )
     else:
         exc_type, exc_value, exc_traceback = sys.exc_info()
 

--- a/pwndbg/exception.py
+++ b/pwndbg/exception.py
@@ -12,6 +12,7 @@ import traceback
 
 import gdb
 
+import pwndbg.color
 import pwndbg.config
 import pwndbg.stdio
 
@@ -36,7 +37,18 @@ def handle(name = 'Error'):
         print(traceback.format_exc())
     else:
         exc_type, exc_value, exc_traceback = sys.exc_info()
-        print('{}: {} ({})'.format(name, exc_value, exc_type))
+
+        print(pwndbg.color.red('Exception occured: {}: {} ({})'.format(name, exc_value, exc_type)))
+
+        print(pwndbg.color.purple('For more info invoke `') +
+              pwndbg.color.yellow('set exception-verbose on') +
+              pwndbg.color.purple('` and rerun the command'))
+
+        print(pwndbg.color.purple(
+            'If that is an issue, you can report it on https://github.com/pwndbg/pwndbg/issues\n'
+            "(Please don't forget to search if it hasn't been reported before)\n"
+            "PS: Pull requests are welcome")
+        )
 
     # Break into the interactive debugger
     if debug:

--- a/pwndbg/memoize.py
+++ b/pwndbg/memoize.py
@@ -11,23 +11,24 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import collections
-import copy
 import functools
 import sys
-
-import gdb
 
 import pwndbg.events
 
 debug = False
 
+
 class memoize(object):
+    """
+    Base memoization class. Do not use directly. Instead use one of classes defined below.
+    """
     caching = True
 
     def __init__(self, func):
         self.func  = func
         self.cache = {}
-        self.caches.append(self)
+        self.caches.append(self)  # must be provided by base class
         functools.update_wrapper(self, func)
 
     def __call__(self, *args, **kwargs):
@@ -68,6 +69,17 @@ class memoize(object):
         self.cache.clear()
 
 
+class forever(memoize):
+    """
+    Memoizes forever - for a pwndbg session or until `_reset` is called explicitly.
+    """
+    caches = []
+
+    @staticmethod
+    def _reset():
+        for obj in forever.caches:
+            obj.cache.clear()
+
 
 class reset_on_stop(memoize):
     caches = []
@@ -83,6 +95,7 @@ class reset_on_stop(memoize):
 
     _reset = __reset_on_stop
 
+
 class reset_on_exit(memoize):
     caches = []
     kind   = 'exit'
@@ -95,6 +108,7 @@ class reset_on_exit(memoize):
 
     _reset = __reset_on_exit
 
+
 class reset_on_objfile(memoize):
     caches = []
     kind   = 'objfile'
@@ -106,6 +120,7 @@ class reset_on_objfile(memoize):
             obj.clear()
 
     _reset = __reset_on_objfile
+
 
 class reset_on_start(memoize):
     caches = []
@@ -120,6 +135,7 @@ class reset_on_start(memoize):
 
     _reset = __reset_on_start
 
+
 class reset_on_cont(memoize):
     caches = []
     kind   = 'cont'
@@ -131,6 +147,7 @@ class reset_on_cont(memoize):
             obj.clear()
 
     _reset = __reset_on_cont
+
 
 class while_running(memoize):
     caches = []
@@ -153,6 +170,7 @@ class while_running(memoize):
 
 
 def reset():
+    forever._reset()
     reset_on_stop._reset()
     reset_on_exit._reset()
     reset_on_objfile._reset()

--- a/pwndbg/search.py
+++ b/pwndbg/search.py
@@ -17,6 +17,7 @@ import pwndbg.memory
 import pwndbg.typeinfo
 import pwndbg.vmmap
 
+
 def search(searchfor, mappings=None, start=None, end=None, 
            executable=False, writable=False):
     """Search inferior memory for a byte sequence.


### PR DESCRIPTION
Enchances the exception display.

An example (with modified vmmap command):
https://i.gyazo.com/1e8f37a6cb4a2241fb09d2644346530c.png

Previously we just shown:
```
vmmap: 'str' object is not callable (<class 'TypeError'>)
```


