### PR TITLE
refix: let emulate works on unicorn-1.0.2rc1 ~ unicorn-1.0.2

### DIFF
--- a/pwndbg/disasm/__init__.py
+++ b/pwndbg/disasm/__init__.py
@@ -218,6 +218,8 @@ def near(address, instructions=1, emulate=False, show_prev_insns=True):
     # If we hit the current instruction, we can do emulation going forward from there.
     if address == pc and emulate:
         emu = pwndbg.emu.emulator.Emulator()
+        # skip current line
+        emu.single_step()
 
     # Now find all of the instructions moving forward.
     #
@@ -225,8 +227,6 @@ def near(address, instructions=1, emulate=False, show_prev_insns=True):
     # and the instruction at 'address'.
     insn = current
     total_instructions = 1 + (2*instructions)
-    last_emu_target = None
-    target_candidate = address
 
     while insn and len(insns) < total_instructions:
         target = insn.target
@@ -239,14 +239,7 @@ def near(address, instructions=1, emulate=False, show_prev_insns=True):
         # If we initialized the emulator and emulation is still enabled, we can use it
         # to figure out the next instruction.
         if emu:
-            # For whatever reason, the first instruction is emulated twice on
-            # unicorn-1.0.2rc1~unicorn-1.0.2rc3, but not on >= unicorn-1.0.2rc4.
-            # If the address is equal with the last one, skip it
-            last_emu_target = target_candidate
-            while last_emu_target == target_candidate:
-                target_candidate, size_candidate = emu.single_step()
-                if not target_candidate:
-                    break
+            target_candidate, size_candidate = emu.single_step()
 
             if None not in (target_candidate, size_candidate):
                 target = target_candidate


### PR DESCRIPTION
I found that this problem should not be fixed in func `nearpc()`, but in class `Emulator()`

After debugging, I found `single_step_hook_code()` will be call **twice** on unicorn1.0.2rc4+ while emulating single instruction.

https://github.com/pwndbg/pwndbg/blob/87da998fcefe8cba85f51dba0056b923483c6c1c/pwndbg/emu/emulator.py#L434-L437

https://github.com/pwndbg/pwndbg/blob/87da998fcefe8cba85f51dba0056b923483c6c1c/pwndbg/emu/emulator.py#L320-L325

https://github.com/pwndbg/pwndbg/blob/87da998fcefe8cba85f51dba0056b923483c6c1c/pwndbg/emu/emulator.py#L448-L450

Here is the log:

- 1.0.2rc3:
```
emulate_with_hook():  pc @ 0x555555559cd0
single_step_hook_code():  _single_step -> 0x555555559cd0 4
emulate_with_hook():  pc @ 0x555555559cd4
single_step_hook_code():  _single_step -> 0x555555559cd4 2
emulate_with_hook():  pc @ 0x555555559cd6
single_step_hook_code():  _single_step -> 0x555555559cd6 3
emulate_with_hook():  pc @ 0x555555559cd9
single_step_hook_code():  _single_step -> 0x555555559cd9 1
emulate_with_hook():  pc @ 0x555555559cda
single_step_hook_code():  _single_step -> 0x555555559cda 3
emulate_with_hook():  pc @ 0x555555559cdd
single_step_hook_code():  _single_step -> 0x555555559cdd 4
emulate_with_hook():  pc @ 0x555555559ce1
single_step_hook_code():  _single_step -> 0x555555559ce1 1
emulate_with_hook():  pc @ 0x555555559ce2
single_step_hook_code():  _single_step -> 0x555555559ce2 1
emulate_with_hook():  pc @ 0x555555559ce3
single_step_hook_code():  _single_step -> 0x555555559ce3 7
emulate_with_hook():  pc @ 0x555555559cea
single_step_hook_code():  _single_step -> 0x555555559cea 7
emulate_with_hook():  pc @ 0x555555559cf1
single_step_hook_code():  _single_step -> 0x555555559cf1 7
```

- 1.0.2:
```
emulate_with_hook():  pc @ 0x555555559cd0
single_step_hook_code():  _single_step -> 0x555555559cd0 4
single_step_hook_code():  _single_step -> 0x555555559cd4 2
emulate_with_hook():  pc @ 0x555555559cd4
single_step_hook_code():  _single_step -> 0x555555559cd4 2
single_step_hook_code():  _single_step -> 0x555555559cd6 3
emulate_with_hook():  pc @ 0x555555559cd6
single_step_hook_code():  _single_step -> 0x555555559cd6 3
single_step_hook_code():  _single_step -> 0x555555559cd9 1
emulate_with_hook():  pc @ 0x555555559cd9
single_step_hook_code():  _single_step -> 0x555555559cd9 1
single_step_hook_code():  _single_step -> 0x555555559cda 3
emulate_with_hook():  pc @ 0x555555559cda
single_step_hook_code():  _single_step -> 0x555555559cda 3
single_step_hook_code():  _single_step -> 0x555555559cdd 4
emulate_with_hook():  pc @ 0x555555559cdd
single_step_hook_code():  _single_step -> 0x555555559cdd 4
single_step_hook_code():  _single_step -> 0x555555559ce1 1
emulate_with_hook():  pc @ 0x555555559ce1
single_step_hook_code():  _single_step -> 0x555555559ce1 1
single_step_hook_code():  _single_step -> 0x555555559ce2 1
emulate_with_hook():  pc @ 0x555555559ce2
single_step_hook_code():  _single_step -> 0x555555559ce2 1
single_step_hook_code():  _single_step -> 0x555555559ce3 7
emulate_with_hook():  pc @ 0x555555559ce3
single_step_hook_code():  _single_step -> 0x555555559ce3 7
single_step_hook_code():  _single_step -> 0x555555559cea 7
emulate_with_hook():  pc @ 0x555555559cea
single_step_hook_code():  _single_step -> 0x555555559cea 7
single_step_hook_code():  _single_step -> 0x555555559cf1 7
emulate_with_hook():  pc @ 0x555555559cf1
single_step_hook_code():  _single_step -> 0x555555559cf1 7
single_step_hook_code():  _single_step -> 0x555555559cf8 6
```

So, if we add a hit counter to `single_step_hook_code` and `self._single_step` is updated only when `counter == 0`, the outputs of both should be the same.