### PR TITLE
Change IDA xmlrpc default port

### DIFF
--- a/ida_script.py
+++ b/ida_script.py
@@ -50,7 +50,7 @@ xmlrpclib.Marshaller.dispatch[type(0)] = create_marshaller("<value><i8>%d</i8></
 xmlrpclib.Marshaller.dispatch[idaapi.cfuncptr_t] = create_marshaller(just_to_str=True)
 
 host = '127.0.0.1'
-port = 8888
+port = 31337
 orig_LineA = idc.LineA
 
 

--- a/pwndbg/ida.py
+++ b/pwndbg/ida.py
@@ -37,7 +37,7 @@ except:
 
 
 ida_rpc_host = pwndbg.config.Parameter('ida-rpc-host', '127.0.0.1', 'ida xmlrpc server address')
-ida_rpc_port = pwndbg.config.Parameter('ida-rpc-port', 8888, 'ida xmlrpc server port')
+ida_rpc_port = pwndbg.config.Parameter('ida-rpc-port', 31337, 'ida xmlrpc server port')
 ida_enabled = pwndbg.config.Parameter('ida-enabled', True, 'whether to enable ida integration')
 ida_timeout = pwndbg.config.Parameter('ida-timeout', 2, 'time to wait for ida xmlrpc in seconds')
 


### PR DESCRIPTION
So that people will have less problems with our automatic IDA connection (it seems people often have some service hosted on port 8888).