### PR TITLE
Added development container configuration for VS Code (Remote Container)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,18 @@
+{
+	"name": "pwndbg",
+	"build": {
+		"context": "..",
+		"dockerfile": "../Dockerfile"
+	},
+	"runArgs": [
+		"--cap-add=SYS_PTRACE",
+		"--security-opt",
+		"seccomp=unconfined"
+	],
+	"workspaceFolder": "/pwndbg",
+	"workspaceMount": "source=${localWorkspaceFolder},target=/pwndbg,type=bind,consistency=cached",
+	"settings": {},
+	"extensions": [
+		"ms-python.python"
+	]
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,9 +5,9 @@
 		"dockerfile": "../Dockerfile"
 	},
 	"runArgs": [
-		"--cap-add=SYS_PTRACE",
-		"--security-opt",
-		"seccomp=unconfined"
+		"--security-opt=no-new-privileges:true",
+		"--cap-drop=ALL",
+		"--cap-add=SYS_PTRACE"
 	],
 	"workspaceFolder": "/pwndbg",
 	"workspaceMount": "source=${localWorkspaceFolder},target=/pwndbg,type=bind,consistency=cached",


### PR DESCRIPTION
Provides .devcontainer configuration to directly develop pwndbg inside Docker container.
This configuration file is used by the Remote Container extension in VS Code to directly start the IDE inside the Docker container and install the dependencies.

Usage:
- Open VS Code and have the Remote Container extension installed.
- Run the command `Remote-Containers: Reopen folder in Container` and wait.
- Open a console with Ctrl + Shift + Backtick and start gdb.
- Done.