### PR TITLE
Fix bins command 'There is no member named tcache_bins'

### DIFF
--- a/pwndbg/heap/ptmalloc.py
+++ b/pwndbg/heap/ptmalloc.py
@@ -44,7 +44,7 @@ class Heap(pwndbg.heap.heap.BaseHeap):
         return self._main_arena
 
     def has_tcache(self):
-        return (self.mp and self.mp['tcache_bins'])
+        return (self.mp and 'tcache_bins' in self.mp.type.keys() and self.mp['tcache_bins'])
 
 
     @property


### PR DESCRIPTION
Bins command fails on a libc that doesn't use tcache at all, e.g.:

```
GNU C Library (Ubuntu GLIBC 2.23-0ubuntu10) stable release version 2.23, by Roland McGrath et al.
```

Here is the output:

```
pwndbg> bins
Traceback (most recent call last):
  File "/root/pwndbg/pwndbg/commands/__init__.py", line 109, in __call__
    return self.function(*args, **kwargs)
  File "/root/pwndbg/pwndbg/commands/__init__.py", line 200, in _OnlyWhenRunning
    return function(*a, **kw)
  File "/root/pwndbg/pwndbg/commands/heap.py", line 255, in bins
    if pwndbg.heap.current.has_tcache():
  File "/root/pwndbg/pwndbg/heap/ptmalloc.py", line 47, in has_tcache
    return (self.mp and self.mp['tcache_bins'])
gdb.error: There is no member named tcache_bins.
```

This commit fixes this issue by checking whether `tcache_bins` field is present in the `malloc_par` structure.

NOTE: This still doesn't fix `bins` completely - the problem described in https://github.com/pwndbg/pwndbg/issues/424 is still there.