### PR TITLE
Ban isort==4.3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 future
-isort
+isort!=4.3.0
 pip
 psutil>=3.1.0
 pycparser


### PR DESCRIPTION
See timothycrosley/isort#652 for more information. tl;dr is `pip install isort==4.3.0` fails, which is what `pip install -Ur requirements.txt` will attempt to do.

Ban this specific version as it causes issues.