### PR TITLE
Fix IDA Pro decompiled code not being displayed

### DIFF
--- a/ida_script.py
+++ b/ida_script.py
@@ -109,8 +109,18 @@ register_module(idaapi)
 server.register_function(lambda a: eval(a, globals(), locals()), 'eval')
 server.register_introspection_functions()
 
-print('Ida Pro xmlrpc hosted on http://%s:%s' % (host, port))
+print('IDA Pro xmlrpc hosted on http://%s:%s' % (host, port))
+print('Call `shutdown()` to shutdown the IDA Pro xmlrpc server.')
 
 thread = threading.Thread(target=server.serve_forever)
 thread.daemon = True
 thread.start()
+
+
+def shutdown():
+    global server
+    global thread
+    server.shutdown()
+    server.server_close()
+    del server
+    del thread

--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -206,8 +206,13 @@ def context_code():
 
     name = pwndbg.ida.GetFunctionName(pwndbg.regs.pc)
     addr = pwndbg.ida.LocByName(name)
-    lines = pwndbg.ida.decompile(addr)
-    return lines.splitlines()
+    # May be None when decompilation failed or user loaded wrong binary in IDA
+    code = pwndbg.ida.decompile(addr)
+
+    if code:
+        return [pwndbg.ui.banner("Hexrays pseudocode")] + code.splitlines()
+    else:
+        return []
 
 
 stack_lines = pwndbg.config.Parameter('context-stack-lines', 8, 'number of lines to print in the stack context')

--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -71,11 +71,10 @@ def context(*args):
         sys.stdout.write(line + '\n')
     sys.stdout.flush()
 
+
 def context_regs():
-    result = []
-    result.append(pwndbg.ui.banner("registers"))
-    result.extend(get_regs())
-    return result
+    return [pwndbg.ui.banner("registers")] + get_regs()
+
 
 @pwndbg.commands.Command
 @pwndbg.commands.OnlyWhenRunning
@@ -85,6 +84,7 @@ def regs(*regs):
 
 pwndbg.config.Parameter('show-flags', False, 'whether to show flags registers')
 pwndbg.config.Parameter('show-retaddr-reg', False, 'whether to show return address register')
+
 
 def get_regs(*regs):
     result = []
@@ -164,6 +164,7 @@ def context_disasm():
 
 theme.Parameter('highlight-source', True, 'whether to highlight the closest source line')
 
+
 def context_code():
     try:
         symtab = gdb.selected_frame().find_sal().symtab
@@ -172,7 +173,7 @@ def context_code():
         closest_pc = -1
         closest_line = -1
         for line in linetable:
-            if line.pc <= pwndbg.regs.pc and line.pc > closest_pc:
+            if closest_pc < line.pc <= pwndbg.regs.pc:
                 closest_line = line.line
                 closest_pc   = line.pc
 
@@ -203,27 +204,24 @@ def context_code():
     if not pwndbg.ida.available():
         return []
 
-    try:
-        name = pwndbg.ida.GetFunctionName(pwndbg.regs.pc)
-        addr = pwndbg.ida.LocByName(name)
-        lines = pwndbg.ida.decompile(addr)
-        return lines.splitlines()
-    except:
-        pass
+    name = pwndbg.ida.GetFunctionName(pwndbg.regs.pc)
+    addr = pwndbg.ida.LocByName(name)
+    lines = pwndbg.ida.decompile(addr)
+    return lines.splitlines()
 
-    return []
 
 stack_lines = pwndbg.config.Parameter('context-stack-lines', 8, 'number of lines to print in the stack context')
 
+
 def context_stack():
-    result = []
-    result.append(pwndbg.ui.banner("stack"))
+    result = [pwndbg.ui.banner("stack")]
     telescope = pwndbg.commands.telescope.telescope(pwndbg.regs.sp, to_string=True, count=stack_lines)
     if telescope:
         result.extend(telescope)
     return result
 
 backtrace_frame_label = theme.Parameter('backtrace-frame-label', 'f ', 'frame number label for backtrace')
+
 
 def context_backtrace(frame_count=10, with_banner=True):
     result = []
@@ -273,6 +271,7 @@ def context_backtrace(frame_count=10, with_banner=True):
         i    += 1
     return result
 
+
 def context_args():
     result = []
 
@@ -291,6 +290,7 @@ def context_args():
     return result
 
 last_signal = []
+
 
 def save_signal(signal):
     global last_signal
@@ -320,6 +320,7 @@ def save_signal(signal):
 gdb.events.cont.connect(save_signal)
 gdb.events.stop.connect(save_signal)
 gdb.events.exited.connect(save_signal)
+
 
 def context_signal():
     return last_signal

--- a/pwndbg/ida.py
+++ b/pwndbg/ida.py
@@ -74,12 +74,16 @@ class withIDA(object):
             return self.fn(*args, **kwargs)
         return None
 
+
 def withHexrays(f):
     @withIDA
     @functools.wraps(f)
     def wrapper(*a, **kw):
         if _ida.init_hexrays_plugin():
             return f(*a, **kw)
+
+    return wrapper
+
 
 def takes_address(function):
     @functools.wraps(function)

--- a/pwndbg/ida.py
+++ b/pwndbg/ida.py
@@ -336,7 +336,12 @@ def has_cached_cfunc(addr):
 @takes_address
 @pwndbg.memoize.reset_on_stop
 def decompile(addr):
-    return _ida.decompile(addr)
+    try:
+        return _ida.decompile(addr)
+    except xmlrpclib.Fault as f:
+        if str(f) == '''<Fault 1: "<class 'idaapi.DecompilationFailure'>:Decompilation failed: ">''':
+            return ''
+        raise
 
 
 @withIDA

--- a/pwndbg/ida.py
+++ b/pwndbg/ida.py
@@ -340,7 +340,8 @@ def decompile(addr):
         return _ida.decompile(addr)
     except xmlrpclib.Fault as f:
         if str(f) == '''<Fault 1: "<class 'idaapi.DecompilationFailure'>:Decompilation failed: ">''':
-            return ''
+            print('Returning an empty string')
+            return None
         raise
 
 


### PR DESCRIPTION
The idea of this PR is to fix IDA Pro decompiled code display whenever Hexrays is available.

**Summary:**
* Fixes `withHexrays` not returning wrapped func
* Fixes IDA Pro xmlrpc failing on marshalling `idaapi.decompile` result - `idaapi.cfuncptr_t` instance - by adding a marshaller for it (also escaping proper XML symbols)
* Fixes IDA Pro xmlrpc server skipping wrapped function exception (instead of getting proper exception we just get `IndexError` from this line: https://github.com/pwndbg/pwndbg/blob/dev/ida_script.py#L62 on the pwndbg side which wasn't the real reason of failure)
* Adds IDA Pro xmlrpc server `shutdown` function which can be used to kill xmlrpc server and let user reload the script (without using it one might get e.g. some Windows related errors)
* Refactors a little bit the `context.py`
* Adds `HEXRAYS PSEUDOCODE` banner for decompiled code display

---
The first problem that occurs here is that we failed with adding [`withHexrays` decorator](https://github.com/pwndbg/pwndbg/blob/dev/pwndbg/ida.py#L77-L82) as it doesn't return the wrapper function.

We failed to spot it due to lack of testing it and the fact [we already catch all exceptions in there](https://github.com/pwndbg/pwndbg/blob/dev/pwndbg/commands/context.py#L207-L212) - so we failed on `'NoneType' object is not callable`, heh.

This is already fixed in this PR. However another problem occurs (I had to comment out the `try:`, `except:`):
```
pwndbg> r
Starting program: /home/dc/test/a.out 

Breakpoint 1, 0x000000010000070e in main ()
Traceback (most recent call last):
  File "/home/dc/installed/pwndbg/pwndbg/commands/__init__.py", line 100, in __call__
    return self.function(*args, **kwargs)
  File "/home/dc/installed/pwndbg/pwndbg/commands/__init__.py", line 192, in _OnlyWhenRunning
    return function(*a, **kw)
  File "/home/dc/installed/pwndbg/pwndbg/commands/context.py", line 64, in context
    result.extend(func())
  File "/home/dc/installed/pwndbg/pwndbg/commands/context.py", line 209, in context_code
    lines = pwndbg.ida.decompile(addr)
  File "/home/dc/installed/pwndbg/pwndbg/ida.py", line 74, in __call__
    return self.fn(*args, **kwargs)
  File "/home/dc/installed/pwndbg/pwndbg/ida.py", line 83, in wrapper
    return f(*a, **kw)
  File "/home/dc/installed/pwndbg/pwndbg/ida.py", line 91, in wrapper
    return function(l2r(address), *args, **kwargs)
  File "/home/dc/installed/pwndbg/pwndbg/memoize.py", line 48, in __call__
    value = self.func(*args, **kwargs)
  File "/home/dc/installed/pwndbg/pwndbg/ida.py", line 339, in decompile
    return _ida.decompile(addr)
  File "/usr/lib/python3.6/xmlrpc/client.py", line 1112, in __call__
    return self.__send(self.__name, args)
  File "/usr/lib/python3.6/xmlrpc/client.py", line 1452, in __request
    verbose=self.__verbose
  File "/usr/lib/python3.6/xmlrpc/client.py", line 1154, in request
    return self.single_request(host, handler, request_body, verbose)
  File "/usr/lib/python3.6/xmlrpc/client.py", line 1170, in single_request
    return self.parse_response(resp)
  File "/usr/lib/python3.6/xmlrpc/client.py", line 1342, in parse_response
    return u.close()
  File "/usr/lib/python3.6/xmlrpc/client.py", line 656, in close
    raise Fault(**self._stack[0])
xmlrpc.client.Fault: <Fault 1: "<type 'exceptions.TypeError'>:cannot marshal <type 'SwigPyObject'> objects">
```

If anyone is willing to help with this, you are welcome.