### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,50 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+<!--
+Before reporting a new issue, make sure that we do not have any duplicates already open.
+If there is one it might be good to take part in the discussion there.
+
+Please make sure you have checked that the issue persists on LATEST pwndbg version.
+
+Below is a template for BUG REPORTS.
+Don't include it if this is a FEATURE REQUEST.
+-->
+
+
+### Description
+
+<!--
+Briefly describe the problem you are having in a few paragraphs.
+-->
+
+### Steps to reproduce
+
+<!--
+What do we have to do to reproduce the problem?
+If this is connected to particular C/asm code, 
+please provide the smallest C code that reproduces the issue.
+-->
+
+### My setup
+
+<!--
+Show us your gdb/python/pwndbg/OS/IDA Pro version (depending on your case).
+
+NOTE: We are currently supporting only Ubuntu installations.
+It is known that pwndbg is not fully working e.g. on Arch Linux (the heap stuff is not working there).
+If you would like to change this situation - help us improving pwndbg and supporting other distros!
+
+This can be displayed in pwndbg through `version` command.
+
+If it is somehow unavailable, use:
+* `show version` - for gdb
+* `py import sys; print(sys.version)` - for python
+* pwndbg version/git commit id
+-->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: feature
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
This adds a new template for Feature Requests.

The Bug template is unchanged.

Both now automatically add the relevant `bug` or `feature` label.