### PR TITLE
Fixed bug when the GDB is debuggin an architecture arm-eabi (disassembly-flavor).

### DIFF
--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -473,10 +473,10 @@ code_lines = pwndbg.config.Parameter('context-code-lines', 10, 'number of additi
 
 def context_disasm(target=sys.stdout, with_banner=True, width=None):
     try:
-        flavor​​ ​​=​​ ​​gdb​​.​​execute​​(​'​show​ ​disassembly​-​flavor​'​, ​to_string​=​True​).​lower​().​split​(​'​"'​)[​​1​​]
+        flavor = gdb.execute('show disassembly-flavor', to_string=True).lower().split('"')[1]
     except gdb.error as e:
         if str(e).find("disassembly-flavor") > -1:
-            flavor​​ ​​=​​ ​​'intel'
+            flavor = 'intel'
         else:
             raise
 

--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -472,7 +472,14 @@ Unicorn emulation of code near the current instruction
 code_lines = pwndbg.config.Parameter('context-code-lines', 10, 'number of additional lines to print in the code context')
 
 def context_disasm(target=sys.stdout, with_banner=True, width=None):
-    flavor = gdb.execute('show disassembly-flavor', to_string=True).lower().split('"')[1]
+    try:
+        flavor​​ ​​=​​ ​​gdb​​.​​execute​​(​'​show​ ​disassembly​-​flavor​'​, ​to_string​=​True​).​lower​().​split​(​'​"'​)[​​1​​]
+    except gdb.error as e:
+        if str(e).find("disassembly-flavor") > -1:
+            flavor​​ ​​=​​ ​​'intel'
+        else:
+            raise
+
     syntax = pwndbg.disasm.CapstoneSyntax[flavor]
 
     # Get the Capstone object to set disassembly syntax

--- a/pwndbg/disasm/__init__.py
+++ b/pwndbg/disasm/__init__.py
@@ -75,7 +75,13 @@ def get_disassembler_cached(arch, ptrsize, endian, extra=None):
 
     mode |= CapstoneEndian[endian]
 
-    flavor = gdb.execute('show disassembly-flavor', to_string=True).lower().split('"')[1]
+    try:
+        flavor​​ ​​=​​ ​​gdb​​.​​execute​​(​'​show​ ​disassembly​-​flavor​'​, ​to_string​=​True​).​lower​().​split​(​'​"'​)[​​1​​]
+    except gdb.error as e:
+        if str(e).find("disassembly-flavor") > -1:
+            flavor​​ ​​=​​ ​​'intel'
+        else:
+            raise
 
     cs = Cs(arch, mode)
     cs.syntax = CapstoneSyntax[flavor]

--- a/pwndbg/disasm/__init__.py
+++ b/pwndbg/disasm/__init__.py
@@ -76,10 +76,10 @@ def get_disassembler_cached(arch, ptrsize, endian, extra=None):
     mode |= CapstoneEndian[endian]
 
     try:
-        flavor​​ ​​=​​ ​​gdb​​.​​execute​​(​'​show​ ​disassembly​-​flavor​'​, ​to_string​=​True​).​lower​().​split​(​'​"'​)[​​1​​]
+        flavor = gdb.execute('show disassembly-flavor', to_string=True).lower().split('"')[1]
     except gdb.error as e:
         if str(e).find("disassembly-flavor") > -1:
-            flavor​​ ​​=​​ ​​'intel'
+            flavor = 'intel'
         else:
             raise
 


### PR DESCRIPTION
Based on the issue commented by @enedil in this post: https://github.com/pwndbg/pwndbg/pull/860#issuecomment-782896531 which is crashing the pwndbg when the `disassembly-flavor` is set up on GDB targeting the architecture `arm-eabi`. The solution is catch the exception and set the default flavor to 'intel'.