### PR TITLE
Added comment command 

### DIFF
--- a/pwndbg/__init__.py
+++ b/pwndbg/__init__.py
@@ -50,6 +50,7 @@ import pwndbg.commands.vmmap
 import pwndbg.commands.windbg
 import pwndbg.commands.xinfo
 import pwndbg.commands.xor
+import pwndbg.commands.comments
 import pwndbg.constants
 import pwndbg.disasm
 import pwndbg.disasm.arm

--- a/pwndbg/__init__.py
+++ b/pwndbg/__init__.py
@@ -159,3 +159,6 @@ signal.signal(signal.SIGWINCH, lambda signum, frame: gdb.execute("set width %i" 
 # After GDB gets the fix, we should disable this only for bugged GDB versions.
 if 1:
     gdb.execute('set remote search-memory-packet off')
+
+# Reading Comment file 
+pwndbg.commands.comments.init()

--- a/pwndbg/color/context.py
+++ b/pwndbg/color/context.py
@@ -17,6 +17,7 @@ config_banner_color             = theme.ColoredParameter('banner-color', 'blue',
 config_banner_title             = theme.ColoredParameter('banner-title-color', 'none', 'color for banner title')
 config_register_changed_color   = theme.ColoredParameter('context-register-changed-color', 'normal', 'color for registers label (change marker)')
 config_register_changed_marker  = theme.Parameter('context-register-changed-marker', '*', 'change marker for registers label')
+config_comment                  = theme.ColoredParameter('comment-color', 'gray', 'color for comment')
 
 def prefix(x):
     return generateColorFunction(config.code_prefix_color)(x)
@@ -50,6 +51,9 @@ def banner(x):
 
 def banner_title(x):
     return generateColorFunction(config.banner_title_color)(x)
+
+def comment(x):
+    return generateColorFunction(config.comment_color)(x)
 
 def format_flags(value, flags, last=None):
     desc = flag_value('%#x' % value)

--- a/pwndbg/commands/comments.py
+++ b/pwndbg/commands/comments.py
@@ -6,23 +6,45 @@ parser = argparse.ArgumentParser(description="Put comments in assembly code")
 parser.add_argument("--addr", metavar='address', default=None, type=str, help="Address to write comments")
 parser.add_argument("comment", type=str, default=None,  help="The text you want to comment")
 
+file_lists = {} # This saves all comments.
+
 @pwndbg.commands.ArgparsedCommand(parser)
 @pwndbg.commands.OnlyWhenRunning
 def comm(addr=None, comment=None):
     if addr is None:
         addr = hex(pwndbg.regs.pc)
     try : 
-        f = open(".gdb_comments", "a+")
-    except :
+        with open(".gdb_comments", "a+") as f:
+            target = int(addr,0)
+
+            if not pwndbg.memory.peek(target):
+                print(message.error("Invalid Address %#x" % target))
+            
+            else:
+                f.write("file:%s=" % pwndbg.proc.exe)
+                f.write("%#x:%s\n" % (target, comment))
+                if not pwndbg.proc.exe in file_lists.keys():
+                    file_lists[pwndbg.proc.exe] = {}
+                file_lists[pwndbg.proc.exe][hex(target)] = comment
+    except FileNotFoundError:
         print(message.error("Permission denied to create file"))
-    else :
-        target = int(addr,0)
 
-        if not pwndbg.memory.peek(target):
-            print(message.error("Invalid Address %#x" % target))
-        
-        else:
-            f.write("file:%s=" % pwndbg.proc.exe)
-            f.write("%#x:%s\n" % (target, comment))
+def init():
+    try :
+        with open(".gdb_comments","r") as f:
+            text = f.read()
+            text = text.split("\n")
+            for i in range(len(text)-1):
+                text1, text2 = text[i].split("=")
 
-        f.close()
+                # split Filename, comments
+                filename = text1.split(":")[1]
+                addr_comm = text2.split(":")
+
+                if not filename in file_lists.keys():
+                    file_lists[filename] = {}
+
+                file_lists[filename][addr_comm[0]] = addr_comm[1]
+
+    except :
+        pass 

--- a/pwndbg/commands/comments.py
+++ b/pwndbg/commands/comments.py
@@ -26,7 +26,7 @@ def comm(addr=None, comment=None):
                 if not pwndbg.proc.exe in file_lists.keys():
                     file_lists[pwndbg.proc.exe] = {}
                 file_lists[pwndbg.proc.exe][hex(target)] = comment
-    except FileNotFoundError:
+    except :
         print(message.error("Permission denied to create file"))
 
 def init():

--- a/pwndbg/commands/comments.py
+++ b/pwndbg/commands/comments.py
@@ -9,7 +9,7 @@ parser.add_argument("comment", type=str, default=None,  help="The text you want 
 @pwndbg.commands.ArgparsedCommand(parser)
 @pwndbg.commands.OnlyWhenRunning
 def comm(addr=None, comment=None):
-    if(addr == None):
+    if addr is None:
         addr = hex(pwndbg.regs.pc)
     try : 
         f = open(".gdb_comments", "a+")

--- a/pwndbg/commands/comments.py
+++ b/pwndbg/commands/comments.py
@@ -22,6 +22,7 @@ def comm(addr=None, comment=None):
             print(message.error("Invalid Address %#x" % target))
         
         else:
+            f.write("file:%s=" % pwndbg.proc.exe)
             f.write("%#x:%s\n" % (target, comment))
 
         f.close()

--- a/pwndbg/commands/comments.py
+++ b/pwndbg/commands/comments.py
@@ -13,7 +13,7 @@ file_lists = {} # This saves all comments.
 def comm(addr=None, comment=None):
     if addr is None:
         addr = hex(pwndbg.regs.pc)
-    try : 
+    try: 
         with open(".gdb_comments", "a+") as f:
             target = int(addr,0)
 
@@ -26,11 +26,11 @@ def comm(addr=None, comment=None):
                 if not pwndbg.proc.exe in file_lists.keys():
                     file_lists[pwndbg.proc.exe] = {}
                 file_lists[pwndbg.proc.exe][hex(target)] = comment
-    except :
+    except:
         print(message.error("Permission denied to create file"))
 
 def init():
-    try :
+    try:
         with open(".gdb_comments","r") as f:
             text = f.read()
             text = text.split("\n")
@@ -41,10 +41,10 @@ def init():
                 filename = text1.split(":")[1]
                 addr_comm = text2.split(":")
 
-                if not filename in file_lists.keys():
+                if not filename in file_lists:
                     file_lists[filename] = {}
 
                 file_lists[filename][addr_comm[0]] = addr_comm[1]
 
-    except :
+    except:
         pass 

--- a/pwndbg/commands/comments.py
+++ b/pwndbg/commands/comments.py
@@ -3,7 +3,7 @@ import pwndbg.commands
 from pwndbg.color import message
 
 parser = argparse.ArgumentParser(description="Put comments in assembly code")
-parser.add_argument("-addr", metavar='address', default=None, type=str, help="Address to write comments")
+parser.add_argument("--addr", metavar='address', default=None, type=str, help="Address to write comments")
 parser.add_argument("comment", type=str, default=None,  help="The text you want to comment")
 
 @pwndbg.commands.ArgparsedCommand(parser)

--- a/pwndbg/commands/comments.py
+++ b/pwndbg/commands/comments.py
@@ -1,0 +1,22 @@
+import argparse
+import pwndbg.commands
+from pwndbg.color import message
+
+parser = argparse.ArgumentParser(description="Put comments in assembly code")
+parser.add_argument("-addr", metavar='address', default=None, type=str, help="Address to write comments")
+parser.add_argument("comment", type=str, default=None,  help="The text you want to comment")
+
+@pwndbg.commands.ArgparsedCommand(parser)
+@pwndbg.commands.OnlyWhenRunning
+def comm(addr=None, comment=None):
+    if(addr == None):
+        addr = hex(pwndbg.regs.pc)
+    f = open(".gdb_comments", "a+")
+
+    target = int(addr,0)
+
+    if not pwndbg.memory.peek(target):
+        print(message.error("Invalid Address %#x" % target))
+    
+    else:
+        f.write("%#x:%s\n" % (target, comment))

--- a/pwndbg/commands/comments.py
+++ b/pwndbg/commands/comments.py
@@ -11,12 +11,17 @@ parser.add_argument("comment", type=str, default=None,  help="The text you want 
 def comm(addr=None, comment=None):
     if(addr == None):
         addr = hex(pwndbg.regs.pc)
-    f = open(".gdb_comments", "a+")
+    try : 
+        f = open(".gdb_comments", "a+")
+    except :
+        print(message.error("Permission denied to create file"))
+    else :
+        target = int(addr,0)
 
-    target = int(addr,0)
+        if not pwndbg.memory.peek(target):
+            print(message.error("Invalid Address %#x" % target))
+        
+        else:
+            f.write("%#x:%s\n" % (target, comment))
 
-    if not pwndbg.memory.peek(target):
-        print(message.error("Invalid Address %#x" % target))
-    
-    else:
-        f.write("%#x:%s\n" % (target, comment))
+        f.close()

--- a/pwndbg/commands/nearpc.py
+++ b/pwndbg/commands/nearpc.py
@@ -168,15 +168,26 @@ def nearpc(pc=None, lines=None, to_string=False, emulate=False):
         except :
             pass
         else:
-            lists = {}
+            file_lists = {}
             text = f.read()
             text = text.split("\n")
             for i in range(len(text)-1):
-                box = text[i].split(":")
-                lists[box[0]] = box[1]
+                text1, text2 = text[i].split("=")
+
+                # split Filename, comments
+                filename = text1.split(":")[1]
+                addr_comm = text2.split(":")
+
+                if not filename in file_lists.keys():
+                    file_lists[filename] = {}
+
+                file_lists[filename][addr_comm[0]] = addr_comm[1]
+
+# Have to Make : Make dictionary with filename for key, comment list for value.
+# So, in printing comments, check in dictionary and get lists. And check address for what to print.
 
             try:
-                line += " "*8 + C.comment(lists[hex(instr.address)])
+                line += " "*8 + C.comment(file_lists[pwndbg.proc.exe][hex(instr.address)])
             except:
                 pass
 

--- a/pwndbg/commands/nearpc.py
+++ b/pwndbg/commands/nearpc.py
@@ -163,8 +163,11 @@ def nearpc(pc=None, lines=None, to_string=False, emulate=False):
                 line += ' <%s>' % N.syscall_name(syscall_name)
 
         # For Comment Function
-        f = open(".gdb_comments","r")
-        if(f != None):
+        try : 
+            f = open(".gdb_comments","r")
+        except :
+            pass
+        else:
             lists = {}
             text = f.read()
             text = text.split("\n")
@@ -175,7 +178,9 @@ def nearpc(pc=None, lines=None, to_string=False, emulate=False):
             try:
                 line += " "*8 + C.comment(lists[hex(instr.address)])
             except:
-                line += ""
+                pass
+
+            f.close()
 
         result.append(line)
 

--- a/pwndbg/commands/nearpc.py
+++ b/pwndbg/commands/nearpc.py
@@ -162,6 +162,21 @@ def nearpc(pc=None, lines=None, to_string=False, emulate=False):
             if syscall_name:
                 line += ' <%s>' % N.syscall_name(syscall_name)
 
+        # For Comment Function
+        f = open(".gdb_comments","r")
+        if(f != None):
+            lists = {}
+            text = f.read()
+            text = text.split("\n")
+            for i in range(len(text)-1):
+                box = text[i].split(":")
+                lists[box[0]] = box[1]
+
+            try:
+                line += " "*8 + C.comment(lists[hex(instr.address)])
+            except:
+                line += ""
+
         result.append(line)
 
         # For call instructions, attempt to resolve the target and

--- a/pwndbg/commands/nearpc.py
+++ b/pwndbg/commands/nearpc.py
@@ -22,6 +22,7 @@ import pwndbg.strings
 import pwndbg.symbol
 import pwndbg.ui
 import pwndbg.vmmap
+import pwndbg.commands.comments
 from pwndbg.color import message
 
 
@@ -163,35 +164,10 @@ def nearpc(pc=None, lines=None, to_string=False, emulate=False):
                 line += ' <%s>' % N.syscall_name(syscall_name)
 
         # For Comment Function
-        try : 
-            f = open(".gdb_comments","r")
-        except :
+        try:
+            line += " "*10 + C.comment(pwndbg.commands.comments.file_lists[pwndbg.proc.exe][hex(instr.address)])
+        except:
             pass
-        else:
-            file_lists = {}
-            text = f.read()
-            text = text.split("\n")
-            for i in range(len(text)-1):
-                text1, text2 = text[i].split("=")
-
-                # split Filename, comments
-                filename = text1.split(":")[1]
-                addr_comm = text2.split(":")
-
-                if not filename in file_lists.keys():
-                    file_lists[filename] = {}
-
-                file_lists[filename][addr_comm[0]] = addr_comm[1]
-
-# Have to Make : Make dictionary with filename for key, comment list for value.
-# So, in printing comments, check in dictionary and get lists. And check address for what to print.
-
-            try:
-                line += " "*8 + C.comment(file_lists[pwndbg.proc.exe][hex(instr.address)])
-            except:
-                pass
-
-            f.close()
 
         result.append(line)
 


### PR DESCRIPTION
This "comm" command makes comment beside of assembly code. Will make easy to analyse and by giving ".gdb_comments" file, other analyst will be able to see comments in binary.
# Example 
Explanation of "comm" command.
![image](https://user-images.githubusercontent.com/39231485/99895513-d2b51c80-2ccb-11eb-8b56-c4d22b5abd2c.png)

By using "comm" command, we can comment at $pc
![image](https://user-images.githubusercontent.com/39231485/99895038-89b09880-2cca-11eb-8488-100305147bb7.png)

By using "-addr" option, we can choose address to comment.
![image](https://user-images.githubusercontent.com/39231485/99895098-a8169400-2cca-11eb-8902-48c55f08d461.png)

These comments are saved in ./.gdb_comments
![image](https://user-images.githubusercontent.com/39231485/101345816-f92da700-38ca-11eb-85aa-c13e52699cf8.png)

