### PR TITLE
Don't check for IDA Pro if it is dissabled

### DIFF
--- a/pwndbg/ida.py
+++ b/pwndbg/ida.py
@@ -88,6 +88,8 @@ class withIDA(object):
         functools.update_wrapper(self, fn)
 
     def __call__(self, *args, **kwargs):
+        if not ida_enabled:
+            return None
         if _ida is None:
             init_ida_rpc_client()
         if _ida is not None:


### PR DESCRIPTION
This makes it so that no checks for the IDA Pro API are performed if it is disabled anyways using the config option `ida-enabled` that was added recently.

Besides improving performance this also fixes connection errors from showing up on WSL.

I'm not sure if this is the right branch to merge this into. I guess this is a bug fix, so should I instead merge it into stable?

Also on a side note on WSL there still is still an error message on startup if the connection to the IDA API fails (which it always does if you don't have IDA). It looks like it's supposed to be this way, but I feel like this doesn't make much sense, as it's not really an error if you simply don't have IDA. Showing a message is okay, but the whole stacktrace is a bit much I think. Any opinions on this? Should I maybe open a seperate issue for this?