### PR TITLE
Ignore printing vertical tabs in vis_heap_chunks command

### DIFF
--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -648,7 +648,7 @@ def vis_heap_chunks(addr=None, count=None, naive=None):
 
 def bin_ascii(bs):
     from string import printable
-    valid_chars = list(map(ord, set(printable) - set('\t\r\n\x0c')))
+    valid_chars = list(map(ord, set(printable) - set('\t\r\n\x0c\x0b')))
     return ''.join(chr(c) if c in valid_chars else '.'for c in bs)
 
 


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/19514368/143084071-fc3e3170-1e06-4ffb-a23a-09ca8ed95fe6.png)


After fix:
![image](https://user-images.githubusercontent.com/19514368/143084088-969d41cf-caef-4cc2-bf23-a5c18d7a2d81.png)
