### PR TITLE
Fix mips32r6 disasm & emu

### DIFF
--- a/pwndbg/disasm/__init__.py
+++ b/pwndbg/disasm/__init__.py
@@ -109,6 +109,9 @@ def get_disassembler(pc):
             
     elif pwndbg.arch.current == 'i8086':
         extra = CS_MODE_16
+
+    elif pwndbg.arch.current == 'mips' and 'isa32r6' in gdb.newest_frame().architecture().name():
+        extra = CS_MODE_MIPS32R6
     
     else:
         extra = None

--- a/pwndbg/disasm/__init__.py
+++ b/pwndbg/disasm/__init__.py
@@ -218,6 +218,8 @@ def near(address, instructions=1, emulate=False, show_prev_insns=True):
     # If we hit the current instruction, we can do emulation going forward from there.
     if address == pc and emulate:
         emu = pwndbg.emu.emulator.Emulator()
+        # skip current line
+        emu.single_step()
 
     # Now find all of the instructions moving forward.
     #
@@ -225,8 +227,6 @@ def near(address, instructions=1, emulate=False, show_prev_insns=True):
     # and the instruction at 'address'.
     insn = current
     total_instructions = 1 + (2*instructions)
-    last_emu_target = None
-    target_candidate = address
 
     while insn and len(insns) < total_instructions:
         target = insn.target
@@ -239,14 +239,7 @@ def near(address, instructions=1, emulate=False, show_prev_insns=True):
         # If we initialized the emulator and emulation is still enabled, we can use it
         # to figure out the next instruction.
         if emu:
-            # For whatever reason, the first instruction is emulated twice on
-            # unicorn-1.0.2rc1~unicorn-1.0.2rc3, but not on >= unicorn-1.0.2rc4.
-            # If the address is equal with the last one, skip it
-            last_emu_target = target_candidate
-            while last_emu_target == target_candidate:
-                target_candidate, size_candidate = emu.single_step()
-                if not target_candidate:
-                    break
+            target_candidate, size_candidate = emu.single_step()
 
             if None not in (target_candidate, size_candidate):
                 target = target_candidate

--- a/pwndbg/emu/emulator.py
+++ b/pwndbg/emu/emulator.py
@@ -201,6 +201,9 @@ class Emulator:
         elif arch in ('arm', 'aarch64'):
             mode |= U.UC_MODE_THUMB if (pwndbg.regs.cpsr & (1<<5)) else U.UC_MODE_ARM
 
+        elif arch == 'mips' and 'isa32r6' in gdb.newest_frame().architecture().name():
+            mode |= U.UC_MODE_MIPS32R6
+
         else:
             mode |= {4:U.UC_MODE_32, 8:U.UC_MODE_64}[pwndbg.arch.ptrsize]
 


### PR DESCRIPTION
When disasm mips32r6 using capstone or emulate mips32r6 using unicorn,
MODE should be XX_MODE_MIPS32R6