### PR TITLE
Add filtering for config and theme commands

### DIFF
--- a/pwndbg/commands/theme.py
+++ b/pwndbg/commands/theme.py
@@ -15,9 +15,9 @@ import pwndbg.commands
 import pwndbg.config
 from pwndbg.color import generateColorFunction
 from pwndbg.color.message import hint
-from pwndbg.commands.config import extend_value_with_default, get_config_parameters
+from pwndbg.commands.config import extend_value_with_default
+from pwndbg.commands.config import get_config_parameters
 from pwndbg.commands.config import print_row
-
 
 parser = argparse.ArgumentParser(description='Shows pwndbg-specific theme config. The list can be filtered.')
 parser.add_argument('filter_pattern', type=str, nargs='?', default=None,

--- a/pwndbg/commands/theme.py
+++ b/pwndbg/commands/theme.py
@@ -15,14 +15,23 @@ import pwndbg.commands
 import pwndbg.config
 from pwndbg.color import generateColorFunction
 from pwndbg.color.message import hint
-from pwndbg.commands.config import extend_value_with_default
+from pwndbg.commands.config import extend_value_with_default, get_config_parameters
 from pwndbg.commands.config import print_row
 
 
-@pwndbg.commands.ArgparsedCommand('Shows pwndbg-specific theme configuration points.')
-def theme():
-    values = [v for k, v in pwndbg.config.__dict__.items()
-              if isinstance(v, pwndbg.config.Parameter) and v.scope == 'theme']
+parser = argparse.ArgumentParser(description='Shows pwndbg-specific theme config. The list can be filtered.')
+parser.add_argument('filter_pattern', type=str, nargs='?', default=None,
+                    help='Filter to apply to theme parameters names/descriptions')
+
+
+@pwndbg.commands.ArgparsedCommand(parser)
+def theme(filter_pattern):
+    values = get_config_parameters('theme', filter_pattern)
+
+    if not values:
+        print(hint('No theme parameter found with filter "{}"'.format(filter_pattern)))
+        return
+
     longest_optname = max(map(len, [v.optname for v in values]))
     longest_value = max(map(len, [extend_value_with_default(str(v.value), str(v.default)) for v in values]))
 


### PR DESCRIPTION
So that now all of `pwndbg`, `config` and `theme` can be filtered:
```
pwndbg> config ida
Name               Value (Def)       Documentation
--------------------------------------------------
ida-enabled        True              whether to enable ida integration
ida-rpc-host       '127.0.0.1'       ida xmlrpc server address
ida-rpc-port       8888              ida xmlrpc server port
ida-timeout        2                 time to wait for ida xmlrpc in seconds
You can set config variable with `set <config-var> <value>`
You can generate configuration file using `configfile` - then put it in your .gdbinit after initializing pwndbg
```
```
pwndbg> theme telescope
Name                                   Value (Def)  Documentation
-----------------------------------------------------------------
telescope-offset-color                 normal       color of the telescope command (offset prefix)
telescope-offset-delimiter             ':' (:)      offset delimiter of the telescope command
telescope-offset-delimiter-color       normal       color of the telescope command (offset delimiter)
telescope-offset-separator             '│' (│)      offset separator of the telescope command
telescope-offset-separator-color       normal       color of the telescope command (offset separator)
telescope-register-color               bold         color of the telescope command (register)
telescope-repeating-marker             '... ↓' (... ↓) repeating values marker of the telescope command
telescope-repeating-marker-color       normal       color of the telescope command (repeating values marker)
You can set theme variable with `set <theme-var> <value>`
You can generate theme config file using `themefile` - then put it in your .gdbinit after initializing pwndbg
pwndbg> 
```
```
pwndbg> config bla
No config parameter found with filter "bla"
pwndbg> theme bla
No theme parameter found with filter "bla"
```