### PR TITLE
Check if override built-in command

### DIFF
--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -25,7 +25,7 @@ commands = []
 
 def list_current_commands():
     current_pagination = gdb.execute('show pagination', to_string=True)
-    current_pagination = current_pagination.split()[-1][:-1] # Take last word and skip period
+    current_pagination = current_pagination.split()[-1].rstrip('.')  # Take last word and skip period
 
     gdb.execute('set pagination off')
     command_list = gdb.execute('help all', to_string=True).strip().split('\n')

--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -24,25 +24,28 @@ import pwndbg.ui
 commands = []
 
 def list_current_commands():
+    current_pagination = gdb.execute('show pagination', to_string=True)
+    current_pagination = current_pagination.split()[-1][:-1] # Take last word and skip period
+
     gdb.execute('set pagination off')
-    command_list = gdb.execute('help all', False, True).strip().split('\n')
+    command_list = gdb.execute('help all', to_string=True).strip().split('\n')
     existing_commands = set()
     for line in command_list:
         line = line.strip()
         # Skip non-command entries
         if len(line) == 0 or line.startswith('Command class:') or line.startswith('Unclassified commands'):
             continue
-        command = line.split(' ')[0]
+        command = line.split()[0]
         existing_commands.add(command)
-    return list(existing_commands)
+    gdb.execute('set pagination %s' % current_pagination) # Restore original setting
+    return existing_commands
 
-builtin_commands = list_current_commands()
+GDB_BUILTIN_COMMANDS = list_current_commands()
 
 class Command(gdb.Command):
     """Generic command wrapper"""
     command_names = set()
-    builtin_commands = builtin_commands
-    builtin_override_whitelist = ['up', 'down', 'search', 'pwd', 'start']
+    builtin_override_whitelist = {'up', 'down', 'search', 'pwd', 'start'}
     history = {}
 
     def __init__(self, function, prefix=False):
@@ -53,7 +56,7 @@ class Command(gdb.Command):
 
         if command_name in self.command_names:
             raise Exception('Cannot add command %s: already exists.' % command_name)
-        if command_name in self.builtin_commands and command_name not in self.builtin_override_whitelist:
+        if command_name in GDB_BUILTIN_COMMANDS and command_name not in self.builtin_override_whitelist:
             raise Exception('Cannot override non-whitelisted built-in command "%s"' % command_name)
 
         self.command_names.add(command_name)

--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -42,6 +42,7 @@ class Command(gdb.Command):
     """Generic command wrapper"""
     command_names = set()
     builtin_commands = builtin_commands
+    builtin_override_whitelist = ['up', 'down', 'search', 'pwd', 'start']
     history = {}
 
     def __init__(self, function, prefix=False):
@@ -52,8 +53,8 @@ class Command(gdb.Command):
 
         if command_name in self.command_names:
             raise Exception('Cannot add command %s: already exists.' % command_name)
-        if command_name in self.builtin_commands:
-            print(pwndbg.color.message.warn('Pwndbg overrides builtin command "%s"' % command_name))
+        if command_name in self.builtin_commands and command_name not in self.builtin_override_whitelist:
+            raise Exception('Cannot override non-whitelisted built-in command "%s"' % command_name)
 
         self.command_names.add(command_name)
         commands.append(self)


### PR DESCRIPTION
This PR aims to start a discussion on https://github.com/pwndbg/pwndbg/issues/230
This code fetches current gdb command on start-up and stores them in a list in the Command class.

The question is what to do with this list. As an example, I simply print out a warning but this is not really desirable since it prints out warnings for intended behaviour and is not actionable for the end-user. Another way to go would be to have a whitelist of the currently overridden commands: up, down, search, pwd and start and abort/exit if you try to override any other.

Thoughts?