### PR TITLE
Fix IDA 7 unhandled DecompilationFailure

### DIFF
--- a/ida_script.py
+++ b/ida_script.py
@@ -102,11 +102,25 @@ def register_module(module):
             server.register_function(wrap(function), name)
 
 
+def decompile(addr):
+    """
+    Function that overwrites `idaapi.decompile` for xmlrpc so that instead
+    of throwing an exception on `idaapi.DecompilationFailure` it just returns `None`.
+    (so that we don't have to parse xmlrpc Fault's exception string on pwndbg side
+    as it differs between IDA versions).
+    """
+    try:
+        return idaapi.decompile(addr)
+    except idaapi.DecompilationFailure:
+        return None
+
+
 server = SimpleXMLRPCServer((host, port), logRequests=True, allow_none=True)
 register_module(idc)
 register_module(idautils)
 register_module(idaapi)
 server.register_function(lambda a: eval(a, globals(), locals()), 'eval')
+server.register_function(decompile)  # overwrites idaapi/ida_hexrays.decompie
 server.register_introspection_functions()
 
 print('IDA Pro xmlrpc hosted on http://%s:%s' % (host, port))

--- a/pwndbg/ida.py
+++ b/pwndbg/ida.py
@@ -388,13 +388,7 @@ def has_cached_cfunc(addr):
 @takes_address
 @pwndbg.memoize.reset_on_stop
 def decompile(addr):
-    try:
-        return _ida.decompile(addr)
-    except xmlrpclib.Fault as f:
-        if str(f) == '''<Fault 1: "<class 'idaapi.DecompilationFailure'>:Decompilation failed: ">''':
-            print('Returning an empty string')
-            return None
-        raise
+    return _ida.decompile(addr)
 
 
 @withIDA


### PR DESCRIPTION
The xmlrpc Fault exception after a DecompilationFailure (e.g. when we step on `_start` without symbols for it) on IDA 7 has a string of `<Fault 1: "<class 'ida_hexrays.DecompilationFailure'>:Decompilation failed: ">` (NOTE: the `idaapi` changed to `ida_hexrays`).

Instead of handling 'just another string' I applied a better solution: overriding `_ida.decompile` so it returns `None` in case off `DecompilationFailure`.