### PR TITLE
typeinfo: more types for golang programs

### DIFF
--- a/pwndbg/typeinfo.py
+++ b/pwndbg/typeinfo.py
@@ -52,18 +52,18 @@ def update():
     module.ulong  = lookup_types('unsigned long', 'uint', 'u32')
     module.long   = lookup_types('long', 'int', 'i32')
     module.uchar  = lookup_types('unsigned char', 'ubyte', 'u8')
-    module.ushort = lookup_types('unsigned short', 'ushort', 'u16')
+    module.ushort = lookup_types('unsigned short', 'ushort', 'u16', 'uint16')
     module.uint   = lookup_types('unsigned int', 'uint', 'u32')
     module.void   = lookup_types('void', '()')
     module.uint8  = module.uchar
     module.uint16 = module.ushort
     module.uint32 = module.uint
-    module.uint64 = lookup_types('unsigned long long', 'ulong', 'u64')
+    module.uint64 = lookup_types('unsigned long long', 'ulong', 'u64', 'uint64')
 
     module.int8   = lookup_types('char', 'i8')
-    module.int16  = lookup_types('short', 'i16')
+    module.int16  = lookup_types('short', 'i16', 'int16')
     module.int32  = lookup_types('int', 'i32')
-    module.int64  = lookup_types('long long', 'long', 'i64')
+    module.int64  = lookup_types('long long', 'long', 'i64', 'int64')
 
     module.ssize_t = module.long
     module.size_t = module.ulong


### PR DESCRIPTION
Hey,

I was looking at a golang binary in pwndbg and got these:
```
  File "/opt/pwndbg/pwndbg/typeinfo.py", line 54, in update
    module.ushort = lookup_types('unsigned short', 'ushort', 'u16')
  File "/opt/pwndbg/pwndbg/typeinfo.py", line 43, in lookup_types
    raise exc
  File "/opt/pwndbg/pwndbg/typeinfo.py", line 40, in lookup_types
    return gdb.lookup_type(type_str)
gdb.error: No type named u16.
```

Associated patch fixes them and lets me continue debugging nicely so far.