### PR TITLE
Remove shebang and coding lines

### DIFF
--- a/pwndbg/argv.py
+++ b/pwndbg/argv.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import gdb
 
 import pwndbg.abi

--- a/pwndbg/auxv.py
+++ b/pwndbg/auxv.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import os
 import re
 import sys

--- a/pwndbg/chain.py
+++ b/pwndbg/chain.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import gdb
 
 import pwndbg.abi

--- a/pwndbg/color/__init__.py
+++ b/pwndbg/color/__init__.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import os
 import re
 

--- a/pwndbg/color/backtrace.py
+++ b/pwndbg/color/backtrace.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import pwndbg.color.theme as theme
 import pwndbg.config as config
 from pwndbg.color import generateColorFunction

--- a/pwndbg/color/chain.py
+++ b/pwndbg/color/chain.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import pwndbg.color.theme as theme
 import pwndbg.config as config
 from pwndbg.color import generateColorFunction

--- a/pwndbg/color/context.py
+++ b/pwndbg/color/context.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import pwndbg.color.theme as theme
 import pwndbg.config as config
 from pwndbg.color import generateColorFunction

--- a/pwndbg/color/disasm.py
+++ b/pwndbg/color/disasm.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import capstone
 
 import pwndbg.chain

--- a/pwndbg/color/enhance.py
+++ b/pwndbg/color/enhance.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import pwndbg.color.theme as theme
 import pwndbg.config as config
 from pwndbg.color import generateColorFunction

--- a/pwndbg/color/hexdump.py
+++ b/pwndbg/color/hexdump.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import pwndbg.color.theme as theme
 import pwndbg.config as config
 from pwndbg.color import generateColorFunction

--- a/pwndbg/color/nearpc.py
+++ b/pwndbg/color/nearpc.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import pwndbg.color.theme as theme
 import pwndbg.config as config
 from pwndbg.color import generateColorFunction

--- a/pwndbg/color/telescope.py
+++ b/pwndbg/color/telescope.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import pwndbg.color.theme as theme
 import pwndbg.config as config
 from pwndbg.color import generateColorFunction

--- a/pwndbg/color/theme.py
+++ b/pwndbg/color/theme.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import pwndbg.config
 
 

--- a/pwndbg/commands/argv.py
+++ b/pwndbg/commands/argv.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import argparse
 
 import gdb

--- a/pwndbg/commands/aslr.py
+++ b/pwndbg/commands/aslr.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import argparse
 
 import gdb

--- a/pwndbg/commands/canary.py
+++ b/pwndbg/commands/canary.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import pwndbg.auxv
 import pwndbg.commands
 import pwndbg.commands.telescope

--- a/pwndbg/commands/checksec.py
+++ b/pwndbg/commands/checksec.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import pwndbg.commands
 import pwndbg.which
 import pwndbg.wrappers.checksec

--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import argparse
 import ast
 import os

--- a/pwndbg/commands/cpsr.py
+++ b/pwndbg/commands/cpsr.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import pwndbg.arch
 import pwndbg.commands
 import pwndbg.regs

--- a/pwndbg/commands/defcon.py
+++ b/pwndbg/commands/defcon.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import argparse
 
 import gdb

--- a/pwndbg/commands/dt.py
+++ b/pwndbg/commands/dt.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import argparse
 
 import gdb

--- a/pwndbg/commands/dumpargs.py
+++ b/pwndbg/commands/dumpargs.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import argparse
 
 import pwndbg.arguments

--- a/pwndbg/commands/elf.py
+++ b/pwndbg/commands/elf.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 from elftools.elf.elffile import ELFFile
 
 import pwndbg.commands

--- a/pwndbg/commands/got.py
+++ b/pwndbg/commands/got.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import argparse
 
 import pwndbg.chain

--- a/pwndbg/commands/ida.py
+++ b/pwndbg/commands/ida.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import argparse
 import bz2
 import datetime

--- a/pwndbg/commands/misc.py
+++ b/pwndbg/commands/misc.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import argparse
 import errno as _errno
 

--- a/pwndbg/commands/mprotect.py
+++ b/pwndbg/commands/mprotect.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import argparse
 
 import gdb

--- a/pwndbg/commands/nearpc.py
+++ b/pwndbg/commands/nearpc.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import argparse
 
 from capstone import *

--- a/pwndbg/commands/peda.py
+++ b/pwndbg/commands/peda.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import argparse
 
 import gdb

--- a/pwndbg/commands/pie.py
+++ b/pwndbg/commands/pie.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import argparse
 import os
 

--- a/pwndbg/commands/probeleak.py
+++ b/pwndbg/commands/probeleak.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import argparse
 import math
 import os

--- a/pwndbg/commands/procinfo.py
+++ b/pwndbg/commands/procinfo.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import string
 
 import gdb

--- a/pwndbg/commands/radare2.py
+++ b/pwndbg/commands/radare2.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import argparse
 import subprocess
 

--- a/pwndbg/commands/reload.py
+++ b/pwndbg/commands/reload.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import types
 
 import gdb

--- a/pwndbg/commands/rop.py
+++ b/pwndbg/commands/rop.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import argparse
 import re
 import subprocess

--- a/pwndbg/commands/ropper.py
+++ b/pwndbg/commands/ropper.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import argparse
 import subprocess
 import tempfile

--- a/pwndbg/commands/search.py
+++ b/pwndbg/commands/search.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import argparse
 import binascii
 import codecs

--- a/pwndbg/commands/segments.py
+++ b/pwndbg/commands/segments.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import gdb
 
 import pwndbg.commands

--- a/pwndbg/commands/xinfo.py
+++ b/pwndbg/commands/xinfo.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import argparse
 
 import gdb

--- a/pwndbg/constants/__init__.py
+++ b/pwndbg/constants/__init__.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import pwndbg.arch
 
 from . import aarch64

--- a/pwndbg/constants/aarch64.py
+++ b/pwndbg/constants/aarch64.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 from .constant import Constant
 
 __NR_io_setup = Constant('__NR_io_setup',0)

--- a/pwndbg/constants/alpha.py
+++ b/pwndbg/constants/alpha.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 from .constant import Constant
 
 __NR_osf_syscall = Constant('__NR_osf_syscall',0)

--- a/pwndbg/constants/amd64.py
+++ b/pwndbg/constants/amd64.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 from .constant import Constant
 
 __NR_read = Constant('__NR_read',0)

--- a/pwndbg/constants/arm.py
+++ b/pwndbg/constants/arm.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 from .constant import Constant
 
 __NR_OABI_SYSCALL_BASE = Constant('__NR_OABI_SYSCALL_BASE',0x900000)

--- a/pwndbg/constants/constant.py
+++ b/pwndbg/constants/constant.py
@@ -1,7 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
-
 class Constant(int):
     def __new__(cls, s, i):
         obj = super(Constant, cls).__new__(cls, i)

--- a/pwndbg/constants/i386.py
+++ b/pwndbg/constants/i386.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 from .constant import Constant
 
 __NR_exit = Constant('__NR_exit',1)

--- a/pwndbg/constants/ia64.py
+++ b/pwndbg/constants/ia64.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 from .constant import Constant
 
 __NR_ni_syscall = Constant('__NR_ni_syscall',1024)

--- a/pwndbg/constants/mips.py
+++ b/pwndbg/constants/mips.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 from .constant import Constant
 
 __NR_Linux = Constant('__NR_Linux',4000)

--- a/pwndbg/constants/powerpc.py
+++ b/pwndbg/constants/powerpc.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 from .constant import Constant
 
 __NR_exit = Constant('__NR_exit',1)

--- a/pwndbg/constants/powerpc64.py
+++ b/pwndbg/constants/powerpc64.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 from .constant import Constant
 
 __NR_exit = Constant('__NR_exit',1)

--- a/pwndbg/constants/ptmalloc.py
+++ b/pwndbg/constants/ptmalloc.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import platform
 
 import gdb

--- a/pwndbg/constants/s390.py
+++ b/pwndbg/constants/s390.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 from .constant import Constant
 
 __NR_exit = Constant('__NR_exit',1)

--- a/pwndbg/constants/s390x.py
+++ b/pwndbg/constants/s390x.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 from .constant import Constant
 
 __NR_exit = Constant('__NR_exit',1)

--- a/pwndbg/constants/sparc.py
+++ b/pwndbg/constants/sparc.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 from .constant import Constant
 
 __NR_exit = Constant('__NR_exit',1)

--- a/pwndbg/constants/sparc64.py
+++ b/pwndbg/constants/sparc64.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 from .constant import Constant
 
 __NR_exit = Constant('__NR_exit',1)

--- a/pwndbg/constants/thumb.py
+++ b/pwndbg/constants/thumb.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 from .constant import Constant
 
 __NR_OABI_SYSCALL_BASE = Constant('__NR_OABI_SYSCALL_BASE',0x900000)

--- a/pwndbg/decorators.py
+++ b/pwndbg/decorators.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import functools
 
 first_prompt = False

--- a/pwndbg/disasm/arch.py
+++ b/pwndbg/disasm/arch.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import gdb
 from capstone import *
 

--- a/pwndbg/disasm/arm.py
+++ b/pwndbg/disasm/arm.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 from capstone import *
 from capstone.arm import *
 

--- a/pwndbg/disasm/jump.py
+++ b/pwndbg/disasm/jump.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 from capstone import CS_GRP_JUMP
 
 import pwndbg.arch

--- a/pwndbg/disasm/x86.py
+++ b/pwndbg/disasm/x86.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 from capstone import *
 from capstone.x86 import *
 

--- a/pwndbg/exception.py
+++ b/pwndbg/exception.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import functools
 import pdb
 import sys

--- a/pwndbg/funcparser.py
+++ b/pwndbg/funcparser.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import collections
 
 from pycparser import CParser

--- a/pwndbg/functions.py
+++ b/pwndbg/functions.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import collections
 
 Function = collections.namedtuple('Function', ('type', 'derefcnt', 'name', 'args'))

--- a/pwndbg/heap/__init__.py
+++ b/pwndbg/heap/__init__.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import pwndbg.heap.heap
 import pwndbg.symbol
 

--- a/pwndbg/heap/heap.py
+++ b/pwndbg/heap/heap.py
@@ -1,7 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
-
 class BaseHeap:
     """Heap abstraction layer."""
 

--- a/pwndbg/heap/ptmalloc.py
+++ b/pwndbg/heap/ptmalloc.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 from collections import OrderedDict
 
 import gdb

--- a/pwndbg/prompt.py
+++ b/pwndbg/prompt.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import gdb
 
 import pwndbg.decorators

--- a/pwndbg/version.py
+++ b/pwndbg/version.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import os
 import subprocess
 

--- a/pwndbg/which.py
+++ b/pwndbg/which.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 # This license covers everything within this project, except for a few pieces
 # of code that we either did not write ourselves or which we derived from code
 # that we did not write ourselves. These few pieces have their license specified

--- a/pwndbg/wrappers/__init__.py
+++ b/pwndbg/wrappers/__init__.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import functools
 import subprocess
 from subprocess import STDOUT

--- a/pwndbg/wrappers/checksec.py
+++ b/pwndbg/wrappers/checksec.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 from subprocess import CalledProcessError
 
 import pwndbg.commands

--- a/pwndbg/wrappers/readelf.py
+++ b/pwndbg/wrappers/readelf.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import pwndbg.wrappers
 
 cmd_name = "readelf"

--- a/tests/test_attachp.py
+++ b/tests/test_attachp.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import codecs
 import os
 import re

--- a/tests/test_loads.py
+++ b/tests/test_loads.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import os
 import re
 


### PR DESCRIPTION
Those lines are redundant in our case: pwndbg is not imported or launched directly.
Also, the coding lines were relevant in Py2 but are not really needed in Py3.