### PR TITLE
feature(shell): put 'pwn' into allow list for pwntools

### DIFF
--- a/pwndbg/commands/shell.py
+++ b/pwndbg/commands/shell.py
@@ -48,6 +48,7 @@ shellcmds = [
     "ps",
     "pstree",
     "pwd",
+    "pwn", # pwntools
     "rm",
     "sed",
     "sh",


### PR DESCRIPTION
if pwntools is using the proxy commany and distributed with
--only-use-pwn-command we need to make 'pwn' usable from the pwndbg
prompt.