### PR TITLE
Migrate to 3.10 compatible abc usage.

### DIFF
--- a/pwndbg/memoize.py
+++ b/pwndbg/memoize.py
@@ -32,7 +32,7 @@ class memoize:
     def __call__(self, *args, **kwargs):
         how = None
 
-        if not isinstance(args, collections.Hashable):
+        if not isinstance(args, collections.abc.Hashable):
             print("Cannot memoize %r!", file=sys.stderr)
             how   = "Not memoizeable!"
             value = self.func(*args)

--- a/pwndbg/memoize.py
+++ b/pwndbg/memoize.py
@@ -6,13 +6,19 @@ e.g. execution stops because of a SIGINT or breakpoint, or a
 new library/objfile are loaded, etc.
 """
 
-import collections
 import functools
 import sys
 
 import gdb
 
 import pwndbg.events
+
+try:
+    # Python >= 3.10
+    from collections.abc import Hashable
+except ImportError:
+    # Python < 3.10
+    from collections import Hashable
 
 debug = False
 
@@ -32,7 +38,7 @@ class memoize:
     def __call__(self, *args, **kwargs):
         how = None
 
-        if not isinstance(args, collections.abc.Hashable):
+        if not isinstance(args, Hashable):
             print("Cannot memoize %r!", file=sys.stderr)
             how   = "Not memoizeable!"
             value = self.func(*args)


### PR DESCRIPTION
This is a one-line fix. Python 3.10 has [deprecated](https://github.com/python/cpython/commit/c47c78b878ff617164b2b94ff711a6103e781753#diff-c92f871cb9b4aa1583c89f82cd416d58a5d70fff41faf41e45dedf775dbe7713) using direct `abc` imports from `collections`.