### PR TITLE
Fix #555 - The return address register not restored

### DIFF
--- a/pwndbg/emu/emulator.py
+++ b/pwndbg/emu/emulator.py
@@ -142,7 +142,7 @@ class Emulator(object):
         self._curr = None
 
         # Initialize the register state
-        for reg in list(self.regs.misc) + list(self.regs.common) + list(self.regs.flags):
+        for reg in list(self.regs.retaddr) + list(self.regs.misc) + list(self.regs.common) + list(self.regs.flags):
             enum = self.get_reg_enum(reg)
 
             if not reg:
@@ -450,7 +450,7 @@ class Emulator(object):
         self._single_step = (address, instruction_size)
 
     def dumpregs(self):
-        for reg in list(self.regs.misc) + list(self.regs.common) + list(self.regs.flags):
+        for reg in list(self.regs.retaddr) + list(self.regs.misc) + list(self.regs.common) + list(self.regs.flags):
             enum = self.get_reg_enum(reg)
 
             if not reg or enum is None:


### PR DESCRIPTION
Fixed #555.

Since #556 has been fixed in the master branch of unicorn (the release version 1.0.1 still hangs), the gdb no longer hangs when debug an aarch64 program, but there is still a little difference between before and after the fix.

Before fix, because of the `lr` register not restored, pwndbg can not get the next instruction correctly after the `ret` instruction at `0x8026c`:
<img width="1202" alt="2018-10-24 21 06 36" src="https://user-images.githubusercontent.com/11389231/47434498-43c83400-d7d5-11e8-9128-6516291f4b11.png">

After fix, pwndbg can get the correct return address `0x800b8`:
<img width="1202" alt="2018-10-24 21 33 37" src="https://user-images.githubusercontent.com/11389231/47434533-56426d80-d7d5-11e8-8ed1-2132631707df.png">
