### PR TITLE
Run each test in a separate GDB session

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,7 @@ npm-debug.log
 
 # PyCharm project files
 .idea/
+
+# PyTest files
+.pytest_cache/
+tests/.pytest_cache/

--- a/pytests_collect.py
+++ b/pytests_collect.py
@@ -1,0 +1,36 @@
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+import os
+import sys
+
+import pytest
+
+
+TESTS_PATH = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    'tests'
+)
+
+
+class CollectTestFunctionNames:
+    """See https://github.com/pytest-dev/pytest/issues/2039#issuecomment-257753269"""
+    def __init__(self):
+        self.collected = []
+
+    def pytest_collection_modifyitems(self, items):
+        for item in items:
+            self.collected.append(item.nodeid)
+
+
+collector = CollectTestFunctionNames()
+pytest.main(['--collect-only', TESTS_PATH], plugins=[collector])
+
+print('Listing collected tests:')
+for nodeid in collector.collected:
+    print('Test:', nodeid)
+
+# easy way to exit GDB session
+sys.exit(0)

--- a/pytests_launcher.py
+++ b/pytests_launcher.py
@@ -10,13 +10,14 @@ print(sys.argv)
 
 sys._pwndbg_unittest_run = True
 
-TESTS_PATH = os.path.join(
-    os.path.dirname(os.path.realpath(__file__)),
-    'tests'
-)
+CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
+
+test = os.environ['PWNDBG_LAUNCH_TEST']
+
+test = os.path.join(CURRENT_DIR, test)
 
 # If you want to debug tests locally, add '--pdb' here
-args = [TESTS_PATH, '-vvv', '-s', '--showlocals', '--color=yes']
+args = [test, '-vvv', '-s', '--showlocals', '--color=yes']
 
 print('Launching pytest with args: %s' % args)
 

--- a/tests.sh
+++ b/tests.sh
@@ -1,3 +1,10 @@
 #!/bin/bash
 
-PWNDBG_DISABLE_COLORS=1 gdb --silent --nx --nh --command gdbinit.py --command pytests_launcher.py
+
+# NOTE: We run tests under GDB sessions and because of some cleanup/tests dependencies problems
+# we decided to run each test in a separate GDB session
+TESTS_LIST=$(gdb --silent --nx --nh --command gdbinit.py --command pytests_collect.py | grep -o "tests/.*::.*")
+
+for test_case in ${TESTS_LIST}; do
+    PWNDBG_LAUNCH_TEST="${test_case}" PWNDBG_DISABLE_COLORS=1 gdb --silent --nx --nh --command gdbinit.py --command pytests_launcher.py
+done

--- a/tests/test_loads.py
+++ b/tests/test_loads.py
@@ -9,7 +9,6 @@ import codecs
 import os
 import re
 import subprocess
-import tempfile
 
 import pytest
 
@@ -37,7 +36,6 @@ def run_gdb_with_script(binary='', core='', pybefore=None, pyafter=None):
     if core:
         command += ['--core', core]
 
-
     for cmd in pyafter:
         command += ['--eval-command', cmd]
 
@@ -54,6 +52,7 @@ def run_gdb_with_script(binary='', core='', pybefore=None, pyafter=None):
     output = re.sub(r'loaded [0-9]+ commands', r'loaded ### commands', output)
 
     return output
+
 
 HELLO = (
     'pwndbg: loaded ### commands. Type pwndbg [filter] for a list.\n'

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -3,9 +3,6 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import gdb
-import pytest
-
 import pwndbg.memory
 import pwndbg.stack
 


### PR DESCRIPTION
* it would be cool to have tests that run within GDB so that we don't have to parse GDB output and deal with weird problems
* we can't run all tests in one GDB session as `file x; entry; <some pwndbg command>; file y; entry; <some wndbg command>;` may have different results - it seems either us or GDB fails to cleanup everything properly

That being said this PR makes so that we launch each testcase in a separate GDB session.
Yeah, this adds output to travis and slows down testing but right now it is not a big problem.