### PR TITLE
Bump Capstone to 4.0.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,6 @@ ROPgadget
 six
 unicorn>=1.0.0
 pygments
-capstone==4.0.0
+capstone==4.0.1
 enum34
 pytest


### PR DESCRIPTION
As it is there! https://pypi.org/project/capstone/#history

It has a minor bug which hits us when we do `version` command, but it isn't that big deal (see https://github.com/aquynh/capstone/issues/1315#issuecomment-454386418).