### PR TITLE
Fix shell commands descriptions

### DIFF
--- a/pwndbg/commands/radare2.py
+++ b/pwndbg/commands/radare2.py
@@ -10,7 +10,7 @@ import subprocess
 
 import pwndbg.commands
 
-parser = argparse.ArgumentParser(description=".",
+parser = argparse.ArgumentParser(description='Launches radare2',
                                  epilog="Example: r2 -- -S -AA")
 parser.add_argument('--no-seek', action='store_true',
                     help='Do not seek to current pc')
@@ -32,4 +32,4 @@ def r2(arguments, no_seek=False):
     try:
         subprocess.call(cmd)
     except Exception:
-        print("Could not run radare2.  Please ensure it's installed and in $PATH.")
+        print("Could not run radare2. Please ensure it's installed and in $PATH.")

--- a/pwndbg/commands/shell.py
+++ b/pwndbg/commands/shell.py
@@ -76,11 +76,13 @@ shellcmds = filter(pwndbg.which.which, shellcmds)
 
 def register_shell_function(cmd):
     def handler(*a):
-        """Invokes %s""" % cmd
         if os.fork() == 0:
             os.execvp(cmd, (cmd,) + a)
         os.wait()
+
     handler.__name__ = str(cmd)
+    handler.__doc__ = 'Invokes {}'.format(cmd)
+
     pwndbg.commands.Command(handler, False)
 
 for cmd in shellcmds:


### PR DESCRIPTION
Before that change all shell commands had a description of `None`.

This was because we used string formatting for a docstring and if one
does so, the string isn't a docstring anymore.

This also fixes `r2` command description.