### PR TITLE
Fixed alignment bug in vis_heap_chunks command

### DIFF
--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -490,12 +490,18 @@ def vis_heap_chunks(address=None, count=None, naive=None):
     heap_region = main_heap.get_heap_boundaries(address)
     main_arena = main_heap.get_arena_for_chunk(address) if address else main_heap.main_arena
 
+    first_chunk = heap_region.start
     top_chunk = main_arena['top']
     ptr_size = main_heap.size_sz
 
+    # Check if there is an alignment at the start of the heap
+    first_chunk_size = pwndbg.arch.unpack(pwndbg.memory.read(first_chunk + ptr_size, ptr_size))
+    if first_chunk_size == 0:
+        first_chunk += ptr_size * 2
+
     # Build a list of addresses that delimit each chunk.
     chunk_delims = []
-    cursor = int(address) if address else heap_region.start
+    cursor = int(address) if address else first_chunk
 
     for _ in range(count + 1):
         # Don't read beyond the heap mapping if --naive or corrupted heap.

--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -551,7 +551,7 @@ def vis_heap_chunks(address=None, count=None, naive=None):
     out = ''
     asc = ''
     labels = []
-    cursor = int(address) if address else heap_region.start
+    cursor = int(address) if address else first_chunk
 
     for c, stop in enumerate(chunk_delims):
         color_func = color_funcs[c % len(color_funcs)]


### PR DESCRIPTION
Used alignment code from the "heap" command as a reference to fix this bug that sometimes causes "vis_heap_chunks" to print nothing due to an assumption that was being made in vis_heap_chunks (that the first chunk starts exactly on the heap region start).  The specific target that I saw this bug behavior in was bcloud in https://github.com/ctfs/write-ups-2016/tree/master/bctf-2016/exploit/bcloud-200 (from a breakpoint before any heap exploit shenanigans, just legitimate mallocs/data).  This patch fixes this behavior/bug.