### PR TITLE
Add GitHub Actions support

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,37 @@
+name: Lint
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+    - uses: actions/checkout@v2
+    - name: Cache for pip
+      uses: actions/cache@v1
+      with:
+        path: ~/.cache/pip
+        key: ${{ matrix.os }}-cache-pip
+
+    - name: Set up Python 2.7
+      uses: actions/setup-python@v1
+      with:
+        python-version: 2.7
+
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.8
+
+    - name: Install linters
+      run: |
+        pip install isort future
+
+    - name: Run tests
+      run: |
+        futurize --all-imports --stage1 --print-function --write --unicode-literals pwndbg tests
+        git diff-index --quiet HEAD -- pwndbg tests
+        isort --check-only --diff --recursive pwndbg tests
+        python2.7 -m py_compile ida_script.py $(git ls-files 'pwndbg/*.py')
+        python3   -m py_compile               $(git ls-files 'pwndbg/*.py')
+

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,32 @@
+name: Unit tests
+on: [push, pull_request]
+
+jobs:
+  tests:
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    steps:
+    - uses: actions/checkout@v2
+    - name: Cache for pip
+      uses: actions/cache@v1
+      with:
+        path: ~/.cache/pip
+        key: ${{ matrix.os }}-cache-pip
+
+    - name: Install dependencies
+      run: |
+        ./setup.sh --user
+
+    - name: Python version info
+      run: |
+        echo 'GDB py:'
+        gdb --batch --quiet --nx --nh --ex 'py import sys; print(sys.version)'
+        echo 'Installed py:'
+        python -V
+
+    - name: Run tests
+      run: |
+        PWNDBG_TRAVIS_TEST_RUN=1 ./tests.sh


### PR DESCRIPTION
GitHub provides an integrated CI solution, which has more capabilities than Travis.
This adds basic jobs based on what pwntools have, and on current `.travis.yml`.

Tests are currently broken, since they didn't run for quite a while, but I think I know why:
* ` ► 0x400080 <_start>    jmp    label                      <label>` is caused by #801,
* the try_heap (#744) tests are broken since the beginning with `/bin/sh: 1: exec: /home/runner/work/pwndbg/pwndbg/tests/binaries/heap_bugs.out: not found`, which basically means that the hardcoded `/home/gros/Informatics/hax/wargames/how2heap/glibc_versions/2.29/tcache_x64/elf/ld.so` dynamic linker is not present on Travis / GH workers, and simply removing `heap_bugs.out` from git makes [more than half](https://github.com/Arusekk/pwndbg/runs/849443759?check_suite_focus=true#step:6:933) its tests pass (not all, since the libc versions differ)
  (we now know @GrosQuildu's filesystem layout 😄),
* The rest of the tests would simply pass if it weren't for additional messages like
  `warning: Unexpected size of section '.reg-xstate/13562' in core file.` (no idea what this means, a CPU model mismatch??)
  or
  `warning: .dynamic section for "/lib/x86_64-linux-gnu/libtinfo.so.5" is not at the expected address (wrong library or version mismatch?)`
  because, indeed, library versions do not match.

I can think of several solutions:
1. It would probably be good to really crash binaries on the testing system, and then examine core files dropped by the testing system (I think it is a rare case for someone to examine core files outside of the faulty system, or without a sysroot at least), then just use system libraries for everything.
2. It can be easier to have a copy of all the necessary binaries, and set up runpath or LD_LIBRARY_PATH, PT_INTERP, and everything to use a single libc version with non-system paths, inside the repo, or downloaded from somewhere reliably static.
It would look just like in the second bullet above. Binaries compiled this way must be able to run on any reasonable distro.
3. A hybrid solution! Crash all the binaries that don't heavily depend on libc versions during testing, and use system libs for them, but use special libc for stuff that is best served with special libc. And it would behave best with a nice separation in the Makefile, with two (or more?) distinct suffixes/prefixes (I don't know, since most binaries seem to be used as they are, and not compiled from source).

EDIT: test_heap.py is also to be blamed for lint failure.