### PR TITLE
Add initial support for ARM Cortex-M baremetal debugging (#264)

### DIFF
--- a/pwndbg/arch.py
+++ b/pwndbg/arch.py
@@ -26,9 +26,15 @@ native_endian = str(sys.byteorder)
 
 
 def fix_arch(arch):
-    arches = ['x86-64', 'i386', 'mips', 'powerpc', 'sparc', 'arm', 'aarch64', arch]
-    return next(a for a in arches if a in arch)
+    for match in ['x86-64', 'i386', 'mips', 'powerpc', 'sparc', 'aarch64']:
+        if match in arch:
+            return match
 
+    # Distinguish between Cortex-M and other ARM
+    if 'arm' in arch:
+        return 'armcm' if '-m' in arch else 'arm'
+
+    return arch
 
 @pwndbg.events.start
 @pwndbg.events.new_objfile

--- a/pwndbg/color/context.py
+++ b/pwndbg/color/context.py
@@ -54,3 +54,25 @@ def banner(x):
 
 def banner_title(x):
     return generateColorFunction(config.banner_title_color)(x)
+
+def format_flags(value, flags, last=None):
+    desc = flag_value('%#x' % value)
+    if not flags:
+        return desc
+
+    names = []
+    for name, bit in flags.items():
+        bit = 1<<bit
+        if value & bit:
+            name = name.upper()
+            name = flag_set(name)
+        else:
+            name = name.lower()
+            name = flag_unset(name)
+
+        if last is not None and value & bit != last & bit:
+            name = flag_changed(name)
+        names.append(name)
+
+    return '%s %s %s %s' % (desc, flag_bracket('['), ' '.join(names), flag_bracket(']'))
+

--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -167,30 +167,11 @@ def get_regs(*regs):
         change_marker = "%s" % C.config_register_changed_marker
         m = ' ' * len(change_marker) if reg not in changed else C.register_changed(change_marker)
 
-        if reg not in pwndbg.regs.flags:
-            desc = pwndbg.chain.format(value)
+        if reg in pwndbg.regs.flags:
+            desc = C.format_flags(value, pwndbg.regs.flags[reg], pwndbg.regs.last.get(reg, 0))
 
         else:
-            names = []
-            desc  = C.flag_value('%#x' % value)
-            last  = pwndbg.regs.last.get(reg, 0) or 0
-            flags = pwndbg.regs.flags[reg]
-
-            for name, bit in sorted(flags.items()):
-                bit = 1<<bit
-                if value & bit:
-                    name = name.upper()
-                    name = C.flag_set(name)
-                else:
-                    name = name.lower()
-                    name = C.flag_unset(name)
-
-                if value & bit != last & bit:
-                    name = C.flag_changed(name)
-                names.append(name)
-
-            if names:
-                desc = '%s %s %s %s' % (desc, C.flag_bracket('['), ' '.join(names), C.flag_bracket(']'))
+            desc = pwndbg.chain.format(value)
 
         result.append("%s%s %s" % (m, regname, desc))
 

--- a/pwndbg/commands/cpsr.py
+++ b/pwndbg/commands/cpsr.py
@@ -12,28 +12,21 @@ from pwndbg.color import context
 from pwndbg.color import message
 
 
-@pwndbg.commands.ArgparsedCommand('Print out ARM CPSR register')
+@pwndbg.commands.ArgparsedCommand('Print out ARM CPSR or xPSR register')
 @pwndbg.commands.OnlyWhenRunning
 def cpsr():
-    if pwndbg.arch.current != 'arm':
+    arm_print_psr()
+
+@pwndbg.commands.ArgparsedCommand('Print out ARM xPSR or CPSR register')
+@pwndbg.commands.OnlyWhenRunning
+def xpsr():
+    arm_print_psr()
+
+def arm_print_psr():
+    if pwndbg.arch.current not in ('arm', 'armcm'):
         print(message.warn("This is only available on ARM"))
         return
 
-    cpsr = pwndbg.regs.cpsr
+    reg = 'cpsr' if pwndbg.arch.current == 'arm' else 'xpsr'
+    print('%s %s' % (reg, context.format_flags(getattr(pwndbg.regs, reg), pwndbg.regs.flags[reg])))
 
-    N = cpsr & (1 << 31)
-    Z = cpsr & (1 << 30)
-    C = cpsr & (1 << 29)
-    V = cpsr & (1 << 28)
-    T = cpsr & (1 << 5)
-
-    result = [
-        context.flag_set('N') if N else context.flag_unset('n'),
-        context.flag_set('Z') if Z else context.flag_unset('z'),
-        context.flag_set('C') if C else context.flag_unset('c'),
-        context.flag_set('V') if V else context.flag_unset('v'),
-        context.flag_set('T') if T else context.flag_unset('t')
-    ]
-
-    print('CPSR %s %s %s %s' % (context.flag_value('%#x' % cpsr),
-          context.flag_bracket('['), ' '.join(result), context.flag_bracket(']')))

--- a/pwndbg/constants/__init__.py
+++ b/pwndbg/constants/__init__.py
@@ -16,6 +16,7 @@ from . import thumb
 
 arches = {
     'arm': arm,
+    'armcm': arm,
     'i386': i386,
     'mips': mips,
     'x86-64': amd64,

--- a/pwndbg/disasm/arm.py
+++ b/pwndbg/disasm/arm.py
@@ -46,12 +46,12 @@ class DisassemblyAssistant(pwndbg.disasm.arch.DisassemblyAssistant):
         if instruction.address != pwndbg.regs.pc:
             return False
 
-        cpsr = pwndbg.regs.cpsr
+        value = pwndbg.regs.cpsr if pwndbg.arch.current == 'arm' else pwndbg.regs.xpsr
 
-        N = cpsr & (1<<31)
-        Z = cpsr & (1<<30)
-        C = cpsr & (1<<29)
-        V = cpsr & (1<<28)
+        N = value & (1<<31)
+        Z = value & (1<<30)
+        C = value & (1<<29)
+        V = value & (1<<28)
 
         cc = {
             ARM_CC_EQ: Z,

--- a/pwndbg/emu/emulator.py
+++ b/pwndbg/emu/emulator.py
@@ -199,8 +199,12 @@ class Emulator(object):
         arch = pwndbg.arch.current
         mode = 0
 
-        if arch in ('arm', 'aarch64'):
-            mode |= {0:U.UC_MODE_ARM,0x20:U.UC_MODE_THUMB}[pwndbg.regs.cpsr & 0x20]
+        if arch == 'armcm':
+            mode |= (U.UC_MODE_MCLASS | U.UC_MODE_THUMB) if (pwndbg.regs.xpsr & (1<<24)) else U.UC_MODE_MCLASS
+
+        elif arch in ('arm', 'aarch64'):
+            mode |= U.UC_MODE_THUMB if (pwndbg.regs.cpsr & (1<<5)) else U.UC_MODE_ARM
+
         else:
             mode |= {4:U.UC_MODE_32, 8:U.UC_MODE_64}[pwndbg.arch.ptrsize]
 

--- a/pwndbg/gcc.py
+++ b/pwndbg/gcc.py
@@ -57,7 +57,7 @@ def which_binutils(util, **kwargs):
     # Fix up binjitsu vs Debian triplet naming, and account
     # for 'thumb' being its own binjitsu architecture.
     arches = [arch] + {
-        'thumb':  ['arm',    'aarch64'],
+        'thumb':  ['arm', 'armcm', 'aarch64'],
         'i386':   ['x86_64', 'amd64'],
         'i686':   ['x86_64', 'amd64'],
         'i386:x86-64': ['x86_64', 'amd64'],


### PR DESCRIPTION
This commit adds support for xPSR to be used instead of cPSR on Cortex-M. Prior to this commit, pwndbg would crash when attached to a Cortex-M core.

This patch adds a new internal arch "armcm" to describe Cortex-M ARMs.

Closes #542, fixes the second issue in #264