### PR TITLE
Add leakfind command

### DIFF
--- a/pwndbg/__init__.py
+++ b/pwndbg/__init__.py
@@ -31,6 +31,7 @@ import pwndbg.commands.got
 import pwndbg.commands.heap
 import pwndbg.commands.hexdump
 import pwndbg.commands.ida
+import pwndbg.commands.leakfind
 import pwndbg.commands.misc
 import pwndbg.commands.next
 import pwndbg.commands.peda
@@ -106,6 +107,7 @@ __all__ = [
 'hexdump',
 'ida',
 'info',
+'leakfind',
 'linkmap',
 'malloc',
 'memoize',

--- a/pwndbg/commands/leakfind.py
+++ b/pwndbg/commands/leakfind.py
@@ -9,15 +9,15 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import argparse
+from queue import *
 
 import gdb
 
+import pwndbg.color.chain as C
 import pwndbg.color.memory as M
+import pwndbg.color.theme as theme
 import pwndbg.commands
 import pwndbg.vmmap
-import pwndbg.color.theme as theme
-import pwndbg.color.chain as C
-from queue import *
 
 config_arrow_right = theme.Parameter('chain-arrow-right', '—▸', 'right arrow of chain formatting')
 arrow_right = C.arrow(' %s ' % config_arrow_right)
@@ -34,7 +34,10 @@ def get_rec_addr_string(addr,visitedMap):
         parentInfo = visitedMap[addr]
         parent = parentInfo[0]
         parent_base_addr = parentInfo[1]
-        curText = hex(parent_base_addr) + "+"+hex(parent-parent_base_addr)
+        if parent-parent_base_addr < 0:
+            curText = hex(parent_base_addr) + hex(parent-parent_base_addr)
+        else:
+            curText = hex(parent_base_addr) + "+"+ hex(parent-parent_base_addr)
         if parent_base_addr == addr:
             return ""
         return get_rec_addr_string(parent_base_addr,visitedMap) + M.get(parent_base_addr,text=curText)+arrow_right
@@ -58,14 +61,14 @@ Example: leakfind $rsp filename 0x48 6. This would look for any chains of leaks 
 and are a maximum length of 6.\n
 """
 parser.add_argument("address",help="Starting address to find a leak chain from.")
-parser.add_argument("page_name",type=str,nargs="?",default=None,help="Substring required to be part of the name of any found pages")
-parser.add_argument("max_offset",default=0x48,nargs="?",help="Max Offset to add to addresses when looking for leak.")
-parser.add_argument("max_depth",default=0x4,nargs="?",help="Maximum depth to follow pointers to.")
-parser.add_argument("stride",nargs="?",default=0x1,help="Stride to add to add between pointers considered. For example, if this is 4 it would only consider pointers at an offset divisible by 4 from the starting pointer.")
-
+parser.add_argument("-p","--page_name",type=str,nargs="?",default=None,help="Substring required to be part of the name of any found pages")
+parser.add_argument("-o","--max_offset",default=0x48,nargs="?",help="Max offset to add to addresses when looking for leak.")
+parser.add_argument("-d","--max_depth",default=0x4,nargs="?",help="Maximum depth to follow pointers to.")
+parser.add_argument("-s","--stride",nargs="?",default=0x1,help="Stride to add to add between pointers considered. For example, if this is 4 it would only consider pointers at an offset divisible by 4 from the starting pointer.")
+parser.add_argument('--negative_offset',nargs="?",default=0x0,help="Max negative offset to search before an address when looking for a leak.")
 @pwndbg.commands.ArgparsedCommand(parser)
 @pwndbg.commands.OnlyWhenRunning
-def leakfind(address=-1,page_name=None,max_offset=0x40,max_depth=0x4,stride=0x1):
+def leakfind(address=-1,page_name=None,max_offset=0x40,max_depth=0x4,stride=0x1,negative_offset=0x0):
     if address == -1:
         print("No starting address provided. Please run leakfind -h for more information.")
         return
@@ -88,7 +91,7 @@ def leakfind(address=-1,page_name=None,max_offset=0x40,max_depth=0x4,stride=0x1)
     stride = int(stride)
     address=int(address)
     max_offset = int(max_offset)
-
+    negative_offset=int(negative_offset)
     
     #The below map stores a map of child address->(parent_address,parent_start_address)
     #In the above tuple, parent_address is the exact address with a pointer to the child adddress.
@@ -111,7 +114,7 @@ def leakfind(address=-1,page_name=None,max_offset=0x40,max_depth=0x4,stride=0x1)
             timeToDepthIncrease=addressQueue.qsize()
         cur_start_addr = addressQueue.get()
         timeToDepthIncrease-=1
-        for cur_addr in range(cur_start_addr,cur_start_addr+max_offset,stride):
+        for cur_addr in range(cur_start_addr-negative_offset,cur_start_addr+max_offset,stride):
             try:
                 result = int(pwndbg.memory.pvoid(cur_addr))
                 if result in visitedMap:
@@ -125,13 +128,14 @@ def leakfind(address=-1,page_name=None,max_offset=0x40,max_depth=0x4,stride=0x1)
                 #That means the memory was unreadable. Just skip it if we can't read it. 
                 break
 
-    #A map of chain_length->list of lines. Used to let us print in a somewhat nice manner.
+    #A map of length->list of lines. Used to let us print in a somewhat nice manner.
     outputMap = {}
 
+ 
     for child in visitedMap:
         childPage = getPage(child)
-        if (not childPage is None) and not (childPage.vaddr == foundPages.vaddr):
-            if not page_name == None:
+        if childPage is not None:
+            if page_name is not None:
                 if not page_name in childPage.objfile:
                     continue
             line = get_rec_addr_string(child,visitedMap) + M.get(child) + " " + M.get(child,text=childPage.objfile)

--- a/pwndbg/commands/leakfind.py
+++ b/pwndbg/commands/leakfind.py
@@ -66,7 +66,7 @@ parser.add_argument("-s", "--step", nargs="?", default=0x1, help="Step to add be
 parser.add_argument('--negative_offset',nargs="?", default=0x0, help="Max negative offset to search before an address when looking for a leak")
 @pwndbg.commands.ArgparsedCommand(parser)
 @pwndbg.commands.OnlyWhenRunning
-def leakfind(address=-1, page_name=None, max_offset=0x40, max_depth=0x4, stride=0x1, negative_offset=0x0):
+def leakfind(address=None, page_name=None, max_offset=0x40, max_depth=0x4, stride=0x1, negative_offset=0x0):
     if address is None:
         raise argparse.ArgumentTypeError('No starting address provided.')
 

--- a/pwndbg/commands/leakfind.py
+++ b/pwndbg/commands/leakfind.py
@@ -21,9 +21,9 @@ import pwndbg.vmmap
 from pwndbg.chain import config_arrow_right
 
 
-#Used to recursively print the pointer chain. 
-#addr is a pointer. It is taken to be a child pointer.
-#visited_map is a map of children -> (parent,parent_start)
+# Used to recursively print the pointer chain. 
+# addr is a pointer. It is taken to be a child pointer.
+# visited_map is a map of children -> (parent,parent_start)
 def get_rec_addr_string(addr,visited_map):
     page = pwndbg.vmmap.find(addr)
     arrow_right = C.arrow(' %s ' % config_arrow_right)
@@ -41,15 +41,15 @@ def get_rec_addr_string(addr,visited_map):
             curText = hex(parent_base_addr) + "+" + hex(parent - parent_base_addr)
         if parent_base_addr == addr:
             return ""
-        return get_rec_addr_string(parent_base_addr,visited_map) + M.get(parent_base_addr,text=curText)+arrow_right
+        return get_rec_addr_string(parent_base_addr,visited_map) + M.get(parent_base_addr,text=curText) + arrow_right
     else:
         return ""
 
 
-#Useful for debugging. Prints a map of child -> (parent, parent_start)
+# Useful for debugging. Prints a map of child -> (parent, parent_start)
 def dbg_print_map(maps):
     for child, parent_info in maps.items():
-        print("0x%x + (0x%x, 0x%x)" % ((child, parent_info[0],parent_info[1])))
+        print("0x%x + (0x%x, 0x%x)" % (child, parent_info[0], parent_info[1]))
 
 parser = argparse.ArgumentParser()
 parser.description = """
@@ -59,14 +59,14 @@ Example: leakfind $rsp --page_name=filename --max_offset=0x48 --max_depth=6. Thi
 and are a maximum length of 6\n
 """
 parser.add_argument("address",help="Starting address to find a leak chain from")
-parser.add_argument("-p","--page_name",type=str,nargs="?",default=None,help="Substring required to be part of the name of any found pages")
-parser.add_argument("-o","--max_offset",default=0x48,nargs="?",help="Max offset to add to addresses when looking for leak")
-parser.add_argument("-d","--max_depth",default=0x4,nargs="?",help="Maximum depth to follow pointers to")
-parser.add_argument("-s","--stride",nargs="?",default=0x1,help="Stride to add to add between pointers considered. For example, if this is 4 it would only consider pointers at an offset divisible by 4 from the starting pointer")
-parser.add_argument('--negative_offset',nargs="?",default=0x0,help="Max negative offset to search before an address when looking for a leak")
+parser.add_argument("-p", "--page_name", type=str, nargs="?", default=None, help="Substring required to be part of the name of any found pages")
+parser.add_argument("-o", "--max_offset", default=0x48, nargs="?", help="Max offset to add to addresses when looking for leak")
+parser.add_argument("-d", "--max_depth", default=0x4, nargs="?", help="Maximum depth to follow pointers to")
+parser.add_argument("-s", "--stride", nargs="?", default=0x1, help="Stride to add to add between pointers considered. For example, if this is 4 it would only consider pointers at an offset divisible by 4 from the starting pointer")
+parser.add_argument('--negative_offset',nargs="?", default=0x0, help="Max negative offset to search before an address when looking for a leak")
 @pwndbg.commands.ArgparsedCommand(parser)
 @pwndbg.commands.OnlyWhenRunning
-def leakfind(address=-1,page_name=None,max_offset=0x40,max_depth=0x4,stride=0x1,negative_offset=0x0):
+def leakfind(address=-1, page_name=None, max_offset=0x40, max_depth=0x4, stride=0x1, negative_offset=0x0):
     if address == -1:
         raise argparse.ArgumentTypeError('No starting address provided.')
 
@@ -78,20 +78,21 @@ def leakfind(address=-1,page_name=None,max_offset=0x40,max_depth=0x4,stride=0x1,
     if not pwndbg.memory.peek(address):
         raise argparse.ArgumentTypeError('Unable to read from starting address.')
 
-    max_depth=int(max_depth)
-    #Just warn the user that a large depth might be slow. Probably worth checking offset^depth < threshold. Do this when more benchmarking is established.
+    max_depth = int(max_depth)
+    # Just warn the user that a large depth might be slow.
+    # Probably worth checking offset^depth < threshold. Do this when more benchmarking is established.
     if max_depth > 8:
         print("leakfind may take a while to run on larger depths.")
     
     stride = int(stride)
-    address=int(address)
+    address = int(address)
     max_offset = int(max_offset)
-    negative_offset=int(negative_offset)
+    negative_offset = int(negative_offset)
     
-    #The below map stores a map of child address->(parent_address,parent_start_address)
-    #In the above tuple, parent_address is the exact address with a pointer to the child adddress.
-    #parent_start_address is an address that a previous address pointed to.
-    #We need to store both so that we can nicely create our leak chain.
+    # The below map stores a map of child address->(parent_address,parent_start_address)
+    # In the above tuple, parent_address is the exact address with a pointer to the child adddress.
+    # parent_start_address is an address that a previous address pointed to.
+    # We need to store both so that we can nicely create our leak chain.
     visited_map = {}
     visited_set = {int(address)}
     address_queue = Queue()
@@ -99,30 +100,28 @@ def leakfind(address=-1,page_name=None,max_offset=0x40,max_depth=0x4,stride=0x1,
     depth = 0
     time_to_depth_increase = 0
 
-    #Run a bfs
-    #TODO look into performance gain from checking if an address is mapped before calling pwndbg.memory.pvoid()
-    #TODO also check using pwndbg.memory.read for possible performance boosts.
+    # Run a bfs
+    # TODO look into performance gain from checking if an address is mapped before calling pwndbg.memory.pvoid()
+    # TODO also check using pwndbg.memory.read for possible performance boosts.
     while address_queue.qsize() > 0 and depth < max_depth:
         if time_to_depth_increase == 0:
-            depth=depth+1
+            depth = depth + 1
             time_to_depth_increase = address_queue.qsize()
         cur_start_addr = address_queue.get()
         time_to_depth_increase -= 1
         for cur_addr in range(cur_start_addr - negative_offset, cur_start_addr + max_offset, stride):
             try:
                 result = int(pwndbg.memory.pvoid(cur_addr))
-                if result in visited_map:
+                if result in visited_map or result in visited_set:
                     continue
-                if result in visited_set:
-                    continue
-                visited_map[result] = (cur_addr,cur_start_addr) #map is of form child->(parent,parent_start)
+                visited_map[result] = (cur_addr, cur_start_addr) # map is of form child->(parent,parent_start)
                 address_queue.put(result)
                 visited_set.add(result)
             except gdb.error:
-                #That means the memory was unmapped. Just skip it if we can't read it. 
+                # That means the memory was unmapped. Just skip it if we can't read it. 
                 break
 
-    #A map of length->list of lines. Used to let us print in a somewhat nice manner.
+    # A map of length->list of lines. Used to let us print in a somewhat nice manner.
     output_map = {}
     arrow_right = C.arrow(' %s ' % config_arrow_right)
 
@@ -139,7 +138,7 @@ def leakfind(address=-1,page_name=None,max_offset=0x40,max_depth=0x4,stride=0x1,
                 output_map[chain_length] = [line]
 
 
-    #Output sorted by length of chain
+    # Output sorted by length of chain
     for chain_length in output_map:
         for line in output_map[chain_length]:
             print(line)

--- a/pwndbg/commands/leakfind.py
+++ b/pwndbg/commands/leakfind.py
@@ -62,7 +62,7 @@ parser.add_argument("address",help="Starting address to find a leak chain from")
 parser.add_argument("-p", "--page_name", type=str, nargs="?", default=None, help="Substring required to be part of the name of any found pages")
 parser.add_argument("-o", "--max_offset", default=0x48, nargs="?", help="Max offset to add to addresses when looking for leak")
 parser.add_argument("-d", "--max_depth", default=0x4, nargs="?", help="Maximum depth to follow pointers to")
-parser.add_argument("-s", "--stride", nargs="?", default=0x1, help="Stride to add to add between pointers considered. For example, if this is 4 it would only consider pointers at an offset divisible by 4 from the starting pointer")
+parser.add_argument("-s", "--step", nargs="?", default=0x1, help="Step to add between pointers so they are considered. For example, if this is 4 it would only consider pointers at an offset divisible by 4 from the starting pointer")
 parser.add_argument('--negative_offset',nargs="?", default=0x0, help="Max negative offset to search before an address when looking for a leak")
 @pwndbg.commands.ArgparsedCommand(parser)
 @pwndbg.commands.OnlyWhenRunning

--- a/pwndbg/commands/leakfind.py
+++ b/pwndbg/commands/leakfind.py
@@ -67,7 +67,7 @@ parser.add_argument('--negative_offset',nargs="?", default=0x0, help="Max negati
 @pwndbg.commands.ArgparsedCommand(parser)
 @pwndbg.commands.OnlyWhenRunning
 def leakfind(address=-1, page_name=None, max_offset=0x40, max_depth=0x4, stride=0x1, negative_offset=0x0):
-    if address == -1:
+    if address is None:
         raise argparse.ArgumentTypeError('No starting address provided.')
 
     foundPages = pwndbg.vmmap.find(address)

--- a/pwndbg/commands/leakfind.py
+++ b/pwndbg/commands/leakfind.py
@@ -57,15 +57,15 @@ parser = argparse.ArgumentParser()
 parser.description = """
 Attempt to find a leak chain given a starting address. Scans memory near the given address, looks for pointers, 
 and continues that process to attempt to find leaks.\n
-Example: leakfind $rsp filename 0x48 6. This would look for any chains of leaks that point to a section in filename which begin near $rsp, are never 0x48 bytes further from a known pointer, 
-and are a maximum length of 6.\n
+Example: leakfind $rsp --page_name=filename --offset=0x48 --max_depth=6. This would look for any chains of leaks that point to a section in filename which begin near $rsp, are never 0x48 bytes further from a known pointer, 
+and are a maximum length of 6\n
 """
-parser.add_argument("address",help="Starting address to find a leak chain from.")
+parser.add_argument("address",help="Starting address to find a leak chain from")
 parser.add_argument("-p","--page_name",type=str,nargs="?",default=None,help="Substring required to be part of the name of any found pages")
-parser.add_argument("-o","--max_offset",default=0x48,nargs="?",help="Max offset to add to addresses when looking for leak.")
-parser.add_argument("-d","--max_depth",default=0x4,nargs="?",help="Maximum depth to follow pointers to.")
-parser.add_argument("-s","--stride",nargs="?",default=0x1,help="Stride to add to add between pointers considered. For example, if this is 4 it would only consider pointers at an offset divisible by 4 from the starting pointer.")
-parser.add_argument('--negative_offset',nargs="?",default=0x0,help="Max negative offset to search before an address when looking for a leak.")
+parser.add_argument("-o","--max_offset",default=0x48,nargs="?",help="Max offset to add to addresses when looking for leak")
+parser.add_argument("-d","--max_depth",default=0x4,nargs="?",help="Maximum depth to follow pointers to")
+parser.add_argument("-s","--stride",nargs="?",default=0x1,help="Stride to add to add between pointers considered. For example, if this is 4 it would only consider pointers at an offset divisible by 4 from the starting pointer")
+parser.add_argument('--negative_offset',nargs="?",default=0x0,help="Max negative offset to search before an address when looking for a leak")
 @pwndbg.commands.ArgparsedCommand(parser)
 @pwndbg.commands.OnlyWhenRunning
 def leakfind(address=-1,page_name=None,max_offset=0x40,max_depth=0x4,stride=0x1,negative_offset=0x0):

--- a/pwndbg/commands/leakfind.py
+++ b/pwndbg/commands/leakfind.py
@@ -25,7 +25,7 @@ from pwndbg.chain import config_arrow_right
 #addr is a pointer. It is taken to be a child pointer.
 #visitedMap is a map of children -> (parent,parent_start)
 def get_rec_addr_string(addr,visitedMap):
-    page = getPage(addr)
+    page = pwndbg.vmmap.find(addr)
     arrow_right = C.arrow(' %s ' % config_arrow_right)
 
     if not page is None:
@@ -45,9 +45,6 @@ def get_rec_addr_string(addr,visitedMap):
     else:
         return ""
 
-#Utility function to get a page from an address.
-def getPage(address):
-    return pwndbg.vmmap.find(address)
 
 #Useful for debugging. Prints a map of child -> (parent, parent_start)
 def dbg_print_map(maps):
@@ -74,7 +71,7 @@ def leakfind(address=-1,page_name=None,max_offset=0x40,max_depth=0x4,stride=0x1,
         print("No starting address provided. Please run leakfind -h for more information.")
         return
 
-    foundPages = getPage(address)
+    foundPages = pwndbg.vmmap.find(address)
 
     if not foundPages:
         print("Starting address is not mapped. Please run leakfind -h for more information.")
@@ -135,7 +132,7 @@ def leakfind(address=-1,page_name=None,max_offset=0x40,max_depth=0x4,stride=0x1,
     arrow_right = C.arrow(' %s ' % config_arrow_right)
 
     for child in visitedMap:
-        childPage = getPage(child)
+        childPage = pwndbg.vmmap.find(child)
         if childPage is not None:
             if page_name is not None:
                 if not page_name in childPage.objfile:

--- a/pwndbg/commands/leakfind.py
+++ b/pwndbg/commands/leakfind.py
@@ -18,15 +18,16 @@ import pwndbg.color.memory as M
 import pwndbg.color.theme as theme
 import pwndbg.commands
 import pwndbg.vmmap
+from pwndbg.chain import config_arrow_right
 
-config_arrow_right = theme.Parameter('chain-arrow-right', '—▸', 'right arrow of chain formatting')
-arrow_right = C.arrow(' %s ' % config_arrow_right)
 
 #Used to recursively print the pointer chain. 
 #addr is a pointer. It is taken to be a child pointer.
 #visitedMap is a map of children -> (parent,parent_start)
 def get_rec_addr_string(addr,visitedMap):
     page = getPage(addr)
+    arrow_right = C.arrow(' %s ' % config_arrow_right)
+
     if not page is None:
         if not addr in visitedMap:
             return ""
@@ -57,7 +58,7 @@ parser = argparse.ArgumentParser()
 parser.description = """
 Attempt to find a leak chain given a starting address. Scans memory near the given address, looks for pointers, 
 and continues that process to attempt to find leaks.\n
-Example: leakfind $rsp --page_name=filename --offset=0x48 --max_depth=6. This would look for any chains of leaks that point to a section in filename which begin near $rsp, are never 0x48 bytes further from a known pointer, 
+Example: leakfind $rsp --page_name=filename --max_offset=0x48 --max_depth=6. This would look for any chains of leaks that point to a section in filename which begin near $rsp, are never 0x48 bytes further from a known pointer, 
 and are a maximum length of 6\n
 """
 parser.add_argument("address",help="Starting address to find a leak chain from")
@@ -131,7 +132,8 @@ def leakfind(address=-1,page_name=None,max_offset=0x40,max_depth=0x4,stride=0x1,
     #A map of length->list of lines. Used to let us print in a somewhat nice manner.
     outputMap = {}
 
- 
+    arrow_right = C.arrow(' %s ' % config_arrow_right)
+
     for child in visitedMap:
         childPage = getPage(child)
         if childPage is not None:

--- a/pwndbg/commands/leakfind.py
+++ b/pwndbg/commands/leakfind.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Find a chain of leaks given some starting address.
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import argparse
+
+import gdb
+
+import pwndbg.color.memory as M
+import pwndbg.commands
+import pwndbg.vmmap
+import pwndbg.color.theme as theme
+import pwndbg.color.chain as C
+from queue import *
+
+config_arrow_right = theme.Parameter('chain-arrow-right', '—▸', 'right arrow of chain formatting')
+arrow_right = C.arrow(' %s ' % config_arrow_right)
+
+#Used to recursively print the pointer chain. 
+#addr is a pointer. It is taken to be a child pointer.
+#visitedMap is a map of children -> (parent,parent_start)
+def get_rec_addr_string(addr,visitedMap):
+    page = getPage(addr)
+    if not page is None:
+        if not addr in visitedMap:
+            return ""
+        
+        parentInfo = visitedMap[addr]
+        parent = parentInfo[0]
+        parent_base_addr = parentInfo[1]
+        curText = hex(parent_base_addr) + "+"+hex(parent-parent_base_addr)
+        if parent_base_addr == addr:
+            return ""
+        return get_rec_addr_string(parent_base_addr,visitedMap) + M.get(parent_base_addr,text=curText)+arrow_right
+    else:
+        return ""
+
+#Utility function to get a page from an address.
+def getPage(address):
+    return pwndbg.vmmap.find(address)
+
+#Useful for debugging. Prints a map of child -> (parent, parent_start)
+def dbg_print_map(maps):
+    for child, parentInfo in maps.items():
+        print(hex(child) + "("+hex(parentInfo[0])+","+hex(parentInfo[1])+")")
+
+parser = argparse.ArgumentParser()
+parser.description = """
+Attempt to find a leak chain given a starting address. Scans memory near the given address, looks for pointers, 
+and continues that process to attempt to find leaks.\n
+Example: leakfind $rsp filename 0x48 6. This would look for any chains of leaks that point to a section in filename which begin near $rsp, are never 0x48 bytes further from a known pointer, 
+and are a maximum length of 6.\n
+"""
+parser.add_argument("address",help="Starting address to find a leak chain from.")
+parser.add_argument("page_name",type=str,nargs="?",default=None,help="Substring required to be part of the name of any found pages")
+parser.add_argument("max_offset",default=0x48,nargs="?",help="Max Offset to add to addresses when looking for leak.")
+parser.add_argument("max_depth",default=0x4,nargs="?",help="Maximum depth to follow pointers to.")
+parser.add_argument("stride",nargs="?",default=0x1,help="Stride to add to add between pointers considered. For example, if this is 4 it would only consider pointers at an offset divisible by 4 from the starting pointer.")
+
+@pwndbg.commands.ArgparsedCommand(parser)
+@pwndbg.commands.OnlyWhenRunning
+def leakfind(address=-1,page_name=None,max_offset=0x40,max_depth=0x4,stride=0x1):
+    if address == -1:
+        print("No starting address provided. Please run leakfind -h for more information.")
+        return
+
+    foundPages = getPage(address)
+
+    if not foundPages:
+        print("Starting address is not mapped. Please run leakfind -h for more information.")
+        return
+
+    if not pwndbg.memory.peek(address):
+        print("Unable to read from starting address. Please run leakfind -h for more information.")
+        return
+
+    max_depth=int(max_depth)
+    #Just warn the user that a large depth might be slow. Probably worth checking offset^depth < threshold. Do this when more benchmarking is established.
+    if max_depth > 8:
+        print("leakfind may take a while to run on larger depths.")
+    
+    stride = int(stride)
+    address=int(address)
+    max_offset = int(max_offset)
+
+    
+    #The below map stores a map of child address->(parent_address,parent_start_address)
+    #In the above tuple, parent_address is the exact address with a pointer to the child adddress.
+    #parent_start_address is an address that a previous address pointed to.
+    #We need to store both so that we can nicely create our leak chain.
+    visitedMap = {}
+    visitedSet = set()
+    visitedSet.add(int(address))
+    addressQueue = Queue()
+    addressQueue.put(int(address))
+    depth = 0
+    timeToDepthIncrease=0
+
+    #Run a bfs
+    #TODO look into performance gain from checking if an address is mapped before calling pwndbg.memory.pvoid()
+    #TODO also check using pwndbg.memory.read for possible performance boosts.
+    while addressQueue.qsize() > 0 and depth < max_depth:
+        if timeToDepthIncrease == 0:
+            depth=depth+1
+            timeToDepthIncrease=addressQueue.qsize()
+        cur_start_addr = addressQueue.get()
+        timeToDepthIncrease-=1
+        for cur_addr in range(cur_start_addr,cur_start_addr+max_offset,stride):
+            try:
+                result = int(pwndbg.memory.pvoid(cur_addr))
+                if result in visitedMap:
+                    continue
+                if result in visitedSet:
+                    continue
+                visitedMap[result]=(cur_addr,cur_start_addr) #map is of form child->(parent,parent_start)
+                addressQueue.put(result)
+                visitedSet.add(result)
+            except gdb.error:
+                #That means the memory was unreadable. Just skip it if we can't read it. 
+                break
+
+    #A map of chain_length->list of lines. Used to let us print in a somewhat nice manner.
+    outputMap = {}
+
+    for child in visitedMap:
+        childPage = getPage(child)
+        if (not childPage is None) and not (childPage.vaddr == foundPages.vaddr):
+            if not page_name == None:
+                if not page_name in childPage.objfile:
+                    continue
+            line = get_rec_addr_string(child,visitedMap) + M.get(child) + " " + M.get(child,text=childPage.objfile)
+            chain_length = line.count(arrow_right)
+            if chain_length in outputMap:
+                outputMap[chain_length].append(line)
+            else:
+                outputMap[chain_length]=[line]
+
+
+    #Output sorted by length of chain
+    for chain_length in outputMap:
+        for line in outputMap[chain_length]:
+            print(line)
+
+    if pwndbg.qemu.is_qemu():
+        print("\n[QEMU target detected - leakfind result might not be accurate; see `help vmmap`]")

--- a/pwndbg/commands/leakfind.py
+++ b/pwndbg/commands/leakfind.py
@@ -38,7 +38,7 @@ def get_rec_addr_string(addr,visited_map):
         if parent - parent_base_addr < 0:
             curText = hex(parent_base_addr) + hex(parent - parent_base_addr)
         else:
-            curText = hex(parent_base_addr) + "+"+ hex(parent - parent_base_addr)
+            curText = hex(parent_base_addr) + "+" + hex(parent - parent_base_addr)
         if parent_base_addr == addr:
             return ""
         return get_rec_addr_string(parent_base_addr,visited_map) + M.get(parent_base_addr,text=curText)+arrow_right
@@ -124,7 +124,6 @@ def leakfind(address=-1,page_name=None,max_offset=0x40,max_depth=0x4,stride=0x1,
 
     #A map of length->list of lines. Used to let us print in a somewhat nice manner.
     output_map = {}
-
     arrow_right = C.arrow(' %s ' % config_arrow_right)
 
     for child in visited_map:

--- a/pwndbg/commands/peda.py
+++ b/pwndbg/commands/peda.py
@@ -5,14 +5,13 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import argparse
 import sys
 
 import gdb
 
-import argparse
-
-import pwndbg.color.message as message
 import pwndbg.auxv
+import pwndbg.color.message as message
 import pwndbg.commands
 import pwndbg.commands.context
 import pwndbg.commands.telescope


### PR DESCRIPTION
Leakfind is a command meant to help finding leaks. While pwndbg already supports probeleak for this purpose, probeleak can only find leaks by following a pointer to a depth of one.

The purpose of leakfind is to remedy this by looking deeper than a depth of one. Instead, leakfind takes a depth parameter and can find chains up to that length. An example use of it finding a leak chain is shown below.

![leakfind](https://user-images.githubusercontent.com/19600162/55664384-a7ca3c00-57fa-11e9-8280-e43bacc5aec7.PNG)
In the above example it shows multiple possible ways to find a pointer into a section containing "v8" as part of the name. Finding this chain proved to be impossible for me to manually do, but with leakfind it is extremely easy.

