### PR TITLE
fix splitmind compatibility issues from PR #1012

### DIFF
--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -137,6 +137,8 @@ banner_arg = parser.add_argument("banner", type=str, nargs='?', default="both", 
 parser.add_argument("width", type=int, nargs='?', default=None, help="Sets a fixed width (used for banner). Set to None for auto")
 @pwndbg.commands.ArgparsedCommand(parser, aliases=['ctx-out'])
 def contextoutput(section, path, clearing, banner="both", width=None):
+    if not banner:  # synonym for splitmind backwards compatibility
+        banner = 'none'
     if banner not in ('both', 'top', 'bottom', 'none'):
         raise argparse.ArgumentError(banner_arg, f"banner can not be '{banner}'")
     if width is not None:


### PR DESCRIPTION
PR #1012 added a check for `banner`, which introduced a compatibility issue with splitmind.

[e9b9ebe36480a535de4ae516a5dad608d889349d](https://github.com/pwndbg/pwndbg/commit/e9b9ebe36480a535de4ae516a5dad608d889349d) adds a check, which combined with the [Pwndbg mind `nobanner` arg](https://github.com/jerdna-regeiz/splitmind/blob/master/README.md#pwndbg), [specifically this line](https://github.com/jerdna-regeiz/splitmind/blob/a95b50f308f6e78b15c1fae9ed11239a6b70bdb7/splitmind/thinker/pwndbg.py#L28), results in a mismatch in expectations regarding `banner`. In my case this resulted in errors like:

```
Traceback (most recent call last):
  File "/opt/pwndbg/pwndbg/commands/__init__.py", line 131, in __call__
    return self.function(*args, **kwargs)
  File "/opt/pwndbg/pwndbg/commands/context.py", line 141, in contextoutput
    raise argparse.ArgumentError(banner_arg, f"banner can not be '{banner}'")
argparse.ArgumentError: argument banner: banner can not be 'False'
```

I thought about submitting a fix to splitmind, but since this behavior has been around since 2020, I figure it's easiest to maintain backwards compatibility by changing pwndbg. Otherwise there would be a new version dependency between pwndbg and splitmind.