### PR TITLE
Changes in dependencies needed for Ubuntu, starting from scratch.

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -21,8 +21,8 @@ osx() {
 install_apt() {
     sudo apt-get update || true
     # This breaks Ubuntu 20.04, but is probably still needed for older version
-    sudo apt-get -y  python-pip || true
-    sudo apt-get -y install gdb python-dev python3-dev python3-pip libglib2.0-dev libc6-dbg
+    sudo apt-get -y install python-pip || true
+    sudo apt-get -y install git gdb python-dev python3-dev python3-pip libglib2.0-dev libc6-dbg
 
     if uname -m | grep x86_64 > /dev/null; then
         sudo apt-get -y install libc6-dbg:i386 || true


### PR DESCRIPTION
* Added install to apt line: this fixes bug mentioned by @martinclauss in #748 that might be needed for Ubuntu <20.04.
* Added git to apt-get, which is needed for a docker run -it ubuntu