### PR TITLE
Fixed bug: bins gets the wrong pointer offset

### DIFF
--- a/pwndbg/heap/ptmalloc.py
+++ b/pwndbg/heap/ptmalloc.py
@@ -299,7 +299,7 @@ class Heap(pwndbg.heap.heap.BaseHeap):
             "mchunk_prev_size": "prev_size",
         }
         val = self.malloc_chunk
-        chunk_keys = list(dict({renames.get(key, key): 0 for key in val.keys()}).keys())
+        chunk_keys = [renames[key] if key in renames else key for key in val.keys()]
 
         try:
             return chunk_keys.index(key) * pwndbg.arch.ptrsize


### PR DESCRIPTION
In python3, the dict created using 'dict({renames. Get (key, key): 0 for key in val.keys()})' is unordered, causing 'chunk_key_offset' to return an error offset