### PR TITLE
Use set literal instead of set() for set literals

### DIFF
--- a/pwndbg/regs.py
+++ b/pwndbg/regs.py
@@ -323,7 +323,7 @@ class module(ModuleType):
         return item
 
     def __iter__(self):
-        regs = set(arch_to_regs[pwndbg.arch.current]) | set(['pc','sp'])
+        regs = set(arch_to_regs[pwndbg.arch.current]) | {'pc', 'sp'}
         for item in regs:
             yield item
 


### PR DESCRIPTION
Why? Bcoz calls are expensive and there is an opcode for building sets.
```
In [4]: dis.dis(compile('{"pc", "sp"}', '<filename>', 'exec'))
  1           0 LOAD_CONST               0 ('pc')
              2 LOAD_CONST               1 ('sp')
              4 BUILD_SET                2
              6 POP_TOP
              8 LOAD_CONST               2 (None)
             10 RETURN_VALUE

In [5]: dis.dis(compile('set(["pc", "sp"])', '<filename>', 'exec'))
  1           0 LOAD_NAME                0 (set)
              2 LOAD_CONST               0 ('pc')
              4 LOAD_CONST               1 ('sp')
              6 BUILD_LIST               2
              8 CALL_FUNCTION            1
             10 POP_TOP
             12 LOAD_CONST               2 (None)
             14 RETURN_VALUE
```

I also searched for other occurrences and this is the only one.
```
$ git grep "set[(][[]'"
pwndbg/regs.py:323:        regs = set(arch_to_regs[pwndbg.arch.current]) | set(['pc','sp'])
$

$ git grep 'set[(][[]"'
$
```
