### PR TITLE
format_args: display fd path

### DIFF
--- a/pwndbg/arguments.py
+++ b/pwndbg/arguments.py
@@ -201,5 +201,11 @@ def format_args(instruction):
     for arg, value in get(instruction):
         code   = arg.type != 'char'
         pretty = pwndbg.chain.format(value, code=code)
+
+        # Enhance args display
+        if arg.name == 'fd' and isinstance(value, int):
+            path = pwndbg.file.readlink('/proc/%d/fd/%d' % (pwndbg.proc.pid, value))
+            pretty += ' (%s)' % path
+
         result.append('%-10s %s' % (N.argument(arg.name) + ':', pretty))
     return result

--- a/pwndbg/arguments.py
+++ b/pwndbg/arguments.py
@@ -205,7 +205,8 @@ def format_args(instruction):
         # Enhance args display
         if arg.name == 'fd' and isinstance(value, int):
             path = pwndbg.file.readlink('/proc/%d/fd/%d' % (pwndbg.proc.pid, value))
-            pretty += ' (%s)' % path
+            if path:
+                pretty += ' (%s)' % path
 
         result.append('%-10s %s' % (N.argument(arg.name) + ':', pretty))
     return result


### PR DESCRIPTION
E.g. for calls like this:
```
 ► 0x555555554a57 <main+296>    call   ioctl@plt <ioctl@plt>
        fd: 0x3
        request: 0xae01
        vararg: 0x0
```

We want to display the `fd` as: `fd: 0x3 (/some/path)` fetched from
`readlink -f /proc/$PID/fd/$FD`.