### PR TITLE
Fixes wrong pc/ip display in context introduced in 9fd5d35

### DIFF
--- a/pwndbg/regs.py
+++ b/pwndbg/regs.py
@@ -266,6 +266,7 @@ ARCH_GET_GS = 0x1004
 class module(ModuleType):
     last = {}
 
+    @pwndbg.memoize.reset_on_stop
     @pwndbg.memoize.reset_on_prompt
     def __getattr__(self, attr):
         attr = attr.lstrip('$')


### PR DESCRIPTION
Before this PR we could get wrong RIP (like off by one) when single stepping through the code:

```
[...]

 RIP  0x555555559850 ◂— xor    ebp, ebp
───────────────────────[ DISASM ]──────────────────────
   0x555555559850    xor    ebp, ebp
 ► 0x555555559852    mov    r9, rdx <0x7ffff7de59a0>

[...]

pwndbg> i r rip
rip            0x555555559852	0x555555559852
```

The patch fixes the issue by reassigning GDB stop signal handler to getting register values.