### PR TITLE
Fixes #391 - kills compat.py module

### DIFF
--- a/docs/source/api/compat.rst
+++ b/docs/source/api/compat.rst
@@ -1,5 +1,0 @@
-:mod:`pwndbg.compat` --- pwndbg.compat
-=============================================
-
-.. automodule:: pwndbg.compat
-    :members:

--- a/pwndbg/__init__.py
+++ b/pwndbg/__init__.py
@@ -93,7 +93,6 @@ __all__ = [
 'auxv',
 'chain',
 'color',
-'compat',
 'disasm',
 'dt',
 'elf',

--- a/pwndbg/color/lexer.py
+++ b/pwndbg/color/lexer.py
@@ -18,8 +18,6 @@ from pygments.token import Punctuation
 from pygments.token import String
 from pygments.token import Text
 
-import pwndbg.compat
-
 __all__ = ['PwntoolsLexer']
 
 class PwntoolsLexer(RegexLexer):
@@ -122,7 +120,7 @@ class PwntoolsLexer(RegexLexer):
 # Note: convert all unicode() to str() if in Python2.7 since unicode_literals is enabled
 # The pygments<=2.2.0 (latest stable when commit) in Python2.7 use 'str' type in rules matching
 # We must convert all unicode back to str()
-if pwndbg.compat.python2:
+if six.PY2:
     def _to_str(obj):
         type_ = type(obj)
         if type_ in (tuple, list):

--- a/pwndbg/compat.py
+++ b/pwndbg/compat.py
@@ -15,8 +15,3 @@ import sys
 # Quickly determine which version is running
 python2 = sys.version_info.major == 2
 python3 = sys.version_info.major == 3
-
-if python3:
-    basestring = str
-else:
-    basestring = basestring

--- a/pwndbg/ida.py
+++ b/pwndbg/ida.py
@@ -18,9 +18,9 @@ import time
 import traceback
 
 import gdb
+import six
 
 import pwndbg.arch
-import pwndbg.compat
 import pwndbg.config
 import pwndbg.decorators
 import pwndbg.elf
@@ -43,7 +43,7 @@ ida_timeout = pwndbg.config.Parameter('ida-timeout', 2, 'time to wait for ida xm
 
 xmlrpclib.Marshaller.dispatch[int] = lambda _, v, w: w("<value><i8>%d</i8></value>" % v)
 
-if pwndbg.compat.python2:
+if six.PY2:
     xmlrpclib.Marshaller.dispatch[long] = lambda _, v, w: w("<value><i8>%d</i8></value>" % v)
 
 xmlrpclib.Marshaller.dispatch[type(0)] = lambda _, v, w: w("<value><i8>%d</i8></value>" % v)

--- a/pwndbg/inthook.py
+++ b/pwndbg/inthook.py
@@ -17,10 +17,9 @@ import gdb
 import six
 from future.utils import with_metaclass
 
-import pwndbg.compat
 import pwndbg.typeinfo
 
-if pwndbg.compat.python2:
+if six.PY2:
     import __builtin__ as builtins
 else:
     import builtins
@@ -60,6 +59,6 @@ class xint(with_metaclass(IsAnInt, builtins.int)):
 if os.environ.get('SPHINX', None) is None:
     builtins.int = xint
     globals()['int'] = xint
-    if pwndbg.compat.python3:
+    if six.PY3:
         builtins.long = xint
         globals()['long'] = xint

--- a/pwndbg/memory.py
+++ b/pwndbg/memory.py
@@ -14,7 +14,6 @@ from builtins import bytes
 import gdb
 
 import pwndbg.arch
-import pwndbg.compat
 import pwndbg.events
 import pwndbg.qemu
 import pwndbg.typeinfo
@@ -68,9 +67,6 @@ def read(addr, count, partial=False):
 
             # Move down by another page
             stop_addr -= PAGE_SIZE
-
-    # if pwndbg.compat.python3:
-        # result = bytes(result)
 
     return bytearray(result)
 

--- a/pwndbg/regs.py
+++ b/pwndbg/regs.py
@@ -19,7 +19,6 @@ import gdb
 import six
 
 import pwndbg.arch
-import pwndbg.compat
 import pwndbg.events
 import pwndbg.memoize
 import pwndbg.proc

--- a/pwndbg/stdio.py
+++ b/pwndbg/stdio.py
@@ -16,8 +16,6 @@ import sys
 
 import gdb
 
-import pwndbg.compat
-
 
 class Stdio(object):
     queue = []

--- a/pwndbg/vmmap.py
+++ b/pwndbg/vmmap.py
@@ -17,9 +17,9 @@ import os
 import sys
 
 import gdb
+import six
 
 import pwndbg.abi
-import pwndbg.compat
 import pwndbg.elf
 import pwndbg.events
 import pwndbg.file
@@ -188,7 +188,7 @@ def proc_pid_maps():
     else:
         return tuple()
 
-    if pwndbg.compat.python3:
+    if six.PY3:
         data = data.decode()
 
     pages = []


### PR DESCRIPTION
Just use `six.PY2` and `six.PY3`.