### PR TITLE
Fixes bins command (#424)

### DIFF
--- a/pwndbg/chain.py
+++ b/pwndbg/chain.py
@@ -19,7 +19,7 @@ import pwndbg.vmmap
 
 LIMIT = pwndbg.config.Parameter('dereference-limit', 5, 'max number of pointers to dereference in a chain')
 
-def get(address, limit=LIMIT, offset=0, hard_stop=None, hard_end=0):
+def get(address, limit=LIMIT, offset=0, hard_stop=None, hard_end=0, include_start=True):
     """
     Recursively dereferences an address. For bare metal, it will stop when the address is not in any of vmmap pages to avoid redundant dereference.
 
@@ -29,13 +29,14 @@ def get(address, limit=LIMIT, offset=0, hard_stop=None, hard_end=0):
         offset(int): offset into the address to get the next pointer
         hard_stop(int): address to stop at
         hard_end: value to append when hard_stop is reached
+        include_start(bool): whether to include starting address or not
 
     Returns:
         A list representing pointers of each ```address``` and reference
     """
     limit = int(limit)
 
-    result = [address]
+    result = [address] if include_start else []
     for i in range(limit):
         # Don't follow cycles, except to stop at the second occurrence.
         if result.count(address) >= 2:

--- a/pwndbg/heap/ptmalloc.py
+++ b/pwndbg/heap/ptmalloc.py
@@ -365,7 +365,7 @@ class Heap(pwndbg.heap.heap.BaseHeap):
         front, back = normal_bins[index * 2], normal_bins[index * 2 + 1]
         fd_offset   = self.chunk_key_offset('fd')
 
-        chain = pwndbg.chain.get(int(front), offset=fd_offset, hard_stop=current_base, limit=heap_chain_limit)
+        chain = pwndbg.chain.get(int(front), offset=fd_offset, hard_stop=current_base, limit=heap_chain_limit, include_start=False)
         return chain
 
 


### PR DESCRIPTION
The problem was that after some of the recent changes to chain/get to prevent dereferencing too much addresses and having better display when dereferencing limit is 0 (used for bare metal debugging) the bins command displayed wrong results for everything except fastbins.

This was due to the fact we are adding the dereference start address to the list.

This fixes the `bins` command by adding `include_start=True` keyword argument to the `chain.get` function. The `bins` simply uses `include_start=False`.