### PR TITLE
Fix telescope function default arg and dqs windbg command

### DIFF
--- a/pwndbg/commands/telescope.py
+++ b/pwndbg/commands/telescope.py
@@ -42,7 +42,7 @@ parser.add_argument("address", nargs="?", default=None, type=int, help="The addr
 parser.add_argument("count", nargs="?", default=telescope_lines, type=int, help="The number of lines to show.")
 @pwndbg.commands.ArgparsedCommand(parser)
 @pwndbg.commands.OnlyWhenRunning
-def telescope(address=None, count=None, to_string=False):
+def telescope(address=None, count=telescope_lines, to_string=False):
     """
     Recursively dereferences pointers starting at the specified address
     ($sp by default)


### PR DESCRIPTION
The `dqs` command was broken as it called `telescope` not passing any `count` explicitly. The `count` default value was set o `telescope_lines` at some point in `telescope`'s `ArgparseCommand`, but not in the `telescope`'s function's `count` argument. Since it was still `None`, the `dqs` command crashed as shown below:

 
```
pwndbg> set exception-verbose on
Set whether to print a full stacktrace for exceptions raised in Pwndbg commands to True
pwndbg> set exception-debugger on
Set whether to debug exceptions raised in Pwndbg commands to True
pwndbg> dqs $rsp
'telescope': Recursively dereferences pointers starting at the specified address
    ($sp by default)
Traceback (most recent call last):
  File "/opt/pwndbg/pwndbg/commands/__init__.py", line 136, in __call__
    return self.function(*args, **kwargs)
  File "/opt/pwndbg/pwndbg/commands/__init__.py", line 227, in _OnlyWhenRunning
    return function(*a, **kw)
  File "/opt/pwndbg/pwndbg/commands/telescope.py", line 58, in telescope
    count   = max(int(count), 1) & pwndbg.arch.ptrmask
  File "/opt/pwndbg/pwndbg/inthook.py", line 54, in __new__
    return _int.__new__(cls, value, *a, **kw)
TypeError: int() argument must be a string, a bytes-like object or a number, not 'NoneType'

If that is an issue, you can report it on https://github.com/pwndbg/pwndbg/issues
(Please don't forget to search if it hasn't been reported before)
To generate the report and open a browser, you may run `bugreport --run-browser`
PS: Pull requests are welcome
> /opt/pwndbg/pwndbg/inthook.py(54)__new__()
-> return _int.__new__(cls, value, *a, **kw)
(Pdb) print(cls, value, a, kw)
<class 'pwndbg.inthook.xint'> None () {}
(Pdb)
```

After the PR the `dqs` command works properly and respects the `telescope_lines` value (not sure if we want it, but it is rather ok):
```
pwndbg> dqs $rsp
00:0000│ r13 rsp  0x7ffc48262870 ◂— 0x1
01:0008│          0x7ffc48262878 —▸ 0x7ffc482648d4 ◂— '/usr/bin/ls'
02:0010│          0x7ffc48262880 ◂— 0x0
03:0018│ rcx      0x7ffc48262888 —▸ 0x7ffc482648e0 ◂— 'LESSOPEN=| /usr/bin/lesspipe %s'
04:0020│          0x7ffc48262890 —▸ 0x7ffc48264900 ◂— 'PYTHONIOENCODING=UTF-8'
05:0028│          0x7ffc48262898 —▸ 0x7ffc48264917 ◂— 'HOSTNAME=a74efe876cb8'
06:0030│          0x7ffc482628a0 —▸ 0x7ffc4826492d ◂— 0x313d4c564c4853 /* 'SHLVL=1' */
07:0038│          0x7ffc482628a8 —▸ 0x7ffc48264935 ◂— 'HOME=/root'
pwndbg> set telescope-lines 2
Set number of lines to printed by the telescope command to 2
pwndbg> dqs $rsp
00:0000│ r13 rsp  0x7ffc48262870 ◂— 0x1
01:0008│          0x7ffc48262878 —▸ 0x7ffc482648d4 ◂— '/usr/bin/ls'
pwndbg>```