### PR TITLE
Fix #587 - bug in enhance_next

### DIFF
--- a/pwndbg/disasm/arch.py
+++ b/pwndbg/disasm/arch.py
@@ -8,6 +8,7 @@ from __future__ import unicode_literals
 import collections
 
 import capstone
+import gdb
 from capstone import *
 
 import pwndbg.memoize
@@ -147,7 +148,12 @@ class DisassemblyAssistant(object):
 
             # self.memory may return none, so we need to check it here again
             if addr is not None:
-                addr = int(pwndbg.memory.poi(pwndbg.typeinfo.ppvoid, addr))
+                try:
+                    # fails with gdb.MemoryError if the dereferenced address
+                    # doesn't belong to any of process memory maps
+                    addr = int(pwndbg.memory.poi(pwndbg.typeinfo.ppvoid, addr))
+                except gdb.MemoryError:
+                    return None
         if op.type == CS_OP_REG:
             addr = self.register(instruction, op)
 
@@ -243,6 +249,9 @@ class DisassemblyAssistant(object):
         return None # raise NotImplementedError
 
     def dump(self, instruction):
+        """
+        Debug-only method.
+        """
         ins = instruction
         rv  = []
         rv.append('%s %s' % (ins.mnemonic, ins.op_str))


### PR DESCRIPTION
See issue #587.

For instructions such as CALL or JUMP that uses indirect addresses fetched from memory, e.g: `call qword [r11 + 0x30]`, we enhance displaying them by showing the address we are going to call or jump to.

The problem is that when the dereferenced address, in the above example: `r11 + 0x30` didn't belong to process memory, the instruction-enhancing procedure (`enhance_next`) was crashing.

This PR fixes it by try-catching the address dereference operation (`pwndbg.memory.poi`) and returning `None` if it fails (throws a `gdb.MemoryError`).

As a result, for such bad cases, no enhancement is done.