### PR TITLE
Make de-reference only works on known pages in bare metal mode and add commands to manually add pages

### DIFF
--- a/pwndbg/abi.py
+++ b/pwndbg/abi.py
@@ -164,5 +164,5 @@ def LinuxOnly(default=None):
     return decorator
 
 
-# XXX: Update when starting the gdb to show warning message for non-Linux ABI user.
+# Update when starting the gdb to show warning message for non-Linux ABI user.
 update()

--- a/pwndbg/abi.py
+++ b/pwndbg/abi.py
@@ -10,6 +10,7 @@ import re
 import gdb
 
 import pwndbg.arch
+import pwndbg.color.message as M
 
 
 class ABI(object):
@@ -136,6 +137,17 @@ def update():
 
         linux = 'Linux' in abi
 
+    if not linux:
+        msg = M.warn(
+            "The bare metal debugging will enable since the gdb's osabi is '%s' which is not 'GNU/Linux'.\n"
+            "Ex. the page resolving and memory de-referencing ONLY works on known pages.\n"
+            "This option is seleted from compile arguments of gdb client and will be corrected if you load an ELF that contains ABI information.\n"
+            "If you are debuging some program that running on Linux ABI, please select the correct gdb client."
+            % abi
+        )
+        print(msg)
+
+
 def LinuxOnly(default=None):
     """Create a decorator that the function will be called when ABI is Linux.
     Otherwise, return `default`.
@@ -150,3 +162,7 @@ def LinuxOnly(default=None):
         return caller
 
     return decorator
+
+
+# XXX: Update when starting the gdb to show warning message for non-Linux ABI user.
+update()

--- a/pwndbg/abi.py
+++ b/pwndbg/abi.py
@@ -139,10 +139,10 @@ def update():
 
     if not linux:
         msg = M.warn(
-            "The bare metal debugging will enable since the gdb's osabi is '%s' which is not 'GNU/Linux'.\n"
+            "The bare metal debugging is enabled since the gdb's osabi is '%s' which is not 'GNU/Linux'.\n"
             "Ex. the page resolving and memory de-referencing ONLY works on known pages.\n"
-            "This option is seleted from compile arguments of gdb client and will be corrected if you load an ELF that contains ABI information.\n"
-            "If you are debuging some program that running on Linux ABI, please select the correct gdb client."
+            "This option is based ib gdb client compile arguments (by default) and will be corrected if you load an ELF which has the '.note.ABI-tag' section.\n"
+            "If you are debuging a program that runs on Linux ABI, please select the correct gdb client."
             % abi
         )
         print(msg)

--- a/pwndbg/chain.py
+++ b/pwndbg/chain.py
@@ -21,7 +21,7 @@ LIMIT = pwndbg.config.Parameter('dereference-limit', 5, 'max number of pointers 
 
 def get(address, limit=LIMIT, offset=0, hard_stop=None, hard_end=0):
     """
-    Recursively dereferences an address.
+    Recursively dereferences an address. For bare metal, it will stop when the address is not in any of vmmap pages to avoid redundant dereference.
 
     Arguments:
         address(int): the first address to begin dereferencing
@@ -34,7 +34,7 @@ def get(address, limit=LIMIT, offset=0, hard_stop=None, hard_end=0):
         A list representing pointers of each ```address``` and reference
     """
     limit = int(limit)
-    
+
     result = [address]
     for i in range(limit):
         # Don't follow cycles, except to stop at the second occurrence.
@@ -48,8 +48,8 @@ def get(address, limit=LIMIT, offset=0, hard_stop=None, hard_end=0):
         try:
             address = address + offset
 
-            # If in bare metal mode, check the vmmap pages for the address
-            # to avoid de-reference the unused address
+            # Avoid redundant dereferences in bare metal mode by checking
+            # if address is in any of vmmap pages
             if not pwndbg.abi.linux and not pwndbg.vmmap.find(address):
                 break
 

--- a/pwndbg/commands/vmmap.py
+++ b/pwndbg/commands/vmmap.py
@@ -12,10 +12,13 @@ import argparse
 
 import gdb
 import six
+from elftools.elf.constants import SH_FLAGS
+from elftools.elf.elffile import ELFFile
 
 import pwndbg.color.memory as M
 import pwndbg.commands
 import pwndbg.compat
+import pwndbg.elf
 import pwndbg.vmmap
 
 
@@ -54,3 +57,81 @@ def vmmap(pages_filter=None):
     print(M.legend())
     for page in pages:
         print(M.get(page.vaddr, text=str(page)))
+
+
+parser = argparse.ArgumentParser()
+parser.description = 'Add Print virtual memory map page.'
+parser.add_argument('start', help='Starting virtual address')
+parser.add_argument('size', help='Size of the address space, in bytes')
+parser.add_argument('flags', nargs='?', type=str, default='', help='Flags set by the ELF file, see PF_X, PF_R, PF_W')
+parser.add_argument('offset', nargs='?', default=0, help='Offset into the original ELF file that the data is loaded from')
+
+@pwndbg.commands.ArgparsedCommand(parser)
+def vmmap_add(start, size, flags, offset):
+    page_flags = {
+        'r': pwndbg.elf.PF_R,
+        'w': pwndbg.elf.PF_W,
+        'x': pwndbg.elf.PF_X,
+    }
+    perm = 0
+    for flag in flags:
+        flag_val = page_flags.get(flag, None)
+        if flag_val is None:
+            print('Invalid page flag "%s"', flag)
+            return
+        perm |= flag_val
+
+    page = pwndbg.memory.Page(start, size, perm, offset)
+    pwndbg.vmmap.add_custom_page(page)
+
+    print('%r added' % page)
+
+
+@pwndbg.commands.ParsedCommand
+def vmmap_clear():
+    pwndbg.vmmap.clear_custom_page()
+
+
+parser = argparse.ArgumentParser()
+parser.description = 'Load virtual memory map pages from ELF file.'
+parser.add_argument('filename', nargs='?', type=str, help='Filename of ELF, default use the value of pwndbg.proc.exe')
+
+@pwndbg.commands.ArgparsedCommand(parser)
+def vmmap_load(filename):
+    if filename is None:
+        filename = pwndbg.proc.exe
+
+    print('Load "%s" ...' % filename)
+
+    # Use sections information to recover the segments information.
+    # The entry point of bare metal enviroment is often at the first segments.
+    # This may cause a value < 0x8000 will be considered as a valid pointer.
+    # Ex. entry point is at 0x8000 and its segment starts with 0x0.
+    # TODO: make an argument to choose loading the page information from section or segments
+    pages = []
+    with open(filename, 'rb') as f:
+        elffile = ELFFile(f)
+
+        for section in elffile.iter_sections():
+            vaddr = section['sh_addr']
+            memsz = section['sh_size']
+            sh_flags = section['sh_flags']
+            offset = section['sh_offset']
+
+            # Don't add the sections that aren't mapped into memory
+            if not sh_flags & SH_FLAGS.SHF_ALLOC:
+                continue
+
+            # Guess the segment flags from section flags
+            flags = pwndbg.elf.PF_R
+            if sh_flags & SH_FLAGS.SHF_WRITE:
+                flags |= pwndbg.elf.PF_W
+            if sh_flags & SH_FLAGS.SHF_EXECINSTR:
+                flags |= pwndbg.elf.PF_X
+
+            page = pwndbg.memory.Page(vaddr, memsz, flags, offset, filename)
+            pages.append(page)
+
+    for page in pages:
+        pwndbg.vmmap.add_custom_page(page)
+        print('%r added' % page)

--- a/pwndbg/commands/vmmap.py
+++ b/pwndbg/commands/vmmap.py
@@ -94,7 +94,7 @@ def vmmap_clear():
 
 parser = argparse.ArgumentParser()
 parser.description = 'Load virtual memory map pages from ELF file.'
-parser.add_argument('filename', nargs='?', type=str, help='Filename of ELF, default use the value of pwndbg.proc.exe')
+parser.add_argument('filename', nargs='?', type=str, help='ELF filename, by default uses current loaded filename.')
 
 @pwndbg.commands.ArgparsedCommand(parser)
 def vmmap_load(filename):
@@ -103,11 +103,13 @@ def vmmap_load(filename):
 
     print('Load "%s" ...' % filename)
 
-    # Use sections information to recover the segments information.
-    # The entry point of bare metal enviroment is often at the first segments.
-    # This may cause a value < 0x8000 will be considered as a valid pointer.
-    # Ex. entry point is at 0x8000 and its segment starts with 0x0.
-    # TODO: make an argument to choose loading the page information from section or segments
+    # TODO: Add an argument to let use to choose loading the page information from sections or segments
+
+    # Use section information to recover the segment information.
+    # The entry point of bare metal enviroment is often at the first segment.
+    # For example, assume the entry point is at 0x8000.
+    # In most of case, link will create a segment and starts from 0x0.
+    # This cause all values less than 0x8000 be considered as a valid pointer.
     pages = []
     with open(filename, 'rb') as f:
         elffile = ELFFile(f)

--- a/pwndbg/elf.py
+++ b/pwndbg/elf.py
@@ -126,7 +126,6 @@ def reset_ehdr_type_loaded():
     ehdr_type_loaded = 0
 
 
-@pwndbg.abi.LinuxOnly()
 def find_elf_magic(pointer, max_pages=1024, search_down=False, ret_addr_anyway=False):
     """Search the nearest page which contains the ELF headers
     by comparing the ELF magic with first 4 bytes.

--- a/pwndbg/elf.py
+++ b/pwndbg/elf.py
@@ -126,6 +126,7 @@ def reset_ehdr_type_loaded():
     ehdr_type_loaded = 0
 
 
+@pwndbg.abi.LinuxOnly()
 def find_elf_magic(pointer, max_pages=1024, search_down=False, ret_addr_anyway=False):
     """Search the nearest page which contains the ELF headers
     by comparing the ELF magic with first 4 bytes.
@@ -172,14 +173,12 @@ def get_ehdr(pointer):
     # the ELF header.
     base = pwndbg.memory.page_align(pointer)
 
-    # XXX: for non linux ABI, the ELF header may not be found in memory.
+    # For non linux ABI, the ELF header may not be found in memory.
     # This will hang the gdb when using the remote gdbserver to scan 1024 pages
-    if not pwndbg.abi.linux:
-        return None, None
-
     base = find_elf_magic(pointer, search_down=True)
     if base is None:
-        print("ERROR: Could not find ELF base!")
+        if pwndbg.abi.linux:
+            print("ERROR: Could not find ELF base!")
         return None, None
 
     # Determine whether it's 32- or 64-bit

--- a/pwndbg/stack.py
+++ b/pwndbg/stack.py
@@ -45,8 +45,8 @@ def find(address):
 def find_upper_stack_boundary(addr, max_pages=1024):
     addr = pwndbg.memory.page_align(int(addr))
 
-    # For bare metal, we can not get the stack size from stack layout and page fault.
-    # Return current page for a walkaround.
+    # We can't get the stack size from stack layout and page fault on bare metal mode,
+    # so we return current page as a walkaround.
     if not pwndbg.abi.linux:
         return addr + pwndbg.memory.PAGE_SIZE
 

--- a/pwndbg/stack.py
+++ b/pwndbg/stack.py
@@ -45,6 +45,11 @@ def find(address):
 def find_upper_stack_boundary(addr, max_pages=1024):
     addr = pwndbg.memory.page_align(int(addr))
 
+    # For bare metal, we can not get the stack size from stack layout and page fault.
+    # Return current page for a walkaround.
+    if not pwndbg.abi.linux:
+        return addr + pwndbg.memory.PAGE_SIZE
+
     return pwndbg.elf.find_elf_magic(addr, max_pages=max_pages, ret_addr_anyway=True)
 
 

--- a/pwndbg/vmmap.py
+++ b/pwndbg/vmmap.py
@@ -34,6 +34,7 @@ import pwndbg.typeinfo
 # List of manually-explored pages which were discovered
 # by analyzing the stack or register context.
 explored_pages = []
+custom_pages = []
 
 @pwndbg.events.new_objfile
 @pwndbg.memoize.reset_on_stop
@@ -50,6 +51,7 @@ def get():
         pages.extend(pwndbg.stack.stacks.values())
 
     pages.extend(explored_pages)
+    pages.extend(custom_pages)
     pages.sort()
     return tuple(pages)
 
@@ -113,6 +115,16 @@ def explore_registers():
 def clear_explored_pages():
     while explored_pages:
         explored_pages.pop()
+
+
+def add_custom_page(page):
+    custom_pages.append(page)
+    custom_pages.sort()
+
+def clear_custom_page():
+    while custom_pages:
+        custom_pages.pop()
+
 
 @pwndbg.memoize.reset_on_stop
 def proc_pid_maps():

--- a/pwndbg/vmmap.py
+++ b/pwndbg/vmmap.py
@@ -12,6 +12,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import bisect
 import os
 import sys
 
@@ -34,6 +35,8 @@ import pwndbg.typeinfo
 # List of manually-explored pages which were discovered
 # by analyzing the stack or register context.
 explored_pages = []
+
+# List of custom pages that can be managed manually by vmmap_* commands family
 custom_pages = []
 
 @pwndbg.events.new_objfile
@@ -118,12 +121,22 @@ def clear_explored_pages():
 
 
 def add_custom_page(page):
-    custom_pages.append(page)
-    custom_pages.sort()
+    bisect.insort(custom_pages, page)
+
+    # Reset all the cache
+    # We can not reset get() only, since the result may be used by others.
+    # TODO: avoid flush all caches
+    pwndbg.memoize.reset()
+
 
 def clear_custom_page():
     while custom_pages:
         custom_pages.pop()
+
+    # Reset all the cache
+    # We can not reset get() only, since the result may be used by others.
+    # TODO: avoid flush all caches
+    pwndbg.memoize.reset()
 
 
 @pwndbg.memoize.reset_on_stop

--- a/tests/testLoadsWithoutCrashing.py
+++ b/tests/testLoadsWithoutCrashing.py
@@ -17,5 +17,5 @@ def escape_ansi(line):
 def test_loads_wivout_crashing_bruv():
     output = escape_ansi(common.run_gdb_with_script())
 
-    assert ('pwndbg: loaded 156 commands. Type pwndbg [filter] for a list.\n'
+    assert ('pwndbg: loaded 159 commands. Type pwndbg [filter] for a list.\n'
             'pwndbg: created $rebase, $ida gdb functions (can be used with print/break)') in output, output


### PR DESCRIPTION
Since the address are all valid when mmu is not enable and all the value are valid physical address. It will be de-referenced even these addresses are not used. Actually, it is data in the most of case. Ex. 0x1 often means the value 1, not the address 0x1.

Also, for issue #371, some addresses may be the MMIO registers. The read operation on these address will break the state. It is better to limit the de-reference address range. This PR will also fix it, hopefully.

First, we limit the de-reference only happened when the value is in the known page range.
Moreover, I create some API in `vmmap.py` to maintain the manually added pages. Also, add some commands called `vmmap_add`, `vmmap_del`, `vmmap_load` to add pages, delete pages, load page and guess the permission from ELF sections information.

1. I am out of idea about the naming of variable name and command name. Any better suggestions are welcome.
2. `vmmap.get()` has cache. The manually adding pages will not work immediately.

----

The following issues have been found while I was creating this PR, but not related:
1. Use the different source to get the page permission `RWX` value.
Ex. in `memory.py` use `os.R`, in `elf.py` use `PF_R`, and in `vmmap.py` use a hardcoded value `4`.
2. gdb `load` command will not generate the gdb event so that it will not clear the cache and update to new information.
3. The implementation of `vmmap_load` is similar with some code in `elf.py` to parse the ELF sections. Maybe we can create some useful ELF util functions and make 2 part use the same function.


  