### PR TITLE
feature(radare2): add argument to set base when loading for PIE

### DIFF
--- a/pwndbg/commands/radare2.py
+++ b/pwndbg/commands/radare2.py
@@ -14,7 +14,7 @@ parser.add_argument('arguments', nargs='*', type=str,
                     help='Arguments to pass to radare')
 
 
-@pwndbg.commands.ArgparsedCommand(parser)
+@pwndbg.commands.ArgparsedCommand(parser, aliases=['radare2'])
 @pwndbg.commands.OnlyWithFile
 def r2(arguments, no_seek=False):
     filename = pwndbg.file.get_file(pwndbg.proc.exe)

--- a/pwndbg/commands/radare2.py
+++ b/pwndbg/commands/radare2.py
@@ -23,7 +23,7 @@ def r2(arguments, no_seek=False, no_rebase=False):
 
     # Build up the command line to run
     cmd = ['radare2']
-    flags = []
+    flags = ['-e', 'io.cache=true']
     if pwndbg.proc.alive:
         addr = pwndbg.regs.pc
         if pwndbg.elf.get_elf_info(filename).is_pie:

--- a/pwndbg/commands/radare2.py
+++ b/pwndbg/commands/radare2.py
@@ -10,23 +10,30 @@ parser = argparse.ArgumentParser(description='Launches radare2',
                                  epilog="Example: r2 -- -S -AA")
 parser.add_argument('--no-seek', action='store_true',
                     help='Do not seek to current pc')
+parser.add_argument('--no-rebase', action='store_true',
+                    help='Do not set the base address for PIE according to the current mapping')
 parser.add_argument('arguments', nargs='*', type=str,
                     help='Arguments to pass to radare')
 
 
 @pwndbg.commands.ArgparsedCommand(parser, aliases=['radare2'])
 @pwndbg.commands.OnlyWithFile
-def r2(arguments, no_seek=False):
+def r2(arguments, no_seek=False, no_rebase=False):
     filename = pwndbg.file.get_file(pwndbg.proc.exe)
 
     # Build up the command line to run
     cmd = ['radare2']
+    flags = []
     if pwndbg.proc.alive:
         addr = pwndbg.regs.pc
         if pwndbg.elf.get_elf_info(filename).is_pie:
-            addr -= pwndbg.elf.exe().address
+            if no_rebase:
+                addr -= pwndbg.elf.exe().address
+            else:
+                flags.extend(['-B', hex(pwndbg.elf.exe().address)])
         if not no_seek:
             cmd.extend(['-s', hex(addr)])
+    cmd.extend(flags)
     cmd += arguments
     cmd.extend([filename])
 


### PR DESCRIPTION
Depending on the use case, one may want to have either the same
addresses for PIE as in gdb or just use the non rebased plain addresses
without taking the current memory mapping into account.