### PR TITLE
Improve probeleak command

### DIFF
--- a/pwndbg/commands/probeleak.py
+++ b/pwndbg/commands/probeleak.py
@@ -5,6 +5,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import os
 import argparse
 import math
 
@@ -32,34 +33,51 @@ def find_module(addr, max_distance):
 
     return pages[-1]
 
+def satisfied_flags(require_flags, flags):
+    return (require_flags & ~(flags)) == 0
+
+def flags_str2int(flags_s):
+    flag_i = 0
+    if 'r' in flags_s:
+        flag_i |= os.R_OK
+    if 'w' in flags_s:
+        flag_i |= os.W_OK
+    if 'x' in flags_s:
+        flag_i |= os.X_OK
+    return flag_i
+
 parser = argparse.ArgumentParser(description='''
 Pointer scan for possible offset leaks.
 Examples:
     probeleak $rsp 0x64 - leaks 0x64 bytes starting at stack pointer and search for valid pointers
-    probeleak $rsp 0x64 0x10 - as above, but pointers may point 0x10 bytes outside of memory page
-    probeleak $rsp 0x64 0 libc 1 - leaks 0x64 bytes starting at stack pointer and search for one valid pointer 
-        which points to libc
+    probeleak $rsp 0x64 --max-dist 0x10 - as above, but pointers may point 0x10 bytes outside of memory page
+    probeleak $rsp 0x64 --point-to libc --max-ptrs 1 --flags rwx - leaks 0x64 bytes starting at stack pointer and 
+        search for one valid pointer which points to a libc rwx page
 ''')
 parser.add_argument('address', nargs='?', default='$sp',
                     help='Leak memory address')
 parser.add_argument('count', nargs='?', default=0x40,
                     help='Leak size in bytes')
-parser.add_argument('max_distance', nargs='?', default=0x0,
+parser.add_argument('--max-distance', type=int, default=0x0,
                     help='Max acceptable distance between memory page boundry and leaked pointer')
-parser.add_argument('mapping_name', type=str, nargs='?', default=None,
-                    help='Mapping you want the pointers point to')
-parser.add_argument('stop_cnt', nargs='?', default=0,
-                    help='Stop search after get n required pointers, default 0')
+parser.add_argument('--point-to', type=str, default=None,
+                    help='Mapping name of the page that you want the pointers point to')
+parser.add_argument('--max-ptrs', type=int, default=0,
+                    help='Stop search after find n pointers, default 0')
+parser.add_argument('--flags', type=str, default=None,
+                    help='flags of the page that you want the pointers point to. [e.g. rwx]')
 
 @pwndbg.commands.ArgparsedCommand(parser)
 @pwndbg.commands.OnlyWhenRunning
-def probeleak(address=None, count=0x40, max_distance=0x0, mapping_name=None, stop_cnt=0):
+def probeleak(address=None, count=0x40, max_distance=0x0, point_to=None, max_ptrs=0, flags=None):
 
     address = int(address)
     address &= pwndbg.arch.ptrmask
     ptrsize = pwndbg.arch.ptrsize
     count   = max(int(count), ptrsize)
     off_zeros = int(math.ceil(math.log(count,2)/4))
+    if flags != None:
+        require_flags = flags_str2int(flags)
 
     if count > address > 0x10000: # in case someone puts in an end address and not a count (smh)
         print(message.warn("Warning: you gave an end address, not a count. Substracting 0x%x from the count." % (address)))
@@ -81,7 +99,9 @@ def probeleak(address=None, count=0x40, max_distance=0x0, mapping_name=None, sto
         p = pwndbg.arch.unpack(data[i:i+ptrsize])
         page = find_module(p, max_distance)
         if page:
-            if mapping_name != None and mapping_name not in page.objfile:
+            if point_to != None and point_to not in page.objfile:
+                continue
+            if flags != None and not satisfied_flags(require_flags, page.flags):
                 continue
             if not found:
                 print(M.legend())
@@ -108,7 +128,7 @@ def probeleak(address=None, count=0x40, max_distance=0x0, mapping_name=None, sto
             print(text)
 
             find_cnt += 1
-            if stop_cnt != 0 and find_cnt >= stop_cnt:
+            if max_ptrs != 0 and find_cnt >= max_ptrs:
                 break
 
     if not found:

--- a/pwndbg/commands/probeleak.py
+++ b/pwndbg/commands/probeleak.py
@@ -29,7 +29,7 @@ def find_module(addr, max_distance):
 
         if not pages:
             return None
-            
+
     return pages[-1]
 
 parser = argparse.ArgumentParser(description='''
@@ -46,7 +46,7 @@ parser.add_argument('max_distance', nargs='?', default=0x0,
                     help='Max acceptable distance between memory page boundry and leaked pointer')
 parser.add_argument('mapping_name', type=str, nargs='?', default=None,
                     help='Mapping to search [e.g. libc]')
-parser.add_argument('stop_cnt', nargs='?', default=1,
+parser.add_argument('stop_cnt', nargs='?', default=0,
                     help='stop search after get n required pointers, default 1')
 
 @pwndbg.commands.ArgparsedCommand(parser)
@@ -99,7 +99,7 @@ def probeleak(address=None, count=0x40, max_distance=0x0, mapping_name=None, sto
             offset_text = '0x%0*x' % (off_zeros, i)
             p_text = '0x%0*x' % (int(ptrsize*2), p)
             text = '%s: %s = %s' % (offset_text, M.get(p, text=p_text), M.get(p, text=right_text))
-            
+
             symbol = pwndbg.symbol.get(p)
             if symbol:
                 text += ' (%s)' % symbol

--- a/pwndbg/commands/probeleak.py
+++ b/pwndbg/commands/probeleak.py
@@ -37,6 +37,8 @@ Pointer scan for possible offset leaks.
 Examples:
     probeleak $rsp 0x64 - leaks 0x64 bytes starting at stack pointer and search for valid pointers
     probeleak $rsp 0x64 0x10 - as above, but pointers may point 0x10 bytes outside of memory page
+    probeleak $rsp 0x64 0 libc 1 - leaks 0x64 bytes starting at stack pointer and search for one valid pointer 
+        which points to libc
 ''')
 parser.add_argument('address', nargs='?', default='$sp',
                     help='Leak memory address')
@@ -45,9 +47,9 @@ parser.add_argument('count', nargs='?', default=0x40,
 parser.add_argument('max_distance', nargs='?', default=0x0,
                     help='Max acceptable distance between memory page boundry and leaked pointer')
 parser.add_argument('mapping_name', type=str, nargs='?', default=None,
-                    help='Mapping to search [e.g. libc]')
+                    help='Mapping you want the pointers point to')
 parser.add_argument('stop_cnt', nargs='?', default=0,
-                    help='stop search after get n required pointers, default 1')
+                    help='Stop search after get n required pointers, default 0')
 
 @pwndbg.commands.ArgparsedCommand(parser)
 @pwndbg.commands.OnlyWhenRunning


### PR DESCRIPTION
add two more options: mapping_name and stop_cnt. And do not effect previous usage.

mapping_name  : Mapping you want the pointers point to
stop_cnt : Stop search after get n required pointers, default 0. which means don't stop until reach the end


Here are some examples:
Before, if I want to find a libc address somewhere after 0x601000, I may excute below command, and find a libc address among the outputs.
```
pwndbg> probeleak 0x601000 0x1000                                                                         
LEGEND: STACK | HEAP | CODE | DATA | RWX | RODATA                                                         
0x000: 0x0000000000600e28 = (r--p) /mnt/hgfs/ctf_games/replay/diary_TW_2016/test + 0xe28 (_DYNAMIC)       
0x008: 0x00007ffff7ffe168 = (rw-p) [anon] + 0x168                                                         
0x010: 0x00007ffff7deee10 = (r-xp) /lib/x86_64-linux-gnu/ld-2.23.so + 0x17e10 (_dl_runtime_resolve_xsave) 
0x018: 0x00000000004004f6 = (r-xp) /mnt/hgfs/ctf_games/replay/diary_TW_2016/test + 0x4f6 (puts@plt+6)     
0x020: 0x0000000000400506 = (r-xp) /mnt/hgfs/ctf_games/replay/diary_TW_2016/test + 0x506 (setbuf@plt+6)   
0x028: 0x00007ffff7a2d740 = (r-xp) /lib/x86_64-linux-gnu/libc-2.23.so.init + 0x20740 (__libc_start_main)  
0x040: 0x00007ffff7dd2620 = (rw-p) /lib/x86_64-linux-gnu/libc-2.23.so.init + 0x1620 (_IO_2_1_stdout_)     
0x050: 0x00007ffff7dd18e0 = (rw-p) /lib/x86_64-linux-gnu/libc-2.23.so.init + 0x8e0 (_IO_2_1_stdin_)       
0x060: 0x00007ffff7dd2540 = (rw-p) /lib/x86_64-linux-gnu/libc-2.23.so.init + 0x1540 (_IO_2_1_stderr_)     
```

But with the improvment I can use below command
```
pwndbg> probeleak 0x601000 0x1000 0 libc 1                                                              
LEGEND: STACK | HEAP | CODE | DATA | RWX | RODATA                                                       
0x028: 0x00007ffff7a2d740 = (r-xp) /lib/x86_64-linux-gnu/libc-2.23.so.init + 0x20740 (__libc_start_main)
```

I think this improvment is really useful when there are lots of pointers(such as one qemu escape challenge I worked recently).




