### PR TITLE
Update heap implementation

### DIFF
--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -229,6 +229,15 @@ def OnlyWhenRunning(function):
             print("%s: The program is not being run." % function.__name__)
     return _OnlyWhenRunning
 
+def OnlyWithTcache(function):
+    @functools.wraps(function)
+    def _OnlyWithTcache(*a, **kw):
+        if pwndbg.heap.current.has_tcache():
+            return function(*a, **kw)
+        else:
+            print("%s: This version of GLIBC was not compiled with tcache support." % function.__name__)
+    return _OnlyWithTcache
+
 def OnlyWhenHeapIsInitialized(function):
     @functools.wraps(function)
     def _OnlyWhenHeapIsInitialized(*a, **kw):
@@ -307,7 +316,7 @@ class ArgparsedCommand(object):
 def sloppy_gdb_parse(s):
     """
     This function should be used as ``argparse.ArgumentParser`` .add_argument method's `type` helper.
-    
+
     This makes the type being parsed as gdb value and if that parsing fails,
     a string is returned.
 

--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -571,7 +571,7 @@ def vis_heap_chunks(addr=None, count=None, naive=None):
             if printed % 2 == 0:
                 out += "\n0x%x" % cursor
 
-            cell = pwndbg.memory.u(cursor)
+            cell = pwndbg.arch.unpack(pwndbg.memory.read(cursor, ptr_size))
             cell_hex = '\t0x{:0{n}x}'.format(cell, n=ptr_size*2)
 
             out += color_func(cell_hex)

--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -20,9 +20,10 @@ from pwndbg.color import message
 
 
 def read_chunk(addr):
-    # in old versions of glibc, `mchunk_[prev_]size` was simply called `[prev_]size`
-    # to support both versions, we change the new names to the old ones here so that
-    # the rest of the code can deal with uniform names
+    """Read a chunk's metadata."""
+    # In GLIBC versions <= 2.24 the `mchunk_[prev_]size` field was named `[prev_]size`.
+    # To support both versions, change the new names to the old ones here so that
+    # the rest of the code can deal with uniform names.
     renames = {
         "mchunk_size": "size",
         "mchunk_prev_size": "prev_size",
@@ -32,9 +33,9 @@ def read_chunk(addr):
 
 
 def format_bin(bins, verbose=False, offset=None):
-    main_heap = pwndbg.heap.current
+    allocator = pwndbg.heap.current
     if offset is None:
-        offset = main_heap.chunk_key_offset('fd')
+        offset = allocator.chunk_key_offset('fd')
 
     result = []
     bins_type = bins.pop('type')
@@ -71,7 +72,7 @@ def format_bin(bins, verbose=False, offset=None):
         if is_chain_corrupted:
             line = message.hint(size) + message.error(' [corrupted]') + '\n'
             line += message.hint('FD: ') + formatted_chain + '\n'
-            line += message.hint('BK: ') + pwndbg.chain.format(chain_bk[0], offset=main_heap.chunk_key_offset('bk'))
+            line += message.hint('BK: ') + pwndbg.chain.format(chain_bk[0], offset=allocator.chunk_key_offset('bk'))
         else:
             if count is not None:
                 line = (message.hint(size) + message.hint(' [%3d]' % count) + ': ').ljust(13)
@@ -88,146 +89,177 @@ def format_bin(bins, verbose=False, offset=None):
 
 
 parser = argparse.ArgumentParser()
-parser.description = "Prints out chunks starting from the address specified by `addr`."
-parser.add_argument("addr", nargs="?", type=int, default=None, help="The address of the heap.")
+parser.description = "Iteratively print chunks on a heap, default to the current thread's active heap."
+parser.add_argument("addr", nargs="?", type=int, default=None, help="Address of the first chunk.")
 @pwndbg.commands.ArgparsedCommand(parser)
 @pwndbg.commands.OnlyWhenRunning
 @pwndbg.commands.OnlyWithLibcDebugSyms
 @pwndbg.commands.OnlyWhenHeapIsInitialized
 def heap(addr=None):
+    """Iteratively print chunks on a heap, default to the current thread's
+    active heap.
     """
-    Prints out chunks starting from the address specified by `addr`.
-    """
-    main_heap  = pwndbg.heap.current
-    main_arena = main_heap.main_arena
-    if main_arena is None:
-        return
+    allocator = pwndbg.heap.current
+    heap_region = allocator.get_heap_boundaries(addr)
+    arena = allocator.get_arena_for_chunk(addr) if addr else allocator.get_arena()
 
-    page = main_heap.get_heap_boundaries(addr)
-    if addr is None:
-        addr = page.vaddr
+    top_chunk = arena['top']
+    ptr_size = allocator.size_sz
 
-    # Print out all chunks on the heap
-    # TODO: Add an option to print out only free or allocated chunks
+    # Calculate where to start printing; if an address was supplied, use that,
+    # if this heap belongs to the main arena, start at the beginning of the
+    # heap's mapping, otherwise, compensate for the presence of a heap_info
+    # struct and possibly an arena.
+    if addr:
+        cursor = int(addr)
+    elif arena == allocator.main_arena:
+        cursor = heap_region.start
+    else:
+        cursor = heap_region.start + allocator.heap_info.sizeof
+        if pwndbg.vmmap.find(allocator.get_heap(heap_region.start)['ar_ptr']) == heap_region:
+            # Round up to a 2-machine-word alignment after an arena to
+            # compensate for the presence of the have_fastchunks variable
+            # in GLIBC versions >= 2.27.
+            cursor += (allocator.malloc_state.sizeof + ptr_size) & ~allocator.malloc_align_mask
 
-    # Check if there is an alignment at the start of the heap
-    size_t = pwndbg.arch.ptrsize
-    first_chunk_size = pwndbg.arch.unpack(pwndbg.memory.read(addr + size_t, size_t))
-    if first_chunk_size == 0:
-        addr += size_t * 2  # Skip the alignment
-    while addr < page.vaddr + page.memsz:
-        chunk = malloc_chunk(addr)  # Prints the chunk
-        size = int(chunk['size'])
-        # Clear the bottom 3 bits
-        size &= ~7
-        if size == 0:
+    while cursor in heap_region:
+        old_cursor = cursor
+        size_field = pwndbg.memory.u(cursor + allocator.chunk_key_offset('size'))
+        real_size = size_field & ~allocator.malloc_align_mask
+
+        if cursor == top_chunk:
+            out = message.off("Top chunk\n")
+            out += "Addr: {}\nSize: 0x{:02x}".format(M.get(cursor), size_field)
+            print(out)
             break
-        addr += size
+
+        fastbins = allocator.fastbins(arena.address)
+        smallbins = allocator.smallbins(arena.address)
+        largebins = allocator.largebins(arena.address)
+        unsortedbin = allocator.unsortedbin(arena.address)
+        if allocator.has_tcache():
+            tcachebins = allocator.tcachebins(None)
+
+        out = "Addr: {}\nSize: 0x{:02x}\n".format(M.get(cursor), size_field)
+
+        if real_size in fastbins.keys() and cursor in fastbins[real_size]:
+            out = message.on("Free chunk (fastbins)\n") + out
+            out += message.system("fd: ") + "0x{:02x}\n".format(pwndbg.memory.u(cursor + allocator.chunk_key_offset('fd')))
+        elif real_size in smallbins.keys() and cursor in bin_addrs(smallbins[real_size], "smallbins"):
+            out = message.on("Free chunk (smallbins)\n") + out
+            out += message.system("fd: ") + "0x{:02x}\n".format(pwndbg.memory.u(cursor + allocator.chunk_key_offset('fd')))
+            out += message.system("bk: ") + "0x{:02x}\n".format(pwndbg.memory.u(cursor + allocator.chunk_key_offset('bk')))
+        elif real_size >= list(largebins.items())[0][0] and cursor in bin_addrs(largebins[(list(largebins.items())[allocator.largebin_index(real_size) - 64][0])], "largebins"):
+            out = message.on("Free chunk (largebins)\n") + out
+            out += message.system("fd: ") + "0x{:02x}\n".format(pwndbg.memory.u(cursor + allocator.chunk_key_offset('fd')))
+            out += message.system("bk: ") + "0x{:02x}\n".format(pwndbg.memory.u(cursor + allocator.chunk_key_offset('bk')))
+            out += message.system("fd_nextsize: ") + "0x{:02x}\n".format(pwndbg.memory.u(cursor + allocator.chunk_key_offset('fd_nextsize')))
+            out += message.system("bk_nextsize: ") + "0x{:02x}\n".format(pwndbg.memory.u(cursor + allocator.chunk_key_offset('bk_nextsize')))
+        elif cursor in bin_addrs(unsortedbin['all'], "unsortedbin"):
+            out = message.on("Free chunk (unsortedbin)\n") + out
+            out += message.system("fd: ") + "0x{:02x}\n".format(pwndbg.memory.u(cursor + allocator.chunk_key_offset('fd')))
+            out += message.system("bk: ") + "0x{:02x}\n".format(pwndbg.memory.u(cursor + allocator.chunk_key_offset('bk')))
+        elif allocator.has_tcache() and real_size in tcachebins.keys() and cursor + ptr_size*2 in bin_addrs(tcachebins[real_size], "tcachebins"):
+            out = message.on("Free chunk (tcache)\n") + out
+            out += message.system("fd: ") + "0x{:02x}\n".format(pwndbg.memory.u(cursor + allocator.chunk_key_offset('fd')))
+        else:
+            out = message.hint("Allocated chunk\n") + out
+
+        print(out)
+        cursor += real_size
+
+        # Avoid an infinite loop when a chunk's size is 0.
+        if cursor == old_cursor:
+            break
+
+
 parser = argparse.ArgumentParser()
-parser.description = "Prints out the main arena or the arena at the specified by address."
-parser.add_argument("addr", nargs="?", type=int, default=None, help="The address of the arena.")
+parser.description = "Print the contents of an arena, default to the current thread's arena."
+parser.add_argument("addr", nargs="?", type=int, default=None, help="Address of the arena.")
 @pwndbg.commands.ArgparsedCommand(parser)
 @pwndbg.commands.OnlyWhenRunning
 @pwndbg.commands.OnlyWithLibcDebugSyms
 @pwndbg.commands.OnlyWhenHeapIsInitialized
 def arena(addr=None):
-    """
-    Prints out the main arena or the arena at the specified by address.
-    """
-    main_heap   = pwndbg.heap.current
-    main_arena  = main_heap.get_arena(addr)
-
-    if main_arena is None:
-        return
-
-    print(main_arena)
+    """Print the contents of an arena, default to the current thread's arena."""
+    allocator = pwndbg.heap.current
+    arena = allocator.get_arena(addr)
+    print(arena)
 
 
 parser = argparse.ArgumentParser()
-parser.description = "Prints out allocated arenas."
+parser.description = "List this process's arenas."
 @pwndbg.commands.ArgparsedCommand(parser)
 @pwndbg.commands.OnlyWhenRunning
 @pwndbg.commands.OnlyWithLibcDebugSyms
 @pwndbg.commands.OnlyWhenHeapIsInitialized
 def arenas():
-    """
-    Prints out allocated arenas.
-    """
-    heap = pwndbg.heap.current
-    for ar in heap.arenas:
+    """Lists this process's arenas."""
+    allocator = pwndbg.heap.current
+    for ar in allocator.arenas:
         print(ar)
 
 
 parser = argparse.ArgumentParser()
-parser.description = "Print malloc thread cache info."
-parser.add_argument("addr", nargs="?", type=int, default=None, help="The address of the tcache.")
+parser.description = "Print a thread's tcache contents, default to the current thread's tcache."
+parser.add_argument("addr", nargs="?", type=int, default=None, help="Address of the tcache.")
 @pwndbg.commands.ArgparsedCommand(parser)
 @pwndbg.commands.OnlyWhenRunning
 @pwndbg.commands.OnlyWithLibcDebugSyms
 @pwndbg.commands.OnlyWhenHeapIsInitialized
+@pwndbg.commands.OnlyWithTcache
 def tcache(addr=None):
+    """Print a thread's tcache contents, default to the current thread's
+    tcache.
     """
-    Prints out the thread cache.
-
-    Glibc 2.26 malloc introduced per-thread chunk cache. This command prints
-    out per-thread control structure of the cache.
-    """
-    main_heap = pwndbg.heap.current
-    tcache = main_heap.get_tcache(addr)
-
-    if tcache is None:
-        return
-
+    allocator = pwndbg.heap.current
+    tcache = allocator.get_tcache(addr)
     print(tcache)
 
 
 parser = argparse.ArgumentParser()
-parser.description = "Prints out the mp_ structure from glibc."
+parser.description = "Print the mp_ struct's contents."
 @pwndbg.commands.ArgparsedCommand(parser)
 @pwndbg.commands.OnlyWhenRunning
 @pwndbg.commands.OnlyWithLibcDebugSyms
 @pwndbg.commands.OnlyWhenHeapIsInitialized
 def mp():
-    """
-    Prints out the mp_ structure from glibc
-    """
-    main_heap   = pwndbg.heap.current
-
-    print(main_heap.mp)
+    """Print the mp_ struct's contents."""
+    allocator = pwndbg.heap.current
+    print(allocator.mp)
 
 
 parser = argparse.ArgumentParser()
-parser.description = "Prints out the address of the top chunk of the main arena, or of the arena at the specified address."
-parser.add_argument("addr", nargs="?", type=int, default=None, help="The address of the arena.")
+parser.description = "Print relevant information about an arena's top chunk, default to current thread's arena."
+parser.add_argument("addr", nargs="?", type=int, default=None, help="Address of the arena.")
 @pwndbg.commands.ArgparsedCommand(parser)
 @pwndbg.commands.OnlyWhenRunning
 @pwndbg.commands.OnlyWithLibcDebugSyms
 @pwndbg.commands.OnlyWhenHeapIsInitialized
 def top_chunk(addr=None):
+    """Print relevant information about an arena's top chunk, default to the
+    current thread's arena.
     """
-    Prints out the address of the top chunk of the main arena, or of the arena
-    at the specified address.
-    """
-    main_heap   = pwndbg.heap.current
-    main_arena  = main_heap.get_arena(addr)
-    address = main_arena['top']
+    allocator = pwndbg.heap.current
+    arena = allocator.get_arena(addr)
+    address = arena['top']
+    size = pwndbg.memory.u(int(address) + allocator.chunk_key_offset('size'))
 
-    return malloc_chunk(address)
+    out = message.off("Top chunk\n") + "Addr: {}\nSize: 0x{:02x}".format(M.get(address), size)
+    print(out)
 
 
 parser = argparse.ArgumentParser()
-parser.description = "Prints out the malloc_chunk at the specified address."
-parser.add_argument("addr", nargs="?", type=int, default=None, help="The address of the chunk.")
-parser.add_argument("fake", nargs="?", type=bool, default=False, help="If the chunk is a fake chunk.")#TODO describe this better
+parser.description = "Print a malloc_chunk struct's contents."
+parser.add_argument("addr", nargs="?", type=int, default=None, help="Address of the chunk.")
+parser.add_argument("fake", nargs="?", type=bool, default=False, help="Is this a fake chunk?")
 @pwndbg.commands.ArgparsedCommand(parser)
 @pwndbg.commands.OnlyWhenRunning
 @pwndbg.commands.OnlyWithLibcDebugSyms
 @pwndbg.commands.OnlyWhenHeapIsInitialized
 def malloc_chunk(addr,fake=False):
-    """
-    Prints out the malloc_chunk at the specified address.
-    """
-    main_heap = pwndbg.heap.current
+    """Print a malloc_chunk struct's contents."""
+    allocator = pwndbg.heap.current
 
     if not isinstance(addr, six.integer_types):
         addr = int(addr)
@@ -235,12 +267,12 @@ def malloc_chunk(addr,fake=False):
     chunk = read_chunk(addr)
     size = int(chunk['size'])
     actual_size = size & ~7
-    prev_inuse, is_mmapped, non_main_arena = main_heap.chunk_flags(size)
+    prev_inuse, is_mmapped, non_main_arena = allocator.chunk_flags(size)
     arena = None
     if not fake and non_main_arena:
-        arena = main_heap.get_heap(addr)['ar_ptr']
+        arena = allocator.get_heap(addr)['ar_ptr']
 
-    fastbins = [] if fake else main_heap.fastbins(arena)
+    fastbins = [] if fake else allocator.fastbins(arena)
     header = M.get(addr)
     if fake:
         header += message.prompt(' FAKE')
@@ -259,20 +291,16 @@ def malloc_chunk(addr,fake=False):
 
 
 parser = argparse.ArgumentParser()
-parser.description = """
-    Prints out the contents of the tcachebins, fastbins, unsortedbin, smallbins, and largebins from the
-    main_arena or the specified address.
-    """
-parser.add_argument("addr", nargs="?", type=int, default=None, help="The address of the bins.") #TODO describe this better if necessary
-parser.add_argument("tcache_addr", nargs="?", type=int, default=None, help="The address of the tcache.")
+parser.description = "Print the contents of all an arena's bins and a thread's tcache, default to the current thread's arena and tcache."
+parser.add_argument("addr", nargs="?", type=int, default=None, help="Address of the arena.")
+parser.add_argument("tcache_addr", nargs="?", type=int, default=None, help="Address of the tcache.")
 @pwndbg.commands.ArgparsedCommand(parser)
 @pwndbg.commands.OnlyWhenRunning
 @pwndbg.commands.OnlyWithLibcDebugSyms
 @pwndbg.commands.OnlyWhenHeapIsInitialized
 def bins(addr=None, tcache_addr=None):
-    """
-    Prints out the contents of the tcachebins, fastbins, unsortedbin, smallbins, and largebins from the
-    main_arena or the specified address.
+    """Print the contents of all an arena's bins and a thread's tcache,
+    default to the current thread's arena and tcache.
     """
     if pwndbg.heap.current.has_tcache():
         tcachebins(tcache_addr)
@@ -283,23 +311,19 @@ def bins(addr=None, tcache_addr=None):
 
 
 parser = argparse.ArgumentParser()
-parser.description = """
-    Prints out the contents of the fastbins of the main arena or the arena
-    at the specified address.
-    """
-parser.add_argument("addr", nargs="?", type=int, default=None, help="The address of the fastbins.")
-parser.add_argument("verbose", nargs="?", type=bool, default=True, help="Whether to show more details or not.")
+parser.description = "Print the contents of an arena's fastbins, default to the current thread's arena."
+parser.add_argument("addr", nargs="?", type=int, default=None, help="Address of the arena.")
+parser.add_argument("verbose", nargs="?", type=bool, default=True, help="Show extra detail.")
 @pwndbg.commands.ArgparsedCommand(parser)
 @pwndbg.commands.OnlyWhenRunning
 @pwndbg.commands.OnlyWithLibcDebugSyms
 @pwndbg.commands.OnlyWhenHeapIsInitialized
 def fastbins(addr=None, verbose=True):
+    """Print the contents of an arena's fastbins, default to the current
+    thread's arena.
     """
-    Prints out the contents of the fastbins of the main arena or the arena
-    at the specified address.
-    """
-    main_heap = pwndbg.heap.current
-    fastbins  = main_heap.fastbins(addr)
+    allocator = pwndbg.heap.current
+    fastbins = allocator.fastbins(addr)
 
     if fastbins is None:
         return
@@ -312,23 +336,19 @@ def fastbins(addr=None, verbose=True):
 
 
 parser = argparse.ArgumentParser()
-parser.description = """
-    Prints out the contents of the unsorted bin of the main arena or the
-    arena at the specified address.
-    """
-parser.add_argument("addr", nargs="?", type=int, default=None, help="The address of the unsorted bin.")
-parser.add_argument("verbose", nargs="?", type=bool, default=True, help="Whether to show more details or not.")
+parser.description = "Print the contents of an arena's unsortedbin, default to the current thread's arena."
+parser.add_argument("addr", nargs="?", type=int, default=None, help="Address of the arena.")
+parser.add_argument("verbose", nargs="?", type=bool, default=True, help="Show extra detail.")
 @pwndbg.commands.ArgparsedCommand(parser)
 @pwndbg.commands.OnlyWhenRunning
 @pwndbg.commands.OnlyWithLibcDebugSyms
 @pwndbg.commands.OnlyWhenHeapIsInitialized
 def unsortedbin(addr=None, verbose=True):
+    """Print the contents of an arena's unsortedbin, default to the current
+    thread's arena.
     """
-    Prints out the contents of the unsorted bin of the main arena or the
-    arena at the specified address.
-    """
-    main_heap   = pwndbg.heap.current
-    unsortedbin = main_heap.unsortedbin(addr)
+    allocator = pwndbg.heap.current
+    unsortedbin = allocator.unsortedbin(addr)
 
     if unsortedbin is None:
         return
@@ -341,23 +361,19 @@ def unsortedbin(addr=None, verbose=True):
 
 
 parser = argparse.ArgumentParser()
-parser.description = """
-    Prints out the contents of the small bin of the main arena or the arena
-    at the specified address.
-    """
-parser.add_argument("addr", nargs="?", type=int, default=None, help="The address of the smallbins.")
-parser.add_argument("verbose", nargs="?", type=bool, default=False, help="Whether to show more details or not.")
+parser.description = "Print the contents of an arena's smallbins, default to the current thread's arena."
+parser.add_argument("addr", nargs="?", type=int, default=None, help="Address of the arena.")
+parser.add_argument("verbose", nargs="?", type=bool, default=False, help="Show extra detail.")
 @pwndbg.commands.ArgparsedCommand(parser)
 @pwndbg.commands.OnlyWhenRunning
 @pwndbg.commands.OnlyWithLibcDebugSyms
 @pwndbg.commands.OnlyWhenHeapIsInitialized
 def smallbins(addr=None, verbose=False):
+    """Print the contents of an arena's smallbins, default to the current
+    thread's arena.
     """
-    Prints out the contents of the small bin of the main arena or the arena
-    at the specified address.
-    """
-    main_heap = pwndbg.heap.current
-    smallbins = main_heap.smallbins(addr)
+    allocator = pwndbg.heap.current
+    smallbins = allocator.smallbins(addr)
 
     if smallbins is None:
         return
@@ -370,23 +386,19 @@ def smallbins(addr=None, verbose=False):
 
 
 parser = argparse.ArgumentParser()
-parser.description = """
-    Prints out the contents of the large bin of the main arena or the arena
-    at the specified address.
-    """
-parser.add_argument("addr", nargs="?", type=int, default=None, help="The address of the largebins.")
-parser.add_argument("verbose", nargs="?", type=bool, default=False, help="Whether to show more details or not.")
+parser.description = "Print the contents of an arena's largebins, default to the current thread's arena."
+parser.add_argument("addr", nargs="?", type=int, default=None, help="Address of the arena.")
+parser.add_argument("verbose", nargs="?", type=bool, default=False, help="Show extra detail.")
 @pwndbg.commands.ArgparsedCommand(parser)
 @pwndbg.commands.OnlyWhenRunning
 @pwndbg.commands.OnlyWithLibcDebugSyms
 @pwndbg.commands.OnlyWhenHeapIsInitialized
 def largebins(addr=None, verbose=False):
+    """Print the contents of an arena's largebins, default to the current
+    thread's arena.
     """
-    Prints out the contents of the large bin of the main arena or the arena
-    at the specified address.
-    """
-    main_heap = pwndbg.heap.current
-    largebins = main_heap.largebins(addr)
+    allocator = pwndbg.heap.current
+    largebins = allocator.largebins(addr)
 
     if largebins is None:
         return
@@ -399,28 +411,23 @@ def largebins(addr=None, verbose=False):
 
 
 parser = argparse.ArgumentParser()
-parser.description = """
-    Prints out the contents of the bins in current thread tcache or in tcache
-    at the specified address.
-    """
+parser.description = "Print the contents of a tcache, default to the current thread's tcache."
 parser.add_argument("addr", nargs="?", type=int, default=None, help="The address of the tcache bins.")
 parser.add_argument("verbose", nargs="?", type=bool, default=False, help="Whether to show more details or not.")
 @pwndbg.commands.ArgparsedCommand(parser)
 @pwndbg.commands.OnlyWhenRunning
 @pwndbg.commands.OnlyWithLibcDebugSyms
 @pwndbg.commands.OnlyWhenHeapIsInitialized
+@pwndbg.commands.OnlyWithTcache
 def tcachebins(addr=None, verbose=False):
-    """
-    Prints out the contents of the bins in current thread tcache or in tcache
-    at the specified address.
-    """
-    main_heap = pwndbg.heap.current
-    tcachebins = main_heap.tcachebins(addr)
+    """Print the contents of a tcache, default to the current thread's tcache."""
+    allocator = pwndbg.heap.current
+    tcachebins = allocator.tcachebins(addr)
 
     if tcachebins is None:
         return
 
-    formatted_bins = format_bin(tcachebins, verbose, offset = main_heap.tcache_next_offset)
+    formatted_bins = format_bin(tcachebins, verbose, offset = allocator.tcache_next_offset)
 
     print(C.banner('tcachebins'))
     for node in formatted_bins:
@@ -428,29 +435,23 @@ def tcachebins(addr=None, verbose=False):
 
 
 parser = argparse.ArgumentParser()
-parser.description = """
-    Finds candidate fake fast chunks that will overlap with the specified
-    address. Used for fastbin dups and house of spirit
-    """
-parser.add_argument("addr", type=int, help="The start address of a word size value you want to overlap.")
-parser.add_argument("size", nargs="?", type=int, default=None, help="The size of fastbin you want to use.")
+parser.description = "Find candidate fake fast chunks overlapping the specified address."
+parser.add_argument("addr", type=int, help="Address of the word-sized value to overlap.")
+parser.add_argument("size", nargs="?", type=int, default=None, help="Size of fake chunks to find.")
 @pwndbg.commands.ArgparsedCommand(parser)
 @pwndbg.commands.OnlyWhenRunning
 @pwndbg.commands.OnlyWithLibcDebugSyms
 @pwndbg.commands.OnlyWhenHeapIsInitialized
 def find_fake_fast(addr, size=None):
-    """
-    Finds candidate fake fast chunks that will overlap with the specified
-    address. Used for fastbin dups and house of spirit
-    """
+    """Find candidate fake fast chunks overlapping the specified address."""
     psize = pwndbg.arch.ptrsize
-    main_heap = pwndbg.heap.current
-    align = main_heap.malloc_alignment
-    min_fast = main_heap.min_chunk_size
-    max_fast = main_heap.global_max_fast
-    max_fastbin  = main_heap.fastbin_index(max_fast)
-    start    = int(addr) - max_fast + psize
-    mem      = pwndbg.memory.read(start, max_fast - psize, partial=True)
+    allocator = pwndbg.heap.current
+    align = allocator.malloc_alignment
+    min_fast = allocator.min_chunk_size
+    max_fast = allocator.global_max_fast
+    max_fastbin = allocator.fastbin_index(max_fast)
+    start = int(addr) - max_fast + psize
+    mem = pwndbg.memory.read(start, max_fast - psize, partial=True)
 
     fmt = {
         'little': '<',
@@ -467,35 +468,48 @@ def find_fake_fast(addr, size=None):
 
     print(C.banner("FAKE CHUNKS"))
     for size in sizes:
-        fastbin  = main_heap.fastbin_index(size)
+        fastbin  = allocator.fastbin_index(size)
         for offset in range((max_fastbin - fastbin) * align, max_fast - align + 1):
             candidate = mem[offset : offset + psize]
             if len(candidate) == psize:
                 value = struct.unpack(fmt, candidate)[0]
-                if main_heap.fastbin_index(value) == fastbin:
+                if allocator.fastbin_index(value) == fastbin:
                     malloc_chunk(start+offset-psize, fake=True)
 
 
-vis_heap_chunks_parser = argparse.ArgumentParser(description='Visualize heap chunks at the specified address')
-vis_heap_chunks_parser.add_argument('count', type=lambda n:max(int(n, 0),1), nargs='?', default=10, help='Number of chunks to visualize')
-vis_heap_chunks_parser.add_argument('address', help='Start address', nargs='?', default=None)
-vis_heap_chunks_parser.add_argument('--naive', '-n', help='Attempt to keep printing beyond the top chunk', action='store_true', default=False)
-
-@pwndbg.commands.ArgparsedCommand(vis_heap_chunks_parser)
+parser = argparse.ArgumentParser()
+parser.description = "Visualize chunks on a heap, default to the current arena's active heap."
+parser.add_argument("count", nargs="?", type=lambda n:max(int(n, 0),1), default=10, help="Number of chunks to visualize.")
+parser.add_argument("addr", nargs="?", default=None, help="Address of the first chunk.")
+parser.add_argument("--naive", "-n", action="store_true", default=False, help="Attempt to keep printing beyond the top chunk.")
+@pwndbg.commands.ArgparsedCommand(parser)
 @pwndbg.commands.OnlyWhenRunning
 @pwndbg.commands.OnlyWithLibcDebugSyms
 @pwndbg.commands.OnlyWhenHeapIsInitialized
-def vis_heap_chunks(address=None, count=None, naive=None):
-    main_heap = pwndbg.heap.current
-    heap_region = main_heap.get_heap_boundaries(address)
-    main_arena = main_heap.get_arena_for_chunk(address) if address else main_heap.main_arena
+def vis_heap_chunks(addr=None, count=None, naive=None):
+    """Visualize chunks on a heap, default to the current arena's active heap."""
+    allocator = pwndbg.heap.current
+    heap_region = allocator.get_heap_boundaries(addr)
+    arena = allocator.get_arena_for_chunk(addr) if addr else allocator.get_arena()
 
-    top_chunk = main_arena['top']
-    ptr_size = main_heap.size_sz
+    top_chunk = arena['top']
+    ptr_size = allocator.size_sz
 
     # Build a list of addresses that delimit each chunk.
     chunk_delims = []
-    cursor = int(address) if address else heap_region.start
+    if addr:
+        cursor = int(addr)
+    elif arena == allocator.main_arena:
+        cursor = heap_region.start
+    else:
+        cursor = heap_region.start + allocator.heap_info.sizeof
+        if pwndbg.vmmap.find(allocator.get_heap(heap_region.start)['ar_ptr']) == heap_region:
+            # Round up to a 2-machine-word alignment after an arena to
+            # compensate for the presence of the have_fastchunks variable
+            # in GLIBC versions >= 2.27.
+            cursor += (allocator.malloc_state.sizeof + ptr_size) & ~allocator.malloc_align_mask
+
+    cursor_backup = cursor
 
     for _ in range(count + 1):
         # Don't read beyond the heap mapping if --naive or corrupted heap.
@@ -504,8 +518,8 @@ def vis_heap_chunks(address=None, count=None, naive=None):
             break
 
         size_field = pwndbg.memory.u(cursor + ptr_size)
-        real_size = size_field & ~main_heap.malloc_align_mask
-        prev_inuse = main_heap.chunk_flags(size_field)[0]
+        real_size = size_field & ~allocator.malloc_align_mask
+        prev_inuse = allocator.chunk_flags(size_field)[0]
 
         # Don't repeatedly operate on the same address (e.g. chunk size of 0).
         if cursor in chunk_delims or cursor + ptr_size in chunk_delims:
@@ -533,19 +547,22 @@ def vis_heap_chunks(address=None, count=None, naive=None):
     ]
 
     bin_collections = [
-        pwndbg.heap.current.fastbins(None),
-        pwndbg.heap.current.unsortedbin(None),
-        pwndbg.heap.current.smallbins(None),
-        pwndbg.heap.current.largebins(None),
+        allocator.fastbins(arena.address),
+        allocator.unsortedbin(arena.address),
+        allocator.smallbins(arena.address),
+        allocator.largebins(arena.address),
         ]
-    if pwndbg.heap.current.has_tcache():
-        bin_collections.insert(0, pwndbg.heap.current.tcachebins(None))
+    if allocator.has_tcache():
+        # Only check for tcache entries belonging to the current thread,
+        # it's difficult (impossible?) to find all the thread caches for a
+        # specific heap.
+        bin_collections.insert(0, allocator.tcachebins(None))
 
     printed = 0
     out = ''
     asc = ''
     labels = []
-    cursor = int(address) if address else heap_region.start
+    cursor = cursor_backup
 
     for c, stop in enumerate(chunk_delims):
         color_func = color_funcs[c % len(color_funcs)]
@@ -574,10 +591,12 @@ def vis_heap_chunks(address=None, count=None, naive=None):
 
     print(out)
 
+
 def bin_ascii(bs):
     from string import printable
-    valid_chars = list(map(ord, set(printable) - set('\t\r\n')))
+    valid_chars = list(map(ord, set(printable) - set('\t\r\n\x0c')))
     return ''.join(chr(c) if c in valid_chars else '.'for c in bs)
+
 
 def bin_labels(addr, collections):
     labels = []
@@ -597,6 +616,7 @@ def bin_labels(addr, collections):
                     labels.append('{:s}[{:s}][{:d}{}]'.format(bins_type, size, chunks.index(addr), count or ''))
 
     return labels
+
 
 def bin_addrs(b, bins_type):
     addrs = []

--- a/pwndbg/heap/ptmalloc.py
+++ b/pwndbg/heap/ptmalloc.py
@@ -249,7 +249,9 @@ class Heap(pwndbg.heap.heap.BaseHeap):
     def multithreaded(self):
         """Is malloc operating within a multithreaded environment."""
         addr = pwndbg.symbol.address('__libc_multiple_threads')
-        return pwndbg.memory.s32(addr) > 0
+        if addr:
+            return pwndbg.memory.s32(addr) > 0
+        return len(gdb.execute('info threads', to_string=True).split('\n')) > 3
 
     def _request2size(self, req):
         """Corresponds to request2size in glibc malloc.c"""

--- a/pwndbg/heap/ptmalloc.py
+++ b/pwndbg/heap/ptmalloc.py
@@ -17,6 +17,7 @@ from pwndbg.color import message
 from pwndbg.constants import ptmalloc
 from pwndbg.heap import heap_chain_limit
 
+
 # See https://sourceware.org/git/?p=glibc.git;a=blob;f=malloc/arena.c;h=37183cfb6ab5d0735cc82759626670aff3832cd0;hb=086ee48eaeaba871a2300daf85469671cc14c7e9#l30
 # and https://sourceware.org/git/?p=glibc.git;a=blob;f=malloc/malloc.c;h=f8e7250f70f6f26b0acb5901bcc4f6e39a8a52b2;hb=086ee48eaeaba871a2300daf85469671cc14c7e9#l869
 # 1 Mb (x86) or 64 Mb (x64)
@@ -24,7 +25,10 @@ HEAP_MAX_SIZE = 1024 * 1024 if pwndbg.arch.ptrsize == 4 else 2 * 4 * 1024 * 1024
 
 
 def heap_for_ptr(ptr):
-    "find the heap and corresponding arena for a given ptr"
+    """Round a pointer to a chunk down to find its corresponding heap_info
+    struct, the pointer must point inside a heap which does not belong to
+    the main arena.
+    """
     return (ptr & ~(HEAP_MAX_SIZE-1))
 
 
@@ -65,7 +69,6 @@ class Heap(pwndbg.heap.heap.BaseHeap):
         # ptmalloc cache for current thread
         self._thread_cache  = None
 
-
     @property
     def main_arena(self):
         main_arena_addr = pwndbg.symbol.address('main_arena')
@@ -77,7 +80,6 @@ class Heap(pwndbg.heap.heap.BaseHeap):
                                 'debugging symbols and try again.'))
 
         return self._main_arena
-
 
     @property
     @pwndbg.memoize.reset_on_stop
@@ -134,40 +136,20 @@ class Heap(pwndbg.heap.heap.BaseHeap):
         self._arenas = arenas
         return arenas
 
-
     def has_tcache(self):
         return (self.mp and 'tcache_bins' in self.mp.type.keys() and self.mp['tcache_bins'])
 
-    def _fetch_tcache_addr(self):
-        """
-        As of Ubuntu 18.04 and glibc 2.27 the tcache_perthread_struct* tcache
-        is located 0x10 bytes after the heap page, so we just return it here.
-
-        pwndbg> p tcache
-        $1 = (tcache_perthread_struct *) 0x555555756010
-        pwndbg> vmmap 0x555555756010
-        LEGEND: STACK | HEAP | CODE | DATA | RWX | RODATA
-            0x555555756000     0x555555777000 rw-p    21000 0      [heap]
-        """
-        return self.get_heap_boundaries().vaddr + 0x10
-
     @property
     def thread_cache(self):
-        tcache_addr = pwndbg.symbol.address('tcache')
+        """Locate a thread's tcache struct."""
+        if self.multithreaded:
+            tcache = pwndbg.memory.pvoid(pwndbg.symbol.address('tcache'))
+        else:
+            tcache = self.mp['sbrk_base'] + 0x10
 
-        # The symbol.address returns ptr to ptr to tcache struct, as in:
-        # pwndbg> p &tcache
-        # $1 = (tcache_perthread_struct **) 0x7ffff7fd76f0
-        # so we need to dereference it
-        if tcache_addr is not None:
-            tcache_addr = pwndbg.memory.pvoid(tcache_addr)
-
-        if tcache_addr is None:
-            tcache_addr = self._fetch_tcache_addr()
-
-        if tcache_addr is not None:
+        if tcache is not None:
             try:
-                self._thread_cache = pwndbg.memory.poi(self.tcache_perthread_struct, tcache_addr)
+                self._thread_cache = pwndbg.memory.poi(self.tcache_perthread_struct, tcache)
                 _ = self._thread_cache['entries'].fetch_lazy()
             except Exception as e:
                 print(message.error('Error fetching tcache. GDB cannot access '
@@ -183,7 +165,6 @@ class Heap(pwndbg.heap.heap.BaseHeap):
 
         return self._thread_cache
 
-
     @property
     def mp(self):
         mp_addr = pwndbg.symbol.address('mp_')
@@ -193,54 +174,45 @@ class Heap(pwndbg.heap.heap.BaseHeap):
 
         return self._mp
 
-
     @property
     def global_max_fast(self):
         addr = pwndbg.symbol.address('global_max_fast')
         return pwndbg.memory.u(addr)
-
 
     @property
     @pwndbg.memoize.reset_on_objfile
     def heap_info(self):
         return pwndbg.typeinfo.load('heap_info')
 
-
     @property
     @pwndbg.memoize.reset_on_objfile
     def malloc_chunk(self):
         return pwndbg.typeinfo.load('struct malloc_chunk')
-
 
     @property
     @pwndbg.memoize.reset_on_objfile
     def malloc_state(self):
         return pwndbg.typeinfo.load('struct malloc_state')
 
-
     @property
     @pwndbg.memoize.reset_on_objfile
     def tcache_perthread_struct(self):
         return pwndbg.typeinfo.load('struct tcache_perthread_struct')
-
 
     @property
     @pwndbg.memoize.reset_on_objfile
     def tcache_entry(self):
         return pwndbg.typeinfo.load('struct tcache_entry')
 
-
     @property
     @pwndbg.memoize.reset_on_objfile
     def mallinfo(self):
         return pwndbg.typeinfo.load('struct mallinfo')
 
-
     @property
     @pwndbg.memoize.reset_on_objfile
     def malloc_par(self):
         return pwndbg.typeinfo.load('struct malloc_par')
-
 
     @property
     @pwndbg.memoize.reset_on_objfile
@@ -248,13 +220,11 @@ class Heap(pwndbg.heap.heap.BaseHeap):
         """Corresponds to MALLOC_ALIGNMENT in glibc malloc.c"""
         return pwndbg.arch.ptrsize * 2
 
-
     @property
     @pwndbg.memoize.reset_on_objfile
     def size_sz(self):
         """Corresponds to SIZE_SZ in glibc malloc.c"""
         return pwndbg.arch.ptrsize
-
 
     @property
     @pwndbg.memoize.reset_on_objfile
@@ -268,19 +238,24 @@ class Heap(pwndbg.heap.heap.BaseHeap):
         """Corresponds to MINSIZE in glibc malloc.c"""
         return self.min_chunk_size
 
-
     @property
     @pwndbg.memoize.reset_on_objfile
     def min_chunk_size(self):
         """Corresponds to MIN_CHUNK_SIZE in glibc malloc.c"""
         return pwndbg.arch.ptrsize * 4
 
+    @property
+    @pwndbg.memoize.reset_on_objfile
+    def multithreaded(self):
+        """Is malloc operating within a multithreaded environment."""
+        addr = pwndbg.symbol.address('__libc_multiple_threads')
+        return pwndbg.memory.s32(addr) > 0
+
     def _request2size(self, req):
         """Corresponds to request2size in glibc malloc.c"""
         if req + self.size_sz + self.malloc_align_mask < self.minsize:
             return self.minsize
         return (req + self.size_sz + self.malloc_align_mask) & ~self.malloc_align_mask
-
 
     def _spaces_table(self):
         spaces_table =  [ pwndbg.arch.ptrsize * 2 ]      * 64 \
@@ -312,44 +287,50 @@ class Heap(pwndbg.heap.heap.BaseHeap):
                  size & ptmalloc.IS_MMAPPED,
                  size & ptmalloc.NON_MAIN_ARENA )
 
-
     def chunk_key_offset(self, key):
-        """
-        Finds the index of a field in the malloc_chunk struct.
+        """Find the index of a field in the malloc_chunk struct.
 
-        64 bit example.)
+        64bit example:
             prev_size == 0
             size      == 8
             fd        == 16
             bk        == 24
             ...
         """
-        chunk_keys = self.malloc_chunk.keys()
+        renames = {
+            "mchunk_size": "size",
+            "mchunk_prev_size": "prev_size",
+        }
+        val = self.malloc_chunk
+        chunk_keys = list(dict({renames.get(key, key): 0 for key in val.keys()}).keys())
 
         try:
             return chunk_keys.index(key) * pwndbg.arch.ptrsize
         except:
             return None
 
-
     @property
     @pwndbg.memoize.reset_on_objfile
     def tcache_next_offset(self):
         return  self.tcache_entry.keys().index('next') * pwndbg.arch.ptrsize
 
-
-    def get_heap(self,addr):
-        return pwndbg.memory.poi(self.heap_info,heap_for_ptr(addr))
-
+    def get_heap(self, addr):
+        """Find & read the heap_info struct belonging to the chunk at 'addr'."""
+        return pwndbg.memory.poi(self.heap_info, heap_for_ptr(addr))
 
     def get_arena(self, arena_addr=None):
+        """Read a malloc_state struct from the specified address, default to
+        reading the current thread's arena.
+        """
         if arena_addr is None:
-            return self.main_arena
+            if self.multithreaded:
+                return pwndbg.memory.poi(self.malloc_state, pwndbg.memory.u(pwndbg.symbol.address('thread_arena')))
+            else:
+                return self.main_arena
 
         return pwndbg.memory.poi(self.malloc_state, arena_addr)
 
-
-    def get_arena_for_chunk(self,addr):
+    def get_arena_for_chunk(self, addr):
         chunk = pwndbg.commands.heap.read_chunk(addr)
         _,_,nm = self.chunk_flags(chunk['size'])
         if nm:
@@ -358,57 +339,40 @@ class Heap(pwndbg.heap.heap.BaseHeap):
             r=self.main_arena
         return r
 
-
     def get_tcache(self, tcache_addr=None):
         if tcache_addr is None:
             return self.thread_cache
 
         return pwndbg.memory.poi(self.tcache_perthread_struct, tcache_addr)
 
-
     def get_heap_boundaries(self, addr=None):
+        """Find the boundaries of the heap containing `addr`, default to the
+        boundaries of the heap containing the top chunk for the thread's arena.
         """
-        Get the boundaries of the heap containing `addr`. Returns the brk region for
-        adresses inside it or a fake Page for the containing heap for non-main arenas.
-        """
+        region = self.get_region(addr) if addr else self.get_region(self.get_arena()['top'])
+
+        # Occasionally, the [heap] vm region and the actual start of the heap are
+        # different, e.g. [heap] starts at 0x61f000 but mp_.sbrk_base is 0x620000.
+        # Return an adjusted Page object if this is the case.
         page = pwndbg.memory.Page(0, 0, 0, 0)
-        brk = self.get_region(addr)
-        if brk == self.get_region():
-            # Occasionally, the [heap] vm region and the actual start of the heap are
-            # different, e.g. [heap] starts at 0x61f000 but mp_.sbrk_base is 0x620000.
-            # Return an adjusted Page object if this is the case.
-            sbrk_base = int(self.mp['sbrk_base'])
-            if sbrk_base != brk.vaddr:
+        sbrk_base = int(self.mp['sbrk_base'])
+        if region == self.get_region(sbrk_base):
+            if sbrk_base != region.vaddr:
                 page.vaddr = sbrk_base
-                page.memsz = brk.memsz - (sbrk_base - brk.vaddr)
+                page.memsz = region.memsz - (sbrk_base - region.vaddr)
                 return page
 
-        return brk
+        return region
 
-
-    def get_region(self, addr=None):
-        """
-        Finds the memory map used for the heap at addr or the main heap by looking for a
-        mapping named [heap].
-        """
-        if addr:
-            return pwndbg.vmmap.find(addr)
-
-        # No address provided, find the vm region of the main heap.
-        brk = None
-        for m in pwndbg.vmmap.get():
-            if m.objfile == '[heap]':
-                brk = m
-                break
-
-        return brk
+    def get_region(self, addr):
+        """Find the memory map containing 'addr'."""
+        return pwndbg.vmmap.find(addr)
 
     def fastbin_index(self, size):
         if pwndbg.arch.ptrsize == 8:
             return (size >> 4) - 2
         else:
             return (size >> 3) - 2
-
 
     def fastbins(self, arena_addr=None):
         """Returns: chain or None"""
@@ -431,7 +395,6 @@ class Heap(pwndbg.heap.heap.BaseHeap):
 
         result['type'] = 'fastbins'
         return result
-
 
     def tcachebins(self, tcache_addr=None):
         """Returns: tuple(chain, count) or None"""
@@ -459,7 +422,6 @@ class Heap(pwndbg.heap.heap.BaseHeap):
 
         result['type'] = 'tcachebins'
         return result
-
 
     def bin_at(self, index, arena_addr=None):
         """
@@ -507,7 +469,6 @@ class Heap(pwndbg.heap.heap.BaseHeap):
 
         return (chain_fd, chain_bk, is_chain_corrupted)
 
-
     def unsortedbin(self, arena_addr=None):
         chain  = self.bin_at(1, arena_addr=arena_addr)
         result = OrderedDict()
@@ -519,7 +480,6 @@ class Heap(pwndbg.heap.heap.BaseHeap):
 
         result['type'] = 'unsortedbin'
         return result
-
 
     def smallbins(self, arena_addr=None):
         size         = self.min_chunk_size - self.malloc_alignment
@@ -538,7 +498,6 @@ class Heap(pwndbg.heap.heap.BaseHeap):
         result['type'] = 'smallbins'
         return result
 
-
     def largebins(self, arena_addr=None):
         size         = (ptmalloc.NSMALLBINS * self.malloc_alignment) - self.malloc_alignment
         spaces_table = self._spaces_table()
@@ -556,6 +515,33 @@ class Heap(pwndbg.heap.heap.BaseHeap):
         result['type'] = 'largebins'
         return result
 
+    def largebin_index_32(self, sz):
+        """Modeled on the GLIBC malloc largebin_index_32 macro.
+
+        https://sourceware.org/git/?p=glibc.git;a=blob;f=malloc/malloc.c;h=f7cd29bc2f93e1082ee77800bd64a4b2a2897055;hb=9ea3686266dca3f004ba874745a4087a89682617#l1414
+        """
+        return 56 + (sz >> 6) if (sz >> 6) <= 38 else\
+        91 + (sz >> 9) if (sz >> 9) <= 20 else\
+        110 + (sz >> 12) if (sz >> 12) <= 10 else\
+        119 + (sz >> 15) if (sz >> 15) <= 4 else\
+        124 + (sz >> 18) if (sz >> 18) <= 2 else\
+        126
+
+    def largebin_index_64(self, sz):
+        """Modeled on the GLIBC malloc largebin_index_64 macro.
+
+        https://sourceware.org/git/?p=glibc.git;a=blob;f=malloc/malloc.c;h=f7cd29bc2f93e1082ee77800bd64a4b2a2897055;hb=9ea3686266dca3f004ba874745a4087a89682617#l1433
+        """
+        return 48 + (sz >> 6) if (sz >> 6) <= 48 else\
+        91 + (sz >> 9) if (sz >> 9) <= 20 else\
+        110 + (sz >> 12) if (sz >> 12) <= 10 else\
+        119 + (sz >> 15) if (sz >> 15) <= 4 else\
+        124 + (sz >> 18) if (sz >> 18) <= 2 else\
+        126
+
+    def largebin_index(self, sz):
+        """Pick the appropriate largebin_index_ function for this architecture."""
+        return self.largebin_index_64(sz) if pwndbg.arch.ptrsize == 8 else self.largebin_index_32(sz)
 
     def is_initialized(self):
         addr = pwndbg.symbol.address('__libc_malloc_initialized')


### PR DESCRIPTION
This PR makes some improvements to pwndbg's heap-related commands.
### Primary changes

* The "heap" and "top_chunk" commands now print just the relevant information about chunks they encounter, rather than dumping all possible fields whether they are in use or not.

**Before:** 
<img width="370" alt="image" src="https://user-images.githubusercontent.com/16000770/77214591-2af8a680-6acd-11ea-8010-a49ff153a923.png">
<img width="370" alt="image" src="https://user-images.githubusercontent.com/16000770/77214684-7a3ed700-6acd-11ea-8f56-9a7f0dd874d9.png">

**After:**
<img width="370" alt="image" src="https://user-images.githubusercontent.com/16000770/77214785-e7526c80-6acd-11ea-8e70-aa26702452de.png">
<img width="370" alt="image" src="https://user-images.githubusercontent.com/16000770/77214793-ef121100-6acd-11ea-9c3a-98a77fed3088.png">

* Heap commands now default to using the currently debugged thread's arena, rather than the main arena. This makes things a lot more convenient when debugging multi-threaded applications and fixes the issue where no bin labels were displayed when printing a foreign thread's heap.

* Tcache commands have been placed behind an OnlyWithTcache decorator, which stops them from being invoked when debugging versions of GLIBC compiled without tcache support.

### Housekeeping:

* Some variables have been renamed for clarity; for example, a variable named "main_arena" was being used to refer to arenas that may or may not be the main arena. "main_heap" has been renamed to "allocator" because it refers to the allocator implementation rather than any specific heap.

* Argparse descriptions are single-line now so they don't get truncated by the "pwndbg" command.

* Some PEP8 amendments such as whitespace removal and docstring width.