### PR TITLE
Add stepsyscall and rename next_syscall to nextsyscall

### DIFF
--- a/pwndbg/commands/next.py
+++ b/pwndbg/commands/next.py
@@ -74,7 +74,9 @@ def nextsyscall(*args):
     """
     while pwndbg.proc.alive and not pwndbg.next.break_next_interrupt() and pwndbg.next.break_next_branch():
         continue
-    pwndbg.commands.context.context()
+
+    if pwndbg.proc.alive:
+        pwndbg.commands.context.context()
 
 
 @pwndbg.commands.Command
@@ -97,7 +99,9 @@ def stepsyscall(*args):
         # We need to step so that we take this branch instead of ignoring it
         gdb.execute('si')
         continue
-    pwndbg.commands.context.context()
+
+    if pwndbg.proc.alive:
+        pwndbg.commands.context.context()
 
 
 @pwndbg.commands.Command

--- a/pwndbg/commands/next.py
+++ b/pwndbg/commands/next.py
@@ -68,7 +68,7 @@ def so(*args):
 
 @pwndbg.commands.Command
 @pwndbg.commands.OnlyWhenRunning
-def next_syscall(*args):
+def nextsyscall(*args):
     """
     Breaks at the next syscall not taking branches.
     """
@@ -83,7 +83,7 @@ def nextsc(*args):
     """
     Breaks at the next syscall not taking branches.
     """
-    next_syscall(*args)
+    nextsyscall(*args)
 
 
 @pwndbg.commands.Command


### PR DESCRIPTION
### adds `stepsyscall` command (with `stepsc` alias)

This command can be used to "get into this call and stop on its syscall" or just "stop on first syscall". This is superior to GDB's `catch syscall` as it stops exactly ON a `syscall` instruction instead of inside of it ... and does it just once.

**PS: To be honest it stops on interrupts but `syscall` is also one and the command is probably mostly used just for that (?).**

#### Comparison of `nextsc` and `stepsc`

```
mov ...   #<------ we are here
mov ...
call foo
mov ...
syscall  <------ nextsc will stop here

foo:
mov ...
syscall  <------ stepsc will stop here
```

### Other changes
* renames `next_syscall` into `nextsyscall`
* better docstrings