### PR TITLE
Fix inthook for enums in Python 3

### DIFF
--- a/pwndbg/inthook.py
+++ b/pwndbg/inthook.py
@@ -10,6 +10,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import enum
 import os
 
 import gdb
@@ -47,7 +48,10 @@ class xint(with_metaclass(IsAnInt, builtins.int)):
             if symbol.is_function:
                 value = value.cast(pwndbg.typeinfo.ulong)
 
-        elif not isinstance(value, six.string_types) and not isinstance(value, six.integer_types):
+        elif not isinstance(value, (six.string_types, six.integer_types)) \
+                or isinstance(cls, enum.EnumMeta):
+            # without check for EnumMeta math operations with enums were failing e.g.:
+            #     pwndbg> py import re; flags = 1 | re.MULTILINE
             return _int.__new__(cls, value, *a, **kw)
 
         return _int(_int(value, *a, **kw))
@@ -56,7 +60,6 @@ class xint(with_metaclass(IsAnInt, builtins.int)):
 if os.environ.get('SPHINX', None) is None:
     builtins.int = xint
     globals()['int'] = xint
-
     if pwndbg.compat.python3:
         builtins.long = xint
         globals()['long'] = xint


### PR DESCRIPTION
Fixes the problem that can be observed below:

```
pwndbg> py import re; flags = 1 | re.MULTILINE
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/usr/lib/python3.6/enum.py", line 798, in __or__
    result = self.__class__(self._value_ | self.__class__(other)._value_)
  File "/usr/lib/python3.6/enum.py", line 291, in __call__
    return cls.__new__(cls, value)
  File "/usr/lib/python3.6/enum.py", line 533, in __new__
    return cls._missing_(value)
  File "/usr/lib/python3.6/enum.py", line 762, in _missing_
    new_member = cls._create_pseudo_member_(value)
  File "/usr/lib/python3.6/enum.py", line 788, in _create_pseudo_member_
    pseudo_member._name_ = None
AttributeError: 'int' object has no attribute '_name_'
```