### PR TITLE
Ignore non utf-8 characters in the source code

### DIFF
--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -459,7 +459,7 @@ theme.Parameter('code-prefix', '►', "prefix marker for 'context code' command"
 @pwndbg.memoize.reset_on_start
 def get_highlight_source(filename):
     # Notice that the code is cached
-    with open(filename, encoding='utf-8') as f:
+    with open(filename, encoding='utf-8', errors='ignore') as f:
         source = f.read()
 
     if pwndbg.config.syntax_highlight:


### PR DESCRIPTION
If the source code contains some non utf-8 characters, there will be an exception.

e.g.:

```
Exception occurred: context: 'utf-8' codec can't decode byte 0xd4 in position 52951: invalid continuation byte (<class 'UnicodeDecodeError'>)
```

We don't know the correct encoding, but we can ignore it.

If someone finds out that the source code is messed up, they will just ignore it or change the encoding to utf-8.