### PR TITLE
Fix vmmap crash when PG is disabled

### DIFF
--- a/pwndbg/vmmap.py
+++ b/pwndbg/vmmap.py
@@ -245,6 +245,11 @@ def monitor_info_mem():
         # TODO: add debug logging
         return tuple()
 
+    # Handle disabled PG
+    # This will prevent a crash on abstract architectures
+    if len(lines) == 1 and lines[0] == 'PG disabled':
+        return tuple()
+
     pages = []
     for line in lines:
         dash_idx = line.index('-')


### PR DESCRIPTION
Recently I was debugging a 512 byte boot sector. Pwndbg was giving a Value Error and not printing the registers or anything.  

![err](https://user-images.githubusercontent.com/36013983/74909635-b70c9680-5386-11ea-8d0a-f495f6365eef.png)

As it turned out, it was attempting to read the some virtual memory values from qemu. The `monitor_info_mem` function in vmmap.py is calling `monitor info mem` in gdb, which would return `PG disabled`. 

Attempting to parse `PG disabled` was causing an error. I've added a little check to detect this case and prevent the error. With that, everything worked normally. I think more generally this will catch issues with virtual memory mapping on weird / non-standard architectures. I had this same issue when debugging another non-standard architecture.

![boot](https://user-images.githubusercontent.com/36013983/74909648-bf64d180-5386-11ea-855c-76c566c9437c.png)

There is a note in the function referencing #685. It seems that the most recent versions of qemu are now handling the `monitor info mem` differently? Either way, this simple check handles it.