### PR TITLE
vmmap: add QEMU kernel support

### DIFF
--- a/pwndbg/commands/vmmap.py
+++ b/pwndbg/commands/vmmap.py
@@ -42,8 +42,9 @@ parser = argparse.ArgumentParser()
 parser.description = '''Print virtual memory map pages. Results can be filtered by providing address/module name.
 
 Memory pages on QEMU targets may be inaccurate. This is because:
-- for QEMU kernel we fetch memory pages via `monitor info mem` and it doesn't inform if memory page is executable
-- for QEMU user emulation we detected memory pages through AUXV (sometimes by finding AUXV on the stack first) or by exploring values e.g. from registers.
+- for QEMU kernel on X86/X64 we fetch memory pages via `monitor info mem` and it doesn't inform if memory page is executable
+- for QEMU user emulation we detected memory pages through AUXV (sometimes by finding AUXV on the stack first)
+- for others, we create mempages by exploring current register values (this is least correct)
 
 Memory pages can also be added manually, see vmmap_add, vmmap_clear and vmmap_load commands.'''
 parser.add_argument('pages_filter', type=pages_filter, nargs='?', default=None,

--- a/pwndbg/commands/vmmap.py
+++ b/pwndbg/commands/vmmap.py
@@ -41,8 +41,9 @@ def pages_filter(s):
 parser = argparse.ArgumentParser()
 parser.description = '''Print virtual memory map pages. Results can be filtered by providing address/module name.
 
-Please note that memory pages on QEMU targets are detected through AUXV (sometimes with finding AUXV on the stack first)
-or by exploring values e.g. from registers.
+Memory pages on QEMU targets may be inaccurate. This is because:
+- for QEMU kernel we fetch memory pages via `monitor info mem` and it doesn't inform if memory page is executable
+- for QEMU user emulation we detected memory pages through AUXV (sometimes by finding AUXV on the stack first) or by exploring values e.g. from registers.
 
 Memory pages can also be added manually, see vmmap_add, vmmap_clear and vmmap_load commands.'''
 parser.add_argument('pages_filter', type=pages_filter, nargs='?', default=None,

--- a/pwndbg/vmmap.py
+++ b/pwndbg/vmmap.py
@@ -260,7 +260,8 @@ def monitor_info_mem():
         flags = 0
         if 'r' in perm: flags |= 4
         if 'w' in perm: flags |= 2
-        #if 'x' in perm: flags |= 1  # TODO: there is no 'x', is it QEMU's bug?
+        # QEMU does not expose X/NX bit, see #685
+        #if 'x' in perm: flags |= 1
         flags |= 1
 
         pages.append(pwndbg.memory.Page(start, size, flags, 0, '<qemu>'))

--- a/pwndbg/vmmap.py
+++ b/pwndbg/vmmap.py
@@ -47,7 +47,7 @@ def get():
     pages = []
     pages.extend(proc_pid_maps())
 
-    if not pages and pwndbg.qemu.is_qemu():
+    if not pages and pwndbg.arch.current == 'i386' and pwndbg.qemu.is_qemu():
         pages.extend(monitor_info_mem())
 
     if not pages:
@@ -229,6 +229,10 @@ def proc_pid_maps():
 
 @pwndbg.memoize.reset_on_stop
 def monitor_info_mem():
+    # NOTE: This works only on X86/X64/RISC-V
+    # See: https://github.com/pwndbg/pwndbg/pull/685
+    # (TODO: revisit with future QEMU versions)
+    #
     # pwndbg> monitor info mem
     # ffff903580000000-ffff903580099000 0000000000099000 -rw
     # ffff903580099000-ffff90358009b000 0000000000002000 -r-


### PR DESCRIPTION
This feature uses GDB's `monitor info mem` to fetch memory pages for QEMU in kernel mode.

However, at least on QEMU 3.0.0 on `qemu-system-x86_64` the `monitor info mem` command returns memory pages without the `executable` permission bit, so for now we assume that all returned pages are executable.

**EDIT: This feature works only on x86/x64 but does not break other architectures (see some investigations below) (the text below was here before edit)**

The `monitor info mem` works only in QEMU kernel mode and in QEMU-user it does:
```
(gdb) monitor info mem
Target does not support this command.
```

---
Let's see `vmmap` on a Linux kernel launched with:
```
qemu-system-x86_64 -monitor /dev/null \
    -cpu max,+smap,+smep,check \
    -m 64 -nographic \
    -kernel "$DIR/bzImage" \
    -initrd "$DIR/initramfs.cpio.gz" \
    -append "console=ttyS0 init='/init'"  -s
```

Before this PR:
```
pwndbg> vmmap
LEGEND: STACK | HEAP | CODE | DATA | RWX | RODATA
0xffff8c89c0000000 0xffff8c89c0466000 rwxp   466000 0      <explored>
0xffffffff9e600000 0xffffffff9ec07000 rwxp   607000 0      <explored>
0xffffffff9ea29000 0xffffffff9f229000 rwxp   800000 0      <explored>
0xffffffff9f002000 0xffffffff9f400000 rwxp   3fe000 0      [stack]

[QEMU target detected - vmmap result might not be accurate; see `help vmmap`]
```

After this PR:
```
pwndbg> vmmap
LEGEND: STACK | HEAP | CODE | DATA | RWX | RODATA
          0x400000           0x460000 r-xp    60000 0      <qemu>
          0x470000           0x4c0000 r-xp    50000 0      <qemu>
          0x4c7000           0x4c9000 r-xp     2000 0      <qemu>
          0x4c9000           0x4ce000 rwxp     5000 0      <qemu>
         0x245b000          0x245d000 rwxp     2000 0      <qemu>
    0x7ffff8deb000     0x7ffff8ded000 rwxp     2000 0      <qemu>
    0x7ffff8dee000     0x7ffff8def000 rwxp     1000 0      <qemu>
    0x7ffff8df5000     0x7ffff8df6000 r-xp     1000 0      <qemu>
0xffff8c89c0000000 0xffff8c89c0099000 rwxp    99000 0      <qemu>
0xffff8c89c0099000 0xffff8c89c009b000 r-xp     2000 0      <qemu>
0xffff8c89c009b000 0xffff8c89c2000000 rwxp  1f65000 0      <qemu>
0xffff8c89c2000000 0xffff8c89c2603000 r-xp   603000 0      <qemu>
0xffff8c89c2603000 0xffff8c89c2800000 rwxp   1fd000 0      <qemu>
0xffff8c89c2800000 0xffff8c89c285a000 r-xp    5a000 0      <qemu>
0xffff8c89c285a000 0xffff8c89c3109000 rwxp   8af000 0      <qemu>
0xffff8c89c3109000 0xffff8c89c310a000 r-xp     1000 0      <qemu>
0xffff8c89c310a000 0xffff8c89c3110000 rwxp     6000 0      <qemu>
0xffff8c89c3110000 0xffff8c89c3111000 r-xp     1000 0      <qemu>
0xffff8c89c3111000 0xffff8c89c3fe0000 rwxp   ecf000 0      <qemu>
0xffffaa4b40000000 0xffffaa4b40005000 rwxp     5000 0      <qemu>
0xffffaa4b40006000 0xffffaa4b40008000 rwxp     2000 0      <qemu>
0xffffaa4b40009000 0xffffaa4b4000a000 rwxp     1000 0      <qemu>
0xffffaa4b4000c000 0xffffaa4b40010000 rwxp     4000 0      <qemu>
0xffffaa4b40011000 0xffffaa4b40012000 rwxp     1000 0      <qemu>
0xffffaa4b40014000 0xffffaa4b40018000 rwxp     4000 0      <qemu>
0xffffaa4b4001c000 0xffffaa4b40020000 rwxp     4000 0      <qemu>
0xffffaa4b40024000 0xffffaa4b40028000 rwxp     4000 0      <qemu>
0xffffaa4b4002c000 0xffffaa4b40030000 rwxp     4000 0      <qemu>
0xffffaa4b40034000 0xffffaa4b40038000 rwxp     4000 0      <qemu>
0xffffaa4b4003c000 0xffffaa4b40040000 rwxp     4000 0      <qemu>
0xffffaa4b40044000 0xffffaa4b40048000 rwxp     4000 0      <qemu>
0xffffaa4b4004c000 0xffffaa4b40050000 rwxp     4000 0      <qemu>
0xffffaa4b40054000 0xffffaa4b40058000 rwxp     4000 0      <qemu>
0xffffaa4b4005c000 0xffffaa4b40060000 rwxp     4000 0      <qemu>
0xffffaa4b40064000 0xffffaa4b40068000 rwxp     4000 0      <qemu>
0xffffaa4b4006c000 0xffffaa4b40070000 rwxp     4000 0      <qemu>
0xffffaa4b40074000 0xffffaa4b40078000 rwxp     4000 0      <qemu>
0xffffaa4b4007c000 0xffffaa4b40080000 rwxp     4000 0      <qemu>
0xffffaa4b40084000 0xffffaa4b40088000 rwxp     4000 0      <qemu>
0xffffaa4b4008c000 0xffffaa4b40090000 rwxp     4000 0      <qemu>
0xffffaa4b40094000 0xffffaa4b40098000 rwxp     4000 0      <qemu>
0xffffaa4b4009c000 0xffffaa4b400a0000 rwxp     4000 0      <qemu>
0xffffaa4b400a1000 0xffffaa4b400a4000 rwxp     3000 0      <qemu>
0xffffaa4b400a8000 0xffffaa4b400ac000 rwxp     4000 0      <qemu>
0xffffaa4b400b0000 0xffffaa4b400b4000 rwxp     4000 0      <qemu>
0xfffff8a7c0000000 0xfffff8a7c0200000 rwxp   200000 0      <qemu>
0xfffffe0000000000 0xfffffe0000002000 r-xp     2000 0      <qemu>
0xfffffe0000002000 0xfffffe0000003000 rwxp     1000 0      <qemu>
0xfffffe0000003000 0xfffffe0000006000 r-xp     3000 0      <qemu>
0xfffffe0000007000 0xfffffe0000008000 rwxp     1000 0      <qemu>
0xfffffe0000009000 0xfffffe000000a000 rwxp     1000 0      <qemu>
0xfffffe000000d000 0xfffffe000000e000 rwxp     1000 0      <qemu>
0xfffffe000000f000 0xfffffe0000010000 rwxp     1000 0      <qemu>
0xfffffe0000011000 0xfffffe0000012000 rwxp     1000 0      <qemu>
0xffffffff9e600000 0xffffffff9ec03000 r-xp   603000 0      <qemu>
0xffffffff9ec03000 0xffffffff9ee00000 rwxp   1fd000 0      <qemu>
0xffffffff9ee00000 0xffffffff9ee5a000 r-xp    5a000 0      <qemu>
0xffffffff9ee5a000 0xffffffff9f400000 rwxp   5a6000 0      <qemu>
0xffffffffc0201000 0xffffffffc0203000 r-xp     2000 0      <qemu>
0xffffffffc0203000 0xffffffffc0204000 rwxp     1000 0      <qemu>
0xffffffffff5fc000 0xffffffffff5fe000 rwxp     2000 0      <qemu>

[QEMU target detected - vmmap result might not be accurate; see `help vmmap`]
```