### PR TITLE
docs: fix simple typo, divison -> division

### DIFF
--- a/pwndbg/commands/telescope.py
+++ b/pwndbg/commands/telescope.py
@@ -62,7 +62,7 @@ def telescope(address=None, count=telescope_lines, to_string=False):
 
     # Allow invocation of "telescope a b" to dump all bytes from A to B
     if int(address) <= int(count):
-        # adjust count if it is an address. use ceil divison as count is number of
+        # adjust count if it is an address. use ceil division as count is number of
         # ptrsize values and we don't want to strip out a value if dest is unaligned
         count -= address
         count = max(math.ceil(count / ptrsize), 1)


### PR DESCRIPTION
There is a small typo in pwndbg/commands/telescope.py.

Should read `division` rather than `divison`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md