### PR TITLE
fix(telescope): also unroll buffer if last line is skipped

### DIFF
--- a/pwndbg/commands/telescope.py
+++ b/pwndbg/commands/telescope.py
@@ -131,6 +131,7 @@ def telescope(address=None, count=telescope_lines, to_string=False):
 
         result.append(line)
 
+    collapse_repeating_values()
     telescope.offset += i
     telescope.last_address = addr
 


### PR DESCRIPTION
In case the max steps are reached and the loop finished the current skip
buffer remains filled and not unrolled when the last lines are all
skipped values. Fix this by calling the collapse function and
potentially unroll the buffer in case it contains any values.

Fixes #907