### PR TITLE
An attempt to fix dt command

### DIFF
--- a/pwndbg/typeinfo.py
+++ b/pwndbg/typeinfo.py
@@ -123,11 +123,11 @@ def load(name):
         for path in glob.glob(os.path.join(dirname, '*.h')):
             if any(b in path for b in blacklist):
               continue
-            print(path)
             source += '#include "%s"\n' % path
 
 
     source += '''
+
 {name} foo;
 '''.format(**locals())
 


### PR DESCRIPTION
This is an attempt to fix dt command. It still lacks the form of an ArgparsedCommand and does not print info on all types, just the structures.

**Changes (based on pahole-gdb):**

- `o     = getattr(field, 'bitpos', 0)//8` - Python3 division
- printing unused bytes
- printing used bytes


Simple testcase:

```
typedef struct str_type {
	int num;
	int* ptr;
	inside_str* new_inside_str;
	char letter;
	struct str_type* rec;
}str_type;
```

For a structure like the one listed above the result will be following:

```
pwndbg> dt str_type
type str_type:

used bytes:   4    +0x0000 num                  : int
[!--- 32 bits of padding ---!]
used bytes:   8    +0x0008 ptr                  : int *
used bytes:   8    +0x0010 new_inside_str       : inside_str *
used bytes:   1    +0x0018 letter               : char
[!--- 56 bits of padding ---!]
used bytes:   8    +0x0020 rec                  : struct str_type *
pwndbg> 

```

