### PR TITLE
In setup.sh, remove installation of python2 for apt

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -20,9 +20,7 @@ osx() {
 
 install_apt() {
     sudo apt-get update || true
-    # This breaks Ubuntu 20.04, but is probably still needed for older version
-    sudo apt-get -y install python-pip || true
-    sudo apt-get -y install git gdb python-dev python3-dev python3-pip python3-setuptools libglib2.0-dev libc6-dbg
+    sudo apt-get -y install git gdb python3-dev python3-pip python3-setuptools libglib2.0-dev libc6-dbg
 
     if uname -m | grep x86_64 > /dev/null; then
         sudo apt-get -y install libc6-dbg:i386 || true


### PR DESCRIPTION
`setup.sh` still installs python2 related packages for `apt`. This gets rid of them.

Also I removed the comment, "breaks for 20.04" because it works in Ubuntu 20.04.