### PR TITLE
Add xinfo command for extended offset information

### DIFF
--- a/pwndbg/__init__.py
+++ b/pwndbg/__init__.py
@@ -49,6 +49,7 @@ import pwndbg.commands.theme
 import pwndbg.commands.version
 import pwndbg.commands.vmmap
 import pwndbg.commands.windbg
+import pwndbg.commands.xinfo
 import pwndbg.commands.xor
 import pwndbg.constants
 import pwndbg.disasm

--- a/pwndbg/commands/xinfo.py
+++ b/pwndbg/commands/xinfo.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import argparse
+import subprocess
+
+import gdb
+
+import pwndbg.arch
+import pwndbg.color.memory as M
+import pwndbg.commands
+import pwndbg.config
+import pwndbg.memory
+import pwndbg.regs
+import pwndbg.stack
+import pwndbg.vmmap
+import pwndbg.wrappers
+
+parser = argparse.ArgumentParser(description='Shows offsets of the specified address to useful other locations')
+parser.add_argument('address', nargs='?', default='$pc', 
+                    help='Address to inspect')
+
+def print_line(name, addr, first, second, op, width = 20):
+
+    print("{} {} = {} {} {:#x}".format(name.rjust(width), M.get(addr),
+        M.get(first) if type(first) is not str else first.ljust(len(hex(addr))),
+        op, second,))
+
+def xinfo_stack(page, addr):
+    # If it's a stack address, print offsets to top and bottom of stack, as
+    # well as offsets to current stack and base pointer (if used by debugee)
+
+    sp = pwndbg.regs.sp
+    frame = pwndbg.regs[pwndbg.regs.frame]
+    frame_mapping = pwndbg.vmmap.find(frame)
+
+    print_line("Stack Top", addr, page.vaddr, addr - page.vaddr, "+")
+    print_line("Stack End", addr, page.end, page.end - addr, "-")
+    print_line("Stack Pointer", addr, sp, addr - sp, "+")
+
+    if frame_mapping and page.vaddr == frame_mapping.vaddr:
+        print_line("Frame Pointer", addr, frame, frame - addr, "-")
+
+    canary_value = pwndbg.commands.canary.canary_value()[0]
+
+    if canary_value is not None:
+        all_canaries = list(
+            pwndbg.search.search(pwndbg.arch.pack(canary_value), mappings=pwndbg.stack.stacks.values())
+        )
+        follow_canaries = sorted(filter(lambda a: a > addr, all_canaries))
+        if follow_canaries is not None and len(follow_canaries) > 0:
+            nxt = follow_canaries[0]
+            print_line("Next Stack Canary", addr, nxt, nxt - addr, "-")
+
+def xinfo_mmap_file(page, addr):
+    # If it's an address pointing into a memory mapped file, print offsets
+    # to beginning of file in memory and on disk
+
+    file_name = page.objfile
+    objpages = filter(lambda p: p.objfile == file_name, pwndbg.vmmap.get())
+    first = sorted(objpages, key = lambda p: p.vaddr)[0]
+    rva = addr - first.vaddr
+
+    print_line("File (Memory)", addr, first.vaddr, rva, "+")
+
+    for segment in pwndbg.wrappers.readelf.get_load_segment_info():
+        if rva >= segment["VirtAddr"] and rva <= segment["VirtAddr"] + segment["MemSiz"]:
+            print_line("File (Disk)", addr, file_name, rva - (segment["VirtAddr"] - segment["Offset"]), "+")
+
+def xinfo_default(page, addr):
+    # Just print the distance to the beginning of the mapping
+
+    print_line("Mapped Area", addr, page.vaddr, addr - page.vaddr, "+")
+
+
+@pwndbg.commands.ArgparsedCommand(parser)
+@pwndbg.commands.OnlyWhenRunning
+def xinfo(address=None):
+    addr = int(address)
+    addr &= pwndbg.arch.ptrmask
+
+    page = pwndbg.vmmap.find(addr)
+
+    if page is None:
+        print("\n  Virtual address {:#x} is not mapped.".format(addr))
+        return
+
+    print("Extended information for virtual address {}:".format(M.get(addr)))
+
+    print("\n  Containing mapping:")
+    print(M.get(address, text=str(page)))
+
+    print("\n  Offset information:")
+
+    if page.is_stack:
+        xinfo_stack(page, addr)
+    else:
+        xinfo_default(page, addr)
+    
+    if page.is_memory_mapped_file:
+        xinfo_mmap_file(page, addr)

--- a/pwndbg/memory.py
+++ b/pwndbg/memory.py
@@ -400,6 +400,14 @@ class Page(object):
         return self.vaddr + self.memsz
 
     @property
+    def is_stack(self):
+        return self.objfile == '[stack]'
+
+    @property
+    def is_memory_mapped_file(self):
+        return len(self.objfile) > 0 and self.objfile[0] != '['
+
+    @property
     def read(self):
         return bool(self.flags & 4)
 

--- a/pwndbg/wrappers/readelf.py
+++ b/pwndbg/wrappers/readelf.py
@@ -5,6 +5,8 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import re
+
 import pwndbg.wrappers
 
 cmd_name = "readelf"
@@ -16,7 +18,6 @@ def get_jmpslots():
     readelf_out = pwndbg.wrappers.call_cmd(cmd)
 
     return filter(_extract_jumps, readelf_out.splitlines())
-
 
 def _extract_jumps(line):
     '''
@@ -33,3 +34,49 @@ def _extract_jumps(line):
             return False
     except IndexError:
         return False
+
+@pwndbg.wrappers.OnlyWithCommand(cmd_name)
+def get_load_segment_info():
+    '''
+    Looks for LOAD sections by parsing the output of `readelf --program-headers <binary>`
+    '''
+    local_path = pwndbg.file.get_file(pwndbg.proc.exe)
+    cmd = [get_jmpslots.cmd_path, "--program-headers", local_path]
+    readelf_out = pwndbg.wrappers.call_cmd(cmd)
+
+    segments = []
+    load_found = False
+
+    # Output from readelf is 
+    # Type           Offset             VirtAddr           PhysAddr
+    #                FileSiz            MemSiz             Flags  Align
+    # LOAD           0x0000000000000000 0x0000000000000000 0x0000000000000000
+    #                0x0000000000000830 0x0000000000000830  R E    0x200000
+    # Account for this using two regular expressions
+    re_first = re.compile(r"\s+LOAD\s+(0x[0-9A-Fa-f]+) (0x[0-9A-Fa-f]+) (0x[0-9A-Fa-f]+)")
+    re_secnd = re.compile(r"\s+(0x[0-9A-Fa-f]+) (0x[0-9A-Fa-f]+)  (.)(.)(.)\s+(0x[0-9A-Fa-f]+)")
+    hex2int = lambda x: int(x, 16)
+
+    for line in readelf_out.splitlines():
+        if "LOAD" in line:
+            load_found = True
+            offset, vaddr, paddr = map(hex2int, re_first.match(line).groups())
+        elif load_found:
+            fsize, msize, read, write, execute, align = re_secnd.match(line).groups()
+            fsize, msize, align = map(hex2int, (fsize, msize, align))
+            read = read == "R"
+            write = write == "W"
+            execute = execute == "E"
+
+            segments.append({"Offset":   offset,
+                             "VirtAddr": vaddr,
+                             "PhysAddr": paddr,
+                             "FileSiz": fsize,
+                             "MemSiz": msize,
+                             "FlagsRead": read,
+                             "FlagsWrite": write,
+                             "FlagsExecute": execute})
+
+            load_found = False
+
+    return segments


### PR DESCRIPTION
This commit adds a `xinfo` command that calculates the offset of a
specified address to other interesting locations within the address
space:

* In the most general case, simply the offset of the pointer into the
current mapping is displayed.
* If the address specified is a stack adress, the offsets to the top and
the bottom of the stack, as well as to the current stack pointer and
frame pointer value are displayed.
* If the address points into a memory mapped file, the command
additionally shows the offset to the beginning of the file in memory and
on disk.