### PR TITLE
registers split into specified number of columns

### DIFF
--- a/pwndbg/color/__init__.py
+++ b/pwndbg/color/__init__.py
@@ -74,7 +74,7 @@ def generateColorFunction(config):
     return function
 
 def strip(x):
-    return re.sub('\x1b\\[\d+m', '', x)
+    return re.sub('\x1b\\[[\d;]+m', '', x)
 
 def terminateWith(x, color):
     return re.sub('\x1b\\[0m', NORMAL + color, x)

--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -290,6 +290,7 @@ def context(subcontext=None):
 pwndbg.config.Parameter('show-compact-regs', False, 'whether to show a compact register view')
 pwndbg.config.Parameter('show-compact-regs-align', 20, 'the number of characters reserved for each register and value')
 pwndbg.config.Parameter('show-compact-regs-space', 4, 'the minimum number of characters separating each register')
+pwndbg.config.Parameter('show-compact-regs-columns', 0, 'the number of columns to show registers (if 0, using the show-compact-regs-align)')
 
 
 def calculate_padding_to_align(length, align):
@@ -302,6 +303,12 @@ def calculate_padding_to_align(length, align):
 def compact_regs(regs, width):
     align = int(pwndbg.config.show_compact_regs_align)
     space = int(pwndbg.config.show_compact_regs_space)
+    columns = int(pwndbg.config.show_compact_regs_columns)
+
+    # reset align while columns is set
+    if columns > 0:
+        align = max(align, width // columns)
+
     result = []
 
     line = ''


### PR DESCRIPTION
## test.c
```c
int main(void) {
  __asm__("int $3");
  return 0;
}
```

## config
```
source ~/pwndbg/gdbinit.py
set show-compact-regs on
set show-compact-regs-align 92
set show-compact-regs-columns 2
```

## issue
1. need to reset show-compact-regs-align while screen resize
2. sometimes it's not aligned
<img width="1675" alt="Screen Shot 2021-06-23 at 11 36 09 PM" src="https://user-images.githubusercontent.com/20320324/123126262-d1271f00-d47b-11eb-94a4-da239d0a40a5.png">

## future
1. always fix columns to show registers as you wish
2. always aligned perfectly
<img width="1671" alt="Screen Shot 2021-06-23 at 11 42 01 PM" src="https://user-images.githubusercontent.com/20320324/123127228-a8535980-d47c-11eb-89b8-59df1cc650e0.png">
