### PR TITLE
Fix exception if there is an indirect jump

### DIFF
--- a/pwndbg/disasm/arch.py
+++ b/pwndbg/disasm/arch.py
@@ -143,8 +143,11 @@ class DisassemblyAssistant(object):
             addr &= pwndbg.arch.ptrmask
         if op.type == CS_OP_MEM:
             if addr is None:
-                addr = self.memory_sz(instruction, op)
-            addr = int(pwndbg.memory.poi(pwndbg.typeinfo.ppvoid, addr))
+                addr = self.memory(instruction, op)
+
+            # self.memory may return none, so we need to check it here again
+            if addr is not None:
+                addr = int(pwndbg.memory.poi(pwndbg.typeinfo.ppvoid, addr))
         if op.type == CS_OP_REG:
             addr = self.register(instruction, op)
 


### PR DESCRIPTION
This is a simple typo, but the error message that GDB gave was interesting:

Previously, if you stopped on an instruction that does an indirect jump, like
this:

```
jmp [ecx*4 + 0xdeadbeef]
```

then pwndbg would the following exception:

```
gdb.error: evaluation of this expression requires the program to have a function "malloc".
```

The reason is that the code used `memory_sz` and passed that to gdb.Value, thus
creating a string value. When casting the string to a pointer later, GDB tries
to allocate a string in the inferior which failed since malloc is not available.

The fix is, of course, to use the correct function (`memory`) that returns an
int and not a string.