### PR TITLE
fixes #660,  can not get correct arm64 context

### DIFF
--- a/pwndbg/regs.py
+++ b/pwndbg/regs.py
@@ -286,7 +286,7 @@ class module(ModuleType):
         attr = attr.lstrip('$')
         try:
             # Seriously, gdb? Only accepts uint32.
-            if 'eflags' in attr:
+            if 'eflags' in attr or 'cpsr' in attr:
                 value = gdb77_get_register(attr)
                 value = value.cast(pwndbg.typeinfo.uint32)
             else:


### PR DESCRIPTION
A few months ago, my friend @thinkycx opened a issue #660 about arm64 context. I come into the same problem and I think a find the cause.

I know the problem is the invalid cast "value = value.cast(pwndbg.typeinfo.ptrdiff)" after reading the discussion in issue #660, so I try to find the correct type by reading the gdb source code.

The file gdb/features/aarch64-core.xml defines the arm64 registers and it defines cpsr as a 32-bit register.

```xml
  <flags id="cpsr_flags" size="4">
    <field name="SP" start="0" end="0"/>
    <field name="" start="1" end="1"/>
    <field name="EL" start="2" end="3"/>
    <field name="nRW" start="4" end="4"/>
    <field name="" start="5" end="5"/>
    <field name="F" start="6" end="6"/>
    <field name="I" start="7" end="7"/>
    <field name="A" start="8" end="8"/>
    <field name="D" start="9" end="9"/>

    <field name="IL" start="20" end="20"/>
    <field name="SS" start="21" end="21"/>

    <field name="V" start="28" end="28"/>
    <field name="C" start="29" end="29"/>
    <field name="Z" start="30" end="30"/>
    <field name="N" start="31" end="31"/>
  </flags>
  <reg name="cpsr" bitsize="32" type="cpsr_flags"/>
```
So I change the cast to "value = value.cast(pwndbg.typeinfo.uint32)" by adding another condition in the if statement.