### PR TITLE
Fix Parameter config class

### DIFF
--- a/pwndbg/color/__init__.py
+++ b/pwndbg/color/__init__.py
@@ -7,8 +7,6 @@ from __future__ import unicode_literals
 
 import re
 
-import six
-
 import pwndbg.memoize
 
 NORMAL         = "\x1b[0m"
@@ -74,17 +72,9 @@ def terminateWith(x, color):
     return re.sub('\x1b\\[0m', NORMAL + color, x)
 
 def ljust_colored(x, length, char=' '):
-    # TODO: workaround until issue #404
-    if six.PY2:
-        x = x if isinstance(x, six.text_type) else x.decode('utf8')
-        char = char if isinstance(char, six.text_type) else char.decode('utf8')
     remaining = length - len(strip(x))
     return x + ((remaining // len(char) + 1) * char)[:remaining]
 
 def rjust_colored(x, length, char=' '):
-    # TODO: workaround until issue #404
-    if six.PY2:
-        x = x if isinstance(x, six.text_type) else x.decode('utf8')
-        char = char if isinstance(char, six.text_type) else char.decode('utf8')
     remaining = length - len(strip(x))
     return ((remaining // len(char) + 1) * char)[:remaining] + x

--- a/pwndbg/color/__init__.py
+++ b/pwndbg/color/__init__.py
@@ -61,7 +61,7 @@ def generateColorFunctionInner(old, new):
 
 def generateColorFunction(config):
     function = lambda x: x
-    for color in str(config).split(','):
+    for color in config.split(','):
         function = generateColorFunctionInner(function, globals()[color.lower().replace('-', '_')])
     return function
 

--- a/pwndbg/color/syntax_highlight.py
+++ b/pwndbg/color/syntax_highlight.py
@@ -34,9 +34,8 @@ def check_style():
             style=str(style)
         )
     except pygments.util.ClassNotFound:
-        msg = message.warn("The pygment formatter style '%s' is not found, restore to default" % style)
-        print(msg)
-        style.value = style.default
+        print(message.warn("The pygment formatter style '%s' is not found, restore to default" % style))
+        style.revert_default()
 
 
 def syntax_highlight(code, filename='.asm'):

--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -60,7 +60,7 @@ def validate_context_sections():
         if section not in valid_values:
             print(message.warn("Invalid section: %s, valid values: %s" % (section, ', '.join(valid_values))))
             print(message.warn("(setting none of them like '' will make sections not appear)"))
-            config_context_sections.value = config_context_sections.default
+            config_context_sections.revert_default()
             return
 
 
@@ -240,17 +240,8 @@ def context_code():
         source = source[start:end]
 
         # Compute the prefix_sign length
-        # TODO: remove this if the config setter can make sure everything is unicode.
-        # This is needed because the config value may be utf8 byte string.
-        # It is better to convert to unicode at setter of config and then we will not need this.
         prefix_sign = pwndbg.config.code_prefix
-        value = prefix_sign.value
-        if isinstance(value, bytes):
-            value = codecs.decode(value, 'utf-8')
-        prefix_width = len(value)
-
-        # Convert config class to str to make format() work
-        prefix_sign = str(prefix_sign)
+        prefix_width = len(prefix_sign)
 
         # Format the output
         formatted_source = []

--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -51,7 +51,7 @@ def validate_context_sections():
 
     # If someone tries to set an empty string, we let to do that informing about possible values
     # (so that it is possible to have no context at all)
-    if not config_context_sections.value or config_context_sections.value.lower() in ('""', "''", 'none', 'empty'):
+    if not config_context_sections.value or config_context_sections.value.lower() in ('none', 'empty'):
         config_context_sections.value = ''
         print(message.warn("Sections set to be empty. FYI valid values are: %s" % ', '.join(valid_values)))
         return

--- a/pwndbg/commands/nearpc.py
+++ b/pwndbg/commands/nearpc.py
@@ -116,14 +116,11 @@ def nearpc(pc=None, lines=None, to_string=False, emulate=False):
     # Print out each instruction
     for address_str, symbol, instr in zip(addresses, symbols, instructions):
         asm    = D.instruction(instr)
-        value  = pwndbg.config.nearpc_prefix.value
-
-        if isinstance(value, bytes):
-            value = codecs.decode(value, 'utf-8')
+        prefix_sign  = pwndbg.config.nearpc_prefix
 
         # Show prefix only on the specified address and don't show it while in repeat-mode
         show_prefix = instr.address == pc and not nearpc.repeat
-        prefix = ' %s' % (pwndbg.config.nearpc_prefix if show_prefix else ' ' * len(value))
+        prefix = ' %s' % (prefix_sign if show_prefix else ' ' * len(prefix_sign))
         prefix = N.prefix(prefix)
 
         pre = pwndbg.ida.Anterior(instr.address)
@@ -163,7 +160,7 @@ def nearpc(pc=None, lines=None, to_string=False, emulate=False):
 
         # For call instructions, attempt to resolve the target and
         # determine the number of arguments.
-        if show_args.value:
+        if show_args:
             result.extend(['%8s%s' % ('', arg) for arg in pwndbg.arguments.format_args(instruction=instr)])
 
         prev = instr

--- a/pwndbg/config.py
+++ b/pwndbg/config.py
@@ -163,8 +163,15 @@ class Parameter(gdb.Parameter):
     def get_show_string(self, svalue):
         return 'Sets %s (currently: %r)' % (self.docstring, self.value)
 
-    def split(self):
-        return str(self).replace(',', ' ').split()
+    def revert_default(self):
+        self.value = self.default
+
+    # TODO: use __getattribute__ to remapping all member function to self.value's member?
+    # Then, we can use param.member() just like param.value.member()
+
+    # The str type member function, used in color/__init__.py
+    def split(self, *args, **kargs):
+        return str(self).split(*args, **kargs)
 
     def __int__(self):
         return int(self.value)

--- a/pwndbg/config.py
+++ b/pwndbg/config.py
@@ -24,6 +24,7 @@ from __future__ import unicode_literals
 
 import codecs
 import collections
+import re
 import sys
 import types
 from functools import total_ordering
@@ -152,7 +153,11 @@ class Parameter(gdb.Parameter):
 
         # Remove surrounded ' and " characters
         if isinstance(value, six.string_types):
-            value = value.strip("\"\'")
+            # The first character must be ' or " and ends with the same character.
+            # See PR #404 for more information
+            pattern = r"^(?P<quote>[\"'])(?P<content>.*?)(?P=quote)$"
+
+            value = re.sub(pattern, r"\g<content>", value)
 
         # Write back to self.value
         self.value = value

--- a/pwndbg/config.py
+++ b/pwndbg/config.py
@@ -37,15 +37,15 @@ TYPES[bool] = gdb.PARAM_BOOLEAN
 
 # The value is an integer.
 # This is like PARAM_INTEGER, except 0 is interpreted as itself.
-for type in six.integer_types:
-    TYPES[type] = gdb.PARAM_ZINTEGER
+for typ in six.integer_types:
+    TYPES[typ] = gdb.PARAM_ZINTEGER
 
 # The value is a string.
 # When the user modifies the string, any escape sequences,
 # such as ‘\t’, ‘\f’, and octal escapes, are translated into
 # corresponding characters and encoded into the current host charset.
-for type in six.string_types:
-    TYPES[type] = gdb.PARAM_STRING
+for typ in six.string_types:
+    TYPES[typ] = gdb.PARAM_STRING
 
 triggers = collections.defaultdict(lambda: [])
 

--- a/pwndbg/ui.py
+++ b/pwndbg/ui.py
@@ -32,24 +32,23 @@ title_position = theme.Parameter('banner-title-position', 'center', 'banner titl
 @pwndbg.config.Trigger([title_position])
 def check_title_position():
     valid_values = ['center', 'left', 'right']
-    if str(title_position) not in valid_values:
+    if title_position not in valid_values:
         print(message.warn('Invalid title position: %s, must be one of: %s' %
-              (title_position.value, ', '.join(valid_values))))
-        title_position.value = title_position.default
+              (title_position, ', '.join(valid_values))))
+        title_position.revert_default()
 
 
 def banner(title):
     title = title.upper()
     _height, width = get_window_size()
     title = '%s%s%s' % (config.banner_title_surrounding_left, C.banner_title(title), config.banner_title_surrounding_right)
-    position = str(title_position)
-    if 'left' == position:
-        banner = ljust_colored(title, width, str(config.banner_separator))
-    elif 'right' == position:
-        banner = rjust_colored(title, width, str(config.banner_separator))
+    if 'left' == title_position:
+        banner = ljust_colored(title, width, config.banner_separator)
+    elif 'right' == title_position:
+        banner = rjust_colored(title, width, config.banner_separator)
     else:
-        banner = rjust_colored(title, (width + len(strip(title))) // 2, str(config.banner_separator))
-        banner = ljust_colored(banner, width, str(config.banner_separator))
+        banner = rjust_colored(title, (width + len(strip(title))) // 2, config.banner_separator)
+        banner = ljust_colored(banner, width, config.banner_separator)
     return C.banner(banner)
 
 def addrsz(address):


### PR DESCRIPTION
For issue #398.

For 1, Not sure why the format string will not work in origin environment. Since I tested the class which support `__str__` can work with `%s` like the following.
```
class A:
    def __init__(self):
        self.value = 'meow'
    def __str__(self):
        return str(self.value)
a = A()
print('%s' % a)
```
Currently it works perfectly now, so I won't implement `__format__`.

For 2, see fcab5d3.
I remap the member name using `__setattr__` and `__getattribute__`. The gdb python implementation will let any value from set command write to `gdb.Parameter.value`. However, I remap the member name of Parameter by the following rule
* `Parameter.value` will map to `gdb.Parameter._value` (if it is string type, always keep unicode)
* `Parameter.raw_value` will map to `gdb.Parameter.value`

Also,
* Fix `.split()`
* Add `revert_default()`. Then people can just write `param.revert_default()` instead of `param.value = param.default` 
* Fix operator overwriting of `Parameter`
   * Rewrite `__lt__` and `__eq__`