### PR TITLE
Removed unwanted Exception

### DIFF
--- a/pwndbg/heap/ptmalloc.py
+++ b/pwndbg/heap/ptmalloc.py
@@ -150,6 +150,7 @@ class Heap(pwndbg.heap.heap.BaseHeap):
             except Exception as e:
                 print(message.error('Error fetching tcache. GDB cannot access '
                                     'thread-local variables unless you compile with -lpthread.'))
+                return None
         else:
             if not self.has_tcache():
                 print(message.warn('Your libc does not use thread cache'))


### PR DESCRIPTION
Removes an exception in the tcache/bins command where the exception would be printed as well as an error message.
This is purely a UI fix as described in Issue #535 