### PR TITLE
Add option to redirect context output to other tty or files

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -17,6 +17,8 @@ All function call sites are annotated with the arguments to those functions.  Th
 
 A useful summary of the current execution context is printed every time GDB stops (e.g. breakpoint or single-step), displaying all registers, the stack, call frames, disassembly, and additionally recursively dereferencing all pointers.  All memory addresses are color-coded to the type of memory they represent.
 
+The output of the context may be redirected to a file (including other tty) by using `set context-output /path/to/file` while leaving other output in place.
+
 ![](caps/context.png)  
 
 ## Disassembly

--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -7,8 +7,8 @@ from __future__ import unicode_literals
 
 import ast
 import codecs
-import sys
 import ctypes
+import sys
 from io import open
 
 import gdb

--- a/pwndbg/commands/peda.py
+++ b/pwndbg/commands/peda.py
@@ -5,14 +5,13 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import argparse
 import sys
 
 import gdb
 
-import argparse
-
-import pwndbg.color.message as message
 import pwndbg.auxv
+import pwndbg.color.message as message
 import pwndbg.commands
 import pwndbg.commands.context
 import pwndbg.commands.telescope


### PR DESCRIPTION
The output of context/dashboard can be now be redirected with
 "set context-output /dev/pts/x" to everything wich python can open and
 offers a file like "write".

This can be used to create a split view of the current context while still having all other gdb commands and outputs visible in the original place. This avoids scrolling to either view the output of previous commands or to see the context after an other long output.

![pwndbg_split](https://user-images.githubusercontent.com/7195718/56039600-e600b780-5d34-11e9-9ec8-1ba51027eab8.png)
