### PR TITLE
`auxv` command produces wrong AT_RANDOM value

### DIFF
--- a/pwndbg/auxv.py
+++ b/pwndbg/auxv.py
@@ -113,7 +113,7 @@ def use_info_auxv():
 
     auxv = AUXV()
     for line in lines:
-        match = re.match('([0-9]+) .*? (0x[0-9a-f]+|[0-9]+)', line)
+        match = re.match('([0-9]+) .*? (0x[0-9a-f]+|[0-9]+$)', line)
         if not match:
             print("Warning: Skipping auxv entry '{}'".format(line))
             continue


### PR DESCRIPTION
When using an `auxv` command, it should show an address, not `0x10`.
![image](https://user-images.githubusercontent.com/31087829/110082520-066e0b00-7dc0-11eb-8643-5d15e0852602.png)

This is because the regex reads a wrong number in `info auxv` command.  (It reads `16` (0x10) in `"Address of 16 random bytes"` string)
![image](https://user-images.githubusercontent.com/31087829/110082466-f5bd9500-7dbf-11eb-916a-b16049993386.png)

So I changed the regex. And it works.
![image](https://user-images.githubusercontent.com/31087829/110084796-f1df4200-7dc2-11eb-978d-9af5bb97aa64.png)
