### PR TITLE
make everything themeable

### DIFF
--- a/pwndbg/__init__.py
+++ b/pwndbg/__init__.py
@@ -121,16 +121,11 @@ __all__ = [
 'vmmap'
 ]
 
-prompt = "pwndbg> "
-prompt = "\x02" + prompt + "\x01" # STX + prompt + SOH
-prompt = pwndbg.color.red(prompt)
-prompt = pwndbg.color.bold(prompt)
-prompt = "\x01" + prompt + "\x02" # SOH + prompt + STX
+pwndbg.prompt.set_prompt()
 
 pre_commands = """
 set confirm off
 set verbose off
-set prompt %s
 set pagination off
 set height 0
 set history expansion on
@@ -145,7 +140,7 @@ handle SIGALRM nostop print nopass
 handle SIGBUS  stop   print nopass
 handle SIGPIPE nostop print nopass
 handle SIGSEGV stop   print nopass
-""".strip() % (prompt, pwndbg.ui.get_window_size()[1])
+""".strip() % (pwndbg.ui.get_window_size()[1])
 
 for line in pre_commands.strip().splitlines():
     gdb.execute(line)

--- a/pwndbg/android.py
+++ b/pwndbg/android.py
@@ -7,7 +7,7 @@ from __future__ import unicode_literals
 
 import gdb
 
-import pwndbg.color
+import pwndbg.color.message as message
 import pwndbg.events
 import pwndbg.file
 import pwndbg.memoize
@@ -32,7 +32,7 @@ def sysroot():
         if gdb.parameter('sysroot') == 'target:':
             gdb.execute(cmd)
         else:
-            print(pwndbg.color.bold("sysroot is already set, skipping %r" % cmd))
+            print(message.notice("sysroot is already set, skipping %r" % cmd))
 
 KNOWN_AIDS = {
 0: "AID_ROOT",

--- a/pwndbg/color/__init__.py
+++ b/pwndbg/color/__init__.py
@@ -73,3 +73,6 @@ def terminateWith(x, color):
 
 def ljust_colored(x, length, char=' '):
     return x + (length - len(strip(x))) * char
+
+def rjust_colored(x, length, char=' '):
+    return ((length - len(strip(x))) * char) + x

--- a/pwndbg/color/context.py
+++ b/pwndbg/color/context.py
@@ -15,6 +15,7 @@ config_flag_value_color         = theme.ColoredParameter('context-flag-value-col
 config_flag_bracket_color       = theme.ColoredParameter('context-flag-bracket-color', 'none', 'color for flags register (bracket)')
 config_flag_set_color           = theme.ColoredParameter('context-flag-set-color', 'green,bold', 'color for flags register (flag set)')
 config_flag_unset_color         = theme.ColoredParameter('context-flag-unset-color', 'red', 'color for flags register (flag unset)')
+config_flag_changed_color       = theme.ColoredParameter('context-flag-changed-color', 'underline', 'color for flags register (flag changed)')
 config_banner_color             = theme.ColoredParameter('banner-color', 'blue', 'color for banner line')
 config_register_changed_color   = theme.ColoredParameter('context-register-changed-color', 'normal', 'color for registers label (change marker)')
 config_register_changed_marker  = theme.Parameter('context-register-changed-marker', '*', 'change marker for registers label')
@@ -39,6 +40,9 @@ def flag_set(x):
 
 def flag_unset(x):
     return generateColorFunction(config.context_flag_unset_color)(x)
+
+def flag_changed(x):
+    return generateColorFunction(config.context_flag_changed_color)(x)
 
 def banner(x):
     return generateColorFunction(config.banner_color)(x)

--- a/pwndbg/color/context.py
+++ b/pwndbg/color/context.py
@@ -17,6 +17,7 @@ config_flag_set_color           = theme.ColoredParameter('context-flag-set-color
 config_flag_unset_color         = theme.ColoredParameter('context-flag-unset-color', 'red', 'color for flags register (flag unset)')
 config_flag_changed_color       = theme.ColoredParameter('context-flag-changed-color', 'underline', 'color for flags register (flag changed)')
 config_banner_color             = theme.ColoredParameter('banner-color', 'blue', 'color for banner line')
+config_banner_title             = theme.ColoredParameter('banner-title-color', 'none', 'color for banner title')
 config_register_changed_color   = theme.ColoredParameter('context-register-changed-color', 'normal', 'color for registers label (change marker)')
 config_register_changed_marker  = theme.Parameter('context-register-changed-marker', '*', 'change marker for registers label')
 
@@ -46,3 +47,6 @@ def flag_changed(x):
 
 def banner(x):
     return generateColorFunction(config.banner_color)(x)
+
+def banner_title(x):
+    return generateColorFunction(config.banner_title_color)(x)

--- a/pwndbg/color/disasm.py
+++ b/pwndbg/color/disasm.py
@@ -14,9 +14,8 @@ import pwndbg.color.theme as theme
 import pwndbg.config as config
 import pwndbg.disasm.jump
 from pwndbg.color import generateColorFunction
-from pwndbg.color import green
 from pwndbg.color import ljust_colored
-from pwndbg.color import red
+from pwndbg.color.message import on
 
 capstone_branch_groups = set((
     capstone.CS_GRP_CALL,
@@ -76,11 +75,11 @@ def instruction(ins):
     if is_branch:
         asm = asm.replace(ins.mnemonic, branch(ins.mnemonic), 1)
 
-    # If we know the conditional is taken, mark it as green.
+    # If we know the conditional is taken, mark it as taken.
     if ins.condition is None:
         asm = '  ' + asm
     elif ins.condition:
-        asm = green('✔ ') + asm
+        asm = on('✔ ') + asm
     else:
         asm = '  ' + asm
 

--- a/pwndbg/color/message.py
+++ b/pwndbg/color/message.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from pwndbg import config
+from pwndbg.color import generateColorFunction
+from pwndbg.color import theme
+
+config_status_on_color  = theme.ColoredParameter('message-status-on-color', 'green', 'color of on status messages')
+config_status_off_color = theme.ColoredParameter('message-status-off-color', 'red', 'color of off status messages')
+
+config_notice_color  = theme.ColoredParameter('message-notice-color', 'purple', 'color of notice messages')
+config_hint_color    = theme.ColoredParameter('message-hint-color', 'yellow', 'color of hint and marker messages')
+config_success_color = theme.ColoredParameter('message-success-color', 'green', 'color of success messages')
+config_warning_color = theme.ColoredParameter('message-warning-color', 'yellow', 'color of warning messages')
+config_error_color   = theme.ColoredParameter('message-error-color', 'red', 'color of error messages')
+config_system_color  = theme.ColoredParameter('message-system-color', 'light-red', 'color of system messages')
+
+config_exit_color       = theme.ColoredParameter('message-exit-color', 'red', 'color of exit messages')
+config_breakpoint_color = theme.ColoredParameter('message-breakpoint-color', 'yellow', 'color of breakpoint messages')
+config_signal_color     = theme.ColoredParameter('message-signal-color', 'bold,red', 'color of signal messages')
+
+config_prompt_color = theme.ColoredParameter('prompt-color', 'bold,red', 'prompt color')
+
+
+def on(msg):
+    return generateColorFunction(config.message_status_on_color)(msg)
+
+
+def off(msg):
+    return generateColorFunction(config.message_status_off_color)(msg)
+
+
+def notice(msg):
+    return generateColorFunction(config.message_notice_color)(msg)
+
+
+def hint(msg):
+    return generateColorFunction(config.message_hint_color)(msg)
+
+
+def success(msg):
+    return generateColorFunction(config.message_success_color)(msg)
+
+
+def warn(msg):
+    return generateColorFunction(config.message_warning_color)(msg)
+
+
+def error(msg):
+    return generateColorFunction(config.message_error_color)(msg)
+
+
+def system(msg):
+    return generateColorFunction(config.message_system_color)(msg)
+
+
+def exit(msg):
+    return generateColorFunction(config.message_exit_color)(msg)
+
+
+def breakpoint(msg):
+    return generateColorFunction(config.message_breakpoint_color)(msg)
+
+
+def signal(msg):
+    return generateColorFunction(config.message_signal_color)(msg)
+
+
+def prompt(msg):
+    return generateColorFunction(config.prompt_color)(msg)

--- a/pwndbg/commands/aslr.py
+++ b/pwndbg/commands/aslr.py
@@ -9,10 +9,10 @@ import argparse
 
 import gdb
 
-import pwndbg.color
 import pwndbg.commands
 import pwndbg.proc
 import pwndbg.vmmap
+from pwndbg.color import message
 
 options = {'on':'off', 'off':'on'}
 
@@ -35,9 +35,9 @@ def aslr(state=None):
             print("Change will take effect when the process restarts")
 
     aslr = pwndbg.vmmap.check_aslr()
-    status = pwndbg.color.red('OFF')
+    status = message.off('OFF')
 
     if aslr:
-        status = pwndbg.color.green('ON')
+        status = message.on('ON')
 
     print("ASLR is %s" % status)

--- a/pwndbg/commands/canary.py
+++ b/pwndbg/commands/canary.py
@@ -6,12 +6,12 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import pwndbg.auxv
-import pwndbg.color
 import pwndbg.commands
 import pwndbg.commands.telescope
 import pwndbg.memory
 import pwndbg.regs
 import pwndbg.search
+from pwndbg.color import message
 
 
 def canary_value():
@@ -34,20 +34,20 @@ def canary():
     global_canary, at_random = canary_value()
 
     if global_canary is None or at_random is None:
-        print("Couldn't find AT_RANDOM - can't display canary.")
+        print(message.error("Couldn't find AT_RANDOM - can't display canary."))
         return
 
-    print("AT_RANDOM = %#x # points to (not masked) global canary value" % at_random)
-    print("Canary    = 0x%x" % global_canary)
+    print(message.notice("AT_RANDOM = %#x # points to (not masked) global canary value" % at_random))
+    print(message.notice("Canary    = 0x%x" % global_canary))
 
     stack_canaries = list(
         pwndbg.search.search(pwndbg.arch.pack(global_canary), mappings=pwndbg.stack.stacks.values())
     )
 
     if not stack_canaries:
-        print(pwndbg.color.yellow('No valid canaries found on the stacks.'))
+        print(message.warn('No valid canaries found on the stacks.'))
         return
 
-    print(pwndbg.color.green('Found valid canaries on the stacks:'))
+    print(message.success('Found valid canaries on the stacks:'))
     for stack_canary in stack_canaries:
         pwndbg.commands.telescope.telescope(address=stack_canary, count=1)

--- a/pwndbg/commands/config.py
+++ b/pwndbg/commands/config.py
@@ -15,6 +15,7 @@ import pwndbg.config
 from pwndbg.color import light_yellow
 from pwndbg.color import ljust_colored
 from pwndbg.color import strip
+from pwndbg.color.message import hint
 
 
 def print_row(name, value, default, docstring, ljust_optname, ljust_value, empty_space=6):
@@ -45,9 +46,9 @@ def config():
     for v in sorted(values):
         print_row(v.optname, repr(v.value), repr(v.default), v.docstring, longest_optname, longest_value)
 
-    print(light_yellow('You can set config variable with `set <config-var> <value>`'))
-    print(light_yellow('You can generate configuration file using `configfile` '
-                       '- then put it in your .gdbinit after initializing pwndbg'))
+    print(hint('You can set config variable with `set <config-var> <value>`'))
+    print(hint('You can generate configuration file using `configfile` '
+               '- then put it in your .gdbinit after initializing pwndbg'))
 
 
 configfile_parser = argparse.ArgumentParser(description='Generates a configuration file for the current Pwndbg options')
@@ -78,11 +79,11 @@ def configfile_print_scope(scope, show_all=False):
 
     if params:
         if not show_all:
-            print(light_yellow('Showing only changed values:'))
+            print(hint('Showing only changed values:'))
         for p in params:
             print('# %s: %s' % (p.optname, p.docstring))
             print('# default: %s' % p.native_default)
             print('set %s %s' % (p.optname, p.native_value))
             print()
     else:
-        print(light_yellow('No changed values. To see current values use `%s`.' % scope))
+        print(hint('No changed values. To see current values use `%s`.' % scope))

--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -15,7 +15,6 @@ import pwndbg.color
 import pwndbg.color.backtrace as B
 import pwndbg.color.context as C
 import pwndbg.color.memory as M
-import pwndbg.color.theme as theme
 import pwndbg.commands
 import pwndbg.commands.nearpc
 import pwndbg.commands.telescope
@@ -27,6 +26,8 @@ import pwndbg.regs
 import pwndbg.symbol
 import pwndbg.ui
 import pwndbg.vmmap
+from pwndbg.color import message
+from pwndbg.color import theme
 
 
 def clear_screen():
@@ -104,7 +105,7 @@ def get_regs(*regs):
             continue
 
         if reg not in pwndbg.regs:
-            print("Unknown register: %r" % reg)
+            message.warn("Unknown register: %r" % reg)
             continue
 
         value = pwndbg.regs[reg]
@@ -135,7 +136,7 @@ def get_regs(*regs):
                     name = C.flag_unset(name)
 
                 if value & bit != last & bit:
-                    name = pwndbg.color.underline(name)
+                    name = C.flag_changed(name)
                 names.append(name)
 
             if names:
@@ -304,7 +305,7 @@ def save_signal(signal):
     if isinstance(signal, gdb.ExitedEvent):
         # Booooo old gdb
         if hasattr(signal, 'exit_code'):
-            result.append(pwndbg.color.red('Exited: %r' % signal.exit_code))
+            result.append(message.exit('Exited: %r' % signal.exit_code))
 
     elif isinstance(signal, gdb.SignalEvent):
         msg = 'Program received signal %s' % signal.stop_signal
@@ -314,13 +315,11 @@ def save_signal(signal):
                 msg += ' (fault address %#x)' % int(si_addr or 0)
             except gdb.error:
                 pass
-        msg = pwndbg.color.red(msg)
-        msg = pwndbg.color.bold(msg)
-        result.append(msg)
+        result.append(message.signal(msg))
 
     elif isinstance(signal, gdb.BreakpointEvent):
         for bkpt in signal.breakpoints:
-            result.append(pwndbg.color.yellow('Breakpoint %s' % (bkpt.location)))
+            result.append(message.breakpoint('Breakpoint %s' % (bkpt.location)))
 
 gdb.events.cont.connect(save_signal)
 gdb.events.stop.connect(save_signal)

--- a/pwndbg/commands/cpsr.py
+++ b/pwndbg/commands/cpsr.py
@@ -6,16 +6,17 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import pwndbg.arch
-import pwndbg.color
 import pwndbg.commands
 import pwndbg.regs
+from pwndbg.color import context
+from pwndbg.color import message
 
 
 @pwndbg.commands.ArgparsedCommand('Print out ARM CPSR register')
 @pwndbg.commands.OnlyWhenRunning
 def cpsr():
     if pwndbg.arch.current != 'arm':
-        print("This is only available on ARM")
+        print(message.warn("This is only available on ARM"))
         return
 
     cpsr = pwndbg.regs.cpsr
@@ -26,14 +27,13 @@ def cpsr():
     V = cpsr & (1 << 28)
     T = cpsr & (1 << 5)
 
-    bold = pwndbg.color.bold
-
     result = [
-        bold('N') if N else 'n',
-        bold('Z') if Z else 'z',
-        bold('C') if C else 'c',
-        bold('V') if V else 'v',
-        bold('T') if T else 't'
+        context.flag_set('N') if N else context.flag_unset('n'),
+        context.flag_set('Z') if Z else context.flag_unset('z'),
+        context.flag_set('C') if C else context.flag_unset('c'),
+        context.flag_set('V') if V else context.flag_unset('v'),
+        context.flag_set('T') if T else context.flag_unset('t')
     ]
 
-    print('cpsr %#x [ %s ]' % (cpsr, ' '.join(result)))
+    print('CPSR %s %s %s %s' % (context.flag_value('%#x' % cpsr),
+          context.flag_bracket('['), ' '.join(result), context.flag_bracket(']')))

--- a/pwndbg/commands/defcon.py
+++ b/pwndbg/commands/defcon.py
@@ -11,10 +11,7 @@ import pwndbg.commands
 import pwndbg.memory
 import pwndbg.symbol
 import pwndbg.vmmap
-from pwndbg.color import blue
-from pwndbg.color import bold
-from pwndbg.color import green
-from pwndbg.color import red
+from pwndbg.color import message
 
 
 @pwndbg.commands.Command
@@ -38,7 +35,7 @@ def defcon_heap(addr=0x2aaaaaad5000):
 
 
 def heap_freebins(addr=0x0602558):
-    print(bold('Linked List'))
+    print(message.notice('Linked List'))
 
     # addr = 0x0602558
     # addr = 0x060E360
@@ -81,12 +78,12 @@ def heap_allocations(addr, free):
         size   &= ~3
 
         if size > 0x1000:
-            print(red(bold("FOUND CORRUPTION OR END OF DATA")))
+            print(message.error("FOUND CORRUPTION OR END OF DATA"))
 
         data = ''
 
         if not in_use or addr in free:
-            print(blue(bold("%#016x - usersize=%#x - [FREE %i]" % (addr, size, flags))))
+            print(message.hint("%#016x - usersize=%#x - [FREE %i]" % (addr, size, flags)))
 
             linkedlist = (addr + 8 + size - 0x10) & pwndbg.arch.ptrmask
 
@@ -100,7 +97,7 @@ def heap_allocations(addr, free):
             print("    bk: %#x" % bk)
             print("    fd: %#x" % fd)
         else:
-            print(green(bold("%#016x - usersize=%#x" % (addr, size))))
+            print(message.notice("%#016x - usersize=%#x" % (addr, size)))
             pwndbg.commands.hexdump.hexdump(addr+8, size)
 
         addr += size + 8

--- a/pwndbg/commands/elf.py
+++ b/pwndbg/commands/elf.py
@@ -8,6 +8,7 @@ from __future__ import unicode_literals
 from elftools.elf.elffile import ELFFile
 
 import pwndbg.commands
+from pwndbg.color import message
 
 
 @pwndbg.commands.ArgparsedCommand('Prints the section mappings contained in the ELF header.')
@@ -66,13 +67,13 @@ def print_symbols_in_section(section_name, filter_text=''):
     start, end = get_section_bounds(section_name)
 
     if start is None:
-        print(pwndbg.color.red('Could not find section'))
+        print(message.error('Could not find section'))
         return
 
     symbols = get_symbols_in_region(start, end, filter_text)
 
     if not symbols:
-        print(pwndbg.color.red('No symbols found in section %s' % section_name))
+        print(message.error('No symbols found in section %s' % section_name))
 
     for symbol, addr in symbols:
         print(hex(int(addr)) + ': ' + symbol)

--- a/pwndbg/commands/got.py
+++ b/pwndbg/commands/got.py
@@ -14,9 +14,7 @@ import pwndbg.file
 import pwndbg.which
 import pwndbg.wrappers.checksec
 import pwndbg.wrappers.readelf
-from pwndbg.color import green
-from pwndbg.color import light_yellow
-from pwndbg.color import red
+from pwndbg.color import message
 
 parser = argparse.ArgumentParser(description='Show the state of the Global Offset Table')
 parser.add_argument('name_filter', help='Filter results by passed name.',
@@ -30,14 +28,19 @@ def got(name_filter=''):
     relro_status = pwndbg.wrappers.checksec.relro_status()
     pie_status = pwndbg.wrappers.checksec.pie_status()
     jmpslots = list(pwndbg.wrappers.readelf.get_jmpslots())
-
     if not len(jmpslots):
-        print(red("NO JUMP_SLOT entries available in the GOT"))
+        print(message.error("NO JUMP_SLOT entries available in the GOT"))
         return
+
     if "PIE enabled" in pie_status:
         bin_text_base = pwndbg.memory.page_align(pwndbg.elf.entry())
 
-    print("\nGOT protection: %s | GOT functions: %d\n " % (green(relro_status), len(jmpslots)))
+    relro_color = message.off
+    if 'Partial' in relro_status:
+        relro_color = message.warn
+    elif 'Full' in relro_status:
+        relro_color = message.on
+    print("\nGOT protection: %s | GOT functions: %d\n " % (relro_color(relro_status), len(jmpslots)))
 
     for line in jmpslots:
         address, info, rtype, value, name = line.split()[:5]
@@ -51,4 +54,4 @@ def got(name_filter=''):
             address_val = bin_text_base + address_val
 
         got_address = pwndbg.memory.pvoid(address_val)
-        print("[0x%x] %s -> %s" % (address_val, light_yellow(name), pwndbg.chain.format(got_address)))
+        print("[0x%x] %s -> %s" % (address_val, message.hint(name), pwndbg.chain.format(got_address)))

--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -10,13 +10,11 @@ import struct
 import gdb
 import six
 
+import pwndbg.color.context as C
 import pwndbg.color.memory as M
 import pwndbg.commands
 import pwndbg.typeinfo
-from pwndbg.color import bold
-from pwndbg.color import red
-from pwndbg.color import underline
-from pwndbg.color import yellow
+from pwndbg.color import message
 
 
 def read_chunk(addr):
@@ -47,10 +45,10 @@ def format_bin(bins, verbose=False):
         if isinstance(size, int):
             size = hex(size)
 
-        result.append((bold(size) + ': ').ljust(13) + formatted_chain)
+        result.append((message.hint(size) + ': ').ljust(13) + formatted_chain)
 
     if not result:
-        result.append(bold('empty'))
+        result.append(message.hint('empty'))
 
     return result
 
@@ -70,14 +68,14 @@ def heap(addr=None):
     heap_region = main_heap.get_region(addr)
 
     if heap_region is None:
-        print(red('Could not find the heap'))
+        print(message.error('Could not find the heap'))
         return
 
     top = main_arena['top']
     last_remainder = main_arena['last_remainder']
 
-    print(bold('Top Chunk: ') + M.get(top))
-    print(bold('Last Remainder: ') + M.get(last_remainder))
+    print(message.hint('Top Chunk: ') + M.get(top))
+    print(message.hint('Last Remainder: ') + M.get(last_remainder))
     print()
 
     # Print out all chunks on the heap
@@ -124,10 +122,10 @@ def arenas():
         
         h = heap.get_region(addr)
         if not h:
-            print(red('Could not find the heap'))
+            print(message.error('Could not find the heap'))
             return
 
-        hdr = bold(fmt%(hex(addr) if addr else 'main'))
+        hdr = message.hint(fmt % (hex(addr) if addr else 'main'))
         print(hdr, M.heap(str(h)))
         addr = int(arena['next'])        
         arena = heap.get_arena(addr)
@@ -157,7 +155,7 @@ def top_chunk(addr=None):
     if main_arena is None:
         heap_region = main_heap.get_region()
         if not heap_region:
-            print(red('Could not find the heap'))
+            print(message.error('Could not find the heap'))
             return
 
         heap_start = heap_region.vaddr
@@ -206,13 +204,13 @@ def malloc_chunk(addr):
     header = M.get(addr)
     if prev_inuse:
         if actual_size in fastbins:
-            header += yellow(' FASTBIN')
+            header += message.hint(' FASTBIN')
         else:
-            header += yellow(' PREV_INUSE')
+            header += message.hint(' PREV_INUSE')
     if is_mmapped:
-        header += yellow(' IS_MMAPED')
+        header += message.hint(' IS_MMAPED')
     if non_main_arena:
-        header += yellow(' NON_MAIN_ARENA')
+        header += message.hint(' NON_MAIN_ARENA')
     print(header, chunk["value"])
 
     return chunk
@@ -244,7 +242,7 @@ def fastbins(addr=None, verbose=True):
 
     formatted_bins = format_bin(fastbins, verbose)
 
-    print(underline(yellow('fastbins')))
+    print(C.banner('fastbins'))
     for node in formatted_bins:
         print(node)
 
@@ -263,7 +261,7 @@ def unsortedbin(addr=None, verbose=True):
 
     formatted_bins = format_bin(unsortedbin, verbose)
 
-    print(underline(yellow('unsortedbin')))
+    print(C.banner('unsortedbin'))
     for node in formatted_bins:
         print(node)
 
@@ -282,7 +280,7 @@ def smallbins(addr=None, verbose=False):
 
     formatted_bins = format_bin(smallbins, verbose)
 
-    print(underline(yellow('smallbins')))
+    print(C.banner('smallbins'))
     for node in formatted_bins:
         print(node)
 
@@ -301,7 +299,7 @@ def largebins(addr=None, verbose=False):
 
     formatted_bins = format_bin(largebins, verbose)
 
-    print(underline(yellow('largebins')))
+    print(C.banner('largebins'))
     for node in formatted_bins:
         print(node)
 
@@ -327,7 +325,7 @@ def find_fake_fast(addr, size):
         8: 'Q'
     }[pwndbg.arch.ptrsize]
 
-    print(red("FAKE CHUNKS"))
+    print(C.banner("FAKE CHUNKS"))
     for offset in range(max_fast - pwndbg.arch.ptrsize):
         candidate = mem[offset:offset + pwndbg.arch.ptrsize]
         if len(candidate) == pwndbg.arch.ptrsize:

--- a/pwndbg/commands/nearpc.py
+++ b/pwndbg/commands/nearpc.py
@@ -25,6 +25,7 @@ import pwndbg.strings
 import pwndbg.symbol
 import pwndbg.ui
 import pwndbg.vmmap
+from pwndbg.color import message
 
 
 def ljust_padding(lst):
@@ -63,7 +64,7 @@ def nearpc(pc=None, lines=None, to_string=False, emulate=False):
 
     # Check whether we can even read this address
     if not pwndbg.memory.peek(pc):
-        result.append(pwndbg.color.red('Invalid address %#x' % pc))
+        result.append(message.error('Invalid address %#x' % pc))
 
     # # Load source data if it's available
     # pc_to_linenos = collections.defaultdict(lambda: [])
@@ -83,7 +84,7 @@ def nearpc(pc=None, lines=None, to_string=False, emulate=False):
     instructions = pwndbg.disasm.near(pc, lines, emulate=emulate)
 
     if pwndbg.memory.peek(pc) and not instructions:
-        result.append(pwndbg.color.red('Invalid instructions at %#x' % pc))
+        result.append(message.error('Invalid instructions at %#x' % pc))
 
     # In case $pc is in a new map we don't know about,
     # this will trigger an exploratory search.

--- a/pwndbg/commands/search.py
+++ b/pwndbg/commands/search.py
@@ -12,13 +12,13 @@ import os
 import struct
 
 import pwndbg.arch
-import pwndbg.color
 import pwndbg.color.memory as M
 import pwndbg.commands
 import pwndbg.config
 import pwndbg.enhance
 import pwndbg.search
 import pwndbg.vmmap
+from pwndbg.color import message
 
 saved = set()
 
@@ -140,7 +140,7 @@ def search(type, hex, string, executable, writable, value, mapping_name, save, n
         mappings = [m for m in mappings if mapping_name in m.objfile]
 
     if not mappings:
-        print(pwndbg.color.red("Could not find mapping %r" % mapping_name))
+        print(message.error("Could not find mapping %r" % mapping_name))
         return
 
     # Prep the saved set if necessary

--- a/pwndbg/commands/theme.py
+++ b/pwndbg/commands/theme.py
@@ -14,7 +14,7 @@ import pwndbg.color.theme
 import pwndbg.commands
 import pwndbg.config
 from pwndbg.color import generateColorFunction
-from pwndbg.color import light_yellow
+from pwndbg.color.message import hint
 from pwndbg.commands.config import extend_value_with_default
 from pwndbg.commands.config import print_row
 
@@ -40,6 +40,6 @@ def theme():
             default = repr(v.default)
         print_row(v.optname, value, default, v.docstring, longest_optname, longest_value)
 
-    print(light_yellow('You can set theme variable with `set <theme-var> <value>`'))
-    print(light_yellow('You can generate theme config file using `themefile` '
-                       '- then put it in your .gdbinit after initializing pwndbg'))
+    print(hint('You can set theme variable with `set <theme-var> <value>`'))
+    print(hint('You can generate theme config file using `themefile` '
+               '- then put it in your .gdbinit after initializing pwndbg'))

--- a/pwndbg/commands/version.py
+++ b/pwndbg/commands/version.py
@@ -14,8 +14,8 @@ import sys
 import gdb
 
 import pwndbg
-import pwndbg.color
 import pwndbg.commands
+from pwndbg.color import message
 
 
 def _gdb_version():
@@ -54,4 +54,4 @@ def version():
     capstone_str = 'Capstone: %s' % capstone_version()
     unicorn_str  = 'Unicorn:  %s' % unicorn_version()
 
-    print('\n'.join(map(pwndbg.color.light_red, (gdb_str, py_str, pwndbg_str, capstone_str, unicorn_str))))
+    print('\n'.join(map(message.system, (gdb_str, py_str, pwndbg_str, capstone_str, unicorn_str))))

--- a/pwndbg/exception.py
+++ b/pwndbg/exception.py
@@ -12,7 +12,7 @@ import traceback
 
 import gdb
 
-import pwndbg.color
+import pwndbg.color.message as message
 import pwndbg.config
 import pwndbg.memoize
 import pwndbg.stdio
@@ -32,7 +32,7 @@ def inform_report_issue(exception_msg):
     Informs user that he can report an issue.
     The use of `memoize` makes it reporting only once for a given exception message.
     """
-    print(pwndbg.color.purple(
+    print(message.notice(
         'If that is an issue, you can report it on https://github.com/pwndbg/pwndbg/issues\n'
         "(Please don't forget to search if it hasn't been reported before)\n"
         "PS: Pull requests are welcome")
@@ -56,11 +56,11 @@ def handle(name='Error'):
     else:
         exc_type, exc_value, exc_traceback = sys.exc_info()
 
-        print(pwndbg.color.red('Exception occured: {}: {} ({})'.format(name, exc_value, exc_type)))
+        print(message.error('Exception occured: {}: {} ({})'.format(name, exc_value, exc_type)))
 
-        print(pwndbg.color.purple('For more info invoke `') +
-              pwndbg.color.yellow('set exception-verbose on') +
-              pwndbg.color.purple('` and rerun the command'))
+        print(message.notice('For more info invoke `') +
+              message.hint('set exception-verbose on') +
+              message.notice('` and rerun the command'))
 
     # Break into the interactive debugger
     if debug:

--- a/pwndbg/heap/ptmalloc.py
+++ b/pwndbg/heap/ptmalloc.py
@@ -11,8 +11,7 @@ import gdb
 
 import pwndbg.events
 import pwndbg.typeinfo
-from pwndbg.color import bold
-from pwndbg.color import red
+from pwndbg.color.message import message
 from pwndbg.constants import ptmalloc
 from pwndbg.heap import heap_chain_limit
 
@@ -37,8 +36,8 @@ class Heap(pwndbg.heap.heap.BaseHeap):
         if main_arena_addr is not None:
             self._main_arena = pwndbg.memory.poi(self.malloc_state, main_arena_addr)
         else:
-            print(bold(red('Symbol \'main arena\' not found. Try installing libc '
-                           'debugging symbols and try again.')))
+            print(message.error('Symbol \'main arena\' not found. Try installing libc '
+                                'debugging symbols and try again.'))
 
         return self._main_arena
 

--- a/pwndbg/ida.py
+++ b/pwndbg/ida.py
@@ -19,7 +19,6 @@ import traceback
 import gdb
 
 import pwndbg.arch
-import pwndbg.color
 import pwndbg.compat
 import pwndbg.config
 import pwndbg.elf
@@ -27,6 +26,7 @@ import pwndbg.events
 import pwndbg.memoize
 import pwndbg.memory
 import pwndbg.regs
+from pwndbg.color import message
 
 try:
     import xmlrpc.client as xmlrpclib
@@ -61,7 +61,7 @@ def init_ida_rpc_client():
     exception = None # (type, value, traceback)
     try:
         _ida.here()
-        print(pwndbg.color.green("Pwndbg successfully connected to Ida Pro xmlrpc: %s" % addr))
+        print(message.success("Pwndbg successfully connected to Ida Pro xmlrpc: %s" % addr))
     except socket.error as e:
         if e.errno != errno.ECONNREFUSED:
             exception = sys.exc_info()
@@ -75,7 +75,7 @@ def init_ida_rpc_client():
 
     if exception:
         if not isinstance(_ida_last_exception, exception[0]) or _ida_last_exception.args != exception[1].args:
-            print(pwndbg.color.yellow("[!] Ida Pro xmlrpc error"))
+            print(message.error("[!] Ida Pro xmlrpc error"))
             traceback.print_exception(*exception)
 
     _ida_last_exception = exception and exception[1]

--- a/pwndbg/next.py
+++ b/pwndbg/next.py
@@ -16,7 +16,7 @@ import gdb
 
 import pwndbg.disasm
 import pwndbg.regs
-from pwndbg.color import red
+from pwndbg.color import message
 
 jumps = set((
     capstone.CS_GRP_CALL,
@@ -131,7 +131,7 @@ def break_on_program_code():
     end = mp.end
 
     if start <= pwndbg.regs.pc < end:
-        print(red('The pc is already at the binary objfile code. Not stepping.'))
+        print(message.error('The pc is already at the binary objfile code. Not stepping.'))
         return False
 
     while pwndbg.proc.alive:

--- a/pwndbg/prompt.py
+++ b/pwndbg/prompt.py
@@ -7,20 +7,20 @@ from __future__ import unicode_literals
 
 import gdb
 
-import pwndbg.color as C
 import pwndbg.events
 import pwndbg.gdbutils
 import pwndbg.memoize
+from pwndbg.color import message
 
-funcs_list_str = ', '.join(C.purple('$' + f.name) for f in pwndbg.gdbutils.functions.functions)
+funcs_list_str = ', '.join(message.notice('$' + f.name) for f in pwndbg.gdbutils.functions.functions)
 
 hint_lines = (
-    'loaded %i commands. Type %s for a list.' % (len(pwndbg.commands.commands), C.purple('pwndbg [filter]')),
+    'loaded %i commands. Type %s for a list.' % (len(pwndbg.commands.commands), message.notice('pwndbg [filter]')),
     'created %s gdb functions (can be used with print/break)' % funcs_list_str
 )
 
 for line in hint_lines:
-    print(C.light_red(pwndbg.color.bold('pwndbg: ') + line))
+    print(message.prompt('pwndbg: ') + message.system(line))
 
 cur = (gdb.selected_inferior(), gdb.selected_thread())
 
@@ -42,6 +42,13 @@ def prompt_hook_on_stop(*a):
     pwndbg.commands.context.context()
 
 
+@pwndbg.config.Trigger([message.config_prompt_color])
+def set_prompt():
+    prompt = "pwndbg> "
+    prompt = "\x02" + prompt + "\x01"  # STX + prompt + SOH
+    prompt = message.prompt(prompt)
+    prompt = "\x01" + prompt + "\x02"  # SOH + prompt + STX
+    gdb.execute('set prompt %s' % prompt)
 
 
 gdb.prompt_hook = prompt_hook

--- a/pwndbg/ui.py
+++ b/pwndbg/ui.py
@@ -18,6 +18,9 @@ import pwndbg.arch
 import pwndbg.color.context as C
 import pwndbg.color.theme as theme
 import pwndbg.config as config
+from pwndbg.color import ljust_colored
+from pwndbg.color import rjust_colored
+from pwndbg.color import strip
 
 theme.Parameter('banner-separator', '─', 'repeated banner separator character')
 

--- a/pwndbg/ui.py
+++ b/pwndbg/ui.py
@@ -16,19 +16,41 @@ import termios
 
 import pwndbg.arch
 import pwndbg.color.context as C
-import pwndbg.color.theme as theme
-import pwndbg.config as config
+from pwndbg import config
 from pwndbg.color import ljust_colored
+from pwndbg.color import message
 from pwndbg.color import rjust_colored
 from pwndbg.color import strip
+from pwndbg.color import theme
 
 theme.Parameter('banner-separator', '─', 'repeated banner separator character')
+theme.Parameter('banner-title-surrounding-left', '[ ', 'banner title surrounding char (left side)')
+theme.Parameter('banner-title-surrounding-right', ' ]', 'banner title surrounding char (right side)')
+title_position = theme.Parameter('banner-title-position', 'center', 'banner title position')
+
+
+@pwndbg.config.Trigger([title_position])
+def check_title_position():
+    valid_values = ['center', 'left', 'right']
+    if str(title_position) not in valid_values:
+        print(message.warn('Invalid title position: %s, must be one of: %s' %
+              (title_position.value, ', '.join(valid_values))))
+        title_position.value = title_position.default
+
 
 def banner(title):
     title = title.upper()
     _height, width = get_window_size()
-    width -= 2
-    return C.banner(("[{:%s^%ss}]" % (config.banner_separator, width)).format(title))
+    title = '%s%s%s' % (config.banner_title_surrounding_left, C.banner_title(title), config.banner_title_surrounding_right)
+    position = str(title_position)
+    if 'left' == position:
+        banner = ljust_colored(title, width, str(config.banner_separator))
+    elif 'right' == position:
+        banner = rjust_colored(title, width, str(config.banner_separator))
+    else:
+        banner = rjust_colored(title, (width + len(strip(title))) // 2, str(config.banner_separator))
+        banner = ljust_colored(banner, width, str(config.banner_separator))
+    return C.banner(banner)
 
 def addrsz(address):
     address = int(address) & pwndbg.arch.ptrmask


### PR DESCRIPTION
This makes it posssible to theme everything logically grouped by
message types. This will also make it easier for future features
to keep a consistent way of coloring plus make every non-specific
coloring themeable automatically.

Direct explicit usage of colors should be avoided in future commits.