### PR TITLE
Do not sort auxv, use the implicit order

### DIFF
--- a/pwndbg/auxv.py
+++ b/pwndbg/auxv.py
@@ -81,9 +81,6 @@ sys.modules[__name__].__dict__.update({v:k for k,v in AT_CONSTANTS.items()})
 
 
 class AUXV(dict):
-    def __init__(self):
-        for field in AT_CONSTANTS.values():
-            self[field] = None
     def set(self, const, value):
         name         = AT_CONSTANTS.get(const, "AT_UNKNOWN%i" % const)
 
@@ -97,7 +94,7 @@ class AUXV(dict):
 
         self[name] = value
     def __getattr__(self, attr):
-        return self[attr]
+        return self.get(attr)
     def __str__(self):
         return str({k:v for k,v in self.items() if v is not None})
 

--- a/pwndbg/commands/auxv.py
+++ b/pwndbg/commands/auxv.py
@@ -8,6 +8,6 @@ import pwndbg.commands
 @pwndbg.commands.ArgparsedCommand('Print information from the Auxiliary ELF Vector.')
 @pwndbg.commands.OnlyWhenRunning
 def auxv():
-    for k, v in sorted(pwndbg.auxv.get().items()):
+    for k, v in pwndbg.auxv.get().items():
         if v is not None:
             print(k.ljust(24), v if not isinstance(v, int) else pwndbg.chain.format(v))


### PR DESCRIPTION
Before:
```py
AT_BASE                  0x7ffff7fcb000 ◂— 0x3010102464c457f
AT_CLKTCK                0x64
AT_EGID                  0x3e8
AT_ENTRY                 0x5555555563d0 ◂— endbr64 
AT_EUID                  0x3e8
AT_EXECFN                /bin/true
AT_FLAGS                 0x0
AT_GID                   0x3e8
AT_HWCAP                 0x178bfbff
AT_NULL                  0x0
AT_PAGESZ                0x1000
AT_PHDR                  0x555555554040 ◂— 0x400000006
AT_PHENT                 0x38
AT_PHNUM                 0xd
AT_PLATFORM              x86_64
AT_RANDOM                0x7fffffffdce9 ◂— 0x9869a99107cf1d7b
AT_SECURE                0x0
AT_SYSINFO_EHDR          0x7ffff7fca000 ◂— jg     0x7ffff7fca047
AT_UID                   0x3e8
AT_UNKNOWN26             0x2
AT_UNKNOWN51             0x6f0
```

After:
```py
AT_SYSINFO_EHDR          0x7ffff7fca000 ◂— jg     0x7ffff7fca047
AT_UNKNOWN51             0x6f0
AT_HWCAP                 0x178bfbff
AT_PAGESZ                0x1000
AT_CLKTCK                0x64
AT_PHDR                  0x555555554040 ◂— 0x400000006
AT_PHENT                 0x38
AT_PHNUM                 0xd
AT_BASE                  0x7ffff7fcb000 ◂— 0x3010102464c457f
AT_FLAGS                 0x0
AT_ENTRY                 0x5555555563d0 ◂— endbr64 
AT_UID                   0x3e8
AT_EUID                  0x3e8
AT_GID                   0x3e8
AT_EGID                  0x3e8
AT_SECURE                0x0
AT_RANDOM                0x7fffffffdce9 ◂— 0x7e0d8d5d1db97040
AT_UNKNOWN26             0x2
AT_EXECFN                /bin/true
AT_PLATFORM              x86_64
AT_NULL                  0x0
```