### PR TITLE
Added install instruction for Manjaro users on setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -58,6 +58,13 @@ if linux; then
             echo " - https://aur.archlinux.org/packages/pwndbg-git/"
             exit 1
             ;;
+        "manjaro")
+            echo "Pwndbg is not avaiable on Manjaro's repositories."
+            echo "But it can be installed using Arch's AUR community package. See:"
+            echo " - https://www.archlinux.org/packages/community/any/pwndbg/"
+            echo " - https://aur.archlinux.org/packages/pwndbg-git/"
+            exit 1
+            ;;
         *) # we can add more install command for each distros.
             echo "\"$distro\" is not supported distro. Will search for 'apt' or 'dnf' package managers."
             if hash apt; then


### PR DESCRIPTION
On manjaro the following command:
```sudo pacman -Syu pwndbg-git```
would not work.
But with yay or yoaurt it does.