### PR TITLE
ensure length padding works with py2 by enforcing unicode awareness

### DIFF
--- a/pwndbg/color/__init__.py
+++ b/pwndbg/color/__init__.py
@@ -7,6 +7,8 @@ from __future__ import unicode_literals
 
 import re
 
+import six
+
 import pwndbg.memoize
 
 NORMAL         = "\x1b[0m"
@@ -72,9 +74,17 @@ def terminateWith(x, color):
     return re.sub('\x1b\\[0m', NORMAL + color, x)
 
 def ljust_colored(x, length, char=' '):
+    # TODO: workaround until issue #404
+    if six.PY2:
+        x = x if isinstance(x, six.text_type) else x.decode('utf8')
+        char = char if isinstance(char, six.text_type) else char.decode('utf8')
     remaining = length - len(strip(x))
     return x + ((remaining // len(char) + 1) * char)[:remaining]
 
 def rjust_colored(x, length, char=' '):
+    # TODO: workaround until issue #404
+    if six.PY2:
+        x = x if isinstance(x, six.text_type) else x.decode('utf8')
+        char = char if isinstance(char, six.text_type) else char.decode('utf8')
     remaining = length - len(strip(x))
     return ((remaining // len(char) + 1) * char)[:remaining] + x


### PR DESCRIPTION
This works around the issue of python2 not being unicode aware and
the config classes not properly returning instance of decoded raw
strings. This leads to length operations being performed on bytes
rather then logical characters.
We check for python2 and enfore decoding if not a text_type.

Fixes #412