### PR TITLE
fix(ui): fix display of addrsz to be hex formated

### DIFF
--- a/pwndbg/ui.py
+++ b/pwndbg/ui.py
@@ -50,7 +50,7 @@ def banner(title, target=sys.stdin, width=None):
 
 def addrsz(address):
     address = int(address) & pwndbg.arch.ptrmask
-    return "%{}x".format(2*pwndbg.arch.ptrsize) % address
+    return "%#{}x".format(2*pwndbg.arch.ptrsize) % address
 
 def get_window_size(target=sys.stdin):
     fallback = (int(os.environ.get('LINES', 20)), int(os.environ.get('COLUMNS', 80)))


### PR DESCRIPTION
Currently this function is only used for the backtrace context and does
not prefix the frame pointers in hex form, which can be annoying if the
value is copied to be inspected or otherwise processed.