### PR TITLE
Make pwndbg faster

### DIFF
--- a/pwndbg/memoize.py
+++ b/pwndbg/memoize.py
@@ -144,7 +144,6 @@ class reset_on_start(memoize):
     kind   = 'start'
 
     @staticmethod
-    @pwndbg.events.stop
     @pwndbg.events.start
     def __reset_on_start():
         for obj in reset_on_start.caches:

--- a/pwndbg/memory.py
+++ b/pwndbg/memory.py
@@ -322,6 +322,7 @@ assert round_down(0xdeadbeef, 0x1000) == 0xdeadb000
 assert round_up(0xdeadbeef, 0x1000)   == 0xdeadc000
 
 
+@pwndbg.memoize.reset_on_stop
 def find_upper_boundary(addr, max_pages=1024):
     """find_upper_boundary(addr, max_pages=1024) -> int
 
@@ -347,6 +348,7 @@ def find_upper_boundary(addr, max_pages=1024):
     return addr
 
 
+@pwndbg.memoize.reset_on_stop
 def find_lower_boundary(addr, max_pages=1024):
     """find_lower_boundary(addr, max_pages=1024) -> int
 


### PR DESCRIPTION
> BTW, Why `memoize.__reset_on_start` will be invoked by `stop` event? The stop event of `gdb` will be trigger when the inferior has stopped. That is, it will be trigger when gdb stops the inferior and change the control back to you. So, `memoize.reset_on_start` cache will be reset when you use some commands like `si`, `continue`. Is this behavior what you want?

_Originally posted by @cebrusfs in https://github.com/pwndbg/pwndbg/issues/87_