### PR TITLE
Adds stepret command and nextret docstring

### DIFF
--- a/pwndbg/commands/next.py
+++ b/pwndbg/commands/next.py
@@ -38,7 +38,22 @@ def nextcall(*args):
 @pwndbg.commands.Command
 @pwndbg.commands.OnlyWhenRunning
 def nextret(*args):
+    """Breaks at next return-like instruction"""
     if pwndbg.next.break_next_ret():
+        pwndbg.commands.context.context()
+
+
+@pwndbg.commands.Command
+@pwndbg.commands.OnlyWhenRunning
+def stepret(*args):
+    """Breaks at next return-like instruction by 'stepping' to it"""
+    while pwndbg.proc.alive and not pwndbg.next.break_next_ret() and pwndbg.next.break_next_branch():
+        # Here we are e.g. on a CALL instruction (temporarily breakpointed by `break_next_branch`)
+        # We need to step so that we take this branch instead of ignoring it
+        gdb.execute('si')
+        continue
+
+    if pwndbg.proc.alive:
         pwndbg.commands.context.context()
 
 


### PR DESCRIPTION
So that now we can step-until-return-like-instruction like a boss! :)

Below is comparison of `nextret` and `stepret`.

```
mov ...    <------- we are here
mov ...
call foo
mov ...
ret        <------- nextret will stop here

foo:
ret        <------- stepret will stop here
```