### PR TITLE
Fix alias for contextunwatch command

### DIFF
--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -175,7 +175,7 @@ def contextwatch(expression, cmd=None):
 parser = argparse.ArgumentParser()
 parser.description = """Removes an expression previously added to be watched."""
 parser.add_argument("expression", type=str, help="The expression to be removed from context")
-@pwndbg.commands.ArgparsedCommand(parser, aliases=['ctx-watch', 'cunwatch'])
+@pwndbg.commands.ArgparsedCommand(parser, aliases=['ctx-unwatch', 'cunwatch'])
 def contextunwatch(expression):
     global expressions
     expressions = set((exp,cmd) for exp,cmd in expressions if exp != expression)


### PR DESCRIPTION
The last commit (a18e751) that introduced the `contextwatch` and `contextunwatch` commands uses the same alias `ctx-watch` for both.

Besides obviously being wrong this also causes `pwndbg` to crash on startup because of a duplicate command definition.

This PR renames the alias for `contextunwatch` from `ctx-watch` to `ctx-unwatch`.