### PR TITLE
Add end separator

### DIFF
--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -110,6 +110,8 @@ def context(subcontext=None):
         func = context_sections.get(arg, None)
         if func:
             result.extend(func())
+    if len(result) > 0:
+        result.append(pwndbg.ui.banner(""))
     result.extend(context_signal())
 
     with output() as out:

--- a/pwndbg/ui.py
+++ b/pwndbg/ui.py
@@ -41,7 +41,8 @@ def check_title_position():
 def banner(title):
     title = title.upper()
     _height, width = get_window_size()
-    title = '%s%s%s' % (config.banner_title_surrounding_left, C.banner_title(title), config.banner_title_surrounding_right)
+    if title:
+        title = '%s%s%s' % (config.banner_title_surrounding_left, C.banner_title(title), config.banner_title_surrounding_right)
     if 'left' == title_position:
         banner = ljust_colored(title, width, config.banner_separator)
     elif 'right' == title_position:


### PR DESCRIPTION
Hey,

I'm developing a debugger UI : [hyperpwn](https://github.com/bet4it/hyperpwn).
Currently it only supports `GEF`. Because I need an end separator to detect the end of context data.
After this pull request `hyperpwn` can also support `pwndbg`.
This is what it looks like after this pull request:
![hyperpwn-pwndbg](https://user-images.githubusercontent.com/16643669/59671809-e6b04100-91f0-11e9-9035-9d27bfe562b5.gif)
