### PR TITLE
Try with lowercase xpsr register first on ARM Cortex M/gdb 8+

### DIFF
--- a/pwndbg/regs.py
+++ b/pwndbg/regs.py
@@ -282,9 +282,9 @@ class module(ModuleType):
                 value = gdb77_get_register(attr)
                 value = value.cast(pwndbg.typeinfo.uint32)
             else:
-                if attr.lower() == 'xpsr':
-                    attr = 'xPSR'
                 value = get_register(attr)
+                if value is None and attr.lower() == 'xpsr':
+                    value = get_register('xPSR')
                 size = pwndbg.typeinfo.unsigned.get(value.type.sizeof, pwndbg.typeinfo.ulong)
                 value = value.cast(size)
                 if attr.lower() == 'pc' and pwndbg.arch.current == 'i8086':


### PR DESCRIPTION
Running 'context' fails when debugging an armcm arch as it fails to find the xpsr register.

[#264 mentions this](https://github.com/pwndbg/pwndbg/issues/264#issuecomment-739421512) on gdb 8, but I can confirm the same on gdb 10 as well.

Looking at the source, xpsr is special-handled, which is probably a compatibility hack. The register name is lowercase.
With this change, attempt to use xPSR as a fallback only if "xpsr" fails.