### PR TITLE
The disassembly flavor is hard-coded. It does not change from Intel to AT&T

### DIFF
--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -475,8 +475,8 @@ def context_disasm(target=sys.stdout, with_banner=True, width=None):
     flavor = gdb.execute('show disassembly-flavor', to_string=True).lower().split('"')[1]
     syntax = pwndbg.disasm.CapstoneSyntax[flavor]
 
-    cache_get_disassembler_cached = pwndbg.memoize.reset_on_objfile(pwndbg.disasm.get_disassembler_cached)
-    cs = list(cache_get_disassembler_cached.__dict__['cache'].values())[-1]
+    # Get the Capstone object to set disassembly syntax
+    cs = next(iter(pwndbg.disasm.get_disassembler_cached.cache.values()))
 
     if cs.syntax != syntax:
         pwndbg.memoize.reset()

--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -472,6 +472,15 @@ Unicorn emulation of code near the current instruction
 code_lines = pwndbg.config.Parameter('context-code-lines', 10, 'number of additional lines to print in the code context')
 
 def context_disasm(target=sys.stdout, with_banner=True, width=None):
+    flavor = gdb.execute('show disassembly-flavor', to_string=True).lower().split('"')[1]
+    syntax = pwndbg.disasm.CapstoneSyntax[flavor]
+
+    cache_get_disassembler_cached = pwndbg.memoize.reset_on_objfile(pwndbg.disasm.get_disassembler_cached)
+    cs = list(cache_get_disassembler_cached.__dict__['cache'].values())[-1]
+
+    if cs.syntax != syntax:
+        pwndbg.memoize.reset()
+
     banner = [pwndbg.ui.banner("disasm", target=target, width=width)]
     emulate = bool(pwndbg.config.emulate)
     result = pwndbg.commands.nearpc.nearpc(to_string=True, emulate=emulate, lines=code_lines // 2)

--- a/pwndbg/disasm/__init__.py
+++ b/pwndbg/disasm/__init__.py
@@ -45,6 +45,11 @@ CapstoneMode = {
     8: CS_MODE_64
 }
 
+CapstoneSyntax = {
+    'intel': CS_OPT_SYNTAX_INTEL,
+    'att': CS_OPT_SYNTAX_ATT
+}
+
 # For variable-instruction-width architectures
 # (x86 and amd64), we keep a cache of instruction
 # sizes, and where the end of the instruction falls.
@@ -71,6 +76,10 @@ def get_disassembler_cached(arch, ptrsize, endian, extra=None):
     mode |= CapstoneEndian[endian]
 
     cs = Cs(arch, mode)
+
+    flavor = gdb.execute('show disassembly-flavor', to_string=True).lower().split('"')[1]
+    cs.syntax = CapstoneSyntax[flavor]
+
     cs.detail = True
     return cs
 

--- a/pwndbg/disasm/__init__.py
+++ b/pwndbg/disasm/__init__.py
@@ -75,11 +75,10 @@ def get_disassembler_cached(arch, ptrsize, endian, extra=None):
 
     mode |= CapstoneEndian[endian]
 
-    cs = Cs(arch, mode)
-
     flavor = gdb.execute('show disassembly-flavor', to_string=True).lower().split('"')[1]
-    cs.syntax = CapstoneSyntax[flavor]
 
+    cs = Cs(arch, mode)
+    cs.syntax = CapstoneSyntax[flavor]
     cs.detail = True
     return cs
 


### PR DESCRIPTION
# disassembly-flavor [intel/att]

## Cases:
- When the user `set disassembly-flavor att` inside of the `.gdbinit` file.  It's not recognized by `pwndbg`.
- When the user manually `set disassembly-flavor att` running the GDB.  It's not recognized by `pwndbg`.

## Example of this fix

`set disassembly-flavor att`

`context`

```text
─────────────────────────────────────────────────────────────[ DISASM ]─────────────────────────────────────────────────────────────
 ► 0x401000 <_start>       movl   $1, %eax
   0x401005 <_start+5>     movl   $0, %ebx
   0x40100a <_start+10>    int    $0x80
```


`set disassembly-flavor intel`

`context`

```text
─────────────────────────────────────────────────────────────[ DISASM ]─────────────────────────────────────────────────────────────
 ► 0x401000 <_start>       mov    eax, 1
   0x401005 <_start+5>     mov    ebx, 0
   0x40100a <_start+10>    int    0x80
```

