### PR TITLE
Remove quotes from command option interpolation

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -144,14 +144,14 @@ fi
 
 # Make sure that pip is available
 if ! ${PYTHON} -m pip -V; then
-    ${PYTHON} -m ensurepip "${INSTALLFLAGS}" --upgrade
+    ${PYTHON} -m ensurepip ${INSTALLFLAGS} --upgrade
 fi
 
 # Upgrade pip itself
-${PYTHON} -m pip install "${INSTALLFLAGS}" --upgrade pip
+${PYTHON} -m pip install ${INSTALLFLAGS} --upgrade pip
 
 # Install Python dependencies
-${PYTHON} -m pip install "${INSTALLFLAGS}" -Ur requirements.txt
+${PYTHON} -m pip install ${INSTALLFLAGS} -Ur requirements.txt
 
 # Load Pwndbg into GDB on every launch.
 if ! grep pwndbg ~/.gdbinit &>/dev/null; then


### PR DESCRIPTION
There was a quoting bug as `INSTALLFLAGS` contains both the option key and value.
This causes the subsequent commands to look something like `python ... '--target foo'...`, causing
the command to treat the entire string `--target foo` as an option key rather than a key-value pair.

This fixes issue #875