### PR TITLE
Fix nearpc: 'str' object has no attr 'decode'

### DIFF
--- a/pwndbg/commands/nearpc.py
+++ b/pwndbg/commands/nearpc.py
@@ -5,6 +5,8 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import codecs
+
 import gdb
 from capstone import *
 
@@ -104,7 +106,12 @@ def nearpc(pc=None, lines=None, to_string=False, emulate=False):
     # Print out each instruction
     for address_str, s, i in zip(addresses, symbols, instructions):
         asm    = D.instruction(i)
-        prefix = ' %s' % (pwndbg.config.nearpc_prefix if i.address == pc else ' ' * len(pwndbg.config.nearpc_prefix.value.decode('utf-8')))
+        value  = pwndbg.config.nearpc_prefix.value
+
+        if isinstance(value, bytes):
+            value = codecs.decode(value, 'utf-8')
+
+        prefix = ' %s' % (pwndbg.config.nearpc_prefix if i.address == pc else ' ' * len(value))
         prefix = N.prefix(prefix)
         if pwndbg.config.highlight_pc:
             prefix = C.highlight(prefix)

--- a/pwndbg/inthook.py
+++ b/pwndbg/inthook.py
@@ -47,7 +47,7 @@ class xint(with_metaclass(IsAnInt, builtins.int)):
             if symbol.is_function:
                 value = value.cast(pwndbg.typeinfo.ulong)
 
-        elif not isinstance(value, six.string_types):
+        elif not isinstance(value, six.string_types) and not isinstance(value, six.integer_types):
             return _int.__new__(cls, value, *a, **kw)
 
         return _int(_int(value, *a, **kw))


### PR DESCRIPTION
Fixes two bugs that occur on **stable**:
1. `nearpc` being broken - introduced in recent changes -
 https://github.com/pwndbg/pwndbg/commit/d4447027873de212ea896645f36ae511aad4ad28#commitcomment-22960258
2. Python 2 int/long type problems - it is just a cherry-pick - see comments below.

PS: I didn't cherry-pick 940f68a which fixes travis errors as it produces some merge conflicts I don't have time to look at atm.