### PR TITLE
add vis_heap_chunks

### DIFF
--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -453,6 +453,7 @@ def vis_heap_chunks(addr, final_count=2):
 
         printed += 1
 
-    out += "\t <-- Top chunk"
+    if top_chunk in addrs:
+        out += "\t <-- Top chunk"
 
     print(out)

--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -5,8 +5,8 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import struct
 import argparse
+import struct
 
 import gdb
 import six
@@ -15,7 +15,8 @@ import pwndbg.color.context as C
 import pwndbg.color.memory as M
 import pwndbg.commands
 import pwndbg.typeinfo
-from pwndbg.color import message, generateColorFunction
+from pwndbg.color import generateColorFunction
+from pwndbg.color import message
 
 
 def read_chunk(addr):
@@ -374,8 +375,6 @@ def find_fake_fast(addr, size):
                 malloc_chunk(start+offset-pwndbg.arch.ptrsize,fake=True)
 
 
-
-
 vis_heap_chunks_parser = argparse.ArgumentParser(description='Visualize heap chunks at the specified address')
 vis_heap_chunks_parser.add_argument('address', help='Start address')
 vis_heap_chunks_parser.add_argument('count', nargs='?', default=2,
@@ -385,15 +384,10 @@ vis_heap_chunks_parser.add_argument('count', nargs='?', default=2,
 @pwndbg.commands.OnlyWhenRunning
 @pwndbg.commands.OnlyWhenHeapIsInitialized
 def vis_heap_chunks(address, count):
-    """
-    
-    """
     address = int(address)
     main_heap = pwndbg.heap.current
     main_arena = main_heap.get_arena()
     top_chunk = int(main_arena['top'])
-
-    
 
     unpack = pwndbg.arch.unpack
 


### PR DESCRIPTION
This new heap command allows to visualize heap chunks in different colors. Very handy to know to which chunk a memory cell belongs.

# Examples:
Visualize 3 chunks:
<img width="468" alt="screen shot 2018-07-07 at 2 21 45 pm" src="https://user-images.githubusercontent.com/2049730/42411276-2351d1fc-81f1-11e8-8285-04140bdd713b.png">


Visualize 30 chunks (will stop when top_chunk is reached):
<img width="559" alt="screen shot 2018-07-07 at 2 21 57 pm" src="https://user-images.githubusercontent.com/2049730/42411285-353a8260-81f1-11e8-926a-4c7fcf4af0ca.png">
