### PR TITLE
Fixes `u` command `module object is not callable`

### DIFF
--- a/pwndbg/commands/windbg.py
+++ b/pwndbg/commands/windbg.py
@@ -289,7 +289,7 @@ def u(where=None, n=5):
     """
     if where is None:
         where = pwndbg.regs.pc
-    pwndbg.commands.nearpc(where, n)
+    pwndbg.commands.nearpc.nearpc(where, n)
 
 @pwndbg.commands.Command
 @pwndbg.commands.OnlyWhenRunning


### PR DESCRIPTION
Error it fixes:
```
pwndbg> u 0x404030
'u': Starting at the specified address, disassemble
    N instructions (default 5).
Traceback (most recent call last):
  File "/home/dc/installed/pwndbg/pwndbg/commands/__init__.py", line 99, in __call__
    return self.function(*args, **kwargs)
  File "/home/dc/installed/pwndbg/pwndbg/commands/__init__.py", line 191, in _OnlyWhenRunning
    return function(*a, **kw)
  File "/home/dc/installed/pwndbg/pwndbg/commands/windbg.py", line 292, in u
    pwndbg.commands.nearpc(where, n)
TypeError: 'module' object is not callable
```