### PR TITLE
Fixes #749 - stop showing pc marker in disasm loops

### DIFF
--- a/pwndbg/commands/nearpc.py
+++ b/pwndbg/commands/nearpc.py
@@ -119,13 +119,16 @@ def nearpc(pc=None, lines=None, to_string=False, emulate=False):
 
     prev = None
 
+    first_pc = True
+
     # Print out each instruction
     for address_str, symbol, instr in zip(addresses, symbols, instructions):
         asm    = D.instruction(instr)
         prefix_sign  = pwndbg.config.nearpc_prefix
 
         # Show prefix only on the specified address and don't show it while in repeat-mode
-        show_prefix = instr.address == pc and not nearpc.repeat
+        # or when showing current instruction for the second time
+        show_prefix = instr.address == pc and not nearpc.repeat and first_pc
         prefix = ' %s' % (prefix_sign if show_prefix else ' ' * len(prefix_sign))
         prefix = N.prefix(prefix)
 
@@ -138,10 +141,11 @@ def nearpc(pc=None, lines=None, to_string=False, emulate=False):
         if instr.address != pc or not pwndbg.config.highlight_pc or nearpc.repeat:
             address_str = N.address(address_str)
             symbol = N.symbol(symbol)
-        elif pwndbg.config.highlight_pc:
+        elif pwndbg.config.highlight_pc and first_pc:
             prefix = C.highlight(prefix)
             address_str = C.highlight(address_str)
             symbol = C.highlight(symbol)
+            first_pc = False
 
         line   = ' '.join((prefix, address_str, symbol, asm))
 


### PR DESCRIPTION
This commit fixes the issue described in #749.

During disasm output, we enhance the display to show additional information of the instructions.
When a future instruction executes a branch instruction (jmp/call), we fetch the next instruction based on the jmp/call target, as long as we can calculate it statically.

If we can calculate it statically, we will then display the target of the jmp/call as the next instruction, as e.g. in here:
```
 > 0x5555555545fe <main+4>    jmp    main+4 <0x5555555545fe>
    v
 > 0x5555555545fe <main+4>    jmp    main+4 <0x5555555545fe>
```

The issue is, that we mark both instructions as "current", highlighting both of them, making it a bit unambigous "where we are".

While this view is _kinda valid_ as the PC is really the same, we want to mark/hightlight only the first instruction we are on, as it is the one that is being executed right now and the program might go some other path in the future.

This commit fixes this display by simply making it so that the `nearpc` function/command used to display disasm shows the marker only once, for the first time it shows the current PC instruction.