### PR TITLE
Fix sytax hl cache bug

### DIFF
--- a/pwndbg/color/syntax_highlight.py
+++ b/pwndbg/color/syntax_highlight.py
@@ -34,6 +34,10 @@ def check_style():
         formatter = pygments.formatters.Terminal256Formatter(
             style=str(style)
         )
+
+        # Reset the highlighted source cache
+        from pwndbg.commands.context import get_highlight_source
+        get_highlight_source._reset()
     except pygments.util.ClassNotFound:
         print(message.warn("The pygment formatter style '%s' is not found, restore to default" % style))
         style.revert_default()


### PR DESCRIPTION
TLDR: when context has been displayed the higlighted code is cached; if we  change the pygmets style, displaying context again does not show the new style. This commit fixes this issue by resetting the memoized/cached highlighted code.