### PR TITLE
backtrace section in context with more information

### DIFF
--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -545,7 +545,7 @@ def context_backtrace(frame_count=10, with_banner=True, target=sys.stdout, width
     result = []
 
     if with_banner:
-        result.append(pwndbg.ui.banner("backtrace"))
+        result.append(pwndbg.ui.banner("backtrace", target=target, width=width))
 
     frames = gdb.execute('backtrace', to_string=True, from_tty=False).split("\n")
     frames.remove('')

--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -551,7 +551,6 @@ def context_backtrace(frame_count=10, with_banner=True, target=sys.stdout, width
     frames.remove('')
     for frame in frames:
         split = frame.split(" ")
-        print('[+]', split)
         split.remove('') # in case of two adjacent spaces
         idx = split[0][1:] # reomve '#'
         try:


### PR DESCRIPTION
fix issue https://github.com/pwndbg/pwndbg/issues/752#issue-615165861


```
> cat test.c
int f995(){return 995;}
int f996(){return f995();}
int f997(){return f996();}
int f998(){return f997();}
int f999(){return f998();}
int f1000(){return f999();}

int main(){
        f1000();
        return 0;
}
```

test command
```
gcc -g  test.c -o test && gdb -q ./test -ex "b f995" -ex "r"
```

before:
![image](https://user-images.githubusercontent.com/20255635/82009304-8dbb8800-96a1-11ea-8eed-e54c64c78d1e.png)


after:
![image](https://user-images.githubusercontent.com/20255635/82008934-965f8e80-96a0-11ea-9df4-5b28b457a8bc.png)
![image](https://user-images.githubusercontent.com/20255635/82009405-d1ae8d00-96a1-11ea-9a94-359ec8e87b30.png)


