### PR TITLE
Add `desc` to ArgparsedCommand; move some commmands to Argparsed~

### DIFF
--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -221,12 +221,18 @@ class _ArgparsedCommand(Command):
 
 class ArgparsedCommand(object):
     """Adds documentation and offloads parsing for a Command via argparse"""
-    def __init__(self, parser):
-        self.parser = parser
+    def __init__(self, parser_or_desc):
+        """
+        :param parser_or_desc: `argparse.ArgumentParser` instance or `str`
+        """
+        if isinstance(parser_or_desc, str):
+            self.parser = argparse.ArgumentParser(description=parser_or_desc)
+        else:
+            self.parser = parser_or_desc
 
         # We want to run all integer and otherwise-unspecified arguments
         # through fix() so that GDB parses it.
-        for action in parser._actions:
+        for action in self.parser._actions:
             if action.dest == 'help':
                 continue
             if action.type in (int, None):

--- a/pwndbg/commands/auxv.py
+++ b/pwndbg/commands/auxv.py
@@ -5,7 +5,6 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import gdb
 import six
 
 import pwndbg.auxv
@@ -13,12 +12,9 @@ import pwndbg.chain
 import pwndbg.commands
 
 
-@pwndbg.commands.ParsedCommand
+@pwndbg.commands.ArgparsedCommand('Print information from the Auxiliary ELF Vector.')
 @pwndbg.commands.OnlyWhenRunning
 def auxv():
-    """
-    Print information from the Auxiliary ELF Vector.
-    """
-    for k,v in sorted(pwndbg.auxv.get().items()):
+    for k, v in sorted(pwndbg.auxv.get().items()):
         if v is not None:
             print(k.ljust(24), v if not isinstance(v, six.integer_types) else pwndbg.chain.format(v))

--- a/pwndbg/commands/canary.py
+++ b/pwndbg/commands/canary.py
@@ -5,8 +5,6 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import argparse
-
 import pwndbg.auxv
 import pwndbg.color
 import pwndbg.commands
@@ -15,7 +13,6 @@ import pwndbg.memory
 import pwndbg.regs
 import pwndbg.search
 
-parser = argparse.ArgumentParser(description='Print out the current stack canary')
 
 def canary_value():
     auxv = pwndbg.auxv.get()
@@ -31,7 +28,7 @@ def canary_value():
     return global_canary, at_random
 
 
-@pwndbg.commands.ArgparsedCommand(parser)
+@pwndbg.commands.ArgparsedCommand('Print out the current stack canary.')
 @pwndbg.commands.OnlyWhenRunning
 def canary():
     global_canary, at_random = canary_value()

--- a/pwndbg/commands/checksec.py
+++ b/pwndbg/commands/checksec.py
@@ -10,11 +10,7 @@ import pwndbg.which
 import pwndbg.wrappers.checksec
 
 
-@pwndbg.commands.Command
+@pwndbg.commands.ArgparsedCommand('Prints out the binary security settings using `checksec`.')
 @pwndbg.commands.OnlyWithFile
-def checksec(file=None):
-    '''
-    Prints out the binary security settings. Attempts to call the binjitsu
-    checksec first, and then falls back to checksec.sh.
-    '''
+def checksec():
     print(pwndbg.wrappers.checksec.get_raw_out())

--- a/pwndbg/commands/config.py
+++ b/pwndbg/commands/config.py
@@ -32,10 +32,7 @@ def extend_value_with_default(value, default):
     return value
 
 
-config_parser = argparse.ArgumentParser(description='Shows pwndbg-specific configuration points')
-
-
-@pwndbg.commands.ArgparsedCommand(config_parser)
+@pwndbg.commands.ArgparsedCommand('Shows pwndbg-specific configuration points')
 def config():
     values = [v for k, v in pwndbg.config.__dict__.items()
               if isinstance(v, pwndbg.config.Parameter) and v.scope == 'config']

--- a/pwndbg/commands/cpsr.py
+++ b/pwndbg/commands/cpsr.py
@@ -5,29 +5,26 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import gdb
-
 import pwndbg.arch
 import pwndbg.color
 import pwndbg.commands
 import pwndbg.regs
 
 
-@pwndbg.commands.Command
+@pwndbg.commands.ArgparsedCommand('Print out ARM CPSR register')
 @pwndbg.commands.OnlyWhenRunning
 def cpsr():
-    'Print out the ARM CPSR register'
     if pwndbg.arch.current != 'arm':
         print("This is only available on ARM")
         return
 
     cpsr = pwndbg.regs.cpsr
 
-    N = cpsr & (1<<31)
-    Z = cpsr & (1<<30)
-    C = cpsr & (1<<29)
-    V = cpsr & (1<<28)
-    T = cpsr & (1<<5)
+    N = cpsr & (1 << 31)
+    Z = cpsr & (1 << 30)
+    C = cpsr & (1 << 29)
+    V = cpsr & (1 << 28)
+    T = cpsr & (1 << 5)
 
     bold = pwndbg.color.bold
 
@@ -38,4 +35,5 @@ def cpsr():
         bold('V') if V else 'v',
         bold('T') if T else 't'
     ]
+
     print('cpsr %#x [ %s ]' % (cpsr, ' '.join(result)))

--- a/pwndbg/commands/elf.py
+++ b/pwndbg/commands/elf.py
@@ -10,12 +10,9 @@ from elftools.elf.elffile import ELFFile
 import pwndbg.commands
 
 
-@pwndbg.commands.Command
+@pwndbg.commands.ArgparsedCommand('Prints the section mappings contained in the ELF header.')
 @pwndbg.commands.OnlyWithFile
 def elfheader():
-    """
-    Prints the section mappings contained in the ELF header.
-    """
     local_path = pwndbg.file.get_file(pwndbg.proc.exe)
 
     with open(local_path, 'rb') as f:
@@ -32,25 +29,20 @@ def elfheader():
             sections.append((start, start + size, section.name))
 
         sections.sort()
+
         for start, end, name in sections:
             print('%#x - %#x ' % (start, end), name)
 
 
-@pwndbg.commands.Command
+@pwndbg.commands.ArgparsedCommand('Prints any symbols found in the .got.plt section if it exists.')
 @pwndbg.commands.OnlyWithFile
 def gotplt():
-    """
-    Prints any symbols found in the .got.plt section if it exists.
-    """
     print_symbols_in_section('.got.plt', '@got.plt')
 
 
-@pwndbg.commands.Command
+@pwndbg.commands.ArgparsedCommand('Prints any symbols found in the .plt section if it exists.')
 @pwndbg.commands.OnlyWithFile
 def plt():
-    """
-    Prints any symbols found in the .plt section if it exists.
-    """
     print_symbols_in_section('.plt', '@plt')
 
 
@@ -78,6 +70,10 @@ def print_symbols_in_section(section_name, filter_text=''):
         return
 
     symbols = get_symbols_in_region(start, end, filter_text)
+
+    if not symbols:
+        print(pwndbg.color.red('No symbols found in section %s' % section_name))
+
     for symbol, addr in symbols:
         print(hex(int(addr)) + ': ' + symbol)
 

--- a/pwndbg/commands/got.py
+++ b/pwndbg/commands/got.py
@@ -22,6 +22,7 @@ parser = argparse.ArgumentParser(description='Show the state of the Global Offse
 parser.add_argument('name_filter', help='Filter results by passed name.',
                     type=str, nargs='?', default='')
 
+
 @pwndbg.commands.ArgparsedCommand(parser)
 @pwndbg.commands.OnlyWhenRunning
 def got(name_filter=''):

--- a/pwndbg/commands/hexdump.py
+++ b/pwndbg/commands/hexdump.py
@@ -29,6 +29,7 @@ parser.add_argument('address', nargs='?', default='$sp',
 parser.add_argument('count', nargs='?', default=pwndbg.config.hexdump_bytes,
                     help='Number of bytes to dump')
 
+
 @pwndbg.commands.ArgparsedCommand(parser)
 @pwndbg.commands.OnlyWhenRunning
 def hexdump(address=None, count=pwndbg.config.hexdump_bytes):

--- a/pwndbg/commands/stack.py
+++ b/pwndbg/commands/stack.py
@@ -3,8 +3,6 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import argparse
-
 import gdb
 
 import pwndbg.arch
@@ -14,11 +12,7 @@ import pwndbg.regs
 import pwndbg.vmmap
 
 
-p = argparse.ArgumentParser(description='''
-Print out the stack addresses that contain return addresses
-''')
-
-@pwndbg.commands.ArgparsedCommand(p)
+@pwndbg.commands.ArgparsedCommand('Print out the stack addresses that contain return addresses.')
 @pwndbg.commands.OnlyWhenRunning
 def retaddr():
     sp = pwndbg.regs.sp

--- a/pwndbg/commands/theme.py
+++ b/pwndbg/commands/theme.py
@@ -18,10 +18,8 @@ from pwndbg.color import light_yellow
 from pwndbg.commands.config import extend_value_with_default
 from pwndbg.commands.config import print_row
 
-parser = argparse.ArgumentParser(description='Shows pwndbg-specific theme configuration points')
 
-
-@pwndbg.commands.ArgparsedCommand(parser)
+@pwndbg.commands.ArgparsedCommand('Shows pwndbg-specific theme configuration points.')
 def theme():
     values = [v for k, v in pwndbg.config.__dict__.items()
               if isinstance(v, pwndbg.config.Parameter) and v.scope == 'theme']


### PR DESCRIPTION
* adds optional keyword argument -  `desc`  - to `ArgparsedCommand` so we don't have to create `argparse.ArgumentParser` if we don't want any parameters
* adds prints for cases when plt/gotplt sections doesnt have any symbols (so user will get an output out of plt/gotplt instead of nothing)
* minor code refactorings

Potentially we could merge ArgparsedCommand and Command in the future (and remove all other Command children).

Also continuation of https://github.com/pwndbg/pwndbg/issues/244