### PR TITLE
Enhance remote QEMU targets debugging experience

### DIFF
--- a/pwndbg/commands/vmmap.py
+++ b/pwndbg/commands/vmmap.py
@@ -39,7 +39,12 @@ def pages_filter(s):
 
 
 parser = argparse.ArgumentParser()
-parser.description = 'Print virtual memory map pages. Results can be filtered by providing address/module name.'
+parser.description = '''Print virtual memory map pages. Results can be filtered by providing address/module name.
+
+Please note that memory pages on QEMU targets are detected through AUXV (sometimes with finding AUXV on the stack first)
+or by exploring values e.g. from registers.
+
+Memory pages can also be added manually, see vmmap_add, vmmap_clear and vmmap_load commands.'''
 parser.add_argument('pages_filter', type=pages_filter, nargs='?', default=None,
                     help='Address or module name.')
 
@@ -56,6 +61,9 @@ def vmmap(pages_filter=None):
     print(M.legend())
     for page in pages:
         print(M.get(page.vaddr, text=str(page)))
+
+    if pwndbg.qemu.is_qemu():
+        print("\n[QEMU target detected - vmmap result might not be accurate; see `help vmmap`]")
 
 
 parser = argparse.ArgumentParser()

--- a/pwndbg/qemu.py
+++ b/pwndbg/qemu.py
@@ -22,6 +22,10 @@ def is_qemu():
     if not pwndbg.remote.is_remote():
         return False
 
+    # Example:
+    # pwndbg> maintenance packet Qqemu.sstepbits
+    # sending: "Qqemu.sstepbits"
+    # received: "ENABLE=1,NOIRQ=2,NOTIMER=4"
     response = gdb.execute('maintenance packet Qqemu.sstepbits',
                            to_string=True,
                            from_tty=False)

--- a/pwndbg/stack.py
+++ b/pwndbg/stack.py
@@ -66,7 +66,9 @@ def update():
             thread.switch()
             sp = pwndbg.regs.sp
 
-            if sp is None:
+            # Skip if sp is None or 0
+            # (it might be 0 if we debug a qemu kernel)
+            if not sp:
                 continue
 
             sp_low = sp & ~(0xfff)

--- a/pwndbg/vmmap.py
+++ b/pwndbg/vmmap.py
@@ -62,7 +62,7 @@ def get():
 
 @pwndbg.memoize.reset_on_stop
 def find(address):
-    if address is None: # or address < pwndbg.memory.MMAP_MIN_ADDR:
+    if address is None:
         return None
 
     address = int(address)

--- a/pwndbg/vmmap.py
+++ b/pwndbg/vmmap.py
@@ -62,11 +62,10 @@ def get():
 
 @pwndbg.memoize.reset_on_stop
 def find(address):
-    if address is None or address < pwndbg.memory.MMAP_MIN_ADDR:
+    if address is None: # or address < pwndbg.memory.MMAP_MIN_ADDR:
         return None
 
-    if address:
-        address = int(address)
+    address = int(address)
 
     for page in get():
         if address in page:
@@ -103,6 +102,7 @@ def explore(address_maybe):
     flags |= 1 if not pwndbg.stack.nx               else 0
 
     page = find_boundaries(address_maybe)
+    page.objfile = '<explored>'
     page.flags = flags
 
     explored_pages.append(page)
@@ -150,7 +150,9 @@ def proc_pid_maps():
         A list of pwndbg.memory.Page objects.
     """
 
-    if pwndbg.qemu.is_qemu_usermode():
+    # If we debug remotely a qemu-user or qemu-system target,
+    # there is no point of hitting things further
+    if pwndbg.qemu.is_qemu():
         return tuple()
 
     example_proc_pid_maps = """


### PR DESCRIPTION
- improve vmmap command help and inform user that the result might not be accurate for QEMU targets
- updating stack pages (`pwndbg.stack.stacks`): skip detecting stack pages if SP is 0 (this lead to displaying memory page that started at -0x1000)
- `pwndbg.vmmap.find` - don't skip addresses below `pwndbg.memory.MMAP_MIN_ADDR` - this function is used by `pwndbg.color.memory.get` which is used by `vmmap` command - because we skipped addresses - a memory page starting below that address wasn't colored by `vmmap` display
- memory pages found with exploration will now have `<explored>` name (or objfile) in `vmmap`
- The `proc_pid_maps` returns fast for QEMU-user targets - with this PR it will also do for QEMU kernel targets too since there are no files anyway (this was bug-prone as QEMU targets have 42000 pid returned by GDB and we potentially tried adding memory pages from another process, which luckily usually wasn't there)