### PR TITLE
Fix hard error when something else (not IDA) listens on IDA's port

### DIFF
--- a/pwndbg/ida.py
+++ b/pwndbg/ida.py
@@ -13,6 +13,7 @@ from __future__ import unicode_literals
 import errno
 import functools
 import socket
+import sys
 import traceback
 
 import gdb
@@ -45,21 +46,35 @@ xmlrpclib.Marshaller.dispatch[type(0)] = lambda _, v, w: w("<value><i8>%d</i8></
 
 _ida = None
 
+# to avoid printing the same exception multiple times, we store the last exception here
+_ida_last_exception = None
+
 
 @pwndbg.config.Trigger([ida_rpc_host, ida_rpc_port])
 def init_ida_rpc_client():
-    global _ida
+    global _ida, _ida_last_exception
     addr = 'http://{host}:{port}'.format(host=ida_rpc_host, port=ida_rpc_port)
 
     _ida = xmlrpclib.ServerProxy(addr)
 
+    exception = None # (type, value, traceback)
     try:
         _ida.here()
         print(pwndbg.color.green("Pwndbg successfully connected to Ida Pro xmlrpc: %s" % addr))
     except socket.error as e:
         if e.errno != errno.ECONNREFUSED:
-            traceback.print_exc()
+            exception = sys.exc_info()
         _ida = None
+    except xmlrpclib.ProtocolError:
+        exception = sys.exc_info()
+        _ida = None
+
+    if exception:
+        if not isinstance(_ida_last_exception, exception[0]) or _ida_last_exception.args != exception[1].args:
+            print(pwndbg.color.yellow("[!] Ida Pro xmlrpc error"))
+            traceback.print_exception(*exception)
+
+    _ida_last_exception = exception and exception[1]
 
 
 class withIDA(object):

--- a/pwndbg/ida.py
+++ b/pwndbg/ida.py
@@ -56,6 +56,7 @@ def init_ida_rpc_client():
     addr = 'http://{host}:{port}'.format(host=ida_rpc_host, port=ida_rpc_port)
 
     _ida = xmlrpclib.ServerProxy(addr)
+    socket.setdefaulttimeout(3)
 
     exception = None # (type, value, traceback)
     try:
@@ -64,6 +65,9 @@ def init_ida_rpc_client():
     except socket.error as e:
         if e.errno != errno.ECONNREFUSED:
             exception = sys.exc_info()
+        _ida = None
+    except socket.timeout:
+        exception = sys.exc_info()
         _ida = None
     except xmlrpclib.ProtocolError:
         exception = sys.exc_info()


### PR DESCRIPTION
The default IDA port is 8888 and it can happen that some other program (such as
a jupyter notebook) is listening on that address. This made pwndbg unusable,
because it would crash trying to connect to IDA.

It now prints a message. I also added some code to avoid printing the same exception twice (pwndbg will try to connect to ida after every command, printing the same message each time would be a little bit annoying)