### PR TITLE
Make setup.sh work with Podman

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ tests/.pytest_cache/
 tests/binaries/*.o
 tests/binaries/*.out
 tests/binaries/gosample.x*
+
+# VS Code files
+.vscode/

--- a/setup-test-tools.sh
+++ b/setup-test-tools.sh
@@ -5,10 +5,10 @@ echo "# Install testing tools."
 echo "# Only works with Ubuntu / APT."
 echo "# --------------------------------------"
 
-# If we are a root in a Docker container and `sudo` doesn't exist
+# If we are a root in a container and `sudo` doesn't exist
 # lets overwrite it with a function that just executes things passed to sudo
 # (yeah it won't work for sudo executed with flags)
-if [ -f /.dockerenv ] && ! hash sudo 2>/dev/null && whoami | grep root; then
+if ! hash sudo 2>/dev/null && whoami | grep root; then
   sudo() {
     ${*}
   }

--- a/setup.sh
+++ b/setup.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 set -ex
 
-# If we are a root in a Docker container and `sudo` doesn't exist
+# If we are a root in a container and `sudo` doesn't exist
 # lets overwrite it with a function that just executes things passed to sudo
 # (yeah it won't work for sudo executed with flags)
-if [ -f /.dockerenv ] && ! hash sudo 2>/dev/null && whoami | grep root; then
+if ! hash sudo 2>/dev/null && whoami | grep root; then
     sudo() {
         ${*}
     }


### PR DESCRIPTION
Containers created with Podman (https://podman.io/) don't have a .dockerenv file in the root directory, so setup.sh tries to invoke sudo, even though it doesn't exist in the container. This PR fixes that by removing the check for .dockerenv. The other two checks (current user is root and sudo doesn't exist) are enough to detect when the script is running in a container vs. a "real" machine with sudo.