### PR TITLE
Update types on new_objfile event

### DIFF
--- a/pwndbg/typeinfo.py
+++ b/pwndbg/typeinfo.py
@@ -43,6 +43,7 @@ def lookup_types(*types):
     raise exc
 
 
+@pwndbg.events.new_objfile
 @pwndbg.events.start
 @pwndbg.events.stop
 def update():


### PR DESCRIPTION
Fix the types being incorrect prior to a binary running in gdb.
This fixes #609.