### PR TITLE
Fix #373 for python2 environment

### DIFF
--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -9,6 +9,7 @@ import argparse
 import functools
 
 import gdb
+import six
 
 import pwndbg.chain
 import pwndbg.color
@@ -225,7 +226,7 @@ class ArgparsedCommand(object):
         """
         :param parser_or_desc: `argparse.ArgumentParser` instance or `str`
         """
-        if isinstance(parser_or_desc, str):
+        if isinstance(parser_or_desc, six.string_types):
             self.parser = argparse.ArgumentParser(description=parser_or_desc)
         else:
             self.parser = parser_or_desc


### PR DESCRIPTION
The PR #373 use `isinstance(parser_or_desc, str)` to check the variable `parser_or_desc` type.
However, you use `from __future__ import unicode_literals` in every commands.

This cause the string literals will be `unicode` type in python2 and will be bypass the check and cause an exception.
```
Traceback (most recent call last):
  File ".../gdbinit.py", line 36, in <module>
    import pwndbg # isort:skip
  File ".../pwndbg/__init__.py", line 20, in <module>
    import pwndbg.commands.auxv
  File ".../pwndbg/commands/auxv.py", line 15, in <module>
    @pwndbg.commands.ArgparsedCommand('Print information from the Auxiliary ELF Vector.')
  File ".../pwndbg/commands/__init__.py", line 235, in __init__
    for action in self.parser._actions:
AttributeError: 'unicode' object has no attribute '_actions'
```

* Fix: Use `six.string_types` in `isinstance()` instead of using `str` type.

BTW, there are some codes still use `isinstance(var, str)`. They will be potential issues.