### PR TITLE
Add basic coverage testing

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,6 @@
+[run]
+branch = True
+parallel = True
+disable_warnings = module-not-imported
+source = .
+omit = ida_script.py

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,4 +37,10 @@ jobs:
     - name: Process coverage data
       run: |
         coverage combine
-        # coveralls  ## XXX set up coveralls.io like pwntools?
+        coverage xml
+
+    - name: "Upload coverage to Codecov"
+      uses: codecov/codecov-action@v2
+      with:
+        fail_ci_if_error: true
+

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,7 @@ jobs:
       run: |
         ./setup.sh --user
         ./setup-test-tools.sh --user
+        pip install --user coveralls
 
     - name: Python version info
       run: |
@@ -32,3 +33,8 @@ jobs:
     - name: Run tests
       run: |
         PWNDBG_GITHUB_ACTIONS_TEST_RUN=1 sudo --preserve-env ./tests.sh
+
+    - name: Process coverage data
+      run: |
+        coverage combine
+        # coveralls  ## XXX set up coveralls.io like pwntools?

--- a/tests.sh
+++ b/tests.sh
@@ -19,7 +19,7 @@ tests_passed_or_skipped=0
 tests_failed=0
 
 for test_case in ${TESTS_LIST}; do
-    PWNDBG_LAUNCH_TEST="${test_case}" PWNDBG_DISABLE_COLORS=1 gdb --silent --nx --nh --command gdbinit.py --command pytests_launcher.py --eval-command quit
+    COVERAGE_PROCESS_START=.coveragerc PWNDBG_LAUNCH_TEST="${test_case}" PWNDBG_DISABLE_COLORS=1 gdb --silent --nx --nh -ex 'py import coverage;coverage.process_startup()' --command gdbinit.py --command pytests_launcher.py --eval-command quit
     exit_status=$?
 
     if [ ${exit_status} -eq 0 ]; then


### PR DESCRIPTION
Inspired by what pwntools does with [coveralls.io](//coveralls.io) (another option would be [codecov.io](//about.codecov.io/blog/python-code-coverage-using-github-actions-and-codecov/) for example). The coverage collection is started before executing the gdbinit in order to collect all the early executed code as well.

@disconnect3d wdyt?