### PR TITLE
Fix the up and down commands when provided with an argument.

### DIFF
--- a/pwndbg/commands/ida.py
+++ b/pwndbg/commands/ida.py
@@ -43,10 +43,10 @@ def up(n=1):
     """
     f = gdb.selected_frame()
 
-    for i in range(n):
-        o = f.older()
-        if o:
-            o.select()
+    for i in range(int(n)):
+        if f.older():
+            f = f.older()
+    f.select()
 
     bt = pwndbg.commands.context.context_backtrace(with_banner=False)
     print('\n'.join(bt))
@@ -63,10 +63,10 @@ def down(n=1):
     """
     f = gdb.selected_frame()
 
-    for i in range(n):
-        o = f.newer()
-        if o:
-            o.select()
+    for i in range(int(n)):
+        if f.newer():
+            f = f.newer()
+    f.select()
 
     bt = pwndbg.commands.context.context_backtrace(with_banner=False)
     print('\n'.join(bt))


### PR DESCRIPTION
Fixes #472.  This also bounds the integer values so that, e.g., `up 99` just goes to the end of the stack, and `down 99` goes to the innermost frame.  (Assuming fewer than 99 frames, of course.)

The existing loop logic would only go 1 frame even if a proper integer was given.