### PR TITLE
Add missing rust type

### DIFF
--- a/pwndbg/typeinfo.py
+++ b/pwndbg/typeinfo.py
@@ -49,19 +49,19 @@ def update():
 
     module.char   = gdb.lookup_type('char')
     module.ulong  = lookup_types('unsigned long', 'uint', 'u32')
-    module.long   = lookup_types('long', 'int')
-    module.uchar  = lookup_types('unsigned char', 'ubyte')
+    module.long   = lookup_types('long', 'int', 'i32')
+    module.uchar  = lookup_types('unsigned char', 'ubyte', 'u8')
     module.ushort = lookup_types('unsigned short', 'ushort', 'u16')
-    module.uint   = lookup_types('unsigned int', 'uint')
+    module.uint   = lookup_types('unsigned int', 'uint', 'u32')
     module.void   = lookup_types('void', '()')
     module.uint8  = module.uchar
     module.uint16 = module.ushort
     module.uint32 = module.uint
     module.uint64 = lookup_types('unsigned long long', 'ulong', 'u64')
 
-    module.int8   = gdb.lookup_type('char')
+    module.int8   = lookup_types('char', 'i8')
     module.int16  = lookup_types('short', 'i16')
-    module.int32  = gdb.lookup_type('int')
+    module.int32  = lookup_types('int', 'i32')
     module.int64  = lookup_types('long long', 'long', 'i64')
 
     module.ssize_t = module.long


### PR DESCRIPTION
#431 added basic rust support, but some types are missing. Debugging the rust program may cause pwndbg to throw the following exception:

```
Exception occured: Error: No type named int. (<class 'gdb.error'>)
For more info invoke `set exception-verbose on` and rerun the command
or debug it by yourself with `set exception-debugger on`
Python Exception <class 'gdb.error'> No type named int.: 
```