### PR TITLE
Avoid enhancements when dereference limit is zero

### DIFF
--- a/pwndbg/chain.py
+++ b/pwndbg/chain.py
@@ -94,9 +94,11 @@ def format(value, limit=LIMIT, code=True, offset=0, hard_stop=None, hard_end=0):
             symbol = '%#x (%s)' % (link, symbol)
         rest.append(M.get(link, symbol))
 
-    # If the dereference limit is zero, skip enhancement and return the chain
+    # If the dereference limit is zero, skip any enhancements.
     if limit == 0:
-        return arrow_right.join(rest)
+        return rest[0]
+    # Otherwise replace last element with the enhanced information.
+    rest = rest[:-1]
 
     # Enhance the last entry
     # If there are no pointers (e.g. eax = 0x41414141), then enhance

--- a/pwndbg/chain.py
+++ b/pwndbg/chain.py
@@ -32,9 +32,9 @@ def get(address, limit=LIMIT, offset=0, hard_stop=None, hard_end=0):
     Returns:
         A list representing pointers of each ```address``` and reference
     """
-    limit = int(limit)+1
+    limit = int(limit)
     
-    result = []
+    result = [address]
     for i in range(limit):
         # Don't follow cycles, except to stop at the second occurrence.
         if result.count(address) >= 2:
@@ -44,10 +44,10 @@ def get(address, limit=LIMIT, offset=0, hard_stop=None, hard_end=0):
             result.append(hard_end)
             break
 
-        result.append(address)
         try:
             address = int(pwndbg.memory.poi(pwndbg.typeinfo.ppvoid, address + offset))
             address &= pwndbg.arch.ptrmask
+            result.append(address)
         except gdb.MemoryError:
             break
 
@@ -75,16 +75,28 @@ def format(value, limit=LIMIT, code=True, offset=0, hard_stop=None, hard_end=0):
         A string representing pointers of each address and reference
         Strings format: 0x0804a10 —▸ 0x08061000 ◂— 0x41414141
     """
-    limit = int(limit)+1
+    limit = int(limit)
 
     # Allow results from get function to be passed to format
-    if type(value) == list:
+    if isinstance(value, list):
         chain = value
     else:
         chain = get(value, limit, offset, hard_stop, hard_end)
 
     arrow_left  = C.arrow(' %s ' % config_arrow_left)
     arrow_right = C.arrow(' %s ' % config_arrow_right)
+
+    # Colorize the chain
+    rest = []
+    for link in chain:
+        symbol = pwndbg.symbol.get(link) or None
+        if symbol:
+            symbol = '%#x (%s)' % (link, symbol)
+        rest.append(M.get(link, symbol))
+
+    # If the dereference limit is zero, skip enhancement and return the chain
+    if limit == 0:
+        return arrow_right.join(rest)
 
     # Enhance the last entry
     # If there are no pointers (e.g. eax = 0x41414141), then enhance
@@ -95,19 +107,11 @@ def format(value, limit=LIMIT, code=True, offset=0, hard_stop=None, hard_end=0):
     # Otherwise, the last element in the chain is the non-pointer value.
     # We want to enhance the last pointer value. If an offset was used
     # chain failed at that offset, so display that offset.
-    elif len(chain) < limit:
+    elif len(chain) < limit + 1:
         enhanced = pwndbg.enhance.enhance(chain[-2] + offset, code=code)
 
     else:
         enhanced = C.contiguous('%s' % config_contiguous)
-
-    # Colorize the rest
-    rest = []
-    for link in chain[:-1]:
-        symbol = pwndbg.symbol.get(link) or None
-        if symbol:
-            symbol = '%#x (%s)' % (link, symbol)
-        rest.append(M.get(link, symbol))
 
     if len(chain) == 1:
         return enhanced


### PR DESCRIPTION
This fixes and off by one issue mentioned in https://github.com/pwndbg/pwndbg/issues/371#issuecomment-353741672 and modifies the `pwndbg/chain.py` file to prevent accidentally dereferencing addresses by avoiding enhancements when the dereference limit is set to zero. I have made some tests and I have found no regressions. However, unit tests would be ideal. On the diff, I will comment most changes line by line.
