### PR TITLE
typeinfo: more types for golang and tests

### DIFF
--- a/pwndbg/typeinfo.py
+++ b/pwndbg/typeinfo.py
@@ -49,20 +49,20 @@ def lookup_types(*types):
 def update():
 
     module.char   = gdb.lookup_type('char')
-    module.ulong  = lookup_types('unsigned long', 'uint', 'u32')
-    module.long   = lookup_types('long', 'int', 'i32')
-    module.uchar  = lookup_types('unsigned char', 'ubyte', 'u8')
+    module.ulong  = lookup_types('unsigned long', 'uint', 'u32', 'uint32')
+    module.long   = lookup_types('long', 'int', 'i32', 'int32')
+    module.uchar  = lookup_types('unsigned char', 'ubyte', 'u8', 'uint8')
     module.ushort = lookup_types('unsigned short', 'ushort', 'u16', 'uint16')
-    module.uint   = lookup_types('unsigned int', 'uint', 'u32')
+    module.uint   = lookup_types('unsigned int', 'uint', 'u32', 'uint32')
     module.void   = lookup_types('void', '()')
     module.uint8  = module.uchar
     module.uint16 = module.ushort
     module.uint32 = module.uint
     module.uint64 = lookup_types('unsigned long long', 'ulong', 'u64', 'uint64')
 
-    module.int8   = lookup_types('char', 'i8')
+    module.int8   = lookup_types('char', 'i8', 'int8')
     module.int16  = lookup_types('short', 'i16', 'int16')
-    module.int32  = lookup_types('int', 'i32')
+    module.int32  = lookup_types('int', 'i32', 'int32')
     module.int64  = lookup_types('long long', 'long', 'i64', 'int64')
 
     module.ssize_t = module.long

--- a/tests/binaries/gosample.x64.go
+++ b/tests/binaries/gosample.x64.go
@@ -1,0 +1,3 @@
+package main
+
+func main() {}

--- a/tests/binaries/gosample.x86.go
+++ b/tests/binaries/gosample.x86.go
@@ -1,0 +1,3 @@
+package main
+
+func main() {}

--- a/tests/binaries/makefile
+++ b/tests/binaries/makefile
@@ -14,6 +14,10 @@ LDFLAGS         =
 EXTRA_FLAGS     =
 EXTRA_FLAGS_ASM =
 
+GO              =	   go
+SOURCES_GO      =	   $(wildcard *.go)
+COMPILED_GO     =	   $(SOURCES_GO:.go=)
+
 ifeq ($(TARGET), x86)
 CFLAGS		  +=	  -m32
 endif
@@ -27,7 +31,7 @@ endif
 
 .PHONY : all clean
 
-all: $(LINKED) $(LINKED_ASM)
+all: $(LINKED) $(LINKED_ASM) $(COMPILED_GO)
 
 
 %.out : %.c
@@ -42,9 +46,20 @@ all: $(LINKED) $(LINKED_ASM)
 	@echo "[+] Linking '$@'"
 	@$(LD) -o $@ $?
 
+%.x86 : %.x86.go
+	@echo "[+] Building '$@'"
+	@GOARCH=386 $(GO) build $?
+	@# Not stripped on purpose
+
+%.x64 : %.x64.go
+	@echo "[+] Building '$@'"
+	@GOARCH=amd64 $(GO) build $?
+	@# Not stripped on purpose
+
+
 clean :
 	@echo "[+] Cleaning stuff"
-	@rm -f $(COMPILED) $(LINKED)
+	@rm -f $(COMPILED) $(LINKED) $(COMPILED_GO)
 
 
 reference-binary.out: EXTRA_FLAGS := -Dexample=1

--- a/tests/test_go.py
+++ b/tests/test_go.py
@@ -1,0 +1,33 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import gdb
+
+import tests
+
+GOSAMPLE_X64 = tests.binaries.get('gosample.x64')
+GOSAMPLE_X86 = tests.binaries.get('gosample.x86')
+
+
+def test_typeinfo_go_x64(start_binary):
+    """
+    Tests pwndbg's typeinfo knows about the Go x64 types.
+    Catches: Python Exception <class 'gdb.error'> No type named u8.:
+    Test catches the issue only if the binaries are not stripped.
+    """
+    gdb.execute('file ' + GOSAMPLE_X64)
+    start = gdb.execute('start', to_string=True)
+    assert 'Python Exception' not in start
+
+
+def test_typeinfo_go_x86(start_binary):
+    """
+    Tests pwndbg's typeinfo knows about the Go x32 types
+    Catches: Python Exception <class 'gdb.error'> No type named u8.:
+    Test catches the issue only if the binaries are not stripped.
+    """
+    gdb.execute('file ' + GOSAMPLE_X86)
+    start = gdb.execute('start', to_string=True)
+    assert 'Python Exception' not in start


### PR DESCRIPTION
Continuing PR #649.

Commit 493b1a0 added enough types so it works for Go binaries that are dynamic instead of static, linked with libc, which happens when you depend on `net` or `os/user`.
However I noticed that with a dummy Go program like `package main; func main() { }`, which ends up static not dynamic depending on libc, pwndbg is unable to resolve more types like `u8`. Also, only with debug symbols i.e. if not stripped; when stripped, gdb is fine (going back to default types?).

This PR adds those, as well as defensively more Go types in case it's ever needed.

I added tests this time, including two test Go binaries (for x86-32 and x86-64, it doesn't seem to matter but for completeness since cross-compiling is so easy).
The test catches the output of `start` seeing if there was no exception, let me know if there's a better method I could call instead.