### PR TITLE
Inthook size types (Fixes #669)

### DIFF
--- a/pwndbg/inthook.py
+++ b/pwndbg/inthook.py
@@ -37,15 +37,15 @@ class xint(with_metaclass(IsAnInt, builtins.int)):
     def __new__(cls, value, *a, **kw):
         if isinstance(value, gdb.Value):
             if pwndbg.typeinfo.is_pointer(value):
-                value = value.cast(pwndbg.typeinfo.ulong)
+                value = value.cast(pwndbg.typeinfo.size_t)
             else:
-                value = value.cast(pwndbg.typeinfo.long)
+                value = value.cast(pwndbg.typeinfo.ssize_t)
 
         elif isinstance(value, gdb.Symbol):
             symbol = value
             value = symbol.value()
             if symbol.is_function:
-                value = value.cast(pwndbg.typeinfo.ulong)
+                value = value.cast(pwndbg.typeinfo.size_t)
 
         elif not isinstance(value, (six.string_types, six.integer_types)) \
                 or isinstance(cls, enum.EnumMeta):

--- a/pwndbg/typeinfo.py
+++ b/pwndbg/typeinfo.py
@@ -75,11 +75,12 @@ def update():
         module.ptrdiff = module.uint32
         module.size_t = module.uint32
         module.ssize_t = module.int32
-    if pvoid.sizeof == 8: 
+    elif pvoid.sizeof == 8: 
         module.ptrdiff = module.uint64
         module.size_t = module.uint64
         module.ssize_t = module.int64
-
+    else:
+        raise Exception('Pointer size not supported')
     module.null = gdb.Value(0).cast(void)
 
 # Call it once so we load all of the types

--- a/pwndbg/typeinfo.py
+++ b/pwndbg/typeinfo.py
@@ -65,17 +65,20 @@ def update():
     module.int32  = lookup_types('int', 'i32', 'int32')
     module.int64  = lookup_types('long long', 'long', 'i64', 'int64')
 
-    module.ssize_t = module.long
-    module.size_t = module.ulong
-
     module.pvoid  = void.pointer()
     module.ppvoid = pvoid.pointer()
     module.pchar  = char.pointer()
 
     module.ptrsize = pvoid.sizeof
 
-    if pvoid.sizeof == 4: module.ptrdiff = uint32
-    if pvoid.sizeof == 8: module.ptrdiff = uint64
+    if pvoid.sizeof == 4: 
+        module.ptrdiff = module.uint32
+        module.size_t = module.uint32
+        module.ssize_t = module.int32
+    if pvoid.sizeof == 8: 
+        module.ptrdiff = module.uint64
+        module.size_t = module.uint64
+        module.ssize_t = module.int64
 
     module.null = gdb.Value(0).cast(void)
 


### PR DESCRIPTION
Various issues have been created from inthook relying on ulong and long. 
This changes it to rely on (now properly set) size_t and ssize_t. #669 should be fixed, and I think #644 although I haven't tested that one yet.