### PR TITLE
Objfile event dispatching fix

### DIFF
--- a/pwndbg/events.py
+++ b/pwndbg/events.py
@@ -138,7 +138,7 @@ class Pause(object):
 # objects are loaded.  This greatly slows down the debugging session.
 # In order to combat this, we keep track of which objfiles have been loaded
 # this session, and only emit objfile events for each *new* file.
-objfile_cache = set()
+objfile_cache = dict()
 
 
 def connect(func, event_handler, name=''):
@@ -152,14 +152,15 @@ def connect(func, event_handler, name=''):
 
         if a and isinstance(a[0], gdb.NewObjFileEvent):
             objfile = a[0].new_objfile
+            handler = '%s.%s' % (func.__module__, func.__name__)
             path = objfile.filename
+            dispatched = objfile_cache.get(path, set())
 
-            if path in objfile_cache:
+            if handler in dispatched:
                 return
 
-            # print(path, objfile.is_valid())
-
-            objfile_cache.add(path)
+            dispatched.add(handler)
+            objfile_cache[path] = dispatched
 
         if pause:
             return

--- a/pwndbg/vmmap.py
+++ b/pwndbg/vmmap.py
@@ -42,6 +42,8 @@ custom_pages = []
 @pwndbg.events.new_objfile
 @pwndbg.memoize.reset_on_stop
 def get():
+    if not pwndbg.proc.alive:
+        return tuple()
     pages = []
     pages.extend(proc_pid_maps())
 


### PR DESCRIPTION
This PR fixes #481 and a latent bug that is uncovered by the fix. 

* the first commit replaces the `objfile_cache` set with a dictionary, indexed with the objfile names, that contains which event handler functions have already been dispatched for the objfile in question. This allows calling multiple handlers for an objfile, while also preventing multiple dispatch of the same handler.
* after this fix, the previously uncalled handlers are now actually invoked. `pwndbg.vmmap.get` attempts to read process state without checking if the process is alive, leading to exceptions as can be seen [here][0] (interleaved with some debug output). An objfile event is triggered when the binary is loaded before the program is started, so the second commit adds a check to see if the process is alive before trying to access the process state. 

[0]: https://gist.github.com/andigena/c5805b3edc21449eef81cbd63aa336c0