### PR TITLE
Support hex data prefixed with 0x for eX windbg commands

### DIFF
--- a/pwndbg/commands/windbg.py
+++ b/pwndbg/commands/windbg.py
@@ -175,7 +175,13 @@ def eX(size, address, data, hex=True):
 
     for i, bytestr in enumerate(data):
         if hex:
-            bytestr = str(bytestr).rjust(size*2, '0')
+            bytestr = str(bytestr)
+
+            if bytestr.startswith('0x'):
+                bytestr = bytestr[2:]
+
+            bytestr = bytestr.rjust(size*2, '0')
+
             data    = codecs.decode(bytestr, 'hex')
         else:
             data    = bytestr


### PR DESCRIPTION
When using `eX` commands and setting data to hex value prefixed with `0x`, we get an exception:

```
pwndbg> ed 0xffb21ae4 0x55616740
Traceback (most recent call last):
  File "/usr/lib/python3.6/encodings/hex_codec.py", line 19, in hex_decode
    return (binascii.a2b_hex(input), len(input))
binascii.Error: Non-hexadecimal digit found

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/dc/installed/pwndbg/pwndbg/commands/__init__.py", line 109, in __call__
    return self.function(*args, **kwargs)
  File "/home/dc/installed/pwndbg/pwndbg/commands/__init__.py", line 200, in _OnlyWhenRunning
    return function(*a, **kw)
  File "/home/dc/installed/pwndbg/pwndbg/commands/windbg.py", line 141, in ed
    return eX(4, address, data)
  File "/home/dc/installed/pwndbg/pwndbg/commands/windbg.py", line 180, in eX
    data    = codecs.decode(bytestr, 'hex')
binascii.Error: decoding with 'hex' codec failed (Error: Non-hexadecimal digit found)
```

This commit fixes this problem so that if the data input has prefix, it is stripped.