### PR TITLE
change tcache chain size

### DIFF
--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -55,8 +55,15 @@ def format_bin(bins, verbose=False, offset=None):
 
         if not verbose and (chain_fd == [0] and not count) and not is_chain_corrupted:
             continue
+        
+        if bins_type == 'tcachebins':
+            limit = 8
+            if count <= 7:
+                limit = count + 1
+            formatted_chain = pwndbg.chain.format(chain_fd[0], offset=offset, limit=limit)
+        else:
+            formatted_chain = pwndbg.chain.format(chain_fd[0], offset=offset)
 
-        formatted_chain = pwndbg.chain.format(chain_fd[0], offset=offset)
 
         if isinstance(size, int):
             size = hex(size)


### PR DESCRIPTION
Small PR
One tcache bin has max length of 7, so we should limit the chain in `bins` cmd to 7 elements (by default it is 5). Also the bins contains the `count` information, if it is sane we can use it. 

And a question:
```python
tcachebins
0x40 [  7]: 0x555555559aa0 —▸ 0x555555559ae0 —▸ 0x555555559b20 —▸ 0x555555559b60 —▸ 0x555555559ba0 —▸ 0x555555559be0 —▸ 0x555555559c20 ◂— 0x0
fastbins
0x20: 0x0
0x30: 0x0
0x40: 0x555555559250 —▸ 0x555555559290 —▸ 0x5555555592d0 —▸ 0x555555559310 —▸ 0x555555559350 ◂— ...
0x50: 0x0
```
All bins (and other pwndbg commands like malloc_chunk) shows chunks with their start addres (not `chunk->fd` address). Except tcache bins which uses `&chunk->fd`. It is due to the representation in libc code:
```
fastbinsY = {0x0, 0x0, 0x555555559250, 0x0... -> &chunk addr
```
```
{
  counts = "\000\000\a", '\000' <repeats 60 times>, 
  entries = {0x0, 0x0, 0x555555559aa0, 0x0 <repeats 61 times>} -> &chunk->fd addr
}
```
Imho the `bins` cmd is misleading because of that and we should change it so it show chunks in tcache like in other bins. What do you think?