### PR TITLE
Fix upper stack boundary

### DIFF
--- a/pwndbg/elf.py
+++ b/pwndbg/elf.py
@@ -67,6 +67,7 @@ def read(typ, address, blob=None):
     obj.type = typ
     return obj
 
+
 @pwndbg.proc.OnlyWhenRunning
 @pwndbg.memoize.reset_on_start
 def exe():
@@ -77,6 +78,7 @@ def exe():
     e = entry()
     if e:
         return load(e)
+
 
 @pwndbg.proc.OnlyWhenRunning
 @pwndbg.memoize.reset_on_start
@@ -117,10 +119,12 @@ def load(pointer):
 
 ehdr_type_loaded = 0
 
+
 @pwndbg.memoize.reset_on_start
 def reset_ehdr_type_loaded():
     global ehdr_type_loaded
     ehdr_type_loaded = 0
+
 
 @pwndbg.abi.LinuxOnly()
 def find_elf_magic(pointer, max_pages=1024, search_down=False, ret_addr_anyway=False):
@@ -161,6 +165,7 @@ def find_elf_magic(pointer, max_pages=1024, search_down=False, ret_addr_anyway=F
 
     return addr if ret_addr_anyway else None
 
+
 def get_ehdr(pointer):
     """Returns an ehdr object for the ELF pointer points into.
     """
@@ -185,6 +190,7 @@ def get_ehdr(pointer):
     Elfhdr   = read(Ehdr, base)
     return ei_class, Elfhdr
 
+
 def get_phdrs(pointer):
     """
     Returns a tuple containing (phnum, phentsize, gdb.Value),
@@ -203,6 +209,7 @@ def get_phdrs(pointer):
     x = (phnum, phentsize, read(Phdr, Elfhdr.address + phoff))
     return x
 
+
 def iter_phdrs(ehdr):
     if not ehdr:
         raise StopIteration
@@ -219,6 +226,7 @@ def iter_phdrs(ehdr):
         p_phdr = int(first_phdr + (i*phentsize))
         p_phdr = read(PhdrType, p_phdr)
         yield p_phdr
+
 
 def map(pointer, objfile=''):
     """
@@ -242,6 +250,7 @@ def map(pointer, objfile=''):
     """
     ei_class, ehdr         = get_ehdr(pointer)
     return map_inner(ei_class, ehdr, objfile)
+
 
 def map_inner(ei_class, ehdr, objfile):
     if not ehdr:

--- a/pwndbg/stack.py
+++ b/pwndbg/stack.py
@@ -43,9 +43,7 @@ def find(address):
 def find_upper_stack_boundary(addr, max_pages=1024):
     addr = pwndbg.memory.page_align(int(addr))
 
-    base = pwndbg.elf.find_elf_magic(addr)
-
-    return base if base is not None else addr
+    return pwndbg.elf.find_elf_magic(addr, max_pages=max_pages, ret_addr_anyway=True)
 
 @pwndbg.events.stop
 @pwndbg.memoize.reset_on_stop

--- a/pwndbg/stack.py
+++ b/pwndbg/stack.py
@@ -28,6 +28,7 @@ stacks = {}
 # This is updated automatically by is_executable.
 nx     = False
 
+
 def find(address):
     """
     Returns a pwndbg.memory.Page object which corresponds to the
@@ -40,10 +41,12 @@ def find(address):
         if address in stack:
             return stack
 
+
 def find_upper_stack_boundary(addr, max_pages=1024):
     addr = pwndbg.memory.page_align(int(addr))
 
     return pwndbg.elf.find_elf_magic(addr, max_pages=max_pages, ret_addr_anyway=True)
+
 
 @pwndbg.events.stop
 @pwndbg.memoize.reset_on_stop
@@ -98,6 +101,7 @@ def current():
     """
     return find(pwndbg.regs.sp)
 
+
 @pwndbg.events.exit
 def clear():
     """
@@ -108,6 +112,7 @@ def clear():
     stacks.clear()
     global nx
     nx = False
+
 
 @pwndbg.events.stop
 @pwndbg.memoize.reset_on_exit


### PR DESCRIPTION
Fixes bug with getting `upper_stack_boundary` introduced in https://github.com/pwndbg/pwndbg/commit/31f468e0d1c41bcb8a259610b6e42750050aa63f.

TL;DR: `upper_stack_boundary` we got doesn't match the one from `vmmap`.
This breaks `canary` command - and probably something else that is based on stack pages.

Previously we determined upper address by having a memory read failure.
Recent changes made it so we got a `None` instead of the address in such situation.

This adds a parameter to `find_elf_magic` which lets us get a result when gdb.MemoryError occurs.

---

This PR fixes the bug but I am not sure whether this is 100% correct as we may set stack upper boundary for an address that contains `'\x7fELF'` because of this:
```python
        # Return the address if found ELF header
        if data == b'\x7fELF':
            return addr
```

Weird thing: I can actually search for `ELF` and get a result on the stack - then check returned address-1 and see that there is `\x7fELF` string (btw we can't use `\x7f` to search for 0x7f byte with `search` command ;/).
But this was not set as stack upper boundary.