### PR TITLE
Fixed register names and capstone mode flags for sparc

### DIFF
--- a/pwndbg/disasm/__init__.py
+++ b/pwndbg/disasm/__init__.py
@@ -86,6 +86,13 @@ def get_disassembler(pc):
         extra = {0:CS_MODE_ARM,
                  0x20:CS_MODE_THUMB}[pwndbg.regs.cpsr & 0x20]
 
+    if pwndbg.arch.current == 'sparc':
+        if 'v9' in gdb.newest_frame().architecture().name():
+            extra = CS_MODE_V9
+        else:
+            # The ptrsize base modes cause capstone.CsError: Invalid mode (CS_ERR_MODE)
+            extra = 0 
+
     return get_disassembler_cached(pwndbg.arch.current,
                                    pwndbg.arch.ptrsize,
                                    pwndbg.arch.endian,

--- a/pwndbg/regs.py
+++ b/pwndbg/regs.py
@@ -187,7 +187,7 @@ powerpc = RegisterSet(  retaddr = ('lr','r0'),
 # %o0 == %r8                          \
 # ...                                 | o stands for output (note: not 0)
 # %o6 == %r14 == %sp (stack ptr)      |
-# %o7 == %r15 == for return aaddress   |
+# %o7 == %r15 == for return address   |
 # ____________________________________/
 # %l0 == %r16                         \
 # ...                                 | l stands for local (note: not 1)
@@ -200,12 +200,12 @@ powerpc = RegisterSet(  retaddr = ('lr','r0'),
 # ____________________________________/
 
 sparc_gp = tuple(['g%i' % i for i in range(1,8)]
-                +['o%i' % i for i in range(0,6)]
+                +['o%i' % i for i in range(0,6)]+['o7']
                 +['l%i' % i for i in range(0,8)]
                 +['i%i' % i for i in range(0,6)])
-sparc = RegisterSet(stack   = 'o6',
-                    frame   = 'i6',
-                    retaddr = ('o7',),
+sparc = RegisterSet(stack   = 'sp',
+                    frame   = 'fp',
+                    retaddr = ('i7',),
                     flags   = {'psr':{}},
                     gpr     = sparc_gp,
                     args    = ('i0','i1','i2','i3','i4','i5'),


### PR DESCRIPTION
On sparc architecture the original register aliases caused  the `context regs` command to fail. Similarly, the default `CS_MODE_32` causes a `capstone.CsError: Invalid mode (CS_ERR_MODE)` exception, thus the `context disasm` failed. I have tested this with the following sw versions:

```
qemu-sparc32plus --version
qemu-sparc32plus version 3.0.0
Copyright (c) 2003-2017 Fabrice Bellard and the QEMU Project developers

gdb-multiarch --version
GNU gdb (GDB) 8.2
```
Cheers,
Gym