### PR TITLE
Add nextproginstr command

### DIFF
--- a/pwndbg/android.py
+++ b/pwndbg/android.py
@@ -10,8 +10,9 @@ import gdb
 import pwndbg.color
 import pwndbg.events
 import pwndbg.file
-import pwndbg.remote
 import pwndbg.memoize
+import pwndbg.remote
+
 
 @pwndbg.memoize.reset_on_start
 @pwndbg.memoize.reset_on_exit

--- a/pwndbg/commands/next.py
+++ b/pwndbg/commands/next.py
@@ -44,6 +44,14 @@ def nextret(*args):
 
 @pwndbg.commands.Command
 @pwndbg.commands.OnlyWhenRunning
+def nextproginstr(*args):
+    """Breaks at the next instruction that belongs to the running program"""
+    if pwndbg.next.break_on_program_code():
+        pwndbg.commands.context.context()
+
+
+@pwndbg.commands.Command
+@pwndbg.commands.OnlyWhenRunning
 def stepover(*args):
     """Sets a breakpoint on the instruction after this one"""
     pwndbg.next.break_on_next(*args)

--- a/pwndbg/next.py
+++ b/pwndbg/next.py
@@ -124,7 +124,7 @@ def break_next_ret(address=None):
 def break_on_program_code():
     """
     Breaks on next instruction that belongs to process' objfile code.
-    :return: True for success, False when process ended.
+    :return: True for success, False when process ended or when pc is in the code.
     """
     mp = pwndbg.proc.mem_page
     start = mp.start

--- a/pwndbg/next.py
+++ b/pwndbg/next.py
@@ -131,7 +131,7 @@ def break_on_program_code():
     end = mp.end
 
     if start <= pwndbg.regs.pc < end:
-        print(red('The execution is already in the binary objfile code. Not stepping.'))
+        print(red('The pc is already at the binary objfile code. Not stepping.'))
         return False
 
     while pwndbg.proc.alive:

--- a/pwndbg/next.py
+++ b/pwndbg/next.py
@@ -124,7 +124,7 @@ def break_next_ret(address=None):
 def break_on_program_code():
     """
     Breaks on next instruction that belongs to process' objfile code.
-    :return: True for success, False when process ended or when pc is in the code.
+    :return: True for success, False when process ended or when pc is at the code.
     """
     mp = pwndbg.proc.mem_page
     start = mp.start

--- a/pwndbg/proc.py
+++ b/pwndbg/proc.py
@@ -70,6 +70,10 @@ class module(ModuleType):
             auxv = pwndbg.auxv.get()
             return auxv['AT_EXECFN']
 
+    @property
+    def mem_page(self):
+        return next(p for p in pwndbg.vmmap.get() if p.objfile == self.exe)
+
     def OnlyWhenRunning(self, func):
         @functools.wraps(func)
         def wrapper(*a, **kw):


### PR DESCRIPTION
Adds a command that let us "wait until we are in the program's code" (useful when e.g. catching a syscall like `catch syscall read` and then you want to wait till read and some library code is over).

This probably can be coded better - probably `from_tty=False, to_string=False` has to be added into `gdb.execute`.
I will play more with it later on.