### PR TITLE
Workaround for GDB bug described in #632

### DIFF
--- a/pwndbg/commands/ida.py
+++ b/pwndbg/commands/ida.py
@@ -54,6 +54,9 @@ def up(n=1):
             f = f.older()
     f.select()
 
+    # workaround for #632
+    gdb.execute('frame', to_string=True)
+
     bt = pwndbg.commands.context.context_backtrace(with_banner=False)
     print('\n'.join(bt))
 
@@ -78,6 +81,9 @@ def down(n=1):
         if f.newer():
             f = f.newer()
     f.select()
+
+    # workaround for #632
+    gdb.execute('frame', to_string=True)
 
     bt = pwndbg.commands.context.context_backtrace(with_banner=False)
     print('\n'.join(bt))


### PR DESCRIPTION
GDB's `up` and `down` commands trigger internal notification about changed frame. It does not happen for `gdb.Frame.select()` which we use in our own overrides for `up` and `down` commands.

Because of that, the `list` GDB command does not show proper source code lines.

This can be worked around by firing `frame` command and this is what this workaround/PR adds.

This bug has also been reported to GDB bugzilla at https://sourceware.org/bugzilla/show_bug.cgi?id=24534

For more details, see #632