### PR TITLE
improve repeat functionality of commands

### DIFF
--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -44,6 +44,8 @@ class Command(gdb.Command):
         functools.update_wrapper(self, function)
         self.__doc__ = function.__doc__
 
+        self.repeat = False
+
     def split_args(self, argument):
         """Split a command-line string from the user into arguments.
 

--- a/pwndbg/commands/hexdump.py
+++ b/pwndbg/commands/hexdump.py
@@ -36,6 +36,9 @@ def hexdump(address=None, count=pwndbg.config.hexdump_bytes):
 
     if hexdump.repeat:
         address = hexdump.last_address
+        hexdump.offset += 1
+    else:
+        hexdump.offset = 0
 
     address = int(address)
     address &= pwndbg.arch.ptrmask
@@ -52,7 +55,9 @@ def hexdump(address=None, count=pwndbg.config.hexdump_bytes):
         print(e)
         return
 
-    for line in pwndbg.hexdump.hexdump(data, address=address, width=width):
+    for i, line in enumerate(pwndbg.hexdump.hexdump(data, address=address, width=width, offset=hexdump.offset)):
         print(line)
+    hexdump.offset += i
 
 hexdump.last_address = 0
+hexdump.offset = 0

--- a/pwndbg/commands/nearpc.py
+++ b/pwndbg/commands/nearpc.py
@@ -45,6 +45,10 @@ def nearpc(pc=None, lines=None, to_string=False, emulate=False):
     """
     Disassemble near a specified address.
     """
+
+    if nearpc.repeat:
+        pc = nearpc.last_pc
+
     result = []
 
     # Fix the case where we only have one argument, and
@@ -93,6 +97,8 @@ def nearpc(pc=None, lines=None, to_string=False, emulate=False):
     # Gather all addresses and symbols for each instruction
     symbols = [pwndbg.symbol.get(i.address) for i in instructions]
     addresses = ['%#x' % i.address for i in instructions]
+
+    nearpc.last_pc = instructions[-1].address if instructions else 0
 
     # Format the symbol name for each instruction
     symbols = ['<%s> ' % sym if sym else '' for sym in symbols]
@@ -171,6 +177,7 @@ def emulate(pc=None, lines=None, to_string=False, emulate=True):
     """
     Like nearpc, but will emulate instructions from the current $PC forward.
     """
+    nearpc.repeat = emulate.repeat
     return nearpc(pc, lines, to_string, emulate)
 
 @pwndbg.commands.ParsedCommand
@@ -179,4 +186,8 @@ def pdisass(pc=None, lines=None):
     """
     Compatibility layer for PEDA's pdisass command
     """
+    nearpc.repeat = pdisass.repeat
     return nearpc(pc, lines, False, False)
+
+
+nearpc.last_pc = 0

--- a/pwndbg/hexdump.py
+++ b/pwndbg/hexdump.py
@@ -53,7 +53,7 @@ def load_color_scheme():
     color_scheme[-1] = '  '
     printable[-1] = ' '
 
-def hexdump(data, address = 0, width = 16, skip = True):
+def hexdump(data, address = 0, width = 16, skip = True, offset = 0):
     if not color_scheme or not printable:
         load_color_scheme()
     data = list(bytearray(data))
@@ -73,9 +73,9 @@ def hexdump(data, address = 0, width = 16, skip = True):
         hexline = []
 
         if address:
-            hexline.append(H.offset("+%04x " % (i*width)))
+            hexline.append(H.offset("+%04x " % ((i + offset) * width)))
 
-        hexline.append(H.address("%#08x  " % (base + (i*width))))
+        hexline.append(H.address("%#08x  " % (base + (i * width))))
 
         for group in groupby(line, 4):
             for char in group:
@@ -89,8 +89,11 @@ def hexdump(data, address = 0, width = 16, skip = True):
                 hexline.append(printable[char])
             hexline.append(H.separator('%s' % config_separator))
 
-
         yield(''.join(hexline))
+
+    # skip empty fooder if we printed something
+    if last_line:
+        return
 
     hexline = []
 

--- a/pwndbg/hexdump.py
+++ b/pwndbg/hexdump.py
@@ -91,7 +91,7 @@ def hexdump(data, address = 0, width = 16, skip = True, offset = 0):
 
         yield(''.join(hexline))
 
-    # skip empty fooder if we printed something
+    # skip empty footer if we printed something
     if last_line:
         return
 


### PR DESCRIPTION
hexdump: adjust shown offset from src while repeating

nearpc: make command repeatable to show further instructions

The pc gets adjusted to the last instructions address making it
visually easy to follow where to continue reading the assembly.

This also forwards repeating of emulate() and pdisass()

telescope: make command repeatable with adjusted offset from src

This also forwards stack() to be repeatable.