### PR TITLE
Make the "brva" alias accept the same arguments as breakrva

### DIFF
--- a/pwndbg/commands/pie.py
+++ b/pwndbg/commands/pie.py
@@ -94,7 +94,7 @@ parser.add_argument('module', type=str, nargs='?', default='',
 
 @pwndbg.commands.ArgparsedCommand(parser)
 @pwndbg.commands.OnlyWhenRunning
-def breakrva(offset=None, module=None):
+def breakrva(offset=0, module=None):
     offset = int(offset)
     if not module:
         module = get_exe_name()
@@ -107,6 +107,6 @@ def breakrva(offset=None, module=None):
 
 @pwndbg.commands.QuietSloppyParsedCommand #TODO should this just be an alias or does the QuietSloppy have an effect?
 @pwndbg.commands.OnlyWhenRunning
-def brva(map):
+def brva(*args):
     """Alias for breakrva."""
-    return breakrva(map)
+    return breakrva(*args)


### PR DESCRIPTION
Currently the `brva` alias only works with 1 argument, and is broken for 0 and 2 arguments. This rather simple commit makes `brva` take `*args` instead of just a single argument, and changes he default `offset` for `breakrva` from `None` to `0`. This makes `brva` correctly alias `breakrva`, which can take from 0 to 2 arguments.

Before:

```
pwndbg> breakrva
Breakpoint 2 at 0x555555554000
pwndbg> breakrva 0x100
Breakpoint 3 at 0x555555554100
pwndbg> breakrva 0x100 libc
Breakpoint 4 at 0x7ffff7bbe100
pwndbg> brva
'brva': Alias for breakrva.
Exception occurred: brva: brva() missing 1 required positional argument: 'map' (<class 'TypeError'>)
For more info invoke `set exception-verbose on` and rerun the command
or debug it by yourself with `set exception-debugger on`
pwndbg> brva 0x100
Breakpoint 5 at 0x555555554100
pwndbg> brva 0x100 libc
'brva': Alias for breakrva.
Exception occurred: brva: brva() takes 1 positional argument but 2 were given (<class 'TypeError'>)
For more info invoke `set exception-verbose on` and rerun the command
or debug it by yourself with `set exception-debugger on`
```

After:

```
pwndbg> breakrva
Breakpoint 2 at 0x555555554000
pwndbg> breakrva 0x100
Breakpoint 3 at 0x555555554100
pwndbg> breakrva 0x100 libc
Breakpoint 4 at 0x7ffff7bbe100
pwndbg> brva
Breakpoint 5 at 0x555555554000
pwndbg> brva 0x100
Breakpoint 6 at 0x555555554100
pwndbg> brva 0x100 libc
Breakpoint 7 at 0x7ffff7bbe100
```