### PR TITLE
display chain bk and fd if corrupted

### DIFF
--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -39,25 +39,34 @@ def format_bin(bins, verbose=False, offset=None):
     result = []
     for size in bins:
         b = bins[size]
-        if isinstance(b, tuple):
-            chain, count = b
-        else:
-            chain = b
-            count = None
 
-        if not verbose and (chain == [0] and not count):
+        count, is_chain_corrupted = None, False
+        if len(b) == 1:  # fastbin:
+            chain_fd = b
+        elif len(b) == 2:  # tcachebin:
+            chain_fd, count = b
+        else:  # normal bin
+            chain_fd, chain_bk, is_chain_corrupted = b
+
+        if not verbose and (chain_fd == [0] and not count) and not is_chain_corrupted:
             continue
 
-        formatted_chain = pwndbg.chain.format(chain[0], offset=offset)
+        formatted_chain = pwndbg.chain.format(chain_fd[0], offset=offset)
 
         if isinstance(size, int):
             size = hex(size)
 
-        if count is not None:
-            line = (message.hint(size) + message.hint(' [%3d]' % count) + ': ').ljust(13)
+        if is_chain_corrupted:
+            line = message.hint(size) + message.error(' [corrupted]') + '\n'
+            line += message.hint('FD: ') + formatted_chain + '\n'
+            line += message.hint('BK: ') + pwndbg.chain.format(chain_bk[0], offset=main_heap.chunk_key_offset('bk'))
         else:
-            line = (message.hint(size) + ': ').ljust(13)
-        line += formatted_chain
+            if count is not None:
+                line = (message.hint(size) + message.hint(' [%3d]' % count) + ': ').ljust(13)
+            else:
+                line = (message.hint(size) + ': ').ljust(13)
+            line += formatted_chain
+
         result.append(line)
 
     if not result:

--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -41,10 +41,14 @@ def format_bin(bins, verbose=False, offset=None):
         b = bins[size]
 
         count, is_chain_corrupted = None, False
+
+        # fastbins consists of only single linked list
         if len(b) == 1:  # fastbin:
             chain_fd = b
+        # tcachebins consists of single linked list and entries count
         elif len(b) == 2:  # tcachebin:
             chain_fd, count = b
+        # normal bins consists of double linked list and may be corrupted (we can detect corruption)
         else:  # normal bin
             chain_fd, chain_bk, is_chain_corrupted = b
 

--- a/pwndbg/commands/version.py
+++ b/pwndbg/commands/version.py
@@ -189,5 +189,3 @@ If it is somehow unavailable, use:
             print(please_please_submit + github_issue_url)    
     else:
         print(please_please_submit + github_issue_url)
-
-

--- a/pwndbg/heap/ptmalloc.py
+++ b/pwndbg/heap/ptmalloc.py
@@ -471,13 +471,17 @@ class Heap(pwndbg.heap.heap.BaseHeap):
         bk_offset   = self.chunk_key_offset('bk')
 
         is_chain_corrupted = False
-        chain_fd = pwndbg.chain.get(int(front), offset=fd_offset, hard_stop=current_base, limit=heap_chain_limit, include_start=True)
-        chain_bk = pwndbg.chain.get(int(back), offset=bk_offset, hard_stop=current_base, limit=heap_chain_limit, include_start=True)
+
+        get_chain = lambda bin, offset: pwndbg.chain.get(int(bin), offset=offset, hard_stop=current_base, limit=heap_chain_limit, include_start=True)
+        chain_fd = get_chain(front, fd_offset)
+        chain_bk = get_chain(back, bk_offset)
 
         # check if bin[index] points to itself (is empty)
-        if len(chain_fd) == 2 and len(chain_bk) == 2 and chain_fd[0] == chain_bk[0]:
+        if len(chain_fd) == len(chain_bk) == 2 and chain_fd[0] == chain_bk[0]:
             chain_fd = [0]
             chain_bk = [0]
+
+        # check if corrupted
         elif chain_fd[:-1] != chain_bk[:-2][::-1] + [chain_bk[-2]]:
             is_chain_corrupted = True
 


### PR DESCRIPTION
fixes #507 
Adds check for doubly linked bins corruption.
It's WIP, as idk how we want to print the corruption, currently its:
```python
pwndbg> bins
...
smallbins
0x100 [corrupted]
FD: 0x555555756600 ◂— 0xbeef
BK: 0x555555756400 —▸ 0x555555756600 —▸ 0x7ffff7dd3c48 (main_arena+328) ◂— 0x555555756400
0x130 [corrupted]
FD: 0x555555756a60 —▸ 0x7ffff7dd3c78 (main_arena+376) ◂— 0x555555756a60 /* '`juUUU' */
BK: 0x555555756800 —▸ 0x555555756a60 —▸ 0x7ffff7dd3c78 (main_arena+376) ◂— 0x555555756800
...
```

File to test:
```c
#include <stdio.h>
#include <stdlib.h>

int main() {
    char* a1 = malloc(0xf0);
    char* a2 = malloc(0xf0);
    char* a3 = malloc(0xf0);
    char* a4 = malloc(0xf0);
    char* a5 = malloc(0xf0);
    char* a6 = malloc(0xf0);
    char* a7 = malloc(0xf0);
    char* a8 = malloc(0xf0);

    free(a1);
    free(a3);
    free(a5);
    free(a7);
    // breakpoint 1 here

    *(size_t*)a1 = 0xdead;
    // breakpoint 2 here

    a3 = malloc(0xe0);
    char *l1 = malloc(0x123);
    char *l2 = malloc(0x123);
    char *l3 = malloc(0x123);
    char *l4 = malloc(0x123);
    free(l1);
    free(l3);
    malloc(0xe0);
    // breakpoint 3 here

    *(size_t*)a7 = 0xbeef;
    *(size_t*)l3 = *(size_t*)(l3+sizeof(size_t));
    // breakpoint 4 here

    return 0;
}
```