### PR TITLE
Enclose vmmap's anonymous map names in square brackets

### DIFF
--- a/pwndbg/vmmap.py
+++ b/pwndbg/vmmap.py
@@ -212,7 +212,7 @@ def proc_pid_maps():
         try:
             inode, objfile = inode_objfile.split(None, 1)
         except:
-            objfile = 'anon_' + start[:-3]
+            objfile = '[anon_' + start[:-3] + ']'
 
         start  = int(start, 16)
         stop   = int(stop, 16)


### PR DESCRIPTION
Resolves #957 by enclosing anonymous map names printed by `vmmap` in square brackets.
Search still works & `xinfo` plays nice, but please let me know if you find anything this breaks.