### PR TITLE
Remove Py2 class object inheritance

### DIFF
--- a/docs/gdb/__init__.py
+++ b/docs/gdb/__init__.py
@@ -2,17 +2,17 @@
 import types as _types
 
 ARCH_FRAME = 5
-class Architecture(object): pass
+class Architecture: pass
 BP_ACCESS_WATCHPOINT = 9
 BP_BREAKPOINT = 1
 BP_HARDWARE_WATCHPOINT = 7
 BP_NONE = 0
 BP_READ_WATCHPOINT = 8
 BP_WATCHPOINT = 6
-class Block(object): pass
-class BlockIterator(object): pass
-class Breakpoint(object): pass
-class BreakpointEvent(object): pass
+class Block: pass
+class BlockIterator: pass
+class Breakpoint: pass
+class BreakpointEvent: pass
 COMMAND_BREAKPOINTS = 6
 COMMAND_DATA = 1
 COMMAND_FILES = 3
@@ -31,13 +31,13 @@ COMPLETE_FILENAME = 1
 COMPLETE_LOCATION = 2
 COMPLETE_NONE = 0
 COMPLETE_SYMBOL = 4
-class ClearObjFilesEvent(object): pass
-class Command(object): pass
-class ContinueEvent(object): pass
+class ClearObjFilesEvent: pass
+class Command: pass
+class ContinueEvent: pass
 DUMMY_FRAME = 1
-class Event(object): pass
-class EventRegistry(object): pass
-class ExitedEvent(object): pass
+class Event: pass
+class EventRegistry: pass
+class ExitedEvent: pass
 FRAME_UNWIND_INNER_ID = 4
 FRAME_UNWIND_MEMORY_ERROR = 7
 FRAME_UNWIND_NO_REASON = 0
@@ -46,31 +46,31 @@ FRAME_UNWIND_NULL_ID = 1
 FRAME_UNWIND_OUTERMOST = 2
 FRAME_UNWIND_SAME_ID = 5
 FRAME_UNWIND_UNAVAILABLE = 3
-class Field(object): pass
-class FinishBreakpoint(object): pass
-class Frame(object): pass
+class Field: pass
+class FinishBreakpoint: pass
+class Frame: pass
 FrameDecorator = object() # module 'gdb.FrameDecorator' from '/usr/local/Cellar/gdb/7.12_1/share/gdb/python/gdb/FrameDecorator.pyc'>
 FrameIterator = object() # module 'gdb.FrameIterator' from '/usr/local/Cellar/gdb/7.12_1/share/gdb/python/gdb/FrameIterator.pyc'>
-class Function(object): pass
-class GdbError(object): pass
-class GdbOutputErrorFile(object): pass
-class GdbOutputFile(object): pass
+class Function: pass
+class GdbError: pass
+class GdbOutputErrorFile: pass
+class GdbOutputFile: pass
 def GdbSetPythonDirectory(*a, **kw): pass
 HOST_CONFIG = 'x86_64-apple-darwin16.3.0'
 INLINE_FRAME = 2
-class Inferior(object): pass
-class InferiorCallPostEvent(object): pass
-class InferiorCallPreEvent(object): pass
-class InferiorThread(object): pass
-class LineTable(object): pass
-class LineTableEntry(object): pass
-class LineTableIterator(object): pass
-class Membuf(object): pass
-class MemoryChangedEvent(object): pass
-class MemoryError(object): pass
+class Inferior: pass
+class InferiorCallPostEvent: pass
+class InferiorCallPreEvent: pass
+class InferiorThread: pass
+class LineTable: pass
+class LineTableEntry: pass
+class LineTableIterator: pass
+class Membuf: pass
+class MemoryChangedEvent: pass
+class MemoryError: pass
 NORMAL_FRAME = 0
-class NewObjFileEvent(object): pass
-class Objfile(object): pass
+class NewObjFileEvent: pass
+class Objfile: pass
 PARAM_AUTO_BOOLEAN = 1
 PARAM_BOOLEAN = 0
 PARAM_ENUM = 11
@@ -82,10 +82,10 @@ PARAM_STRING_NOESCAPE = 5
 PARAM_UINTEGER = 2
 PARAM_ZINTEGER = 8
 PYTHONDIR = '/usr/local/Cellar/gdb/7.12_1/share/gdb/python'
-class Parameter(object): pass
-class PendingFrame(object): pass
-class Progspace(object): pass
-class RegisterChangedEvent(object): pass
+class Parameter: pass
+class PendingFrame: pass
+class Progspace: pass
+class RegisterChangedEvent: pass
 SENTINEL_FRAME = 6
 SIGTRAMP_FRAME = 4
 STDERR = 1
@@ -113,11 +113,11 @@ SYMBOL_TYPES_DOMAIN = 2
 SYMBOL_UNDEF_DOMAIN = 0
 SYMBOL_VARIABLES_DOMAIN = 0
 SYMBOL_VAR_DOMAIN = 1
-class SignalEvent(object): pass
-class StopEvent(object): pass
-class Symbol(object): pass
-class Symtab(object): pass
-class Symtab_and_line(object): pass
+class SignalEvent: pass
+class StopEvent: pass
+class Symbol: pass
+class Symtab: pass
+class Symtab_and_line: pass
 TAILCALL_FRAME = 3
 TARGET_CONFIG = 'x86_64-apple-darwin16.3.0'
 TYPE_CODE_ARRAY = 2
@@ -146,16 +146,16 @@ TYPE_CODE_STRUCT = 3
 TYPE_CODE_TYPEDEF = 22
 TYPE_CODE_UNION = 4
 TYPE_CODE_VOID = 10
-class ThreadEvent(object): pass
-class Type(object): pass
-class TypeIterator(object): pass
-class UnwindInfo(object): pass
+class ThreadEvent: pass
+class Type: pass
+class TypeIterator: pass
+class UnwindInfo: pass
 VERSION = '7.12'
-class Value(object): pass
+class Value: pass
 WP_ACCESS = 2
 WP_READ = 1
 WP_WRITE = 0
-class _GdbFile(object): pass
+class _GdbFile: pass
 __doc__ = None
 __file__ = '/usr/local/Cellar/gdb/7.12_1/share/gdb/python/gdb/__init__.pyc'
 __name__ = 'gdb'
@@ -163,7 +163,7 @@ __package__ = 'gdb'
 __path__ = ['/usr/local/Cellar/gdb/7.12_1/share/gdb/python/gdb']
 def auto_load_packages(*a, **kw): pass
 command = object() # module 'gdb.command' from '/usr/local/Cellar/gdb/7.12_1/share/gdb/python/gdb/command/__init__.pyc'>
-class error(object): pass
+class error: pass
 def execute_unwinders(*a, **kw): pass
 frame_filters = {}
 frame_unwinders = []
@@ -180,13 +180,13 @@ types = object() # module 'gdb.types' from '/usr/local/Cellar/gdb/7.12_1/share/g
 
 
 # ===================================
-class Command(object):
+class Command:
     def __init__(self, *a, **kw):
         pass
-class Parameter(object):
+class Parameter:
     def __init__(self, *a, **kw):
         pass
-class _event(object):
+class _event:
     def connect(*a, **kw): pass
 class _events(_types.ModuleType):
     exited = _event()
@@ -200,13 +200,13 @@ class _type():
     def pointer(*a, **kw): return _type()
 def lookup_type(*a, **kw): return _type()
 
-class Value(object):
+class Value:
     def __init__(*a, **kw): pass
     def cast(*a, **kw): return Value()
 
 def execute(*a, **kw): return ''
 
-class Function(object):
+class Function:
     def __init__(*a, **kw): pass
 
 def selected_inferior(): pass

--- a/pwndbg/memory.py
+++ b/pwndbg/memory.py
@@ -366,7 +366,7 @@ def find_lower_boundary(addr, max_pages=1024):
     return addr
 
 
-class Page(object):
+class Page:
     """
     Represents the address space and page permissions of at least
     one page of memory.


### PR DESCRIPTION
The `class T(object):` can just be `class T:` in Py3, so this commit just removes such inheritance.