### PR TITLE
context: bring back args section (default off)

### DIFF
--- a/pwndbg/arguments.py
+++ b/pwndbg/arguments.py
@@ -15,6 +15,8 @@ from capstone import CS_GRP_INT
 
 import pwndbg.abi
 import pwndbg.arch
+import pwndbg.chain
+import pwndbg.color.nearpc as N
 import pwndbg.constants
 import pwndbg.disasm
 import pwndbg.funcparser
@@ -192,3 +194,12 @@ def arguments(abi=None):
 
     for i in range(len(regs)):
         yield argname(i, abi), argument(i, abi)
+
+
+def format_args(instruction):
+    result = []
+    for arg, value in get(instruction):
+        code   = arg.type != 'char'
+        pretty = pwndbg.chain.format(value, code=code)
+        result.append('%-10s %s' % (N.argument(arg.name) + ':', pretty))
+    return result

--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -278,22 +278,17 @@ def context_backtrace(frame_count=10, with_banner=True):
     return result
 
 
-def context_args():
-    result = []
+def context_args(with_banner=True):
+    args = pwndbg.arguments.format_args(pwndbg.disasm.one())
 
-    ##################################################
-    # DISABLED FOR NOW, I LIKE INLINE DISPLAY BETTER
-    ##################################################
-    # # For call instructions, attempt to resolve the target and
-    # # determine the number of arguments.
-    # for arg, value in pwndbg.arguments.arguments(pwndbg.disasm.one()):
-    #     code   = False if arg.type == 'char' else True
-    #     pretty = pwndbg.chain.format(value, code=code)
-    #     result.append('%-10s %s' % (arg.name+':', pretty))
-    # if not result:
-    #         return []
-    # result.insert(0, pwndbg.ui.banner("arguments"))
-    return result
+    # early exit to skip section if no arg found
+    if not args:
+        return []
+
+    if with_banner:
+        args.insert(0, pwndbg.ui.banner("arguments"))
+
+    return args
 
 last_signal = []
 
@@ -333,6 +328,7 @@ def context_signal():
 context_sections = {
     'r': context_regs,
     'd': context_disasm,
+    'a': context_args,
     'c': context_code,
     's': context_stack,
     'b': context_backtrace

--- a/pwndbg/commands/nearpc.py
+++ b/pwndbg/commands/nearpc.py
@@ -38,6 +38,7 @@ pwndbg.color.theme.Parameter('highlight-pc', True, 'whether to highlight the cur
 pwndbg.color.theme.Parameter('nearpc-prefix', '►', 'prefix marker for nearpc command')
 pwndbg.config.Parameter('left-pad-disasm', True, 'whether to left-pad disassembly')
 nearpc_lines = pwndbg.config.Parameter('nearpc-lines', 10, 'number of additional lines to print for the nearpc command')
+show_args = pwndbg.config.Parameter('nearpc-show-args', True, 'show call arguments below instruction')
 
 @pwndbg.commands.ParsedCommand
 @pwndbg.commands.OnlyWhenRunning
@@ -152,10 +153,8 @@ def nearpc(pc=None, lines=None, to_string=False, emulate=False):
 
         # For call instructions, attempt to resolve the target and
         # determine the number of arguments.
-        for arg, value in pwndbg.arguments.get(i):
-            code   = False if arg.type == 'char' else True
-            pretty = pwndbg.chain.format(value, code=code)
-            result.append('%8s%-10s %s' % ('', N.argument(arg.name) + ':', pretty))
+        if show_args.value:
+            result.extend(['%8s%s' % ('', arg) for arg in pwndbg.arguments.format_args(instruction=i)])
 
         prev = i
 


### PR DESCRIPTION
This allows to use args section via the context-sections config
setting (default off).
Additionally introduce a nearpc-show-args config value making it
possible to disable showing it trice while using the args section.