### PR TITLE
Fix command description format

### DIFF
--- a/pwndbg/commands/leakfind.py
+++ b/pwndbg/commands/leakfind.py
@@ -54,11 +54,14 @@ def dbg_print_map(maps):
 
 parser = argparse.ArgumentParser()
 parser.description = """
-Attempt to find a leak chain given a starting address. Scans memory near the given address, looks for pointers, 
-and continues that process to attempt to find leaks.\n
-Example: leakfind $rsp --page_name=filename --max_offset=0x48 --max_depth=6. This would look for any chains of leaks that point to a section in filename which begin near $rsp, are never 0x48 bytes further from a known pointer, 
-and are a maximum length of 6\n
+Attempt to find a leak chain given a starting address.
+Scans memory near the given address, looks for pointers, and continues that process to attempt to find leaks.
+
+Example: leakfind $rsp --page_name=filename --max_offset=0x48 --max_depth=6. This would look for any chains of leaks \
+that point to a section in filename which begin near $rsp, are never 0x48 bytes further from a known pointer, \
+and are a maximum length of 6.
 """
+parser.formatter_class=argparse.RawDescriptionHelpFormatter
 parser.add_argument("address",help="Starting address to find a leak chain from")
 parser.add_argument("-p", "--page_name", type=str, nargs="?", default=None, help="Substring required to be part of the name of any found pages")
 parser.add_argument("-o", "--max_offset", default=0x48, nargs="?", help="Max offset to add to addresses when looking for leak")

--- a/pwndbg/commands/probeleak.py
+++ b/pwndbg/commands/probeleak.py
@@ -51,9 +51,10 @@ Pointer scan for possible offset leaks.
 Examples:
     probeleak $rsp 0x64 - leaks 0x64 bytes starting at stack pointer and search for valid pointers
     probeleak $rsp 0x64 --max-dist 0x10 - as above, but pointers may point 0x10 bytes outside of memory page
-    probeleak $rsp 0x64 --point-to libc --max-ptrs 1 --flags rwx - leaks 0x64 bytes starting at stack pointer and 
-        search for one valid pointer which points to a libc rwx page
+    probeleak $rsp 0x64 --point-to libc --max-ptrs 1 --flags rwx - leaks 0x64 bytes starting at stack pointer and \
+search for one valid pointer which points to a libc rwx page
 ''')
+parser.formatter_class=argparse.RawDescriptionHelpFormatter
 parser.add_argument('address', nargs='?', default='$sp',
                     help='Leak memory address')
 parser.add_argument('count', nargs='?', default=0x40,

--- a/pwndbg/commands/vmmap.py
+++ b/pwndbg/commands/vmmap.py
@@ -47,6 +47,7 @@ Memory pages on QEMU targets may be inaccurate. This is because:
 - for others, we create mempages by exploring current register values (this is least correct)
 
 Memory pages can also be added manually, see vmmap_add, vmmap_clear and vmmap_load commands.'''
+parser.formatter_class=argparse.RawDescriptionHelpFormatter
 parser.add_argument('pages_filter', type=pages_filter, nargs='?', default=None,
                     help='Address or module name.')
 

--- a/pwndbg/config.py
+++ b/pwndbg/config.py
@@ -168,8 +168,7 @@ class Parameter(gdb.Parameter):
             trigger()
 
         if not pwndbg.decorators.first_prompt:
-            # Remove the newline that gdb adds automatically
-            return '\b'
+            return ''
         return 'Set %s to %r' % (self.docstring, self.value)
 
     def get_show_string(self, svalue):


### PR DESCRIPTION
* Fix duplicate names when use command `pwndbg`
* Fix the ugly help information of command `vmmap -h`, `leakfind -h` and `probeleak -h`
* Remove extra empty lines when use `help search` and many other similar commands
* The bug [this PR want to resolve](https://github.com/pwndbg/pwndbg/pull/442#pullrequestreview-114178278) has already been fixed by gdb : https://github.com/bminor/binutils-gdb/commit/984ee559a26e138d8bcc1f850c1cacb9eded2b1c
And even in older version of gdb, `\b` doesn't work for me, the newline still occurs