### PR TITLE
Added line to source gdbinit & setup.sh blurb for endeavourOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Installation is straightforward.  Pwndbg is best supported on Ubuntu 18.04 with 
 git clone https://github.com/pwndbg/pwndbg
 cd pwndbg
 ./setup.sh
+echo "source $(pwd)/gdbinit.py" >> ~/.gdbinit
 ```
 
 Other Linux distributions are also supported via `setup.sh`, including:

--- a/setup.sh
+++ b/setup.sh
@@ -91,6 +91,12 @@ if linux; then
             echo " - https://aur.archlinux.org/packages/pwndbg-git/"
             exit 1
             ;;
+        "endeavouros")
+            echo "Install pwndbg using a community package. See:"
+            echo " - https://www.archlinux.org/packages/community/any/pwndbg/"
+            echo " - https://aur.archlinux.org/packages/pwndbg-git/"
+            exit 1
+            ;;
         "manjaro")
             echo "Pwndbg is not available on Manjaro's repositories."
             echo "But it can be installed using Arch's AUR community package. See:"


### PR DESCRIPTION
- I had some issues installing this because I didn't realise we had to source the ``gdbinit.py`` file into the ``.gdbinit``. I added a line that does that.
- Little blurb that tells you what to do to install on EndeavourOS, it is identical to the arch installation procedure
