### PR TITLE
Fixed functionality in setup.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Installation is straightforward.  Pwndbg is best supported on Ubuntu 18.04 with 
 git clone https://github.com/pwndbg/pwndbg
 cd pwndbg
 ./setup.sh
+echo "source $(pwd)/gdbinit.py" >> ~/.gdbinit
 ```
 
 Other Linux distributions are also supported via `setup.sh`, including:

--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ Installation is straightforward.  Pwndbg is best supported on Ubuntu 18.04 with 
 git clone https://github.com/pwndbg/pwndbg
 cd pwndbg
 ./setup.sh
-echo "source $(pwd)/gdbinit.py" >> ~/.gdbinit
 ```
 
 Other Linux distributions are also supported via `setup.sh`, including:

--- a/setup.sh
+++ b/setup.sh
@@ -91,6 +91,12 @@ if linux; then
             echo " - https://aur.archlinux.org/packages/pwndbg-git/"
             exit 1
             ;;
+        "endeavouros")
+            echo "Install pwndbg using a community package. See:"
+            echo " - https://www.archlinux.org/packages/community/any/pwndbg/"
+            echo " - https://aur.archlinux.org/packages/pwndbg-git/"
+            exit 1
+            ;;
         "manjaro")
             echo "Pwndbg is not available on Manjaro's repositories."
             echo "But it can be installed using Arch's AUR community package. See:"

--- a/setup.sh
+++ b/setup.sh
@@ -10,11 +10,6 @@ if ! hash sudo 2>/dev/null && whoami | grep root; then
     }
 fi
 
-# Load Pwndbg into GDB on every launch.
-if ! grep pwndbg ~/.gdbinit &>/dev/null; then
-    echo "source $PWD/gdbinit.py" >> ~/.gdbinit
-fi
-
 # Helper functions
 linux() {
     uname | grep -i Linux &>/dev/null
@@ -164,3 +159,8 @@ ${PYTHON} -m pip install ${INSTALLFLAGS} --upgrade pip
 
 # Install Python dependencies
 ${PYTHON} -m pip install ${INSTALLFLAGS} -Ur requirements.txt
+
+# Load Pwndbg into GDB on every launch.
+if ! grep pwndbg ~/.gdbinit &>/dev/null; then
+    echo "source $PWD/gdbinit.py" >> ~/.gdbinit
+fi

--- a/setup.sh
+++ b/setup.sh
@@ -10,6 +10,11 @@ if ! hash sudo 2>/dev/null && whoami | grep root; then
     }
 fi
 
+# Load Pwndbg into GDB on every launch.
+if ! grep pwndbg ~/.gdbinit &>/dev/null; then
+    echo "source $PWD/gdbinit.py" >> ~/.gdbinit
+fi
+
 # Helper functions
 linux() {
     uname | grep -i Linux &>/dev/null
@@ -159,8 +164,3 @@ ${PYTHON} -m pip install ${INSTALLFLAGS} --upgrade pip
 
 # Install Python dependencies
 ${PYTHON} -m pip install ${INSTALLFLAGS} -Ur requirements.txt
-
-# Load Pwndbg into GDB on every launch.
-if ! grep pwndbg ~/.gdbinit &>/dev/null; then
-    echo "source $PWD/gdbinit.py" >> ~/.gdbinit
-fi


### PR DESCRIPTION
sorry for all the PR's.
in my last PR we added a line to source ``gdbinit.py`` but it was pointed out that it is already done in the ``setup.sh``, i looked at the setup file and realised that the source command is not added since the script prematurely exits with ``exit 1`` when its a non supported distro. By moving this block to the top, before any exit's are called, we remove this issue and the source command will **always** be added to the users ``.gdbinit``

- ToBeatElite