### PR TITLE
Fixes 476 - segfault handling when using rr project

### DIFF
--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -419,4 +419,3 @@ def _is_rr_present():
     interpreter_globals = ast.literal_eval(globals_list_literal_str)
 
     return 'RRCmd' in interpreter_globals and 'RRWhere' in interpreter_globals
-

--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -5,6 +5,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import ast
 import codecs
 import sys
 
@@ -367,12 +368,20 @@ def save_signal(signal):
 
     elif isinstance(signal, gdb.SignalEvent):
         msg = 'Program received signal %s' % signal.stop_signal
+
         if signal.stop_signal == 'SIGSEGV':
-            try:
-                si_addr = gdb.parse_and_eval("$_siginfo._sifields._sigfault.si_addr")
-                msg += ' (fault address %#x)' % int(si_addr or 0)
-            except gdb.error:
-                pass
+
+            # When users use rr (https://rr-project.org or https://github.com/mozilla/rr)
+            # we can't access $_siginfo, so lets just show current pc
+            # see also issue 476
+            if _is_rr_present():
+                msg += ' (current pc: %#x)' % pwndbg.regs.pc
+            else:
+                try:
+                    si_addr = gdb.parse_and_eval("$_siginfo._sifields._sigfault.si_addr")
+                    msg += ' (fault address %#x)' % int(si_addr or 0)
+                except gdb.error:
+                    pass
         result.append(message.signal(msg))
 
     elif isinstance(signal, gdb.BreakpointEvent):
@@ -396,3 +405,18 @@ context_sections = {
     's': context_stack,
     'b': context_backtrace
 }
+
+
+@pwndbg.memoize.forever
+def _is_rr_present():
+    """
+    Checks whether rr project is present (so someone launched e.g. `rr replay <some-recording>`)
+    """
+
+    # this is ugly but I couldn't find a better way to do it
+    # feel free to refactor it
+    globals_list_literal_str = gdb.execute('python print(list(globals().keys()))', to_string=True)
+    interpreter_globals = ast.literal_eval(globals_list_literal_str)
+
+    return 'RRCmd' in interpreter_globals and 'RRWhere' in interpreter_globals
+


### PR DESCRIPTION
https://github.com/pwndbg/pwndbg/issues/476

When using rr project with pwndbg and getting a segfault it is unable to use reverse stepping provided by rr (e.g. `reverse-stepi`).

This is caused by using `gdb.parse_and_eval($_siginfo<something here>)` when handling segfault.

This is there so that we can display a message to the user that a segfault occured AFTER displaying context (GDB displays this info too, but before we display the context...).

We have to either change the logic and don't use `gdb.parse_and_eval` or detect rr.

This PR adds rr detection by checking for two globals that are defined when running with rr. It also changes the way we inform user about segfault to display current pc instead.

There are also some other ways to detect rr but I am not sure which is the best option:
* we could check prompt using `return '(rr)' in gdb.execute('show prompt', to_string=True)`
* we could check memory mappings as there are some additional memory pages present e.g. in `vmmap` when we use rr:
```
        0x70000000         0x70001000 r-xp     1000 0      /usr/lib/rr/rr_page_64_replay
        0x70001000         0x70002000 rw-p     1000 0      /tmp/rr-shared-preload_thread_locals-29373-0

    0x7f7f853c5000     0x7f7f853eb000 r-xp    26000 0      /usr/lib/rr/librrpreload.so
    0x7f7f853eb000     0x7f7f855ea000 ---p   1ff000 26000  /usr/lib/rr/librrpreload.so
    0x7f7f855ea000     0x7f7f855eb000 r--p     1000 25000  /usr/lib/rr/librrpreload.so
```

Each of the approaches have some flaws as they might change in the future or the mappings paths might be different on different machines.

Loud thinking: maybe we should change prompt from `(rr)` to `rr+pwndbg`? But I am not sure if we can do it as probably our code is executed before rr's code (we could try doing it in prompt hook tho).