### PR TITLE
typeinfo: skip failed compile attempts

### DIFF
--- a/pwndbg/typeinfo.py
+++ b/pwndbg/typeinfo.py
@@ -153,7 +153,10 @@ def compile(filename=None, address=0):
     if not os.path.exists(objectname):
         gcc     = pwndbg.gcc.which()
         gcc    += ['-w', '-c', '-g', filename, '-o', objectname]
-        subprocess.check_output(' '.join(gcc), shell=True)
+        try:
+            subprocess.check_output(' '.join(gcc), shell=True)
+        except subprocess.CalledProcessError as e:
+            return
 
     add_symbol_file(objectname, address)
 

--- a/pwndbg/typeinfo.py
+++ b/pwndbg/typeinfo.py
@@ -154,7 +154,7 @@ def compile(filename=None, address=0):
         gcc     = pwndbg.gcc.which()
         gcc    += ['-w', '-c', '-g', filename, '-o', objectname]
         try:
-            subprocess.check_output(' '.join(gcc), shell=True)
+            subprocess.check_output(gcc)
         except subprocess.CalledProcessError as e:
             return
 


### PR DESCRIPTION
This fixes the problem that single header files that are not compilable
do not abort the compilation loop.
Errors about the failure are printed anyway be check_output we just
avoid abortion.