### PR TITLE
command: support alternatives including sub command wrapper like pwn

### DIFF
--- a/pwndbg/wrappers/checksec.py
+++ b/pwndbg/wrappers/checksec.py
@@ -5,32 +5,28 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import subprocess
 from re import search
 from subprocess import STDOUT
+from subprocess import CalledProcessError
 
 import pwndbg.commands
 import pwndbg.memoize
 import pwndbg.wrappers
 
 cmd_name = "checksec"
+cmd_pwntools = ["pwn", "checksec"]
 
-@pwndbg.wrappers.OnlyWithCommand(cmd_name)
+@pwndbg.wrappers.OnlyWithCommand(cmd_name, cmd_pwntools)
 @pwndbg.memoize.reset_on_objfile
 def get_raw_out():
     local_path = pwndbg.file.get_file(pwndbg.proc.exe)
     try:
-        version_output = subprocess.check_output([get_raw_out.cmd_path, "--version"], stderr=STDOUT).decode('utf-8')
-        match = search('checksec v([\\w.]+),', version_output)
-        if match:
-            version = tuple(map(int, (match.group(1).split("."))))
-            if version >= (2, 0):
-                return pwndbg.wrappers.call_cmd([get_raw_out.cmd_path, "--file=" + local_path])
-    except Exception:
+        return pwndbg.wrappers.call_cmd(get_raw_out.cmd + ["--file=" + local_path])
+    except CalledProcessError:
         pass
-    return pwndbg.wrappers.call_cmd([get_raw_out.cmd_path, "--file", local_path])
+    return pwndbg.wrappers.call_cmd(get_raw_out.cmd + ["--file", local_path])
 
-@pwndbg.wrappers.OnlyWithCommand(cmd_name)
+@pwndbg.wrappers.OnlyWithCommand(cmd_name, cmd_pwntools)
 def relro_status():
     relro = "No RELRO"
     out = get_raw_out()
@@ -42,7 +38,7 @@ def relro_status():
 
     return relro
 
-@pwndbg.wrappers.OnlyWithCommand(cmd_name)
+@pwndbg.wrappers.OnlyWithCommand(cmd_name, cmd_pwntools)
 def pie_status():
     pie = "No PIE"
     out = get_raw_out()

--- a/pwndbg/wrappers/checksec.py
+++ b/pwndbg/wrappers/checksec.py
@@ -24,7 +24,11 @@ def get_raw_out():
         return pwndbg.wrappers.call_cmd(get_raw_out.cmd + ["--file=" + local_path])
     except CalledProcessError:
         pass
-    return pwndbg.wrappers.call_cmd(get_raw_out.cmd + ["--file", local_path])
+    try:
+        return pwndbg.wrappers.call_cmd(get_raw_out.cmd + ["--file", local_path])
+    except CalledProcessError:
+        pass
+    return pwndbg.wrappers.call_cmd(get_raw_out.cmd + [local_path])
 
 @pwndbg.wrappers.OnlyWithCommand(cmd_name, cmd_pwntools)
 def relro_status():

--- a/pwndbg/wrappers/readelf.py
+++ b/pwndbg/wrappers/readelf.py
@@ -14,7 +14,7 @@ cmd_name = "readelf"
 @pwndbg.wrappers.OnlyWithCommand(cmd_name)
 def get_jmpslots():
     local_path = pwndbg.file.get_file(pwndbg.proc.exe)
-    cmd = [get_jmpslots.cmd_path, "--relocs", local_path]
+    cmd = get_jmpslots.cmd + ["--relocs", local_path]
     readelf_out = pwndbg.wrappers.call_cmd(cmd)
 
     return filter(_extract_jumps, readelf_out.splitlines())


### PR DESCRIPTION
command: support alternatives including sub command wrapper like pwn
    
Additionally speed up the checksec logic by removing the --version
check. Simply try to shell out and use the first working option variant
as we can't easily detect the different available alternatives in a
bulletproof way.
    
This implementation allows to use the sub command wrapper 'pwn' to call
checksec in case pwntools has been installed using --only-use-pwn-command
    
To unconditionally unify the usage, the functions cmd attribute stores
the base command to execute in form of a list that can be used to
concatenate an array of options against it and pass the final list to
call_cmd
