### PR TITLE
Use default set print elements

### DIFF
--- a/pwndbg/__init__.py
+++ b/pwndbg/__init__.py
@@ -136,7 +136,6 @@ set backtrace past-main on
 set step-mode on
 set print pretty on
 set width %i
-set print elements 15
 handle SIGALRM nostop print nopass
 handle SIGBUS  stop   print nopass
 handle SIGPIPE nostop print nopass


### PR DESCRIPTION
Long strings are truncated anyway when displaying context. And the limit is annoying for commands like `x/s` or `ds`, so I am removing it (it will default to gdb's default which is 200, at least for me).