### PR TITLE
Compact, [big-endian] hexdump

### DIFF
--- a/pwndbg/color/hexdump.py
+++ b/pwndbg/color/hexdump.py
@@ -12,6 +12,9 @@ config_special   = theme.ColoredParameter('hexdump-special-color', 'yellow', 'co
 config_offset    = theme.ColoredParameter('hexdump-offset-color', 'none', 'color for hexdump command (offset label)')
 config_address   = theme.ColoredParameter('hexdump-address-color', 'none', 'color for hexdump command (address label)')
 config_separator = theme.ColoredParameter('hexdump-separator-color', 'none', 'color for hexdump command (group separator)')
+config_highlight_group_lsb = theme.Parameter('hexdump-highlight-group-lsb', 'underline',
+                                             'highlight LSB of each group. Applies only if hexdump-adjust-group-endianess'
+                                             ' actually changes byte order.')
 
 def normal(x):
     return generateColorFunction(config.hexdump_normal_color)(x)
@@ -33,3 +36,6 @@ def address(x):
 
 def separator(x):
     return generateColorFunction(config.hexdump_separator_color)(x)
+
+def highlight_group_lsb(x):
+    return generateColorFunction(config.hexdump_highlight_group_lsb)(x)

--- a/pwndbg/commands/hexdump.py
+++ b/pwndbg/commands/hexdump.py
@@ -19,7 +19,7 @@ pwndbg.config.Parameter('hexdump-bytes',
                          'number of bytes printed by hexdump command')
 pwndbg.config.Parameter('hexdump-group-width',
                          4,
-                         "number of bytes grouped in hexdump command. If -1, the architecture's pointer size is used.")
+                         "number of bytes grouped in hexdump command (If -1, the architecture's pointer size is used)")
 pwndbg.config.Parameter('hexdump-group-use-big-endian',
                          False,
                          'Use big-endian within each group of bytes. Only applies to raw bytes, not the ASCII part. '

--- a/pwndbg/commands/hexdump.py
+++ b/pwndbg/commands/hexdump.py
@@ -23,7 +23,7 @@ pwndbg.config.Parameter('hexdump-group-width',
 pwndbg.config.Parameter('hexdump-group-use-big-endian',
                          False,
                          'Use big-endian within each group of bytes. Only applies to raw bytes, not the ASCII part. '
-                         'Also see hexdump-highlight-group-lsb.')
+                         'See also hexdump-highlight-group-lsb.')
 
 def address_or_module_name(s):
     gdbval_or_str = pwndbg.commands.sloppy_gdb_parse(s)

--- a/pwndbg/commands/hexdump.py
+++ b/pwndbg/commands/hexdump.py
@@ -17,6 +17,13 @@ pwndbg.config.Parameter('hexdump-width',
 pwndbg.config.Parameter('hexdump-bytes',
                          64,
                          'number of bytes printed by hexdump command')
+pwndbg.config.Parameter('hexdump-group-width',
+                         4,
+                         "number of bytes grouped in hexdump command. If -1, the architecture's pointer size is used.")
+pwndbg.config.Parameter('hexdump-group-use-big-endian',
+                         False,
+                         'Use big-endian within each group of bytes. Only applies to raw bytes, not the ASCII part. '
+                         'Also see hexdump-highlight-group-lsb.')
 
 def address_or_module_name(s):
     gdbval_or_str = pwndbg.commands.sloppy_gdb_parse(s)
@@ -50,10 +57,13 @@ def hexdump(address_or_module=None, count=pwndbg.config.hexdump_bytes):
     else:
         hexdump.offset = 0
 
-    address = int(address)
-    address &= pwndbg.arch.ptrmask
-    count   = max(int(count), 0)
-    width   = int(pwndbg.config.hexdump_width)
+    address     = int(address)
+    address     &= pwndbg.arch.ptrmask
+    count       = max(int(count), 0)
+    width       = int(pwndbg.config.hexdump_width)
+    group_width = int(pwndbg.config.hexdump_group_width)
+    group_width = pwndbg.typeinfo.ptrsize if group_width == -1 else group_width
+    flip_group_endianess = pwndbg.config.hexdump_group_use_big_endian and pwndbg.arch.endian == 'little'
 
     if count > address > 0x10000:
         count -= address
@@ -65,7 +75,7 @@ def hexdump(address_or_module=None, count=pwndbg.config.hexdump_bytes):
         print(e)
         return
 
-    for i, line in enumerate(pwndbg.hexdump.hexdump(data, address=address, width=width, offset=hexdump.offset)):
+    for i, line in enumerate(pwndbg.hexdump.hexdump(data, address=address, width=width, group_width=group_width, flip_group_endianess=flip_group_endianess, offset=hexdump.offset)):
         print(line)
     hexdump.offset += i
 

--- a/pwndbg/hexdump.py
+++ b/pwndbg/hexdump.py
@@ -6,7 +6,6 @@ Hexdump implementation, ~= stolen from pwntools.
 
 import copy
 import string
-import itertools
 
 import pwndbg.color.hexdump as H
 import pwndbg.color.theme as theme


### PR DESCRIPTION
I had the need to be able to directly copy pointer values from the hexdump.
This pull requests adds 4 config options (all inactive by default) to allow this.

The first hexdump shows the current default and the last one the setup I needed:
![screenshot](https://user-images.githubusercontent.com/37397269/96098064-fd90a180-0ed1-11eb-89ec-a4b279735ec0.png)

Please let me know what you think!