### PR TITLE
Add filepath banner to source code debugging

### DIFF
--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -25,6 +25,7 @@ import pwndbg.config
 import pwndbg.disasm
 import pwndbg.events
 import pwndbg.ida
+import pwndbg.info
 import pwndbg.regs
 import pwndbg.symbol
 import pwndbg.ui
@@ -261,6 +262,19 @@ def context_code():
             formatted_source.append(line)
 
         banner = [pwndbg.ui.banner("Source (code)")]
+
+        # the `filename` we had before may have full path
+        # this will give us just a relative path to the place we are in
+        # which is probably the thing users wants most of the time
+        filename = pwndbg.info.rel_filepath()
+
+        if filename:
+            banner.append(pwndbg.ui.banner(
+                'In file: %s' % filename,
+                make_upper=False,
+                trunc_after_idx=9
+            ))
+
         banner.extend(formatted_source)
         return banner
     except:

--- a/pwndbg/info.py
+++ b/pwndbg/info.py
@@ -35,3 +35,30 @@ def files():
         return gdb.execute('info files', to_string=True)
     except gdb.error:
         return ''
+
+@pwndbg.memoize.reset_on_stop
+def line():
+    try:
+        return gdb.execute('info line', to_string=True)
+    except gdb.error:
+        return ''
+
+@pwndbg.memoize.reset_on_stop
+def rel_filepath():
+    """
+    Returns relative filepath of currently debugged file.
+
+    For example if `info line` returns:
+    > Line 5 of "./main.c" is at address 0x555555554641 <main> but contains no code.
+
+    This will return just './main.c'
+    """
+    l = line()
+
+    if not l:
+        return ''
+
+    start = l.index('"') + 1
+    end = start + l[start+1:].index('"') + 1
+
+    return l[start:end]

--- a/pwndbg/info.py
+++ b/pwndbg/info.py
@@ -59,6 +59,6 @@ def rel_filepath():
         return ''
 
     start = l.index('"') + 1
-    end = start + l[start+1:].index('"') + 1
+    end = l.rindex('"')
 
     return l[start:end]

--- a/pwndbg/ui.py
+++ b/pwndbg/ui.py
@@ -38,9 +38,28 @@ def check_title_position():
         title_position.revert_default()
 
 
-def banner(title):
-    title = title.upper()
+def banner(title, make_upper=True, trunc_after_idx=-1):
+    """
+    Renders a banner.
+
+    Arguments:
+        title(str): banner title string
+        make_upper(bool): whether the title be uppercase
+        trunc_after_idx(int): if the value is bigger than 0,
+            and the title is too long, it will be truncated
+            on the left side but after the provided index
+    """
+    if make_upper:
+        title = title.upper()
+
     _height, width = get_window_size()
+
+    if trunc_after_idx > 0:
+        size_to_trunc = len(title) - (width - len('-[  ]-'))
+
+        if size_to_trunc > 0:
+            title = title[:trunc_after_idx] + '~' + title[trunc_after_idx+size_to_trunc:]
+
     title = '%s%s%s' % (config.banner_title_surrounding_left, C.banner_title(title), config.banner_title_surrounding_right)
     if 'left' == title_position:
         banner = ljust_colored(title, width, config.banner_separator)
@@ -49,6 +68,7 @@ def banner(title):
     else:
         banner = rjust_colored(title, (width + len(strip(title))) // 2, config.banner_separator)
         banner = ljust_colored(banner, width, config.banner_separator)
+
     return C.banner(banner)
 
 def addrsz(address):

--- a/pwndbg/ui.py
+++ b/pwndbg/ui.py
@@ -55,7 +55,8 @@ def banner(title, make_upper=True, trunc_after_idx=-1):
     _height, width = get_window_size()
 
     if trunc_after_idx > 0:
-        size_to_trunc = len(title) - (width - len('-[  ]-'))
+        banner_len = len(config.banner_title_surrounding_left) + len(config.banner_title_surrounding_right)
+        size_to_trunc = len(title) - (width - banner_len - 3)
 
         if size_to_trunc > 0:
             title = title[:trunc_after_idx] + '~' + title[trunc_after_idx+size_to_trunc:]


### PR DESCRIPTION
As in https://github.com/pwndbg/pwndbg/issues/521

Example:
![image](https://user-images.githubusercontent.com/10009354/45395003-35162b00-b634-11e8-9ecc-22bc7f7851da.png)

With super long path:
![image](https://user-images.githubusercontent.com/10009354/45395027-56771700-b634-11e8-97cc-d6ce608c2e68.png)
