### PR TITLE
Display symbol name for computed disasm address

### DIFF
--- a/pwndbg/color/disasm.py
+++ b/pwndbg/color/disasm.py
@@ -67,8 +67,11 @@ def instruction(ins):
             # XXX: not sure when this ever happens
             asm += '<-- file a pwndbg bug for this'
         else:
-            asm = asm.replace(hex(ins.symbol_addr), ins.symbol)
-            asm = '%s <%s>' % (ljust_colored(asm, 36), M.get(ins.symbol_addr))
+            inlined_sym = asm.replace(hex(ins.symbol_addr), ins.symbol)
+
+            # display symbol as mem text if no inline replacement was made
+            mem_text = ins.symbol if inlined_sym == asm else None
+            asm = '%s <%s>' % (ljust_colored(inlined_sym, 36), M.get(ins.symbol_addr, mem_text))
 
     # Style the instruction mnemonic if it's a branch instruction.
     if is_branch:


### PR DESCRIPTION
Before this change the computed addresses (typically rip-related)
in disasm output were always disaplyed numerically.

After this change - if the address inside instruction is not literal
but computed and wasn't directly substituted inside instruction
it is disaplyed symbolically instead of numerically.

Example - note the change for relative-addressed VARX variable

Before:
```
   0x441d23 <main+80217>    call   FileRead                      <FileRead>

   0x441d28 <main+80222>    sar    eax, 0x16
   0x441d2b <main+80225>    and    eax, 1
   0x441d2e <main+80228>    mov    dword ptr [rbp - 0x154], eax
   0x441d34 <main+80234>    mov    esi, 0x467435
   0x441d39 <main+80239>    mov    edi, VAR_AB                   <0x681dc8>
   0x441d3e <main+80244>    call   strstr@plt                      <strstr@plt>

   0x441d43 <main+80249>    test   rax, rax
   0x441d46 <main+80252>    je     main+80289                      <main+80289>

   0x441d48 <main+80254>    mov    eax, dword ptr [rip + 0x22e6fe] <0x67044c>
   0x441d4e <main+80260>    cmp    eax, 0x60
   0x441d51 <main+80263>    setne  al
   0x441d54 <main+80266>    movzx  eax, al
   0x441d57 <main+80269>    mov    dword ptr [rbp - 0x150], eax
   0x441d5d <main+80275>    mov    eax, dword ptr [rbp - 0x150]
   0x441d63 <main+80281>    mov    dword ptr [rbp - 0x144], eax
   0x441d69 <main+80287>    jmp    main+80309                      <main+80309>

   0x441d6b <main+80289>    mov    dword ptr [rbp - 0x144], 0
   0x441d75 <main+80299>    mov    dword ptr [rbp - 0x150], 1
   0x441d7f <main+80309>    mov    edi, 0x467448
   0x441d84 <main+80314>    call   puts@plt                      <puts@plt>
```

After:
```
   0x441d23 <main+80217>    call   FileRead                      <FileRead>

   0x441d28 <main+80222>    sar    eax, 0x16
   0x441d2b <main+80225>    and    eax, 1
   0x441d2e <main+80228>    mov    dword ptr [rbp - 0x154], eax
   0x441d34 <main+80234>    mov    esi, 0x467435
   0x441d39 <main+80239>    mov    edi, VAR_AB                   <0x681dc8>
   0x441d3e <main+80244>    call   strstr@plt                      <strstr@plt>

   0x441d43 <main+80249>    test   rax, rax
   0x441d46 <main+80252>    je     main+80289                      <main+80289>

   0x441d48 <main+80254>    mov    eax, dword ptr [rip + 0x22e6fe] <VARX>
   0x441d4e <main+80260>    cmp    eax, 0x60
   0x441d51 <main+80263>    setne  al
   0x441d54 <main+80266>    movzx  eax, al
   0x441d57 <main+80269>    mov    dword ptr [rbp - 0x150], eax
   0x441d5d <main+80275>    mov    eax, dword ptr [rbp - 0x150]
   0x441d63 <main+80281>    mov    dword ptr [rbp - 0x144], eax
   0x441d69 <main+80287>    jmp    main+80309                      <main+80309>

   0x441d6b <main+80289>    mov    dword ptr [rbp - 0x144], 0
   0x441d75 <main+80299>    mov    dword ptr [rbp - 0x150], 1
   0x441d7f <main+80309>    mov    edi, 0x467448
   0x441d84 <main+80314>    call   puts@plt                      <puts@plt>
```

Note - gdb 11.2 `disassembly` for same code already includes symbolic name:
```
   0x0000000000441d23 <+80217>: call   0x4021a5 <FileRead>
   0x0000000000441d28 <+80222>: sar    eax,0x16
   0x0000000000441d2b <+80225>: and    eax,0x1
   0x0000000000441d2e <+80228>: mov    DWORD PTR [rbp-0x154],eax
   0x0000000000441d34 <+80234>: mov    esi,0x467435
   0x0000000000441d39 <+80239>: mov    edi,0x681dc8
   0x0000000000441d3e <+80244>: call   0x4012d0 <strstr@plt>
   0x0000000000441d43 <+80249>: test   rax,rax
   0x0000000000441d46 <+80252>: je     0x441d6b <main+80289>
   0x0000000000441d48 <+80254>: mov    eax,DWORD PTR [rip+0x22e6fe]        # 0x67044c <VARX>
   0x0000000000441d4e <+80260>: cmp    eax,0x60
   0x0000000000441d51 <+80263>: setne  al
   0x0000000000441d54 <+80266>: movzx  eax,al
   0x0000000000441d57 <+80269>: mov    DWORD PTR [rbp-0x150],eax
   0x0000000000441d5d <+80275>: mov    eax,DWORD PTR [rbp-0x150]
   0x0000000000441d63 <+80281>: mov    DWORD PTR [rbp-0x144],eax
   0x0000000000441d69 <+80287>: jmp    0x441d7f <main+80309>
   0x0000000000441d6b <+80289>: mov    DWORD PTR [rbp-0x144],0x0
   0x0000000000441d75 <+80299>: mov    DWORD PTR [rbp-0x150],0x1
   0x0000000000441d7f <+80309>: mov    edi,0x467448
   0x0000000000441d84 <+80314>: call   0x401020 <puts@plt>
```