### PR TITLE
Fixes #538 - breakrva on symlink targets

### DIFF
--- a/pwndbg/auxv.py
+++ b/pwndbg/auxv.py
@@ -165,7 +165,7 @@ def walk_stack():
 
     if not auxv.get('AT_EXECFN', None):
         try:
-            auxv['AT_EXECFN'] = get_execfn()
+            auxv['AT_EXECFN'] = _get_execfn()
         except gdb.MemoryError:
             pass
 
@@ -245,7 +245,7 @@ def walk_stack2(offset=0):
 
     return auxv
 
-def get_execfn():
+def _get_execfn():
     # If the stack is not sane, this won't work
     if not pwndbg.memory.peek(pwndbg.regs.sp):
         return

--- a/pwndbg/commands/version.py
+++ b/pwndbg/commands/version.py
@@ -189,5 +189,3 @@ If it is somehow unavailable, use:
             print(please_please_submit + github_issue_url)    
     else:
         print(please_please_submit + github_issue_url)
-
-

--- a/pwndbg/vmmap.py
+++ b/pwndbg/vmmap.py
@@ -48,6 +48,11 @@ def get():
     pages.extend(proc_pid_maps())
 
     if not pages:
+        # If debugee is launched from a symlink the debugee memory maps will be
+        # labeled with symlink path while in normal scenario the /proc/pid/maps
+        # labels debugee memory maps with real path (after symlinks).
+        # This is because the exe path in AUXV (and so `info auxv`) is before
+        # following links.
         pages.extend(info_auxv())
 
         if pages: pages.extend(info_sharedlibrary())
@@ -326,7 +331,8 @@ def info_files():
 def info_auxv(skip_exe=False):
     """
     Extracts the name of the executable from the output of the command
-    "info auxv".
+    "info auxv". Note that if the executable path is a symlink,
+    it is not dereferenced by `info auxv` and we also don't dereference it.
 
     Arguments:
         skip_exe(bool): Do not return any mappings that belong to the exe.


### PR DESCRIPTION
Fixes a bug with `breakrva` and `brva` commands reported in #538 and adds some more
explanation on how certain things works:
* `info auxv` or to be more specific: AUXV's `ET_EXECFN` holds path to
the executable, but if it is a symlink, it is not dereferenced
* because of that we need to call `readlink` in `get_exe_name` in pie.py