### PR TITLE
Fix emulate command crash

### DIFF
--- a/pwndbg/commands/nearpc.py
+++ b/pwndbg/commands/nearpc.py
@@ -165,11 +165,11 @@ def nearpc(pc=None, lines=None, to_string=False, emulate=False):
 
         prev = instr
 
-
     if not to_string:
         print('\n'.join(result))
 
     return result
+
 
 @pwndbg.commands.ParsedCommand
 @pwndbg.commands.OnlyWhenRunning
@@ -177,8 +177,12 @@ def emulate(pc=None, lines=None, to_string=False, emulate=True):
     """
     Like nearpc, but will emulate instructions from the current $PC forward.
     """
-    nearpc.repeat = emulate.repeat
+    nearpc.repeat = emulate_command.repeat
     return nearpc(pc, lines, to_string, emulate)
+
+
+emulate_command = emulate
+
 
 @pwndbg.commands.ParsedCommand
 @pwndbg.commands.OnlyWhenRunning


### PR DESCRIPTION
After we added `repeat` functionality for some commands, the emulate stopped to work:
```
pwndbg> emulate
Traceback (most recent call last):
  File "/home/dc/installed/pwndbg/pwndbg/commands/__init__.py", line 109, in __call__
    return self.function(*args, **kwargs)
  File "/home/dc/installed/pwndbg/pwndbg/commands/__init__.py", line 200, in _OnlyWhenRunning
    return function(*a, **kw)
  File "/home/dc/installed/pwndbg/pwndbg/commands/nearpc.py", line 180, in emulate
    nearpc.repeat = emulate.repeat
AttributeError: 'bool' object has no attribute 'repeat'
```

This is due to the fact the command has the same name as argument which is a bool.