### PR TITLE
Fail on two commands with same name

### DIFF
--- a/pwndbg/commands/misc.py
+++ b/pwndbg/commands/misc.py
@@ -50,7 +50,7 @@ parser.add_argument('filter_pattern', type=str, nargs='?', default=None, help='F
 
 @_pwndbg.commands.ArgparsedCommand(parser)
 def pwndbg(filter_pattern):
-    sorted_commands = list(_pwndbg.commands.Command.commands)
+    sorted_commands = list(_pwndbg.commands.commands)
     sorted_commands.sort(key=lambda x: x.__name__)
 
     if filter_pattern:

--- a/pwndbg/prompt.py
+++ b/pwndbg/prompt.py
@@ -10,7 +10,7 @@ import gdb
 import pwndbg.events
 import pwndbg.memoize
 
-hint_msg = 'Loaded %i commands. Type pwndbg [filter] for a list.' % len(pwndbg.commands.Command.commands)
+hint_msg = 'Loaded %i commands. Type pwndbg [filter] for a list.' % len(pwndbg.commands.commands)
 
 print(pwndbg.color.red(hint_msg))
 cur = (gdb.selected_inferior(), gdb.selected_thread())


### PR DESCRIPTION
This prevents/protect us from having two commands with the same name (we had that once).

I've also removed some redundant/unused variables or arguments here and there.