### PR TITLE
Fix got command

### DIFF
--- a/pwndbg/commands/got.py
+++ b/pwndbg/commands/got.py
@@ -13,8 +13,7 @@ import pwndbg.enhance
 import pwndbg.file
 import pwndbg.which
 import pwndbg.wrappers
-from pwndbg.color import green
-from pwndbg.color import light_yellow
+from pwndbg.color import red, green, light_yellow
 
 parser = argparse.ArgumentParser(description='Show the state of the Global Offset Table')
 parser.add_argument('name_filter', help='Filter results by passed name.',
@@ -29,15 +28,17 @@ def got(name_filter=''):
 
     file_out = pwndbg.wrappers.file(local_path)
     if "statically" in file_out:
-        return "Binary is statically linked."
+        print(red("Binary is statically linked."))
+        return
 
-    readelf_out = pwndbg.wrappers.readelf("-r", local_path)
+    readelf_out = pwndbg.wrappers.readelf("--relocs", local_path)
 
     jmpslots = '\n'.join(filter(lambda l: _extract_jumps(l),
                          readelf_out.splitlines()))
 
     if not len(jmpslots):
-        return "NO JUMP_SLOT entries available in the GOT"
+        print(red("NO JUMP_SLOT entries available in the GOT"))
+        return
 
     if "PIE enabled" in cs_out:
         bin_text_base = pwndbg.memory.page_align(pwndbg.elf.entry())

--- a/pwndbg/commands/got.py
+++ b/pwndbg/commands/got.py
@@ -13,7 +13,9 @@ import pwndbg.enhance
 import pwndbg.file
 import pwndbg.which
 import pwndbg.wrappers
-from pwndbg.color import red, green, light_yellow
+from pwndbg.color import green
+from pwndbg.color import light_yellow
+from pwndbg.color import red
 
 parser = argparse.ArgumentParser(description='Show the state of the Global Offset Table')
 parser.add_argument('name_filter', help='Filter results by passed name.',
@@ -68,7 +70,12 @@ def got(name_filter=''):
 
 def _extract_jumps(l):
     try:
-        if "JUMP" in l.split()[2]:
+        # Checks for records in `readelf --relocs <binary>` which has type e.g. `R_X86_64_JUMP_SLO`
+        # NOTE: Because of that we DO NOT display entries that are not writeable (due to FULL RELRO)
+        # as they have `R_X86_64_GLOB_DAT` type.
+        #
+        # Probably we should display them seperately.
+        if 'JUMP' in l.split()[2]:
             return l
         else:
             return False

--- a/pwndbg/wrappers.py
+++ b/pwndbg/wrappers.py
@@ -24,10 +24,10 @@ def call_program(progname, *args):
     cmd = [progname] + list(args)
 
     try:
-        return subprocess.check_output(cmd).decode('utf-8')
+        return subprocess.check_output(cmd, stderr=subprocess.STDOUT).decode('utf-8')
     except Exception as e:
         raise OSError('Error during execution of %s command: %s' % (progname, e))
 
-checksec = functools.partial(call_program,'checksec')
+checksec = functools.partial(call_program, 'checksec')
 readelf = functools.partial(call_program, 'readelf')
 file = functools.partial(call_program, 'file')


### PR DESCRIPTION
1. Fixes 'got' command not showing meaningful message in its edge case paths (e.g. binary statically linked / full RELRO).

2. Adds comment about how are the jumps extracted under the hood and what are its consequences (we don't show GOT entries from FULL RELRO).

3. Fixes `got` command not displaying got entries when one uses checksec script from pwntools
* The fix just changes `call_program` wrapper to pipe stderr to stdout

This is because there are two `checksec`s:
* [the checksec script](https://github.com/slimm609/checksec.sh)
* checksec script from pwntools

And the latter prints output into stderr and because of that we couldn't detect proper RELRO status (as got command parsed an empty string).