### PR TITLE
ArgparsedCommand: config[file], theme[file]

### DIFF
--- a/pwndbg/commands/config.py
+++ b/pwndbg/commands/config.py
@@ -8,6 +8,8 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import argparse
+
 import pwndbg.commands
 import pwndbg.config
 from pwndbg.color import light_yellow
@@ -30,10 +32,11 @@ def extend_value_with_default(value, default):
     return value
 
 
-@pwndbg.commands.Command
-def config():
-    """Shows pwndbg-specific configuration points"""
+config_parser = argparse.ArgumentParser(description='Shows pwndbg-specific configuration points')
 
+
+@pwndbg.commands.ArgparsedCommand(config_parser)
+def config():
     values = [v for k, v in pwndbg.config.__dict__.items()
               if isinstance(v, pwndbg.config.Parameter) and v.scope == 'config']
     longest_optname = max(map(len, [v.optname for v in values]))
@@ -50,15 +53,23 @@ def config():
                        '- then put it in your .gdbinit after initializing pwndbg'))
 
 
-@pwndbg.commands.Command
+configfile_parser = argparse.ArgumentParser(description='Generates a configuration file for the current Pwndbg options')
+configfile_parser.add_argument('--show-all', action='store_true', help='Force displaying of all configs.')
+
+
+@pwndbg.commands.ArgparsedCommand(configfile_parser)
 def configfile(show_all=False):
-    """Generates a configuration file for the current Pwndbg options"""
     configfile_print_scope('config', show_all)
 
 
-@pwndbg.commands.Command
+themefile_parser = argparse.ArgumentParser(
+    description='Generates a configuration file for the current Pwndbg theme options'
+)
+themefile_parser.add_argument('--show-all', action='store_true', help='Force displaying of all theme options.')
+
+
+@pwndbg.commands.ArgparsedCommand(themefile_parser)
 def themefile(show_all=False):
-    """Generates a configuration file for the current Pwndbg theme options"""
     configfile_print_scope('theme', show_all)
 
 

--- a/pwndbg/commands/theme.py
+++ b/pwndbg/commands/theme.py
@@ -8,6 +8,8 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import argparse
+
 import pwndbg.color.theme
 import pwndbg.commands
 import pwndbg.config
@@ -16,10 +18,11 @@ from pwndbg.color import light_yellow
 from pwndbg.commands.config import extend_value_with_default
 from pwndbg.commands.config import print_row
 
+parser = argparse.ArgumentParser(description='Shows pwndbg-specific theme configuration points')
 
-@pwndbg.commands.Command
+
+@pwndbg.commands.ArgparsedCommand(parser)
 def theme():
-    """Shows pwndbg-specific theme configuration points"""
     values = [v for k, v in pwndbg.config.__dict__.items()
               if isinstance(v, pwndbg.config.Parameter) and v.scope == 'theme']
     longest_optname = max(map(len, [v.optname for v in values]))


### PR DESCRIPTION
Moves `config`, `configfile`, `theme` and `themefile` commands to `ArgparsedCommand`s (see https://github.com/pwndbg/pwndbg/issues/244).

Btw: one weird thing I have found is that when you add a flag like `--show-all`, invoking `--s` works for it oO'. Is it okay for us?