### PR TITLE
display the frame pointer register (x29) in aarch64 context

### DIFF
--- a/pwndbg/regs.py
+++ b/pwndbg/regs.py
@@ -106,6 +106,7 @@ arm = RegisterSet(  retaddr = ('lr',),
 
 aarch64 = RegisterSet(  retaddr = ('lr',),
                         flags   = {'cpsr':{}},
+                        frame   = 'x29',
                         gpr     = tuple('x%i' % i for i in range(29)),
                         misc    = tuple('w%i' % i for i in range(29)),
                         args    = ('x0','x1','x2','x3'),


### PR DESCRIPTION
For issue #406.

result:  
![default](https://user-images.githubusercontent.com/4478350/35720297-fca24c6e-0827-11e8-96f6-80bae2bed1e7.PNG)

For now the context will always display the x29 register. Feel free to discuss if we have to add a config point for it. IMHO it's OK to always display the FP register.
