### PR TITLE
Fixes #777 - missing pyelftools program header name

### DIFF
--- a/pwndbg/elf.py
+++ b/pwndbg/elf.py
@@ -149,8 +149,9 @@ def get_containing_segments(elf_filepath, elf_loadaddr, vaddr):
     elf = get_elf_info_rebased(elf_filepath, elf_loadaddr)
     segments = []
     for seg in elf.segments:
-        # disregard non-LOAD segments that are not file-backed (typically STACK)
-        if 'LOAD' not in seg['p_type'] and seg['p_filesz'] == 0:
+        # disregard segments which were unable to be named by pyelftools (see #777)
+        # and non-LOAD segments that are not file-backed (typically STACK)
+        if isinstance(seg['p_type'], int) or ('LOAD' not in seg['p_type'] and seg['p_filesz'] == 0):
             continue
         # disregard segments not containing vaddr
         if vaddr < seg['p_vaddr'] or vaddr >= seg['x_vaddr_mem_end']:


### PR DESCRIPTION
When pyelftools missed a PT_* name, invoking a `xinfo` command on a library with the missing program header crashed the `xinfo` command due to us assuming the ptype will be a string.

Instead, since pyelftoools didn't have the name, this ph is then an int.

So this commit takes this into acccount and omits those program headers that we weren't able to name due to lack of info in pyelftools.

This solution is not ideal as we might miss something, but given that we care about given program header name, I don't think it will be a big deal for us.