### PR TITLE
Update Capstone to 4.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,6 @@ ROPgadget
 six
 unicorn>=1.0.0
 pygments
-https://github.com/aquynh/capstone/archive/next.zip#subdirectory=bindings/python
+capstone==4.0.0
 enum34
 pytest


### PR DESCRIPTION
Note that there is already Capstone 4.0.1 but it hasn't been released to
pypi yet.

The current `next.zip` points to Capstone 5.0 and currently breaks
pwndbg (due to bindings and capstone versions mismatch).