### PR TITLE
SLES/OpenSUSE: enable debugging repo before installing

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -47,6 +47,7 @@ install_swupd() {
 }
 
 install_zypper() {
+    sudo zypper mr -e repo-debug
     sudo zypper refresh || true
     sudo zypper install -y gdb gdbserver python-devel python3-devel python2-pip python3-pip glib2-devel make glibc-debuginfo
 


### PR DESCRIPTION
Package glibc-debuginfo, which is a requirement,
requires repo-debug to be enabled, which is not enabled
by default.

This commit enables this repo when installing if it is
not already enabled.