### PR TITLE
Fix two bugs in /pwndbg/commands/context.py

### DIFF
--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -137,6 +137,8 @@ parser.add_argument("banner", type=str, nargs='?', default="both", help="Where a
 parser.add_argument("width", type=int, nargs='?', default=None, help="Sets a fixed width (used for banner). Set to None for auto")
 @pwndbg.commands.ArgparsedCommand(parser, aliases=['ctx-out'])
 def contextoutput(section, path, clearing, banner="both", width=None):
+    if(width != None):
+        width = int(width.cast(gdb.lookup_type('long')))
     outputs[section] = path
     output_settings[section] = dict(clearing=clearing,
                                     width=width,

--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -137,7 +137,7 @@ parser.add_argument("banner", type=str, nargs='?', default="both", help="Where a
 parser.add_argument("width", type=int, nargs='?', default=None, help="Sets a fixed width (used for banner). Set to None for auto")
 @pwndbg.commands.ArgparsedCommand(parser, aliases=['ctx-out'])
 def contextoutput(section, path, clearing, banner="both", width=None):
-    if(width != None):
+    if width is not None:
         width = int(width.cast(gdb.lookup_type('long')))
     outputs[section] = path
     output_settings[section] = dict(clearing=clearing,

--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -133,12 +133,14 @@ parser.description = "Sets the output of a context section."
 parser.add_argument("section", type=str, help="The section which is to be configured. ('regs', 'disasm', 'code', 'stack', 'backtrace', and/or 'args')")
 parser.add_argument("path", type=str, help="The path to which the output is written")
 parser.add_argument("clearing", type=bool, help="Indicates weather to clear the output")
-parser.add_argument("banner", type=str, nargs='?', default="both", help="Where a banner should be placed: both, top , bottom, none")
+banner_arg = parser.add_argument("banner", type=str, nargs='?', default="both", help="Where a banner should be placed: both, top , bottom, none")
 parser.add_argument("width", type=int, nargs='?', default=None, help="Sets a fixed width (used for banner). Set to None for auto")
 @pwndbg.commands.ArgparsedCommand(parser, aliases=['ctx-out'])
 def contextoutput(section, path, clearing, banner="both", width=None):
+    if banner not in ('both', 'top', 'bottom', 'none'):
+        raise argparse.ArgumentError(banner_arg, f"banner can not be '{banner}'")
     if width is not None:
-        width = int(width.cast(gdb.lookup_type('long')))
+        width = int(width)
     outputs[section] = path
     output_settings[section] = dict(clearing=clearing,
                                     width=width,

--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -133,8 +133,8 @@ parser.description = "Sets the output of a context section."
 parser.add_argument("section", type=str, help="The section which is to be configured. ('regs', 'disasm', 'code', 'stack', 'backtrace', and/or 'args')")
 parser.add_argument("path", type=str, help="The path to which the output is written")
 parser.add_argument("clearing", type=bool, help="Indicates weather to clear the output")
-parser.add_argument("banner", type=str, default="both", help="Where a banner should be placed: both, top , bottom, none")
-parser.add_argument("width", type=int, default=None, help="Sets a fixed width (used for banner). Set to None for auto")
+parser.add_argument("banner", type=str, nargs='?', default="both", help="Where a banner should be placed: both, top , bottom, none")
+parser.add_argument("width", type=int, nargs='?', default=None, help="Sets a fixed width (used for banner). Set to None for auto")
 @pwndbg.commands.ArgparsedCommand(parser, aliases=['ctx-out'])
 def contextoutput(section, path, clearing, banner="both", width=None):
     outputs[section] = path


### PR DESCRIPTION
1. Without nargs='?' parameter:
The default values banner="both" and width=None will not take effect.

2. The parameter *width* in function *contextoutput* in ui.py has wrong type, which will cause operand types conflict if we pass a integer to width manually:
```
Traceback (most recent call last):
  File "/home/zkv/Softwares/pwndbg/pwndbg/commands/__init__.py", line 131, in __call__
    return self.function(*args, **kwargs)
  File "/home/zkv/Softwares/pwndbg/pwndbg/commands/__init__.py", line 225, in _OnlyWhenRunning
    return function(*a, **kw)
  File "/home/zkv/Softwares/pwndbg/pwndbg/commands/context.py", line 266, in context
    result[target].extend(func(target=out,
  File "/home/zkv/Softwares/pwndbg/pwndbg/commands/context.py", line 554, in context_stack
    result = [pwndbg.ui.banner("stack", target=target, width=width)] if with_banner else []
  File "/home/zkv/Softwares/pwndbg/pwndbg/ui.py", line 47, in banner
    banner = rjust_colored(title, (width + len(strip(title))) // 2, config.banner_separator)
TypeError: unsupported operand type(s) for //: 'gdb.Value' and 'int'
```