### PR TITLE
Add dereference-limit and heap-dereference-limit parameters

### DIFF
--- a/pwndbg/chain.py
+++ b/pwndbg/chain.py
@@ -32,7 +32,8 @@ def get(address, limit=LIMIT, offset=0, hard_stop=None, hard_end=0):
     Returns:
         A list representing pointers of each ```address``` and reference
     """
-
+    limit = int(limit)+1
+    
     result = []
     for i in range(limit):
         # Don't follow cycles, except to stop at the second occurrence.
@@ -74,6 +75,7 @@ def format(value, limit=LIMIT, code=True, offset=0, hard_stop=None, hard_end=0):
         A string representing pointers of each address and reference
         Strings format: 0x0804a10 —▸ 0x08061000 ◂— 0x41414141
     """
+    limit = int(limit)+1
 
     # Allow results from get function to be passed to format
     if type(value) == list:

--- a/pwndbg/chain.py
+++ b/pwndbg/chain.py
@@ -16,7 +16,7 @@ import pwndbg.symbol
 import pwndbg.typeinfo
 import pwndbg.vmmap
 
-LIMIT = 5
+LIMIT = pwndbg.config.Parameter('dereference-limit', 5, 'max number of pointers to dereference in a chain')
 
 def get(address, limit=LIMIT, offset=0, hard_stop=None, hard_end=0):
     """

--- a/pwndbg/heap/__init__.py
+++ b/pwndbg/heap/__init__.py
@@ -10,6 +10,8 @@ import pwndbg.symbol
 
 current = None
 
+heap_chain_limit = pwndbg.config.Parameter('heap-dereference-limit', 8, 'number of bins to dereference')
+
 @pwndbg.events.new_objfile
 def update():
     import pwndbg.heap.dlmalloc

--- a/pwndbg/heap/ptmalloc.py
+++ b/pwndbg/heap/ptmalloc.py
@@ -14,6 +14,7 @@ import pwndbg.typeinfo
 from pwndbg.color import bold
 from pwndbg.color import red
 from pwndbg.constants import ptmalloc
+from pwndbg.heap import heap_chain_limit
 
 HEAP_MAX_SIZE     = 1024 * 1024
 
@@ -222,7 +223,7 @@ class Heap(pwndbg.heap.heap.BaseHeap):
         result = OrderedDict()
         for i in range(num_fastbins):
             size += pwndbg.arch.ptrsize * 2
-            chain = pwndbg.chain.get(int(fastbinsY[i]), offset=fd_offset)
+            chain = pwndbg.chain.get(int(fastbinsY[i]), offset=fd_offset, limit=heap_chain_limit)
 
             result[size] = chain
 
@@ -256,7 +257,7 @@ class Heap(pwndbg.heap.heap.BaseHeap):
         front, back = normal_bins[index * 2], normal_bins[index * 2 + 1]
         fd_offset   = self.chunk_key_offset('fd')
 
-        chain = pwndbg.chain.get(int(front), offset=fd_offset, hard_stop=current_base)
+        chain = pwndbg.chain.get(int(front), offset=fd_offset, hard_stop=current_base, limit=heap_chain_limit)
         return chain
 
 


### PR DESCRIPTION
This allows setting the number of pointers dereferenced during 'telescope'
and in the register context.  Separately, the number of heap bins which
are dereferenced can be set.

Fixes #352 