### PR TITLE
feature(telescope): option to set min repeating values before skipping

### DIFF
--- a/pwndbg/commands/telescope.py
+++ b/pwndbg/commands/telescope.py
@@ -98,12 +98,13 @@ def telescope(address=None, count=telescope_lines, to_string=False):
     result = []
     last = None
     collapse_buffer = []
+    skipped_padding = 2 + len(offset_delimiter) + 4 + len(offset_separator) + 1 + longest_regs + 1 - len(repeating_marker)
 
     # Collapse repeating values exceeding minimum delta.
     def collapse_repeating_values():
         # The first line was already printed, hence increment by 1
         if collapse_buffer and len(collapse_buffer) + 1 >= skip_repeating_values_minimum:
-            result.append(T.repeating_marker('%s' % repeating_marker))
+            result.append(T.repeating_marker('%s%s%i skipped' % (repeating_marker, ' ' * skipped_padding, len(collapse_buffer))))
         else:
             result.extend(collapse_buffer)
         collapse_buffer.clear()

--- a/pwndbg/commands/telescope.py
+++ b/pwndbg/commands/telescope.py
@@ -90,7 +90,7 @@ def telescope(address=None, count=telescope_lines, to_string=False):
 
     # Find the longest set of register information
     if regs:
-        longest_regs = max(map(len, regs.values())) + 1
+        longest_regs = max(map(len, regs.values()))
     else:
         longest_regs = 0
 


### PR DESCRIPTION
Buffer all repeating lines and check the minimum value when to start
marking them with skip lines. In case the minimum value is not hit, just
unroll the buffer.

To stop skipping any lines, there is the existing bool config
telescope-skip-repeat-val so we avoid adding special values to minimum
like -1 and keep the setting separated.

Fixes #803