### PR TITLE
Fix Endianess issue and Memory error on GDB

### DIFF
--- a/pwndbg/arch.py
+++ b/pwndbg/arch.py
@@ -48,7 +48,7 @@ def update():
     m.ptrsize = pwndbg.typeinfo.ptrsize
     m.ptrmask = (1 << 8*pwndbg.typeinfo.ptrsize)-1
 
-    if 'little' in gdb.execute('show endian', to_string=True):
+    if 'little' in gdb.execute('show endian', to_string=True).lower():
         m.endian = 'little'
     else:
         m.endian = 'big'


### PR DESCRIPTION
Due to new way of printing GDB settings in GDB 8 (Here in German Language), Little Endianess isn't detected correctly and will lead to a memory crash due to invalid endianness. Fix is to lowercase the GDB response to match "Little Endian" as well as "little endian" response.

Debug log : 
```
GNU gdb (Ubuntu 8.0.1-0ubuntu1) 8.0.1
Copyright (C) 2017 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.  Type "show copying"
and "show warranty" for details.
This GDB was configured as "x86_64-linux-gnu".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<http://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
<http://www.gnu.org/software/gdb/documentation/>.
For help, type "help".
Type "apropos word" to search for commands related to "word"...
pwndbg: loaded 156 commands. Type pwndbg [filter] for a list.
pwndbg: created $rebase, $ida gdb functions (can be used with print/break)
Reading symbols from ../vuln...done.
Es wird angenommen, dass das Ziel Little Endian benutzt
Es wird angenommen, dass die Ziel-Architektur arm ist
warning: remote target does not support file transfer, attempting to access files from local filesystem.
warning: Unable to find dynamic linker breakpoint function.
GDB will be unable to debug shared library initializers
and track explicitly loaded dynamic code.
Exception occured: Error: Cannot access memory at address 0x34010000 (<class 'gdb.MemoryError'>)
For more info invoke `set exception-verbose on` and rerun the command
Python Exception <class 'gdb.MemoryError'> Cannot access memory at address 0x34010000: 
Exception occured: Error: Cannot access memory at address 0x34010000 (<class 'gdb.MemoryError'>)
For more info invoke `set exception-verbose on` and rerun the command
Python Exception <class 'gdb.MemoryError'> Cannot access memory at address 0x34010000: 
Exception occured: Error: Cannot access memory at address 0x34010000 (<class 'gdb.MemoryError'>)
For more info invoke `set exception-verbose on` and rerun the command
Python Exception <class 'gdb.MemoryError'> Cannot access memory at address 0x34010000: 
Exception occured: Error: Cannot access memory at address 0x34010000 (<class 'gdb.MemoryError'>)
For more info invoke `set exception-verbose on` and rerun the command
Python Exception <class 'gdb.MemoryError'> Cannot access memory at address 0x34010000: 
0xf67ceaf0 in ?? ()
Exception occured: Error: Cannot access memory at address 0x34010000 (<class 'gdb.MemoryError'>)
For more info invoke `set exception-verbose on` and rerun the command
Python Exception <class 'gdb.MemoryError'> Cannot access memory at address 0x34010000:

```