### PR TITLE
let `emulate` works on unicorn-1.0.2rc1 ~ unicorn-1.0.2

### DIFF
--- a/pwndbg/disasm/__init__.py
+++ b/pwndbg/disasm/__init__.py
@@ -214,16 +214,14 @@ def near(address, instructions=1, emulate=False, show_prev_insns=True):
     if address == pc and emulate:
         emu = pwndbg.emu.emulator.Emulator()
 
-        # For whatever reason, the first instruction is emulated twice.
-        # Skip the first one here.
-        emu.single_step()
-
     # Now find all of the instructions moving forward.
     #
     # At this point, we've already added everything *BEFORE* the requested address,
     # and the instruction at 'address'.
     insn = current
     total_instructions = 1 + (2*instructions)
+    last_emu_target = None
+    target_candidate = address
 
     while insn and len(insns) < total_instructions:
         target = insn.target
@@ -236,7 +234,14 @@ def near(address, instructions=1, emulate=False, show_prev_insns=True):
         # If we initialized the emulator and emulation is still enabled, we can use it
         # to figure out the next instruction.
         if emu:
-            target_candidate, size_candidate = emu.single_step()
+            # For whatever reason, the first instruction is emulated twice on
+            # unicorn-1.0.2rc1~unicorn-1.0.2rc3, but not on >= unicorn-1.0.2rc4.
+            # If the address is equal with the last one, skip it
+            last_emu_target = target_candidate
+            while last_emu_target == target_candidate:
+                target_candidate, size_candidate = emu.single_step()
+                if not target_candidate:
+                    break
 
             if None not in (target_candidate, size_candidate):
                 target = target_candidate


### PR DESCRIPTION
Without this patch, if we debug program with unicorn>=1.0.2rc4, the emulate result like this:
```
► 0x555555559cd0    endbr64
    ↓
   0x555555559cd6    mov    r9, rdx
   0x555555559cd9    pop    rsi
   0x555555559cda    mov    rdx, rsp
   0x555555559cdd    and    rsp, 0xfffffffffffffff0
   0x555555559ce1    push   rax
   0x555555559ce2    push   rsp
   0x555555559ce3    lea    r8, [rip + 0x11af6]
   0x555555559cea    lea    rcx, [rip + 0x11a7f]
   0x555555559cf1    lea    rdi, [rip - 0x208]
   0x555555559cf8    call   qword ptr [rip + 0x1a2c2] <__libc_start_main>
```

It skip one line, and the correct result is:
```
pwndbg> x/10i 0x555555559cd0
=> 0x555555559cd0:      endbr64
   0x555555559cd4:      xor    ebp,ebp
   0x555555559cd6:      mov    r9,rdx
   0x555555559cd9:      pop    rsi
   0x555555559cda:      mov    rdx,rsp
   0x555555559cdd:      and    rsp,0xfffffffffffffff0
   0x555555559ce1:      push   rax
   0x555555559ce2:      push   rsp
   0x555555559ce3:      lea    r8,[rip+0x11af6]        # 0x55555556b7e0
   0x555555559cea:      lea    rcx,[rip+0x11a7f]        # 0x55555556b770
```

With this patch, the result is correct both on unicorn>=1.0.2rc1,<1.0.2rc4 and unicorn>=1.0.2rc4