### PR TITLE
checksec: try detect different variants and use appropriate args

### DIFF
--- a/pwndbg/wrappers/checksec.py
+++ b/pwndbg/wrappers/checksec.py
@@ -5,6 +5,10 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import subprocess
+from re import search
+from subprocess import STDOUT
+
 import pwndbg.commands
 import pwndbg.memoize
 import pwndbg.wrappers
@@ -14,10 +18,17 @@ cmd_name = "checksec"
 @pwndbg.wrappers.OnlyWithCommand(cmd_name)
 @pwndbg.memoize.reset_on_objfile
 def get_raw_out():
-
     local_path = pwndbg.file.get_file(pwndbg.proc.exe)
-    cmd = [get_raw_out.cmd_path, "--file", local_path]
-    return pwndbg.wrappers.call_cmd(cmd)
+    try:
+        version_output = subprocess.check_output([get_raw_out.cmd_path, "--version"], stderr=STDOUT).decode('utf-8')
+        match = search('checksec v([\\w.]+),', version_output)
+        if match:
+            version = tuple(map(int, (match.group(1).split("."))))
+            if version >= (2, 0):
+                return pwndbg.wrappers.call_cmd([get_raw_out.cmd_path, "--file=" + local_path])
+    except Exception:
+        pass
+    return pwndbg.wrappers.call_cmd([get_raw_out.cmd_path, "--file", local_path])
 
 @pwndbg.wrappers.OnlyWithCommand(cmd_name)
 def relro_status():


### PR DESCRIPTION
Modern maintained checksec >2.0 requires to use "--file=arg" which
we try to detect. The command call is cached anyway so lets try
to find out what version is running.
In case we can't find a verbose variant, we just fall back to the
common old fessioned "--file arg" variant as if nothing has happened.

Fixes #662