### PR TITLE
Fixes #428 - pwndbg.memory.write encoding error

### DIFF
--- a/pwndbg/memory.py
+++ b/pwndbg/memory.py
@@ -9,6 +9,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import os
+from builtins import bytes
 
 import gdb
 
@@ -99,7 +100,7 @@ def write(addr, data):
         addr(int): Address to write
         data(str,bytes,bytearray): Data to write
     """
-    gdb.selected_inferior().write_memory(addr, bytes(data))
+    gdb.selected_inferior().write_memory(addr, bytes(data, 'utf8'))
 
 
 def peek(address):


### PR DESCRIPTION
It seems that pwndbg.memory.write fix for Py2 introduced in 433bf231 wasn't tested properly on Py3 as `bytes` without an argument fails as:
```
In [1]: bytes('xyz')
TypeError: string argument without an encoding
```

In Py2 by default the `bytes` is just `str` and so doesn't accept the encoding argument.

Because of that a `from builtins import bytes` has been added which makes it behave the same way as in Python 3 and so `utf8` encoding has been passed.

Some more info on `builtins` module can be found here: http://python-future.org/imports.html#imports-of-builtins

---
I have tested this solution on both Py2 and Py3 GDB versions and it works. 