### PR TITLE
Resets the objfile cache to the proper type on exit.

### DIFF
--- a/pwndbg/events.py
+++ b/pwndbg/events.py
@@ -251,4 +251,4 @@ def _start_stop():
 @exit
 def _reset_objfiles():
     global objfile_cache
-    objfile_cache = set()
+    objfile_cache = dict()


### PR DESCRIPTION
In #486 I missed the `objfile_cache` [reset code][0] that's registered to the exit event. This means that the cache is reinitialized as a set instead of a dict when the inferior exits, therefore we'll hit many exceptions on the next run. The errors can be seen in [this gist][1]. `/bin/ls` is ran twice in a single gdb session, the first time everything works as expected, then on the second run ([from line 280][3]), objfile event dispatch breaks because the caching code expects a dict but it has been reset to a set.

After applying this commit and repeating the [session][2], the second run also completes as expected ([from line 280 again][4]).

[0]: https://github.com/pwndbg/pwndbg/blob/dev/pwndbg/events.py#L251
[1]: https://gist.github.com/andigena/24182c87bef3ff45445343c1526f45a2
[2]: https://gist.github.com/andigena/0932dd7857307b037a59ed60c2c8233e
[3]: https://gist.github.com/andigena/24182c87bef3ff45445343c1526f45a2#file-gistfile1-txt-L280
[4]: https://gist.github.com/andigena/0932dd7857307b037a59ed60c2c8233e#file-gistfile1-txt-L280