### PR TITLE
Fixes #636 - bug with regs display on other frames

### DIFF
--- a/pwndbg/regs.py
+++ b/pwndbg/regs.py
@@ -249,7 +249,7 @@ def gdb77_get_register(name):
 
 @pwndbg.proc.OnlyWhenRunning
 def gdb79_get_register(name):
-    return gdb.newest_frame().read_register(name)
+    return gdb.selected_frame().read_register(name)
 
 try:
     gdb.Frame.read_register
@@ -285,6 +285,7 @@ class module(ModuleType):
             return None
 
     @pwndbg.memoize.reset_on_stop
+    @pwndbg.memoize.reset_on_prompt
     def __getitem__(self, item):
         if isinstance(item, six.integer_types):
             return arch_to_regs[pwndbg.arch.current][item]


### PR DESCRIPTION
TLDR:
1. We read registers from `newest_frame` instead of `selected_frame` for GDB>=7.9.
2. We have two ways to fetch registers - `regs.__getitem__` and `regs.__getattr__` - one of them didn't invalidate cache and so after fixing 1st, we still shown the old register after switching frames.