### PR TITLE
version command: show IDA Pro versions

### DIFF
--- a/ida_script.py
+++ b/ida_script.py
@@ -115,12 +115,23 @@ def decompile(addr):
         return None
 
 
+def versions():
+    """Returns IDA & Python versions"""
+    import sys
+    return {
+        'python': sys.version,
+        'ida': idaapi.get_kernel_version(),
+        'hexrays': idaapi.get_hexrays_version() if 'get_hexrays_version' in dir(idaapi) else None
+    }
+
+
 server = SimpleXMLRPCServer((host, port), logRequests=True, allow_none=True)
 register_module(idc)
 register_module(idautils)
 register_module(idaapi)
 server.register_function(lambda a: eval(a, globals(), locals()), 'eval')
 server.register_function(decompile)  # overwrites idaapi/ida_hexrays.decompie
+server.register_function(versions)
 server.register_introspection_functions()
 
 print('IDA Pro xmlrpc hosted on http://%s:%s' % (host, port))

--- a/pwndbg/commands/version.py
+++ b/pwndbg/commands/version.py
@@ -15,6 +15,7 @@ import gdb
 
 import pwndbg
 import pwndbg.commands
+import pwndbg.ida
 from pwndbg.color import message
 
 
@@ -54,4 +55,14 @@ def version():
     capstone_str = 'Capstone: %s' % capstone_version()
     unicorn_str  = 'Unicorn:  %s' % unicorn_version()
 
-    print('\n'.join(map(message.system, (gdb_str, py_str, pwndbg_str, capstone_str, unicorn_str))))
+    all_versions = (gdb_str, py_str, pwndbg_str, capstone_str, unicorn_str)
+
+    ida_versions = pwndbg.ida.get_ida_versions()
+
+    if ida_versions is not None:
+        ida_version = 'IDA PRO:  %s' % ida_versions['ida']
+        ida_py_ver  = 'IDA Py:   %s' % ida_versions['python']
+        ida_hr_ver  = 'Hexrays:  %s' % ida_versions['hexrays']
+        all_versions += (ida_version, ida_py_ver, ida_hr_ver)
+
+    print('\n'.join(map(message.system, all_versions)))

--- a/pwndbg/ida.py
+++ b/pwndbg/ida.py
@@ -392,6 +392,12 @@ def decompile(addr):
 
 
 @withIDA
+@pwndbg.memoize.forever
+def get_ida_versions():
+    return _ida.versions()
+
+
+@withIDA
 @pwndbg.memoize.reset_on_stop
 def GetStrucQty():
     return _ida.GetStrucQty()


### PR DESCRIPTION
The IDA/Python version might be usable in some bug reports.

Without IDA:
```
pwndbg> version
Gdb:      GNU gdb (GDB) 8.1
Python:   3.6.4 (default, Jan  5 2018, 02:35:40)  [GCC 7.2.1 20171224]
Pwndbg:   1.0.0 build: ed4420e
Capstone: 3.0.768
Unicorn:  1.0.1
```

With IDA when hexrays is not initialized (e.g. no binary is loaded):
```
pwndbg> version
Pwndbg successfully connected to Ida Pro xmlrpc: http://127.0.0.1:8888
Gdb:      GNU gdb (GDB) 8.1
Python:   3.6.4 (default, Jan  5 2018, 02:35:40)  [GCC 7.2.1 20171224]
Pwndbg:   1.0.0 build: ed4420e
Capstone: 3.0.768
Unicorn:  1.0.1
IDA PRO:  7.00
IDA Py:   2.7.14 (v2.7.14:84471935ed, Sep 16 2017, 20:25:58) [MSC v.1500 64 bit (AMD64)]
Hexrays:  None
```

With IDA when hexrays is loaded:
```
pwndbg> version
Pwndbg successfully connected to Ida Pro xmlrpc: http://127.0.0.1:8888
Gdb:      GNU gdb (GDB) 8.1
Python:   3.6.4 (default, Jan  5 2018, 02:35:40)  [GCC 7.2.1 20171224]
Pwndbg:   1.0.0 build: ed4420e
Capstone: 3.0.768
Unicorn:  1.0.1
IDA PRO:  7.00
IDA Py:   2.7.14 (v2.7.14:84471935ed, Sep 16 2017, 20:25:58) [MSC v.1500 64 bit (AMD64)]
Hexrays:  7.0.0.170914
```