### PR TITLE
Added installation configuration for Gentoo

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -102,9 +102,11 @@ if linux; then
             ;;
         "gentoo")
             install_emerge
-            sudo() {
-                $*
-            }
+            if ! hash sudo 2>/dev/null && whoami | grep root; then
+                sudo() {
+                    $*
+                }
+            fi
             ;;
         *) # we can add more install command for each distros.
             echo "\"$distro\" is not supported distro. Will search for 'apt' or 'dnf' package managers."

--- a/setup.sh
+++ b/setup.sh
@@ -55,6 +55,10 @@ install_zypper() {
     fi
 }
 
+install_emerge() {
+    emerge --oneshot --deep --newuse --changed-use --changed-deps dev-lang/python dev-python/pip sys-devel/gdb
+}
+
 PYTHON=''
 INSTALLFLAGS=''
 
@@ -95,6 +99,12 @@ if linux; then
             ;;
         "void")
             install_xbps
+            ;;
+        "gentoo")
+            install_emerge
+            sudo() {
+                $*
+            }
             ;;
         *) # we can add more install command for each distros.
             echo "\"$distro\" is not supported distro. Will search for 'apt' or 'dnf' package managers."


### PR DESCRIPTION
Quick and dirty implementation of the installation code for Gentoo.

Some details which might need discussion:
- [ ] The package dev-lang/python should probably be already installed when using emerge, but I'm not sure if all emerge variants require it.
- [x] Check for the sudo command added
- [ ] Maybe the dependencies should be added to the world file? (Remove the --oneshot parameter)