### PR TITLE
Refactors heap.get_region, adds special case for get_heap_boundaries.

### DIFF
--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -155,7 +155,7 @@ def top_chunk(addr=None):
     main_arena  = main_heap.get_arena(addr)
 
     if main_arena is None:
-        heap_region = main_heap.get_region()
+        heap_region = main_heap.get_heap_boundaries()
         if not heap_region:
             print(message.error('Could not find the heap'))
             return

--- a/pwndbg/heap/ptmalloc.py
+++ b/pwndbg/heap/ptmalloc.py
@@ -85,7 +85,7 @@ class Heap(pwndbg.heap.heap.BaseHeap):
         arenas          = []
         arena_cnt       = 0
         main_arena_addr = int(arena.address)
-        sbrk_page       = self.get_region().vaddr
+        sbrk_page       = self.get_heap_boundaries().vaddr
 
         # Create the main_arena with a fake HeapInfo
         main_arena      = Arena(main_arena_addr, [HeapInfo(sbrk_page, sbrk_page)])
@@ -347,42 +347,42 @@ class Heap(pwndbg.heap.heap.BaseHeap):
         Get the boundaries of the heap containing `addr`. Returns the brk region for
         adresses inside it or a fake Page for the containing heap for non-main arenas.
         """
+        page = pwndbg.memory.Page(0, 0, 0, 0)
         brk = self.get_region()
         if addr is None or brk.vaddr < addr < brk.vaddr + brk.memsz:
-            return brk
+            # Occasionally, the [heap] vm region and the actual start of the heap are
+            # different, e.g. [heap] starts at 0x61f000 but mp_.sbrk_base is 0x620000.
+            # Return an adjusted Page object if this is the case.
+            sbrk_base = int(self.mp['sbrk_base'])
+            if sbrk_base != brk.vaddr:
+                page.vaddr = sbrk_base
+                page.memsz = brk.memsz - (sbrk_base - brk.vaddr)
+                return page
+            else:
+                return brk
         else:
-            page = pwndbg.memory.Page(0, 0, 0, 0)
             page.vaddr = heap_for_ptr(addr)
             heap = self.get_heap(page.vaddr)
             page.memsz = int(heap['size'])
             return page
 
 
-    def get_region(self,addr=None):
+    def get_region(self, addr=None):
         """
-        Finds the memory map used for heap by using mp_ structure's sbrk_base property
-        and falls back to using /proc/self/maps (vmmap) which can be wrong
-        when .bss is very large
-        For non main-arena heaps use heap_info struct provieded at the beging of the page.
+        Finds the memory map used for the heap at addr or the main heap by looking for a
+        mapping named [heap].
         """
         if addr:
             return pwndbg.vmmap.find(addr)
 
-        page = None
+        # No address provided, find the vm region of the main heap.
+        brk = None
         for m in pwndbg.vmmap.get():
             if m.objfile == '[heap]':
-                page = m
+                brk = m
                 break
 
-        if page is not None:
-            mp = self.mp
-            if mp:
-                ## this can't fail right?
-                page.vaddr = int(mp['sbrk_base'])
-            return page
-
-        return None
-
+        return brk
 
     def fastbin_index(self, size):
         if pwndbg.arch.ptrsize == 8:


### PR DESCRIPTION
As discussed [here](https://github.com/pwndbg/pwndbg/commit/dfb69bd91777cb7889973a65447db45ca68fe901#commitcomment-29463129), the [heap] vm region and the actual start of the heap are sometimes different, e.g. `[heap]` starts at `0x61f000` while `mp_.sbrk_base` is `0x620000`.

This PR refactors `get_region` and `get_heap_boundaries`, so that the first one only returns the actual mappings without modifying them and the latter returns a (possibly fake) Page object that correspond to the actual heap boundaries. Also changes the callers of these functions where appropriate.

I have done minimal manual testing.