### PR TITLE
fix: linetable.line.pc negative address when debug kernel

### DIFF
--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -8,6 +8,7 @@ from __future__ import unicode_literals
 import ast
 import codecs
 import sys
+import ctypes
 from io import open
 
 import gdb
@@ -215,9 +216,11 @@ def context_code():
         closest_pc = -1
         closest_line = -1
         for line in linetable:
-            if closest_pc < line.pc <= pwndbg.regs.pc:
+            real_address = ctypes.c_uint64(line.pc).value
+            # print("line is %d, address is %s" % (line.line, hex(real_address)))
+            if closest_pc < real_address <= pwndbg.regs.pc:
                 closest_line = line.line
-                closest_pc   = line.pc
+                closest_pc   = real_address
 
         if closest_line < 0:
             return []


### PR DESCRIPTION
There is a bug when I was debugging the kernel which make me can't get the right source line.

Since kernel address starts with 0xfffffff, and so the line.pc becomes a negative value(I don't know why, is it bug of gdb.python?)