### PR TITLE
Inform about `exception-debugger` on exceptions

### DIFF
--- a/pwndbg/exception.py
+++ b/pwndbg/exception.py
@@ -68,7 +68,9 @@ def handle(name='Error'):
 
         print(message.notice('For more info invoke `') +
               message.hint('set exception-verbose on') +
-              message.notice('` and rerun the command'))
+              message.notice('` and rerun the command\nor debug it by yourself with `') +
+              message.hint('set exception-debugger on') +
+              message.notice('`'))
 
     # Break into the interactive debugger
     if debug:


### PR DESCRIPTION
Instead of hiding this feature just for devs who reads our dev guide or just knows that this exists lets make pwndbg development great again and show this command to the world!