### PR TITLE
Fix disasm call target display when symbol is known

### DIFF
--- a/pwndbg/color/disasm.py
+++ b/pwndbg/color/disasm.py
@@ -53,13 +53,11 @@ def instruction(ins):
 
         # If it's a constant expression, color it directly in the asm.
         if const:
+            asm = '%s <%s>' % (ljust_colored(asm, 36), target)
             asm = asm.replace(hex(ins.target), sym or target)
 
-            if sym:
-                asm = '%s <%s>' % (ljust_colored(asm, 36), target)
-
         # It's not a constant expression, but we've calculated the target
-        # address by emulation.
+        # address by emulation or other means (for example showing ret instruction target)
         elif sym:
             asm = '%s <%s; %s>' % (ljust_colored(asm, 36), target, sym)
 


### PR DESCRIPTION
This commit fixes the issue described in https://github.com/pwndbg/pwndbg/issues/772#issuecomment-652260420

tl;dr: when we displayed a known constant call instruction like
`call qword ptr [rip + 0x1c7d2]` when it called a known symbol we only
displayed the target address instead of the symbol.

Now, we will display only the target address.

Note that there are still cases when we can display both. This can
happen for example for a `ret` instruction (even without emulation).

This commit extends a comment around that code to give such example.