### PR TITLE
Fix got command

### DIFF
--- a/pwndbg/commands/got.py
+++ b/pwndbg/commands/got.py
@@ -33,7 +33,7 @@ def got(name_filter=''):
         return
 
     if "PIE enabled" in pie_status:
-        bin_text_base = pwndbg.memory.page_align(pwndbg.elf.entry())
+        bin_text_base = pwndbg.vmmap.find(pwndbg.elf.entry()).start
 
     relro_color = message.off
     if 'Partial' in relro_status:

--- a/pwndbg/memory.py
+++ b/pwndbg/memory.py
@@ -359,7 +359,7 @@ def find_lower_boundary(addr, max_pages=1024):
             if addr < 0:
                 break
     except gdb.MemoryError:
-        pass
+        addr += pwndbg.memory.PAGE_SIZE
     return addr
 
 


### PR DESCRIPTION
fixes #517 
got addresses were calculated (on PIE binaries only) as bin_text_base + offset, where bin_text_base was entrypoint aligned down to 0x1000
So when entrypoint was further than 0x1000 from real base addr, the command was wrong

Also small fix in memory.find_lower_boundary