### PR TITLE
Compact register list for context view

### DIFF
--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -357,13 +357,17 @@ pwndbg.config.Parameter('show-compact-regs-align', 20, 'the number of characters
 pwndbg.config.Parameter('show-compact-regs-space', 4, 'the number of characters separating each register')
 
 
+def calculate_padding_to_align(length, align):
+    ''' Calculates the number of spaces to append to reach the next alignment.
+        The next alignment point is given by "x * align >= length".
+    '''
+    return 0 if length % align == 0 else (align - (length % align))
+
+
 def compact_regs(regs, width):
     align = int(pwndbg.config.show_compact_regs_align)
     space = int(pwndbg.config.show_compact_regs_space)
     result = []
-
-    def calculate_padding(length):
-        return 0 if length % align == 0 else (align - (length % align))
 
     def get_text_length(text):
         '''Returns the text length while ignoring color-code escape sequences.'''
@@ -388,7 +392,7 @@ def compact_regs(regs, width):
         # register string onto the screen / display
         line_length_with_padding = line_length
         line_length_with_padding += space if line_length != 0 else 0
-        line_length_with_padding += calculate_padding(line_length_with_padding)
+        line_length_with_padding += calculate_padding_to_align(line_length_with_padding, align)
 
         # When element does not fully fit, then start a new line
         if line_length_with_padding + max(reg_length, align) > width:

--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -369,24 +369,10 @@ def compact_regs(regs, width):
     space = int(pwndbg.config.show_compact_regs_space)
     result = []
 
-    def get_text_length(text):
-        '''Returns the text length while ignoring color-code escape sequences.'''
-        length = 0
-
-        escape_sequence = False
-        for char in text:
-            if escape_sequence:
-                escape_sequence = (char != 'm')
-            else:
-                escape_sequence = (char == '\033')
-                length += 0 if escape_sequence else 1
-
-        return length
-
     line = ''
     line_length = 0
     for reg in regs:
-        reg_length = get_text_length(reg)
+        reg_length = len(pwndbg.color.strip(reg))
 
         # Length of line with space and padding is required for fitting the
         # register string onto the screen / display

--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -354,7 +354,7 @@ def context(subcontext=None):
 
 pwndbg.config.Parameter('show-compact-regs', False, 'whether to show a compact register view')
 pwndbg.config.Parameter('show-compact-regs-align', 20, 'the number of characters reserved for each register and value')
-pwndbg.config.Parameter('show-compact-regs-space', 4, 'the number of characters separating each register')
+pwndbg.config.Parameter('show-compact-regs-space', 4, 'the minimum number of characters separating each register')
 
 
 def calculate_padding_to_align(length, align):

--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -352,7 +352,7 @@ def context(subcontext=None):
             out.flush()
 
 
-pwndbg.config.Parameter('show-compact-regs', True, 'whether to show a compact register view')
+pwndbg.config.Parameter('show-compact-regs', False, 'whether to show a compact register view')
 pwndbg.config.Parameter('show-compact-regs-align', 20, 'the number of characters reserved for each register and value')
 pwndbg.config.Parameter('show-compact-regs-space', 4, 'the number of characters separating each register')
 

--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -402,14 +402,14 @@ def compact_regs(regs, width):
 
 
 def context_regs(target=sys.stdout, with_banner=True, width=None):
-    banner = [pwndbg.ui.banner("registers", target=target, width=width)]
-    regs = get_regs()
+    if width is None:
+        _height, width = pwndbg.ui.get_window_size(target=target)
 
+    regs = get_regs()
     if pwndbg.config.show_compact_regs:
-        if width is None:
-            _height, width = pwndbg.ui.get_window_size(target=target)
         regs = compact_regs(regs, width)
 
+    banner = [pwndbg.ui.banner("registers", target=target, width=width)]
     return banner + regs if with_banner else regs
 
 


### PR DESCRIPTION
This enables to compact the register list when displayed in the context view.
The register list is aligned to improve readability.
When a chain is displayed the required space is reserved and following registers are shifted to then next alignment point / line.

See the screenshot below as an example.

This might be useful for architectures where there are a lot of registers (MIPS, RISC-V, etc.).
The compact view can be configured and enabled by the following configuration options:

- **show-compact-regs**: Enables / disables the compact view
- **show-compact-regs-align**: Sets the number of characters for each column
- **show-compact-regs-space**: The minimum number of spaces between each register

Feedback about the implementation is appreciated.

![CompactRegisterView](https://user-images.githubusercontent.com/1679294/93637654-35e9b080-f9f6-11ea-9922-40c32f7a62f8.png)
