### PR TITLE
Fix context display when thread is not stopped

### DIFF
--- a/pwndbg/proc.py
+++ b/pwndbg/proc.py
@@ -2,7 +2,8 @@
 # -*- coding: utf-8 -*-
 """
 Provides values which would be available from /proc which
-are not fulfilled by other modules.
+are not fulfilled by other modules and some process/gdb flow
+related information.
 """
 from __future__ import absolute_import
 from __future__ import division
@@ -48,6 +49,18 @@ class module(ModuleType):
         return gdb.selected_thread() is not None
 
     @property
+    def thread_is_stopped(self):
+        """
+        This detects whether selected thread is stopped. 
+        It is not stopped in situations when gdb is executing commands 
+        that are attached to a breakpoint by `command` command.
+
+        For more info see issue #229 ( https://github.com/pwndbg/pwndbg/issues/299 )
+        :return: Whether gdb executes commands attached to bp with `command` command.
+        """
+        return gdb.selected_thread().is_stopped()
+
+    @property
     def exe(self):
         for obj in gdb.objfiles():
             if obj.filename:
@@ -56,12 +69,15 @@ class module(ModuleType):
         if self.alive:
             auxv = pwndbg.auxv.get()
             return auxv['AT_EXECFN']
+
     def OnlyWhenRunning(self, func):
         @functools.wraps(func)
         def wrapper(*a, **kw):
             if self.alive:
                 return func(*a, **kw)
+
         return wrapper
+
 
 # To prevent garbage collection
 tether = sys.modules[__name__]

--- a/pwndbg/prompt.py
+++ b/pwndbg/prompt.py
@@ -24,7 +24,7 @@ def prompt_hook(*a):
         pwndbg.events.after_reload(start=False)
         cur = new
 
-    if pwndbg.proc.alive:
+    if pwndbg.proc.alive and pwndbg.proc.thread_is_stopped:
         prompt_hook_on_stop(*a)
 
 
@@ -32,5 +32,6 @@ def prompt_hook(*a):
 def prompt_hook_on_stop(*a):
     with pwndbg.stdio.stdio:
         pwndbg.commands.context.context()
+
 
 gdb.prompt_hook = prompt_hook


### PR DESCRIPTION
It seems that we try to display context when we can't do it - e.g. in situation where `command` is added to a breakpoint and it is gdb handling the breakpoint itself.

See https://github.com/pwndbg/pwndbg/issues/299 for more info.
