### PR TITLE
Allow return offsets and use it for 'start' method.

### DIFF
--- a/pwndbg/commands/start.py
+++ b/pwndbg/commands/start.py
@@ -49,7 +49,7 @@ def start(args=None):
                 "_init"]
 
     for symbol in symbols:
-        address = pwndbg.symbol.address(symbol)
+        address = pwndbg.symbol.address(symbol, allow_unmapped=True)
 
         if not address:
             continue

--- a/pwndbg/symbol.py
+++ b/pwndbg/symbol.py
@@ -190,7 +190,7 @@ def get(address, gdb_only=False):
     return ''
 
 @pwndbg.memoize.reset_on_objfile
-def address(symbol):
+def address(symbol, allow_unmapped=False):
     if isinstance(symbol, int):
         return symbol
 
@@ -215,7 +215,7 @@ def address(symbol):
         # pwndbg> info address tcache
         # Symbol "tcache" is a thread-local variable at offset 0x40
         # in the thread-local storage for `/lib/x86_64-linux-gnu/libc.so.6'.
-        if not pwndbg.vmmap.find(address):
+        if not allow_unmapped and not pwndbg.vmmap.find(address):
             return None
 
         return address


### PR DESCRIPTION
The 8f33ec4 made `pwndbg.symbol.address` to discard addresses
of symbols not mapped.

Unfortunately this broke pwndbg's `start`.

GDB's `start` puts a temporal break in `main` and pwndbg's `start` does
the same but when GDB returns the address of `main`, it returns an
offset the first time because the symbol was not mapped yet.

The offset is then discarded and pwndbg doesn't put the breakpoint when
it should.

This PR fixes pwndbg's `start` allowing `pwndbg.symbol.address` to
return offsets instead of addresses: GDB will resolve the correct
address when it builds the breakpoint and pwndbg's `start` will behave
like GDB's `start`.

Closes #793 