### PR TITLE
ptmalloc multiple heaps per non-main arena support, related fixes

### DIFF
--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -111,24 +111,9 @@ def arenas():
     """
     Prints out allocated arenas.
     """
-    def format_heap(h):
-        fmt = '[%%%ds]' % (pwndbg.arch.ptrsize * 2)
-        return message.hint(fmt % (hex(h.first_chunk))) + M.heap(str(pwndbg.vmmap.find(h.addr)))
-
-    def format_arena(ar):
-        res = []
-        prefix = '[%%%ds]    ' % (pwndbg.arch.ptrsize * 2)
-        prefix_len = len(prefix % (''))
-        arena_name = hex(ar.addr) if ar.addr != heap.main_arena.address else 'main'
-        res.append(message.hint(prefix % (arena_name)) + format_heap(ar.heaps[0]))
-        for h in ar.heaps[1:]:
-            res.append(' '*prefix_len + format_heap(h))
-
-        return '\n'.join(res)
-
     heap = pwndbg.heap.current
     for ar in heap.arenas:
-        print(format_arena(ar))
+        print(ar)
 
 
 @pwndbg.commands.ArgparsedCommand('Print malloc thread cache info.')

--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -67,32 +67,20 @@ def format_bin(bins, verbose=False, offset=None):
 @pwndbg.commands.OnlyWhenRunning
 def heap(addr=None):
     """
-    Prints out all chunks in the main_arena, or the arena specified by `addr`.
+    Prints out chunks starting from the address specified by `addr`.
     """
-
-    main_heap   = pwndbg.heap.current
-    main_arena  = main_heap.get_arena(addr)
-
+    main_heap  = pwndbg.heap.current
+    main_arena = main_heap.main_arena
     if main_arena is None:
         return
 
-    heap_region = main_heap.get_region(addr)
-
-    if heap_region is None:
-        print(message.error('Could not find the heap'))
-        return
-
-    top = main_arena['top']
-    last_remainder = main_arena['last_remainder']
-
-    print(message.hint('Top Chunk: ') + M.get(top))
-    print(message.hint('Last Remainder: ') + M.get(last_remainder))
-    print()
+    page = main_heap.get_heap_boundaries(addr)
+    if addr is None:
+        addr = page.vaddr
 
     # Print out all chunks on the heap
     # TODO: Add an option to print out only free or allocated chunks
-    addr = heap_region.vaddr
-    while addr <= top:
+    while addr < page.vaddr + page.memsz:
         chunk = malloc_chunk(addr)
         size = int(chunk['size'])
 
@@ -121,25 +109,26 @@ def arena(addr=None):
 @pwndbg.commands.OnlyWhenRunning
 def arenas():
     """
-    Prints out allocated arenas
+    Prints out allocated arenas.
     """
+    def format_heap(h):
+        fmt = '[%%%ds]' % (pwndbg.arch.ptrsize * 2)
+        return message.hint(fmt % (hex(h.first_chunk))) + M.heap(str(pwndbg.vmmap.find(h.addr)))
 
-    heap  = pwndbg.heap.current
-    addr  = None
-    arena = heap.get_arena(addr)
-    main_arena_addr = int(arena.address)
-    fmt = '[%%%ds]' % (pwndbg.arch.ptrsize *2)
-    while addr != main_arena_addr:
+    def format_arena(ar):
+        res = []
+        prefix = '[%%%ds]    ' % (pwndbg.arch.ptrsize * 2)
+        prefix_len = len(prefix % (''))
+        arena_name = hex(ar.addr) if ar.addr != heap.main_arena.address else 'main'
+        res.append(message.hint(prefix % (arena_name)) + format_heap(ar.heaps[0]))
+        for h in ar.heaps[1:]:
+            res.append(' '*prefix_len + format_heap(h))
 
-        h = heap.get_region(addr)
-        if not h:
-            print(message.error('Could not find the heap'))
-            return
+        return '\n'.join(res)
 
-        hdr = message.hint(fmt % (hex(addr) if addr else 'main'))
-        print(hdr, M.heap(str(h)))
-        addr = int(arena['next'])
-        arena = heap.get_arena(addr)
+    heap = pwndbg.heap.current
+    for ar in heap.arenas:
+        print(format_arena(ar))
 
 
 @pwndbg.commands.ArgparsedCommand('Print malloc thread cache info.')

--- a/pwndbg/heap/ptmalloc.py
+++ b/pwndbg/heap/ptmalloc.py
@@ -15,6 +15,8 @@ from pwndbg.color import message
 from pwndbg.constants import ptmalloc
 from pwndbg.heap import heap_chain_limit
 
+# See https://sourceware.org/git/?p=glibc.git;a=blob;f=malloc/arena.c;h=37183cfb6ab5d0735cc82759626670aff3832cd0;hb=086ee48eaeaba871a2300daf85469671cc14c7e9#l30
+# and https://sourceware.org/git/?p=glibc.git;a=blob;f=malloc/malloc.c;h=f8e7250f70f6f26b0acb5901bcc4f6e39a8a52b2;hb=086ee48eaeaba871a2300daf85469671cc14c7e9#l869
 HEAP_MAX_SIZE = 1024 * 1024 if pwndbg.arch.ptrsize == 4 else 2 * 4 * 1024 * 1024 * 8
 
 Arena = namedtuple('Arena', ['addr', 'heaps'])

--- a/pwndbg/heap/ptmalloc.py
+++ b/pwndbg/heap/ptmalloc.py
@@ -18,6 +18,7 @@ from pwndbg.heap import heap_chain_limit
 
 # See https://sourceware.org/git/?p=glibc.git;a=blob;f=malloc/arena.c;h=37183cfb6ab5d0735cc82759626670aff3832cd0;hb=086ee48eaeaba871a2300daf85469671cc14c7e9#l30
 # and https://sourceware.org/git/?p=glibc.git;a=blob;f=malloc/malloc.c;h=f8e7250f70f6f26b0acb5901bcc4f6e39a8a52b2;hb=086ee48eaeaba871a2300daf85469671cc14c7e9#l869
+# 1 Mb (x86) or 64 Mb (x64)
 HEAP_MAX_SIZE = 1024 * 1024 if pwndbg.arch.ptrsize == 4 else 2 * 4 * 1024 * 1024 * 8
 
 


### PR DESCRIPTION
This PR is an attempt at adding some support for multiple heaps per arena in the ptmalloc code and fixing  related issues (#451, #443).

Currently, the ptmalloc code in pwndbg is oblivious to the fact that a non-main arena can have multiple mmapped heaps. The main arena doesn't have separate heaps, just the contiguous brk region. A heap in a non-main arena is typically 1 Mb (x86) or 64 Mb (x64) in size and as soon as one is full, a new one is created with mmap and the top pointer of the arena is updated. Each of these heaps begin with a `heap_info` structure, that has a pointer to the owning arena. The first one also has the actual arena structure (`malloc_state`) after the `heap_info`. The heaps corresponding to an arena are linked via a backward linked list. 

I'll use the following code to showcase the changes below:

```C
//  gcc -o thread_heaps_multi -O0  -ggdb thread_heaps_multi.c -lpthread
#include <stdio.h>
#include <stdlib.h>
#include <pthread.h>
#include <unistd.h>
#include <sys/types.h>

void* threadFunc(void* arg) {
        void *ptr;
        size_t heap_size = 64 * 1024 * 1024;
        for (size_t i = 0 ; i < heap_size / 16; i++)
            ptr = malloc(0);
        printf("11ptr: %p\n", ptr);
}

int main() {
        pthread_t t1;
        void* s;
        int ret;
        ret = pthread_create(&t1, NULL, threadFunc, NULL);
        if(ret)
        {
                printf("Thread creation error\n");
                return -1;
        }
        ret = pthread_join(t1, &s);
        if(ret)
        {
                printf("Thread join error\n");
                return -1;
        }
        return 0;
}
```

The code starts a thread and allocates enough memory in it so that 3 different heaps are created under that non-main arena.

When compiling and running this on Ubuntu 16.04 x64 under pwndbg, the arenas and vmmap commands give the following output when invoked at a breakpoint on line 12 (the printf in `threadFunc`):

![image](https://user-images.githubusercontent.com/9214393/41042502-1bce0304-69a2-11e8-8380-da1fcc116d85.png)

In the output of the `arenas` command, only one heap is shown for the non-main arena, which corresponds to the 0x4000000 (64 mb) sized mapping in the vmmap output, while in fact there are two more at `0x7fffe8000000` and `0x7fffec000000` as can be seen when examining the memory there:

![image](https://user-images.githubusercontent.com/9214393/41043111-78b2484a-69a3-11e8-9ea7-398159443ce4.png)

All three has the same arena pointer, and they are used in the order `0x7ffff0000000`, `0x7fffe8000000`, `0x7fffec000000`. Note that it's not a strictly decreasing order, this is a result of an optimization in the malloc implementation. To find these heaps, we need to travel the linked list of heaps, that starts from the last heap and ends in the original one for the arena. To find the last heap of a non-main arena, I used arena->top. Here's the output of the same command with this patch applied:

![image](https://user-images.githubusercontent.com/9214393/41044472-a4670a4a-69a6-11e8-9dab-3c66dfc8b653.png)

The output of the arenas command is the arena name/address (omitted for heaps that belong to the same arena), the address of the first chunk in the heap, then the containing vm map.

Visiting the heaps allows us to:

* provide objfile names for the corresponding vm mappings that begin with `[heap`, which allows proper coloring. I chose the format `[heap arena_id:heap_id]`. Note how in the screenshot above, two heaps share a single memory mapping, due to the above mentioned optimization. Also note the 0x3fdf000 sized region at `0x7fffec021000`. This is space that's part of the last allocated heap but malloc mprotects it to rw as needed. This fixes #451.
* add support for multiple heaps per arena for the `arenas` command.
* keep the vmmap output consistent with /proc/pid/maps. Note how in the first picture, a mapping starts at `0x7ffff00008b0`, which is of course not correct. This is a result of alterations made to the Page object in `get_region`. This enabled the `heap` command to find the location to start dumping chunks from at the cost of the maps inconsistency and making the beginning of the region (`0x7ffff0000000-0x7ffff00008b0`) incorrectly colored. However, since this PR provides a way to display heaps, along with the address of the first chunk in the heap, this is no longer needed. Subsequently, the `heap` command is also refactored a bit, so that it simply dumps chunks from the address provided (or the main_arena if no address is given). This addresses #443.