### PR TITLE
Fix error message on interrupts

### DIFF
--- a/pwndbg/emu/emulator.py
+++ b/pwndbg/emu/emulator.py
@@ -64,7 +64,7 @@ arch_to_CS = {
 DEBUG = False
 
 
-def debug(fmt, args=""):
+def debug(fmt, args=()):
     if DEBUG: print(fmt % args)
 
 

--- a/pwndbg/emu/emulator.py
+++ b/pwndbg/emu/emulator.py
@@ -64,7 +64,7 @@ arch_to_CS = {
 DEBUG = False
 
 
-def debug(fmt, args):
+def debug(fmt, args=""):
     if DEBUG: print(fmt % args)
 
 


### PR DESCRIPTION
On interrupts pwndbg produce this error:

![interrupt error](https://camo.githubusercontent.com/e79580db7d1ef3941dbd9b867126d0f6192b409361098ab6acfb53965b6a5d9c/68747470733a2f2f692e6962622e636f2f425a6a6a5834792f53637265656e73686f742d66726f6d2d323032312d31312d31332d31352d30382d34382e706e67)

This PR fix it