### PR TITLE
vmmap: name anonymous pages

### DIFF
--- a/pwndbg/vmmap.py
+++ b/pwndbg/vmmap.py
@@ -200,10 +200,12 @@ def proc_pid_maps():
     for line in data.splitlines():
         maps, perm, offset, dev, inode_objfile = line.split(None, 4)
 
-        try:    inode, objfile = inode_objfile.split(None, 1)
-        except: objfile = ''
-
         start, stop = maps.split('-')
+        
+        try:
+            inode, objfile = inode_objfile.split(None, 1)
+        except:
+            objfile = 'anon_' + start[:-3]
 
         start  = int(start, 16)
         stop   = int(stop, 16)


### PR DESCRIPTION
By naming anonymous pages we allow `search` to be used against them! ;)

```
pwndbg> vmmap
LEGEND: STACK | HEAP | CODE | DATA | RWX | RODATA
    0x555555554000     0x555555558000 r--p     4000 0      /usr/bin/ls
    0x555555558000     0x55555556c000 r-xp    14000 4000   /usr/bin/ls
    0x55555556c000     0x555555575000 r--p     9000 18000  /usr/bin/ls
    0x555555576000     0x555555577000 r--p     1000 21000  /usr/bin/ls
    0x555555577000     0x555555578000 rw-p     1000 22000  /usr/bin/ls
    0x555555578000     0x55555559a000 rw-p    22000 0      [heap]
    0x7ffff7ccd000     0x7ffff7ccf000 rw-p     2000 0      anon_7ffff7ccd
    ...

pwndbg> search -8 0x1100
ls              0x555555556e2b 0x1100
libpthread-2.31.so 0x7ffff7ccf65f 0x1100
...
anon_7ffff7cee  0x7ffff7cf13f8 0x1100
libdl-2.31.so   0x7ffff7cf26e3 0x1100
...
libpcre2-8.so.0.9.0 0x7ffff7cf8a5f 0x1100
libpcre2-8.so.0.9.0 0x7ffff7cf8ad7 0x1100
...
libc-2.31.so    0x7ffff7d8f57b 0x1100
libc-2.31.so    0x7ffff7d8f593 0x1100
libc-2.31.so    0x7ffff7d8f5db 0x1100
...
libselinux.so.1 0x7ffff7f7ac0b 0x1100
libselinux.so.1 0x7ffff7f7ace3 0x1100
...
ld-2.31.so      0x7ffff7fcf018 0x1100
ld-2.31.so      0x7ffff7fcf38b 0x1100
ld-2.31.so      0x7ffff7fcff73 0x1100
ld-2.31.so      0x7ffff7ffdfb8 0x1100
[stack]         0x7fffffffe06f 0x1100

pwndbg> search -8 0x1100 anon_7ffff7cee
anon_7ffff7cee  0x7ffff7cf13f8 0x1100
```