### PR TITLE
Support bare metal environment

### DIFF
--- a/pwndbg/abi.py
+++ b/pwndbg/abi.py
@@ -4,6 +4,11 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import functools
+import re
+
+import gdb
+
 import pwndbg.arch
 
 
@@ -111,3 +116,37 @@ linux_arm_sigreturn = SigreturnABI(['r7'], 4, 0)
 linux_i386_srop = ABI(['eax'], 4, 0)
 linux_amd64_srop = ABI(['rax'], 4, 0)
 linux_arm_srop = ABI(['r7'], 4, 0)
+
+
+@pwndbg.events.start
+def update():
+    global abi
+    global linux
+
+    # Detect current ABI of client side by 'show osabi'
+    osabi_string = gdb.execute('show osabi', to_string=True)
+
+    # The return string will be:
+    # The current OS ABI is "auto" (currently "GNU/Linux").
+    match = re.search('currently "([^"]+)"', osabi_string)
+    if match:
+        # 'GNU/Linux': linux
+        # 'none': bare metal
+        abi = match.group(1)
+
+        linux = 'Linux' in abi
+
+def LinuxOnly(default=None):
+    """Create a decorator that the function will be called when ABI is Linux.
+    Otherwise, return `default`.
+    """
+    def decorator(func):
+        @functools.wraps(func)
+        def caller(*args, **kwargs):
+            if linux:
+                return func(*args, **kwargs)
+            else:
+                return default
+        return caller
+
+    return decorator

--- a/pwndbg/argv.py
+++ b/pwndbg/argv.py
@@ -7,6 +7,7 @@ from __future__ import unicode_literals
 
 import gdb
 
+import pwndbg.abi
 import pwndbg.arch
 import pwndbg.events
 import pwndbg.memory
@@ -25,6 +26,7 @@ envp = None
 envc = None
 
 @pwndbg.events.start
+@pwndbg.abi.LinuxOnly()
 def update():
     global argc
     global argv

--- a/pwndbg/auxv.py
+++ b/pwndbg/auxv.py
@@ -11,6 +11,7 @@ import sys
 
 import gdb
 
+import pwndbg.abi
 import pwndbg.arch
 import pwndbg.events
 import pwndbg.info
@@ -150,6 +151,8 @@ def find_stack_boundary(addr):
     return addr
 
 def walk_stack():
+    if not pwndbg.abi.linux:
+        return None
     if pwndbg.qemu.is_qemu_kernel():
         return None
 

--- a/pwndbg/elf.py
+++ b/pwndbg/elf.py
@@ -18,6 +18,7 @@ import sys
 import gdb
 from six.moves import reload_module
 
+import pwndbg.arch
 import pwndbg.auxv
 import pwndbg.elftypes
 import pwndbg.events
@@ -120,6 +121,44 @@ def reset_ehdr_type_loaded():
     global ehdr_type_loaded
     ehdr_type_loaded = 0
 
+def find_elf_magic(pointer, max_pages=1024, search_down=False):
+    """Search the nearest page which contains the ELF headers
+    by comparing the ELF magic with first 4 bytes.
+
+    Parameter:
+        search_down: change the search direction
+        to search over the lower address.
+        That is, decreasing the page pointer instead of increasing.
+            (default: False)
+    Returns:
+        An integer address of ELF page base
+        None if not found within the page limit
+    """
+    base = pwndbg.memory.page_align(pointer)
+    step = pwndbg.memory.PAGE_SIZE
+    if search_down:
+        step = -step
+
+    max_addr = pwndbg.arch.ptrmask
+
+    for i in range(max_pages):
+        # Make sure address within valid range or gdb will raise Overflow exception
+        if base < 0 or base > max_addr:
+            return None
+
+        try:
+            data = pwndbg.memory.read(base, 4)
+        except gdb.MemoryError:
+            return None
+
+        # Return the address if found ELF header
+        if data == b'\x7FELF':
+            return base
+
+        base += step
+
+    return None
+
 def get_ehdr(pointer):
     """Returns an ehdr object for the ELF pointer points into.
     """
@@ -127,21 +166,9 @@ def get_ehdr(pointer):
     # the ELF header.
     base = pwndbg.memory.page_align(pointer)
 
-    try:
-        data = pwndbg.memory.read(base, 4)
-
-        # Do not search more than 4MB of memory
-        for i in range(1024):
-            if data == b'\x7FELF':
-                break
-
-            base -= pwndbg.memory.PAGE_SIZE
-            data = pwndbg.memory.read(base, 4)
-
-        else:
-            print("ERROR: Could not find ELF base!")
-            return None, None
-    except gdb.MemoryError:
+    base = find_elf_magic(pointer, search_down=True)
+    if base is None:
+        print("ERROR: Could not find ELF base!")
         return None, None
 
     # Determine whether it's 32- or 64-bit

--- a/pwndbg/stack.py
+++ b/pwndbg/stack.py
@@ -14,6 +14,7 @@ from __future__ import unicode_literals
 
 import gdb
 
+import pwndbg.elf
 import pwndbg.events
 import pwndbg.memoize
 import pwndbg.memory
@@ -41,15 +42,10 @@ def find(address):
 
 def find_upper_stack_boundary(addr, max_pages=1024):
     addr = pwndbg.memory.page_align(int(addr))
-    try:
-        for i in range(max_pages):
-            data = pwndbg.memory.read(addr, 4)
-            if b'\x7fELF' == pwndbg.memory.read(addr, 4):
-                break
-            addr += pwndbg.memory.PAGE_SIZE
-    except gdb.MemoryError:
-        pass
-    return addr
+
+    base = pwndbg.elf.find_elf_magic(addr)
+
+    return base if base is not None else addr
 
 @pwndbg.events.stop
 @pwndbg.memoize.reset_on_stop

--- a/pwndbg/vmmap.py
+++ b/pwndbg/vmmap.py
@@ -17,6 +17,7 @@ import sys
 
 import gdb
 
+import pwndbg.abi
 import pwndbg.compat
 import pwndbg.elf
 import pwndbg.events
@@ -66,6 +67,7 @@ def find(address):
 
     return explore(address)
 
+@pwndbg.abi.LinuxOnly()
 def explore(address_maybe):
     """
     Given a potential address, check to see what permissions it has.


### PR DESCRIPTION
Hi all,

I read the issue #264 and give a *draft* PR to disable the some magic AUXV and ELF header finding. Any suggestions are welcome.

This version will disable the AUXV looking up in `walking_stack()` and return empty `AUXV()`. This will cause all the section information are not available. Also, disable the page scan in `get_ehdr()` and `find_upper_stack_boundary()`.

Here's some idea and some topic want to discuss:
1. The pwndbg rely tidily with ELF format and AUXV, this make me hardly to add other ABI support. Maybe we need to re-design framework to support the ABI detection and dispatch to the correct functions.

2. Without the page information, the `telescope` works badly and it will try to de-reference everything. Maybe the next step is automatic load the page information from ELF file. (I have not start to do that yet, any ideas are welcome). BTW, is it possible to create `AUXV()` from ELF the file? or it is created by OS loader when loading into the virtual memory?

3. If we add the page information from ELF file (create some guessing page like `vmmap.explore()` do), but in my bare metal environment, the mmu is disabled, the addresses are all physical address. That is, there is no *page* in my environment, so using the current `Page()` design may be wired or may cause some unexpected bugs.