### PR TITLE
Replace malloc initialization heuristics

### DIFF
--- a/pwndbg/heap/ptmalloc.py
+++ b/pwndbg/heap/ptmalloc.py
@@ -563,14 +563,8 @@ class Heap(pwndbg.heap.heap.BaseHeap):
 
 
     def is_initialized(self):
-        """
-        malloc state is initialized when a new arena is created. 
-            https://sourceware.org/git/?p=glibc.git;a=blob;f=malloc/malloc.c;h=96149549758dd424f5c08bed3b7ed1259d5d5664;hb=HEAD#l1807
-        By default main_arena is partially initialized, and during the first usage of a glibc allocator function some other field are populated.
-        global_max_fast is one of them thus the call of set_max_fast() when initializing the main_arena, 
-        making it one of the ways to check if the allocator is initialized or not.
-        """
-        return self.global_max_fast != 0
+        addr = pwndbg.symbol.address('__libc_malloc_initialized')
+        return pwndbg.memory.u32(addr) == 1
 
     def libc_has_debug_syms(self):
         return pwndbg.symbol.address('global_max_fast') is not None

--- a/pwndbg/heap/ptmalloc.py
+++ b/pwndbg/heap/ptmalloc.py
@@ -564,7 +564,7 @@ class Heap(pwndbg.heap.heap.BaseHeap):
 
     def is_initialized(self):
         addr = pwndbg.symbol.address('__libc_malloc_initialized')
-        return pwndbg.memory.u32(addr) == 1
+        return pwndbg.memory.s32(addr) > 0
 
     def libc_has_debug_syms(self):
         return pwndbg.symbol.address('global_max_fast') is not None


### PR DESCRIPTION
Use the __libc_malloc_initialized symbol to determine whether malloc has been initialized rather than checking whether global_max_fast has been populated. This has the advantage of being compatible with older versions of GLIBC that don't have a global_max_fast symbol.