### PR TITLE
Add basic i8086 support

### DIFF
--- a/pwndbg/arch.py
+++ b/pwndbg/arch.py
@@ -32,6 +32,7 @@ def fix_arch(arch):
     return arch
 
 @pwndbg.events.start
+@pwndbg.events.stop
 @pwndbg.events.new_objfile
 def update():
     m = sys.modules[__name__]

--- a/pwndbg/disasm/__init__.py
+++ b/pwndbg/disasm/__init__.py
@@ -28,6 +28,7 @@ CapstoneArch = {
     'armcm': CS_ARCH_ARM,
     'aarch64': CS_ARCH_ARM64,
     'i386': CS_ARCH_X86,
+    'i8086': CS_ARCH_X86,
     'x86-64': CS_ARCH_X86,
     'powerpc': CS_ARCH_PPC,
     'mips': CS_ARCH_MIPS,
@@ -52,6 +53,7 @@ CapstoneMode = {
 VariableInstructionSizeMax = {
     'i386':   16,
     'x86-64': 16,
+    'i8086':  16,
     'mips':   8,
 }
 
@@ -85,6 +87,10 @@ def get_disassembler(pc):
         else:
             # The ptrsize base modes cause capstone.CsError: Invalid mode (CS_ERR_MODE)
             extra = 0 
+            
+    elif pwndbg.arch.current == 'i8086':
+        extra = CS_MODE_16
+    
     else:
         extra = None
 

--- a/pwndbg/regs.py
+++ b/pwndbg/regs.py
@@ -162,7 +162,6 @@ i386 = RegisterSet( pc      = 'eip',
                                 'di','si','bp','sp','ip'),
                     retval  = 'eax')
 
-
 # http://math-atlas.sourceforge.net/devel/assembly/elfspec_ppc.pdf
 # r0      Volatile register which may be modified during function linkage
 # r1      Stack frame pointer, always valid
@@ -242,6 +241,7 @@ mips = RegisterSet( frame   = 'fp',
 
 arch_to_regs = {
     'i386': i386,
+    'i8086': i386,
     'x86-64': amd64,
     'mips': mips,
     'sparc': sparc,
@@ -289,6 +289,8 @@ class module(ModuleType):
                 value = get_register(attr)
                 size = pwndbg.typeinfo.unsigned.get(value.type.sizeof, pwndbg.typeinfo.ulong)
                 value = value.cast(size)
+                if attr.lower() == 'pc' and pwndbg.arch.current == 'i8086':
+                    value += self.cs * 16
 
             value = int(value)
             return value & pwndbg.arch.ptrmask


### PR DESCRIPTION
Fixes #834.

Note that emulation for i8086 is missing in this patch (only basic `nearpc`).

Some reminders:
- **`@pwndbg.events.stop` line in `arch.py` will force rechecking architecture once debugger stops, so this may cause some performance overhead** (maybe we can make this rechecking behavior configurable, as "changing architecture on the fly" is a rare thing)
- `pc` register is set to IP+CS*16 (in order to make `nearpc` happy) in i8086, which may confuse some people who assume it to be IP
- This patch is not fully tested (but at least works for JOS)