### PR TITLE
Changed register list to use precomputed tuples

### DIFF
--- a/pwndbg/regs.py
+++ b/pwndbg/regs.py
@@ -183,7 +183,7 @@ powerpc = RegisterSet(  retaddr = ('lr','r0'),
                                    'r20', 'r21', 'r22', 'r23', 'r24', 'r25', 'r26', 'r27', 'r28', 'r29',
                                    'r30', 'r31'),
                         misc    = ('cr','lr','r2'),
-                        args    = tuple('r%i' for i in range(3,11)),
+                        args    = ('r3', 'r4', 'r5', 'r6', 'r7', 'r8', 'r9', 'r10'),
                         retval  = 'r3')
 
 # http://people.cs.clemson.edu/~mark/sparc/sparc_arch_desc.txt

--- a/pwndbg/regs.py
+++ b/pwndbg/regs.py
@@ -98,14 +98,14 @@ arm_xpsr_flags = collections.OrderedDict([
 
 arm = RegisterSet(  retaddr = ('lr',),
                     flags   = {'cpsr': arm_cpsr_flags},
-                    gpr     = tuple('r%i' % i for i in range(13)),
+                    gpr     = ('r0', 'r1', 'r2', 'r3', 'r4', 'r5', 'r6', 'r7', 'r8', 'r9', 'r10', 'r11', 'r12'),
                     args    = ('r0','r1','r2','r3'),
                     retval  = 'r0')
 
 # ARM Cortex-M
 armcm = RegisterSet(  retaddr = ('lr',),
                     flags   = {'xpsr': arm_xpsr_flags},
-                    gpr     = tuple('r%i' % i for i in range(13)),
+                    gpr     = ('r0', 'r1', 'r2', 'r3', 'r4', 'r5', 'r6', 'r7', 'r8', 'r9', 'r10', 'r11', 'r12'),
                     args    = ('r0','r1','r2','r3'),
                     retval  = 'r0')
 
@@ -113,8 +113,12 @@ armcm = RegisterSet(  retaddr = ('lr',),
 aarch64 = RegisterSet(  retaddr = ('lr',),
                         flags   = {'cpsr':{}},
                         frame   = 'x29',
-                        gpr     = tuple('x%i' % i for i in range(29)),
-                        misc    = tuple('w%i' % i for i in range(29)),
+                        gpr     = ('x0', 'x1', 'x2', 'x3', 'x4', 'x5', 'x6', 'x7', 'x8', 'x9',
+                                   'x10', 'x11', 'x12', 'x13', 'x14', 'x15', 'x16', 'x17', 'x18', 'x19',
+                                   'x20', 'x21', 'x22', 'x23', 'x24', 'x25', 'x26', 'x27', 'x28'),
+                        misc    = ('w0', 'w1', 'w2', 'w3', 'w4', 'w5', 'w6', 'w7', 'w8', 'w9',
+                                   'w10', 'w11', 'w12', 'w13', 'w14', 'w15', 'w16', 'w17', 'w18', 'w19',
+                                   'w20', 'w21', 'w22', 'w23', 'w24', 'w25', 'w26', 'w27', 'w28'),
                         args    = ('x0','x1','x2','x3'),
                         retval  = 'x0')
 
@@ -174,7 +178,10 @@ i386 = RegisterSet( pc      = 'eip',
 # r31     Used for local variables or "environment pointers"
 powerpc = RegisterSet(  retaddr = ('lr','r0'),
                         flags   = {'msr':{},'xer':{}},
-                        gpr     = tuple('r%i' % i for i in range(3,32)),
+                        gpr     = ('r3', 'r4', 'r5', 'r6', 'r7', 'r8', 'r9',
+                                   'r10', 'r11', 'r12', 'r13', 'r14', 'r15', 'r16', 'r17', 'r18', 'r19',
+                                   'r20', 'r21', 'r22', 'r23', 'r24', 'r25', 'r26', 'r27', 'r28', 'r29',
+                                   'r30', 'r31'),
                         misc    = ('cr','lr','r2'),
                         args    = tuple('r%i' for i in range(3,11)),
                         retval  = 'r3')
@@ -205,18 +212,16 @@ powerpc = RegisterSet(  retaddr = ('lr','r0'),
 # %i7 == %r31 == for return address   |
 # ____________________________________/
 
-sparc_gp = tuple(['g%i' % i for i in range(1,8)]
-                +['o%i' % i for i in range(0,6)]+['o7']
-                +['l%i' % i for i in range(0,8)]
-                +['i%i' % i for i in range(0,6)])
 sparc = RegisterSet(stack   = 'sp',
                     frame   = 'fp',
                     retaddr = ('i7',),
                     flags   = {'psr':{}},
-                    gpr     = sparc_gp,
+                    gpr     = ('g1', 'g2', 'g3', 'g4', 'g5', 'g6', 'g7',
+                               'o0', 'o1', 'o2', 'o3', 'o4', 'o5', 'o7',
+                               'l0', 'l1', 'l2', 'l3', 'l4', 'l5', 'l6', 'l7',
+                               'i0', 'i1', 'i2', 'i3', 'i4', 'i5'),
                     args    = ('i0','i1','i2','i3','i4','i5'),
                     retval  = 'o0')
-
 
 # http://logos.cs.uic.edu/366/notes/mips%20quick%20tutorial.htm
 # r0        => zero
@@ -233,9 +238,9 @@ sparc = RegisterSet(stack   = 'sp',
 # r31       => return address
 mips = RegisterSet( frame   = 'fp',
                     retaddr = ('ra',),
-                    gpr     = ('v0','v1','a0','a1','a2','a3') \
-                              + tuple('t%i' % i for i in range(10)) \
-                              + tuple('s%i' % i for i in range(9)),
+                    gpr     = ('v0','v1','a0','a1','a2','a3',
+                               't0', 't1', 't2', 't3', 't4', 't5', 't6', 't7', 't8', 't9',
+                               's0', 's1', 's2', 's3', 's4', 's5', 's6', 's7', 's8'),
                     args    = ('a0','a1','a2','a3'),
                     retval  = 'v0')
 


### PR DESCRIPTION
The register list for each architecture in pwndbg/regs.py is now precomputed (#829).
