### PR TITLE
Add support to use heap commands without debug symbols

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -228,7 +228,7 @@ contextmanager-decorators=contextlib.contextmanager
 # List of members which are set dynamically and missed by pylint inference
 # system, and so shouldn't trigger E1101 when accessed. Python regular
 # expressions are accepted.
-generated-members=
+generated-members=pwndbg.typeinfo.*
 
 # Tells whether missing members accessed in mixin class should be ignored. A
 # class is considered mixin if its name matches the mixin-class-rgx option.
@@ -533,6 +533,8 @@ known-third-party=enchant
 # Couples of modules and preferred modules, separated by a comma.
 preferred-modules=
 
+# Ignore `Unable to import 'gdb' (import-error)`
+ignored-modules=gdb
 
 [CLASSES]
 
@@ -551,7 +553,10 @@ exclude-protected=_asdict,
                   _fields,
                   _replace,
                   _source,
-                  _make
+                  _make,
+                  _fields_,
+                  _type_,
+                  _length_
 
 # List of valid names for the first argument in a class method.
 valid-classmethod-first-arg=cls

--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -256,10 +256,10 @@ def OnlyAmd64(function):
             print("%s: Only works with \"x86-64\" arch." % function.__name__)
     return _OnlyAmd64
 
-def OnlyWithLibcDebugSyms(function):
+def OnlyWithResolvedHeapSyms(function):
     @functools.wraps(function)
-    def _OnlyWithLibcDebugSyms(*a, **kw):
-        if pwndbg.heap.current.libc_has_debug_syms() or pwndbg.config.resolve_via_heuristic:
+    def _OnlyWithResolvedHeapSyms(*a, **kw):
+        if pwndbg.heap.current.libc_has_debug_syms() or pwndbg.config.resolve_heap_via_heuristic:
             return function(*a, **kw)
         else:
             print('''%s: This command only works with libc debug symbols.
@@ -271,9 +271,10 @@ sudo apt-get install libc6-dbg
 sudo dpkg --add-architecture i386
 sudo apt-get install libc-dbg:i386
 ''' % function.__name__)
-            print(message.warn('pwndbg can still try to use this command without debug symbols by `set resolve-via-heuristic on`.'))
-            print(message.warn("Then pwndbg will resolve some missing symbols via heuristics, but the result of those commands may be incorrect in some cases."))
-    return _OnlyWithLibcDebugSyms
+            print(message.warn('pwndbg can still try to use this command without debug symbols by `set resolve-heap-via-heuristic on`.'))
+            print(message.warn('You can show your current config about heap by `heap_config`.'))
+            print(message.warn("Then pwndbg will resolve some missing symbols via heuristics, but the results of those commands may be incorrect in some cases."))
+    return _OnlyWithResolvedHeapSyms
 
 class QuietSloppyParsedCommand(ParsedCommand):
     def __init__(self, *a, **kw):

--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -259,7 +259,7 @@ def OnlyAmd64(function):
 def OnlyWithLibcDebugSyms(function):
     @functools.wraps(function)
     def _OnlyWithLibcDebugSyms(*a, **kw):
-        if pwndbg.heap.current.libc_has_debug_syms():
+        if pwndbg.heap.current.libc_has_debug_syms() or pwndbg.config.resolve_via_heuristic:
             return function(*a, **kw)
         else:
             print('''%s: This command only works with libc debug symbols.
@@ -271,6 +271,8 @@ sudo apt-get install libc6-dbg
 sudo dpkg --add-architecture i386
 sudo apt-get install libc-dbg:i386
 ''' % function.__name__)
+            print(message.warn('pwndbg can still try to use this command without debug symbols by `set resolve-via-heuristic on`.'))
+            print(message.warn("Then pwndbg will resolve some missing symbols via heuristics, but the result of those commands may be incorrect in some cases."))
     return _OnlyWithLibcDebugSyms
 
 class QuietSloppyParsedCommand(ParsedCommand):

--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -9,6 +9,7 @@ import gdb
 import pwndbg.color.context as C
 import pwndbg.color.memory as M
 import pwndbg.commands
+import pwndbg.config
 import pwndbg.glibc
 import pwndbg.typeinfo
 from pwndbg.color import generateColorFunction
@@ -24,7 +25,10 @@ def read_chunk(addr):
         "mchunk_size": "size",
         "mchunk_prev_size": "prev_size",
     }
-    val = pwndbg.typeinfo.read_gdbvalue("struct malloc_chunk", addr)
+    if not pwndbg.config.resolve_via_heuristic:
+        val = pwndbg.typeinfo.read_gdbvalue("struct malloc_chunk", addr)
+    else:
+        val = pwndbg.heap.current.malloc_chunk(addr)
     return dict({ renames.get(key, key): int(val[key]) for key in val.type.keys() })
 
 

--- a/pwndbg/heap/__init__.py
+++ b/pwndbg/heap/__init__.py
@@ -1,5 +1,5 @@
-import pwndbg.config
 import pwndbg.color.message as message
+import pwndbg.config
 import pwndbg.heap.heap
 import pwndbg.symbol
 
@@ -7,19 +7,23 @@ current = None
 
 heap_chain_limit = pwndbg.config.Parameter('heap-dereference-limit', 8, 'number of bins to dereference')
 
-resolve_via_heuristic = pwndbg.config.Parameter('resolve-via-heuristic', False, 'Resolve some missing symbols via heuristics')
+resolve_via_heuristic = pwndbg.config.Parameter('resolve-via-heuristic', False,
+                                                'Resolve some missing symbols via heuristics')
+
 
 @pwndbg.events.start
 def update():
     resolve_heap(is_first_run=True)
 
+
 @pwndbg.events.stop
 @pwndbg.events.new_objfile
-def clear():
+def reset():
     global current
     # Re-initialize the heap
     if current:
         current = type(current)()
+
 
 @pwndbg.config.Trigger([resolve_via_heuristic])
 def resolve_heap(is_first_run=False):
@@ -28,7 +32,10 @@ def resolve_heap(is_first_run=False):
     if resolve_via_heuristic:
         current = pwndbg.heap.ptmalloc.HeuristicHeap()
         if not is_first_run and pwndbg.proc.alive and current.libc_has_debug_syms():
-            print(message.warn("You are going to resolve the heap via heuristic even though you have libc debug symbols. This is not recommended!"))
+            print(message.warn(
+                "You are going to resolve the heap via heuristic even though you have libc debug symbols."
+                " This is not recommended!")
+            )
         else:
             print(message.warn("You are going to resolve the heap via heuristic. This might not work in all cases."))
     else:

--- a/pwndbg/heap/__init__.py
+++ b/pwndbg/heap/__init__.py
@@ -10,6 +10,43 @@ heap_chain_limit = pwndbg.config.Parameter('heap-dereference-limit', 8, 'number 
 resolve_via_heuristic = pwndbg.config.Parameter('resolve-via-heuristic', False,
                                                 'Resolve some missing symbols via heuristics')
 
+main_arena = pwndbg.config.Parameter('main_arena', "0", 'main_arena address for heuristics')
+
+thread_arena = pwndbg.config.Parameter('thread_arena', "0", 'thread_arena value for heuristics')
+
+mp_ = pwndbg.config.Parameter('mp_', "0", 'mp_ address for heuristics')
+
+tcache = pwndbg.config.Parameter('tcache', "0", 'tcache value for heuristics')
+
+global_max_fast = pwndbg.config.Parameter('global_max_fast', "0", 'global_max_fast address for heuristics')
+
+symbol_list = [main_arena, thread_arena, mp_, tcache, global_max_fast]
+
+
+@pwndbg.config.Trigger(symbol_list)
+def parse_config2address():
+    # Somehow, we can't use integer config because the integer is too big and will cause out of range error for GDB API
+    # So we convert the string to a int manually
+    for symbol in symbol_list:
+        if not isinstance(symbol.value, str):
+            continue
+        address_str = symbol.value.strip()
+        if address_str == "0":
+            continue
+        try:
+            if address_str.startswith("0b"):
+                address = int(address_str, 2)
+            elif address_str.startswith("0o"):
+                address = int(address_str, 8)
+            elif address_str.startswith("0x"):
+                address = int(address_str, 16)
+            else:
+                address = int(address_str)
+        except ValueError:
+            symbol.value = "0"
+            raise ValueError("Please input a valid integer literal string")
+        symbol.value = address
+
 
 @pwndbg.events.start
 def update():
@@ -23,6 +60,8 @@ def reset():
     # Re-initialize the heap
     if current:
         current = type(current)()
+    for symbol in symbol_list:
+        symbol.value = "0"
 
 
 @pwndbg.config.Trigger([resolve_via_heuristic])

--- a/pwndbg/heap/__init__.py
+++ b/pwndbg/heap/__init__.py
@@ -1,3 +1,5 @@
+import pwndbg.config
+import pwndbg.color.message as message
 import pwndbg.heap.heap
 import pwndbg.symbol
 
@@ -5,8 +7,21 @@ current = None
 
 heap_chain_limit = pwndbg.config.Parameter('heap-dereference-limit', 8, 'number of bins to dereference')
 
+resolve_via_heuristic = pwndbg.config.Parameter('resolve-via-heuristic', False, 'Resolve some missing symbols via heuristics')
+
 @pwndbg.events.start
 def update():
+    resolve_heap(is_first_run=True)
+
+@pwndbg.config.Trigger([resolve_via_heuristic])
+def resolve_heap(is_first_run=False):
     import pwndbg.heap.ptmalloc
     global current
-    current = pwndbg.heap.ptmalloc.Heap()
+    if pwndbg.config.resolve_via_heuristic:
+        current = pwndbg.heap.ptmalloc.HeuristicHeap()
+        if not is_first_run and pwndbg.proc.alive and current.libc_has_debug_syms():
+            print(message.warn("You are going to resolve the heap via heuristic even though you have libc debug symbols. This is not recommended!"))
+        else:
+            print(message.warn("You are going to resolve the heap via heuristic. This might not work in all cases."))
+    else:
+        current = pwndbg.heap.ptmalloc.DebugSymsHeap()

--- a/pwndbg/heap/__init__.py
+++ b/pwndbg/heap/__init__.py
@@ -13,11 +13,19 @@ resolve_via_heuristic = pwndbg.config.Parameter('resolve-via-heuristic', False, 
 def update():
     resolve_heap(is_first_run=True)
 
+@pwndbg.events.stop
+@pwndbg.events.new_objfile
+def clear():
+    global current
+    # Re-initialize the heap
+    if current:
+        current = type(current)()
+
 @pwndbg.config.Trigger([resolve_via_heuristic])
 def resolve_heap(is_first_run=False):
     import pwndbg.heap.ptmalloc
     global current
-    if pwndbg.config.resolve_via_heuristic:
+    if resolve_via_heuristic:
         current = pwndbg.heap.ptmalloc.HeuristicHeap()
         if not is_first_run and pwndbg.proc.alive and current.libc_has_debug_syms():
             print(message.warn("You are going to resolve the heap via heuristic even though you have libc debug symbols. This is not recommended!"))

--- a/pwndbg/heap/__init__.py
+++ b/pwndbg/heap/__init__.py
@@ -23,24 +23,6 @@ resolve_heap_via_heuristic = pwndbg.config.Parameter('resolve-heap-via-heuristic
                                                      'Resolve missing heap related symbols via heuristics', 'heap')
 
 
-@pwndbg.config.Trigger(symbol_list)
-def parse_config2address():
-    # Somehow, we can't use integer config because the integer is too big and will cause out of range error for GDB API
-    # So we convert the string to a int manually
-    for symbol in symbol_list:
-        if not isinstance(symbol.value, str):
-            continue
-        address_str = symbol.value.strip()
-        if address_str == "0":
-            continue
-        try:
-            address = int(address_str, 0)
-        except ValueError:
-            symbol.value = "0"
-            raise ValueError("Please input a valid integer literal string")
-        symbol.value = address
-
-
 @pwndbg.events.start
 def update():
     resolve_heap(is_first_run=True)

--- a/pwndbg/heap/ptmalloc.py
+++ b/pwndbg/heap/ptmalloc.py
@@ -5,6 +5,7 @@ from functools import wraps
 import gdb
 
 import pwndbg.color.memory as M
+import pwndbg.config
 import pwndbg.disasm
 import pwndbg.events
 import pwndbg.glibc
@@ -672,6 +673,9 @@ class HeuristicHeap(Heap):
 
     @property
     def main_arena(self):
+        main_arena_via_config = int(pwndbg.config.main_arena)
+        if main_arena_via_config > 0:
+            return self.malloc_state(main_arena_via_config)
         # TODO/FIXME: These are quite dirty, we should find a better way to do this
         if not self._main_arena_addr:
             if pwndbg.glibc.get_version() < (2, 34) and pwndbg.arch.current != "arm":
@@ -766,6 +770,9 @@ class HeuristicHeap(Heap):
 
     @property
     def thread_arena(self):
+        thread_arena_via_config = int(pwndbg.config.thread_arena)
+        if thread_arena_via_config > 0:
+            return thread_arena_via_config
         if not self._thread_arena_offset:
             # TODO/FIXME: This method should be updated if we find a better way to find the target assembly code
             __libc_calloc_instruction = pwndbg.disasm.near(pwndbg.symbol.address('__libc_calloc'), 100,
@@ -849,6 +856,9 @@ class HeuristicHeap(Heap):
         """Locate a thread's tcache struct. If it doesn't have one, use the main
         thread's tcache.
         """
+        thread_cache_via_config = int(pwndbg.config.tcache)
+        if thread_cache_via_config > 0:
+            return self.tcache_perthread_struct(thread_cache_via_config)
         if self.has_tcache():
             if not self._thread_cache_offset:
                 # TODO/FIXME: This method should be updated if we find a better way to find the target assembly code
@@ -982,6 +992,9 @@ class HeuristicHeap(Heap):
 
     @property
     def mp(self):
+        mp_via_config = int(pwndbg.config.mp_)
+        if mp_via_config > 0:
+            return self.malloc_par(mp_via_config)
         if not self._mp_addr:
             # try to find mp_ referenced in __libc_free
             # TODO/FIXME: This method should be updated if we find a better way to find the target assembly code
@@ -1103,6 +1116,9 @@ class HeuristicHeap(Heap):
 
     @property
     def global_max_fast(self):
+        global_max_fast_via_config = int(pwndbg.config.global_max_fast)
+        if global_max_fast_via_config > 0:
+            return pwndbg.memory.u(global_max_fast_via_config)
         # TODO/FIXME: This method should be updated if we find a better way to find the target assembly code
         if not self._global_max_fast_addr:
             # `__libc_malloc` will call `_int_malloc`, so we try to find the reference to `_int_malloc`

--- a/pwndbg/heap/ptmalloc.py
+++ b/pwndbg/heap/ptmalloc.py
@@ -898,7 +898,7 @@ class HeuristicHeap(Heap):
             elif pwndbg.arch.current == "aarch64":
                 # [reg1, reg2]
                 return pwndbg.memory.pvoid(pwndbg.regs.TPIDR_EL0 + self._thread_arena_offset)
-            else:
+            elif pwndbg.arch.current == "arm":
                 # reg1, reg2
                 return pwndbg.memory.pvoid(self.get_arm_tls_base() + self._thread_arena_offset)
 

--- a/pwndbg/heap/ptmalloc.py
+++ b/pwndbg/heap/ptmalloc.py
@@ -792,7 +792,7 @@ class HeuristicHeap(Heap):
             elif pwndbg.arch.current == "i386":
                 for instr in __errno_location_instr:
                     # Find something like: mov eax, dword ptr [eax + disp]
-                    # (disp is a negative value, and eax is come from one of the page address of libc)
+                    # (disp is a negative value, and eax comes from one of the page address of libc)
                     if instr.mnemonic == 'mov':
                         base_offset = pwndbg.vmmap.find(pwndbg.symbol.address('_IO_list_all')).start
                         self._errno_offset = pwndbg.memory.s32(base_offset + instr.disp)

--- a/pwndbg/heap/ptmalloc.py
+++ b/pwndbg/heap/ptmalloc.py
@@ -677,7 +677,7 @@ class HeuristicHeap(Heap):
 
     @property
     def main_arena(self):
-        main_arena_via_config = int(pwndbg.config.main_arena)
+        main_arena_via_config = int(str(pwndbg.config.main_arena), 0)
         if main_arena_via_config > 0:
             return self.malloc_state(main_arena_via_config)
         # TODO/FIXME: These are quite dirty, we should find a better way to do this
@@ -799,7 +799,7 @@ class HeuristicHeap(Heap):
 
     @property
     def thread_arena(self):
-        thread_arena_via_config = int(pwndbg.config.thread_arena)
+        thread_arena_via_config = int(str(pwndbg.config.thread_arena), 0)
         if thread_arena_via_config > 0:
             return thread_arena_via_config
         if not self._thread_arena_offset:
@@ -911,7 +911,7 @@ class HeuristicHeap(Heap):
         """Locate a thread's tcache struct. If it doesn't have one, use the main
         thread's tcache.
         """
-        thread_cache_via_config = int(pwndbg.config.tcache)
+        thread_cache_via_config = int(str(pwndbg.config.tcache), 0)
         if thread_cache_via_config > 0:
             return self.tcache_perthread_struct(thread_cache_via_config)
         if self.has_tcache():
@@ -1074,7 +1074,7 @@ class HeuristicHeap(Heap):
 
     @property
     def mp(self):
-        mp_via_config = int(pwndbg.config.mp_)
+        mp_via_config = int(str(pwndbg.config.mp_), 0)
         if mp_via_config > 0:
             return self.malloc_par(mp_via_config)
         if not self._mp_addr:
@@ -1198,7 +1198,7 @@ class HeuristicHeap(Heap):
 
     @property
     def global_max_fast(self):
-        global_max_fast_via_config = int(pwndbg.config.global_max_fast)
+        global_max_fast_via_config = int(str(pwndbg.config.global_max_fast), 0)
         if global_max_fast_via_config > 0:
             return pwndbg.memory.u(global_max_fast_via_config)
         # TODO/FIXME: This method should be updated if we find a better way to find the target assembly code

--- a/pwndbg/heap/ptmalloc.py
+++ b/pwndbg/heap/ptmalloc.py
@@ -185,7 +185,10 @@ class Heap(pwndbg.heap.heap.BaseHeap):
     @pwndbg.memoize.reset_on_objfile
     def malloc_alignment(self):
         """Corresponds to MALLOC_ALIGNMENT in glibc malloc.c"""
-        return pwndbg.arch.ptrsize * 2
+        # i386 will override it to 16 when GLIBC version >= 2.26
+        # See https://elixir.bootlin.com/glibc/glibc-2.26/source/sysdeps/i386/malloc-alignment.h#L22
+        return 16 if pwndbg.arch.current == "i386" and pwndbg.glibc.get_version() >= (2, 26) \
+            else pwndbg.arch.ptrsize * 2
 
     @property
     @pwndbg.memoize.reset_on_objfile

--- a/pwndbg/heap/ptmalloc.py
+++ b/pwndbg/heap/ptmalloc.py
@@ -3,9 +3,13 @@ from collections import OrderedDict
 import gdb
 
 import pwndbg.color.memory as M
+import pwndbg.disasm
 import pwndbg.events
 import pwndbg.glibc
+import pwndbg.search
+import pwndbg.symbol
 import pwndbg.typeinfo
+import pwndbg.vmmap
 from pwndbg.color import message
 from pwndbg.constants import ptmalloc
 from pwndbg.heap import heap_chain_limit
@@ -54,24 +58,20 @@ class HeapInfo:
 class Heap(pwndbg.heap.heap.BaseHeap):
     def __init__(self):
         # Global ptmalloc objects
-        self._main_arena    = None
-        self._mp            = None
+        self._global_max_fast_addr = None
+        self._global_max_fast      = None
+        self._main_arena_addr      = None
+        self._main_arena           = None
+        self._mp_addr              = None
+        self._mp                   = None
         # List of arenas/heaps
-        self._arenas        = None
+        self._arenas               = None
         # ptmalloc cache for current thread
-        self._thread_cache  = None
+        self._thread_cache         = None
 
     @property
     def main_arena(self):
-        main_arena_addr = pwndbg.symbol.address('main_arena')
-
-        if main_arena_addr is not None:
-            self._main_arena = pwndbg.memory.poi(self.malloc_state, main_arena_addr)
-        else:
-            print(message.error('Symbol \'main_arena\' not found. Try installing libc '
-                                'debugging symbols and try again.'))
-
-        return self._main_arena
+        raise NotImplementedError()
 
     @property
     @pwndbg.memoize.reset_on_stop
@@ -129,82 +129,54 @@ class Heap(pwndbg.heap.heap.BaseHeap):
         return arenas
 
     def has_tcache(self):
-        return (self.mp and 'tcache_bins' in self.mp.type.keys() and self.mp['tcache_bins'])
+        raise NotImplementedError()
 
     @property
     def thread_cache(self):
-        """Locate a thread's tcache struct. If it doesn't have one, use the main
-        thread's tcache.
-        """
-        if self.has_tcache():
-            tcache = self.mp['sbrk_base'] + 0x10
-            if self.multithreaded:
-                tcache_addr = pwndbg.memory.pvoid(pwndbg.symbol.address('tcache'))
-                if tcache_addr != 0:
-                    tcache = tcache_addr
-
-            try:
-                self._thread_cache = pwndbg.memory.poi(self.tcache_perthread_struct, tcache)
-                _ = self._thread_cache['entries'].fetch_lazy()
-            except Exception as e:
-                print(message.error('Error fetching tcache. GDB cannot access '
-                                    'thread-local variables unless you compile with -lpthread.'))
-                return None
-
-            return self._thread_cache
-
-        else:
-            print(message.warn('This version of GLIBC was not compiled with tcache support.'))
-            return None
-
+        raise NotImplementedError()
+    
     @property
     def mp(self):
-        mp_addr = pwndbg.symbol.address('mp_')
-
-        if mp_addr is not None:
-            self._mp = pwndbg.memory.poi(self.malloc_par, mp_addr)
-
-        return self._mp
-
+        raise NotImplementedError()
+    
     @property
     def global_max_fast(self):
-        addr = pwndbg.symbol.address('global_max_fast')
-        return pwndbg.memory.u(addr)
+        raise NotImplementedError()
 
     @property
     @pwndbg.memoize.reset_on_objfile
     def heap_info(self):
-        return pwndbg.typeinfo.load('heap_info')
-
+        raise NotImplementedError()
+    
     @property
     @pwndbg.memoize.reset_on_objfile
     def malloc_chunk(self):
-        return pwndbg.typeinfo.load('struct malloc_chunk')
+        raise NotImplementedError()
 
     @property
     @pwndbg.memoize.reset_on_objfile
     def malloc_state(self):
-        return pwndbg.typeinfo.load('struct malloc_state')
+        raise NotImplementedError()
 
     @property
     @pwndbg.memoize.reset_on_objfile
     def tcache_perthread_struct(self):
-        return pwndbg.typeinfo.load('struct tcache_perthread_struct')
+        raise NotImplementedError()
 
     @property
     @pwndbg.memoize.reset_on_objfile
     def tcache_entry(self):
-        return pwndbg.typeinfo.load('struct tcache_entry')
-
+        raise NotImplementedError()
+    
     @property
     @pwndbg.memoize.reset_on_objfile
     def mallinfo(self):
-        return pwndbg.typeinfo.load('struct mallinfo')
-
+        raise NotImplementedError()
+    
     @property
     @pwndbg.memoize.reset_on_objfile
     def malloc_par(self):
-        return pwndbg.typeinfo.load('struct malloc_par')
+        raise NotImplementedError()
 
     @property
     @pwndbg.memoize.reset_on_objfile
@@ -297,7 +269,6 @@ class Heap(pwndbg.heap.heap.BaseHeap):
         }
         val = self.malloc_chunk
         chunk_keys = [renames[key] if key in renames else key for key in val.keys()]
-
         try:
             return chunk_keys.index(key) * pwndbg.arch.ptrsize
         except:
@@ -309,28 +280,10 @@ class Heap(pwndbg.heap.heap.BaseHeap):
         return  self.tcache_entry.keys().index('next') * pwndbg.arch.ptrsize
 
     def get_heap(self, addr):
-        """Find & read the heap_info struct belonging to the chunk at 'addr'."""
-        return pwndbg.memory.poi(self.heap_info, heap_for_ptr(addr))
+        raise NotImplementedError()
 
     def get_arena(self, arena_addr=None):
-        """Read a malloc_state struct from the specified address, default to
-        reading the current thread's arena. Return the main arena if the
-        current thread is not attached to an arena.
-        """
-        if arena_addr is None:
-            if self.multithreaded:
-                arena_addr = pwndbg.memory.u(pwndbg.symbol.address('thread_arena'))
-                if arena_addr != 0:
-                    return pwndbg.memory.poi(self.malloc_state, arena_addr)
-
-            return self.main_arena
-
-        try:
-            next(i for i in pwndbg.vmmap.get() if arena_addr in i)
-            return pwndbg.memory.poi(self.malloc_state, arena_addr)
-        except (gdb.MemoryError, StopIteration):
-            # print(message.warn('Bad arena address {}'.format(arena_addr.address)))
-            return None
+        raise NotImplementedError()
 
     def get_arena_for_chunk(self, addr):
         chunk = pwndbg.commands.heap.read_chunk(addr)
@@ -342,29 +295,10 @@ class Heap(pwndbg.heap.heap.BaseHeap):
         return r
 
     def get_tcache(self, tcache_addr=None):
-        if tcache_addr is None:
-            return self.thread_cache
-
-        return pwndbg.memory.poi(self.tcache_perthread_struct, tcache_addr)
-
+        raise NotImplementedError()
+    
     def get_heap_boundaries(self, addr=None):
-        """Find the boundaries of the heap containing `addr`, default to the
-        boundaries of the heap containing the top chunk for the thread's arena.
-        """
-        region = self.get_region(addr) if addr else self.get_region(self.get_arena()['top'])
-
-        # Occasionally, the [heap] vm region and the actual start of the heap are
-        # different, e.g. [heap] starts at 0x61f000 but mp_.sbrk_base is 0x620000.
-        # Return an adjusted Page object if this is the case.
-        page = pwndbg.memory.Page(0, 0, 0, 0)
-        sbrk_base = int(self.mp['sbrk_base'])
-        if region == self.get_region(sbrk_base):
-            if sbrk_base != region.vaddr:
-                page.vaddr = sbrk_base
-                page.memsz = region.memsz - (sbrk_base - region.vaddr)
-                return page
-
-        return region
+        raise NotImplementedError()
 
     def get_region(self, addr):
         """Find the memory map containing 'addr'."""
@@ -548,10 +482,478 @@ class Heap(pwndbg.heap.heap.BaseHeap):
         return self.largebin_index_64(sz) if pwndbg.arch.ptrsize == 8 else self.largebin_index_32(sz)
 
     def is_initialized(self):
+        raise NotImplementedError()
+
+    def libc_has_debug_syms(self):
+        return pwndbg.symbol.address('global_max_fast') is not None
+
+class DebugSymsHeap(Heap):
+    @property
+    def main_arena(self):
+        self._main_arena_addr = pwndbg.symbol.address('main_arena')
+        if self._main_arena_addr is not None:
+            self._main_arena = pwndbg.memory.poi(self.malloc_state, self._main_arena_addr)
+
+        return self._main_arena
+
+    def has_tcache(self):
+        return (self.mp and 'tcache_bins' in self.mp.type.keys() and self.mp['tcache_bins'])
+
+    @property
+    def thread_cache(self):
+        """Locate a thread's tcache struct. If it doesn't have one, use the main
+        thread's tcache.
+        """
+        if self.has_tcache():
+            tcache = self.mp['sbrk_base'] + 0x10
+            if self.multithreaded:
+                tcache_addr = pwndbg.memory.pvoid(pwndbg.symbol.address('tcache'))
+                if tcache_addr != 0:
+                    tcache = tcache_addr
+
+            try:
+                self._thread_cache = pwndbg.memory.poi(self.tcache_perthread_struct, tcache)
+                _ = self._thread_cache['entries'].fetch_lazy()
+            except Exception as e:
+                print(message.error('Error fetching tcache. GDB cannot access '
+                                    'thread-local variables unless you compile with -lpthread.'))
+                return None
+
+            return self._thread_cache
+
+        else:
+            print(message.warn('This version of GLIBC was not compiled with tcache support.'))
+            return None
+
+    @property
+    def mp(self):
+        self._mp_addr = pwndbg.symbol.address('mp_')
+        if self._mp_addr is not None:
+            self._mp = pwndbg.memory.poi(self.malloc_par, self._mp_addr)
+
+        return self._mp
+
+    @property
+    def global_max_fast(self):
+        self._global_max_fast_addr = pwndbg.symbol.address('global_max_fast')
+        if self._global_max_fast_addr is not None:
+            self._global_max_fast = pwndbg.memory.u(self._global_max_fast_addr)
+        
+        return self._global_max_fast
+
+    @property
+    @pwndbg.memoize.reset_on_objfile
+    def heap_info(self):
+        return pwndbg.typeinfo.load('heap_info')
+
+    @property
+    @pwndbg.memoize.reset_on_objfile
+    def malloc_chunk(self):
+        return pwndbg.typeinfo.load('struct malloc_chunk')
+
+    @property
+    @pwndbg.memoize.reset_on_objfile
+    def malloc_state(self):
+        return pwndbg.typeinfo.load('struct malloc_state')
+
+    @property
+    @pwndbg.memoize.reset_on_objfile
+    def tcache_perthread_struct(self):
+        return pwndbg.typeinfo.load('struct tcache_perthread_struct')
+
+    @property
+    @pwndbg.memoize.reset_on_objfile
+    def tcache_entry(self):
+        return pwndbg.typeinfo.load('struct tcache_entry')
+
+    @property
+    @pwndbg.memoize.reset_on_objfile
+    def mallinfo(self):
+        return pwndbg.typeinfo.load('struct mallinfo')
+
+    @property
+    @pwndbg.memoize.reset_on_objfile
+    def malloc_par(self):
+        return pwndbg.typeinfo.load('struct malloc_par')
+
+
+    def get_heap(self, addr):
+        """Find & read the heap_info struct belonging to the chunk at 'addr'."""
+        return pwndbg.memory.poi(self.heap_info, heap_for_ptr(addr))
+
+    def get_arena(self, arena_addr=None):
+        """Read a malloc_state struct from the specified address, default to
+        reading the current thread's arena. Return the main arena if the
+        current thread is not attached to an arena.
+        """
+        if arena_addr is None:
+            if self.multithreaded:
+                arena_addr = pwndbg.memory.u(pwndbg.symbol.address('thread_arena'))
+                if arena_addr > 0:
+                    return pwndbg.memory.poi(self.malloc_state, arena_addr)
+
+            return self.main_arena
+
+        try:
+            next(i for i in pwndbg.vmmap.get() if arena_addr in i)
+            return pwndbg.memory.poi(self.malloc_state, arena_addr)
+        except (gdb.MemoryError, StopIteration):
+            # print(message.warn('Bad arena address {}'.format(arena_addr.address)))
+            return None
+
+    def get_tcache(self, tcache_addr=None):
+        if tcache_addr is None:
+            return self.thread_cache
+
+        return pwndbg.memory.poi(self.tcache_perthread_struct, tcache_addr)
+
+    def get_heap_boundaries(self, addr=None):
+        """Find the boundaries of the heap containing `addr`, default to the
+        boundaries of the heap containing the top chunk for the thread's arena.
+        """
+        region = self.get_region(addr) if addr else self.get_region(self.get_arena()['top'])
+
+        # Occasionally, the [heap] vm region and the actual start of the heap are
+        # different, e.g. [heap] starts at 0x61f000 but mp_.sbrk_base is 0x620000.
+        # Return an adjusted Page object if this is the case.
+        page = pwndbg.memory.Page(0, 0, 0, 0)
+        sbrk_base = int(self.mp['sbrk_base'])
+        if region == self.get_region(sbrk_base):
+            if sbrk_base != region.vaddr:
+                page.vaddr = sbrk_base
+                page.memsz = region.memsz - (sbrk_base - region.vaddr)
+                return page
+        return region
+
+    def is_initialized(self):
         addr = pwndbg.symbol.address('__libc_malloc_initialized')
         if addr is None:
             addr = pwndbg.symbol.address('__malloc_initialized')
         return pwndbg.memory.s32(addr) > 0
 
-    def libc_has_debug_syms(self):
-        return pwndbg.symbol.address('global_max_fast') is not None
+class HeuristicHeap(Heap):
+    def __init__(self):
+        super().__init__()
+        self._thread_arena_offset = None
+    
+    @property
+    def main_arena(self):
+        # TODO/FIXME: These are quite dirty, we should find a better way to do this
+        if not self._main_arena_addr:
+            if pwndbg.glibc.get_version() < (2, 34):
+                malloc_hook_addr = pwndbg.symbol.address('__malloc_hook')
+                # Credit: This tricks is modified from https://github.com/hugsy/gef/blob/c530aa518ac96dff6fc810a5552ecf54fd1b3581/gef.py#L1189-L1196
+                # Thank @_hugsy_ and all the contributors of gef!
+                if pwndbg.arch.current == "x86-64" or pwndbg.arch.current == "i386":
+                    self._main_arena_addr = malloc_hook_addr + ((0x20 - (malloc_hook_addr % 0x20)) % 0x20)
+                elif pwndbg.arch.current == "aarch64":
+                    self._main_arena_addr = malloc_hook_addr - pwndbg.arch.ptrsize * 2 - self.malloc_state(0)._c_struct.__sizeof__()
+                elif pwndbg.arch.current == "arm":
+                    self._main_arena_addr = malloc_hook_addr - pwndbg.arch.ptrsize - self.malloc_state(0)._c_struct.__sizeof__()
+            else: # glibc >= 2.34 does not have __malloc_hook
+                # try to find `mstate ar_ptr = &main_arena;` in malloc_trim instructions
+                malloc_trim_instructions = pwndbg.disasm.near(pwndbg.symbol.address('malloc_trim'), 10, show_prev_insns=False)
+                if pwndbg.arch.current == "x86-64":
+                    for instr in malloc_trim_instructions:
+                        # try to find `lea rax,[rip+DISP]`
+                        if instr.mnemonic == 'lea' and "rip" in instr.op_str and instr.disp > 0:
+                            self._main_arena_addr = instr.next + instr.disp # rip + disp
+                            break
+                elif pwndbg.arch.current == "i386":
+                    base_offset = pwndbg.vmmap.find(pwndbg.symbol.address('_IO_list_all')).start
+                    for instr in malloc_trim_instructions:
+                        # try to find `lea edi,[eax+DISP]`
+                        if instr.mnemonic == 'lea' and "eax" in instr.op_str and instr.disp > 0:
+                            self._main_arena_addr = base_offset + instr.disp # eax + disp
+                            break
+                # TODO/FIXME: Add support to arm and aarch64
+            # try to search main_arena in .data of libc if we can't find it via above trick
+            if not self._main_arena_addr:
+                _IO_2_1_stdin_addr = pwndbg.symbol.address('_IO_2_1_stdin_')
+                _IO_list_all_addr = pwndbg.symbol.address('_IO_list_all')
+                # main_arena is between _IO_2_1_stdin and _IO_list_all
+                for addr in range(_IO_2_1_stdin_addr, _IO_list_all_addr, pwndbg.arch.ptrsize):
+                    tmp_arena = self.malloc_state(addr)
+                    if tmp_arena["next"] == addr:
+                        self._main_arena_addr = addr
+                        break
+                if not self._main_arena_addr:
+                    # there are more than one arena, try to find by main_arena.top and main_arena.max_system_mem
+                    heap_page = next(x for x in pwndbg.vmmap.get() if "heap]" in x.objfile)
+                    for addr in range(_IO_2_1_stdin_addr, _IO_list_all_addr, pwndbg.arch.ptrsize):
+                        tmp_arena = self.malloc_state(addr)
+                        if heap_page.start <= tmp_arena["top"] <= heap_page.end:
+                            if tmp_arena["max_system_mem"] != 0:
+                                self._main_arena_addr = addr
+                                break
+
+        if self._main_arena_addr:
+            self._main_arena = self.malloc_state(self._main_arena_addr)
+
+        return self._main_arena
+
+    def has_tcache(self):
+        # TODO/FIXME: Can we determine the tcache_bins existence more reliable?
+
+        # There is no debug symbols, we determine the tcache_bins existence by checking glibc version only
+        return self.is_initialized() and pwndbg.glibc.get_version() >= (2, 26)
+
+    @property
+    def thread_arena(self):
+        if not self._thread_arena_offset:
+            # TODO/FIXME: This method should be updated if we find a better way to find the target assembly code
+            __libc_calloc_instruction = pwndbg.disasm.near(pwndbg.symbol.address('__libc_calloc'), 100, show_prev_insns=False)
+            # try to find the reference to thread_arena in arena_get in __libc_calloc ( ptr = thread_arena; )
+            if pwndbg.arch.current == "x86-64":
+                # try to find something like `mov rax, [rip + disp]`
+                # and its next is `mov reg, qword ptr fs:[rax]`
+                # and then we can get the tls offset to thread_arena by calculating value of rax
+
+                is_possible = lambda i, instr: __libc_calloc_instruction[i+1].op_str.endswith('qword ptr fs:[rax]') \
+                    and instr.op_str.startswith('rax, qword ptr [rip +')
+                get_offset_instruction = next(instr for i, instr in enumerate(__libc_calloc_instruction[:-1]) if is_possible(i, instr))
+                # rip + disp
+                self._thread_arena_offset = pwndbg.memory.s64(get_offset_instruction.next + get_offset_instruction.disp)
+            elif pwndbg.arch.current == "i386":
+                base_offset = pwndbg.vmmap.find(pwndbg.symbol.address('_IO_list_all')).start
+                # try to find something like `mov eax, dword ptr [reg + disp]` (disp is a negative value)
+                # and its next is either `mov reg, dword ptr gs:[eax]` or `mov reg, dword ptr [reg + eax]`
+                # and then we can get the tls offset to thread_arena by calculating value of eax
+
+                # this part is very dirty, but it works
+                is_possible = lambda i, instr: (__libc_calloc_instruction[i+1].op_str.endswith('gs:[eax]') \
+                    ^ __libc_calloc_instruction[i+1].op_str.endswith('+ eax]')) \
+                    and __libc_calloc_instruction[i+1].mnemonic == 'mov' \
+                    and instr.mnemonic == 'mov' \
+                    and instr.op_str.startswith('eax, dword ptr [e') \
+                    and instr.disp < 0
+                get_offset_instruction = [instr for i, instr in enumerate(__libc_calloc_instruction[:-1]) if is_possible(i, instr)][-1]
+                # reg + disp (value of reg is the page start of the last libc page)
+                self._thread_arena_offset = pwndbg.memory.s32(base_offset + get_offset_instruction.disp)
+            # TODO/FIXME: Add support to arm and aarch64
+        
+        if self._thread_arena_offset:
+            if pwndbg.arch.current == "x86-64":
+                # fs:[rax]
+                return pwndbg.memory.pvoid(pwndbg.regs.fsbase + self._thread_arena_offset)
+            elif pwndbg.arch.current == "i386":
+                # reg+eax or gs:[eax] (value of reg is gs:[0x0])
+                return pwndbg.memory.pvoid(pwndbg.regs.gsbase + self._thread_arena_offset)
+
+        return -1
+
+
+    @property
+    def thread_cache(self):
+        """Locate a thread's tcache struct. If it doesn't have one, use the main
+        thread's tcache.
+        """
+        if self.has_tcache():
+            # we guess tcache is the first chunk
+            arena = self.get_arena()
+            heap_region = self.get_heap_boundaries()
+            ptr_size = pwndbg.arch.ptrsize
+            if arena == self.main_arena:
+                cursor = heap_region.start
+            else:
+                cursor = heap_region.start + self.heap_info.sizeof
+                if pwndbg.vmmap.find(self.get_heap(heap_region.start)['ar_ptr']) == heap_region:
+                    # Round up to a 2-machine-word alignment after an arena to
+                    # compensate for the presence of the have_fastchunks variable
+                    # in GLIBC versions >= 2.27.
+                    cursor += (self.malloc_state.sizeof + ptr_size) & ~self.malloc_align_mask
+
+            # i686 alignment heuristic
+            first_chunk_size = pwndbg.arch.unpack(pwndbg.memory.read(cursor + ptr_size, ptr_size))
+            if first_chunk_size == 0:
+                cursor += ptr_size * 2
+            
+            self._thread_cache = self.tcache_perthread_struct(cursor + ptr_size * 2)
+
+            return self._thread_cache
+
+        else:
+            print(message.warn('This version of GLIBC was not compiled with tcache support.'))
+            return None
+
+    @property
+    def mp(self):
+        if not self._mp_addr:
+            # try to find mp_ referenced in __libc_free
+            # TODO/FIXME: This method should be updated if we find a better way to find the target assembly code
+            __libc_free_instructions = pwndbg.disasm.near(pwndbg.symbol.address('__libc_free'), 100, show_prev_insns=False)
+            if pwndbg.arch.current == "x86-64":
+                iter_possible_match = (instr for instr in __libc_free_instructions if instr.mnemonic == 'mov' \
+                    and instr.disp > 0 \
+                    and instr.op_str.startswith('qword ptr [rip +'))
+                try:
+                    mp_mmap_threshold_ref = next(iter_possible_match) # mov qword ptr [rip + (mp.mmap_threshold offset)], reg
+                    mp_ref = next(iter_possible_match) # mov qword ptr [rip + (mp offset)], reg
+                    # references to mp_.mmap_threshold and mp_ are very close to each other
+                    while mp_mmap_threshold_ref.next - mp_ref.address > 0x10:
+                        mp_mmap_threshold_ref = mp_ref
+                        mp_ref = next(iter_possible_match)
+                    self._mp_addr = mp_ref.next + mp_ref.disp
+                except StopIteration:
+                    pass
+            elif pwndbg.arch.current == "i386":
+                iter_possible_match = (instr for instr in __libc_free_instructions if instr.mnemonic == 'mov' \
+                    and instr.disp > 0 \
+                    and instr.op_str.startswith('dword ptr ['))
+                base_offset = pwndbg.vmmap.find(pwndbg.symbol.address('_IO_list_all')).start
+                try:
+                    mp_mmap_threshold_ref = next(iter_possible_match) # mov dword ptr [base_offset + (mp.mmap_threshold offset)], reg
+                    mp_ref = next(iter_possible_match) # mov dword ptr [base_offset + (mp offset)], reg
+                    # references to mp_.mmap_threshold and mp_ are very close to each other
+                    while mp_mmap_threshold_ref.next - mp_ref.address > 0x10:
+                        mp_mmap_threshold_ref = mp_ref
+                        mp_ref = next(iter_possible_match)
+                    self._mp_addr = base_offset + mp_ref.disp
+                except StopIteration:
+                    pass
+            # TODO/FIXME: Add support to arm and aarch64
+            
+            # can't find the reference about mp_ in __libc_free, try to find it with heap boundaries of main_arena
+            if not self._mp_addr:
+                libc_page = pwndbg.vmmap.find(pwndbg.symbol.address('_IO_list_all'))
+                possible_sbrk_base = self.get_heap_boundaries().start
+                sbrk_offset = self.malloc_par(0).field_address('sbrk_base')
+                # try to search sbrk_base in a part of libc page
+                # TODO/FIXME: If mp_.sbrk_base is not same as heap region start, this will fail
+                result = pwndbg.search.search(pwndbg.arch.pack(possible_sbrk_base), start=libc_page.start, end=libc_page.end)
+                try:
+                    self._mp_addr = next(result) - sbrk_offset
+                except StopIteration:
+                    pass
+            
+
+        if self._mp_addr:
+            self._mp = self.malloc_par(self._mp_addr)
+
+        return self._mp
+
+    @property
+    def global_max_fast(self):
+        # TODO/FIXME: This method should be updated if we find a better way to find the target assembly code
+        if not self._global_max_fast_addr:
+            # `__libc_malloc` will call `_int_malloc`, so we try to find the reference to `_int_malloc`
+            __libc_malloc_instructions  = pwndbg.disasm.near(pwndbg.symbol.address('__libc_malloc'), 25, show_prev_insns=False)
+            _int_malloc_addr = next(instr for instr in __libc_malloc_instructions[5:] if instr.mnemonic == 'call').operands[0].imm
+            _int_malloc_instructions = pwndbg.disasm.near(_int_malloc_addr, 25, show_prev_insns=False)
+            # there is a reference to global_max_fast in _int_malloc, which is:
+            # `if ((unsigned long) (nb) <= (unsigned long) (get_max_fast ()))`
+            if pwndbg.arch.current == "x86-64":
+                # cmp qword ptr [rip + global_max_fast_offset], 0x1f
+                global_max_fast_ref = next(instr for instr in _int_malloc_instructions if instr.mnemonic == 'cmp' and instr.op_str.startswith('qword ptr [rip +'))
+                self._global_max_fast_addr = global_max_fast_ref.next + global_max_fast_ref.disp
+            elif pwndbg.arch.current == "i386":
+                base_offset = pwndbg.vmmap.find(pwndbg.symbol.address('_IO_list_all')).start
+                # cmp reg, [base_offset + global_max_fast_offset]
+                global_max_fast_ref = next(instr for instr in _int_malloc_instructions if instr.mnemonic == 'cmp' and 'dword ptr [' in instr.op_str)
+                self._global_max_fast_addr = base_offset + global_max_fast_ref.disp
+            else:
+                # TODO/FIXME: Add support to arm and aarch64
+
+                # return default value to avoid error
+                # this might be a problem if you overwrite it with another value
+                return 128 if pwndbg.ptrsize == 8 else 64
+
+        if self._global_max_fast_addr:
+            self._global_max_fast = pwndbg.memory.u(self._global_max_fast_addr)
+
+        return self._global_max_fast
+
+    @property
+    @pwndbg.memoize.reset_on_objfile
+    def heap_info(self):
+        import pwndbg.heap.structs
+        return pwndbg.heap.structs.HeapInfo
+
+    @property
+    @pwndbg.memoize.reset_on_objfile
+    def malloc_chunk(self):
+        import pwndbg.heap.structs
+        return pwndbg.heap.structs.MallocChunk
+
+    @property
+    @pwndbg.memoize.reset_on_objfile
+    def malloc_state(self):
+        import pwndbg.heap.structs
+        return pwndbg.heap.structs.MallocState
+
+    @property
+    @pwndbg.memoize.reset_on_objfile
+    def tcache_perthread_struct(self):
+        import pwndbg.heap.structs
+        return pwndbg.heap.structs.TcachePerthreadStruct
+
+    @property
+    @pwndbg.memoize.reset_on_objfile
+    def tcache_entry(self):
+        import pwndbg.heap.structs
+        return pwndbg.heap.structs.TcacheEntry
+
+    @property
+    @pwndbg.memoize.reset_on_objfile
+    def mallinfo(self):
+        # TODO/FIXME: Currently, we don't need to create a new class for `struct mallinfo` because we never use it.
+        raise NotImplementedError('`struct mallinfo` is not implemented yet.')
+
+    @property
+    @pwndbg.memoize.reset_on_objfile
+    def malloc_par(self):
+        import pwndbg.heap.structs
+        return pwndbg.heap.structs.MallocPar
+
+    def get_heap(self, addr):
+        """Find & read the heap_info struct belonging to the chunk at 'addr'."""
+        return self.heap_info(heap_for_ptr(addr))
+
+    def get_arena(self, arena_addr=None):
+        """Read a malloc_state struct from the specified address, default to
+        reading the current thread's arena. Return the main arena if the
+        current thread is not attached to an arena.
+        """
+        if arena_addr is None:
+            thread_arena = self.thread_arena
+            if self.multithreaded and thread_arena > 0:
+                return self.malloc_state(thread_arena)
+
+            return self.main_arena
+
+        return self.malloc_state(arena_addr)
+
+    def get_tcache(self, tcache_addr=None):
+        if tcache_addr is None:
+            return self.thread_cache
+
+        return self.tcache_perthread_struct(tcache_addr)
+
+    def get_heap_boundaries(self, addr=None):
+        """Find the boundaries of the heap containing `addr`, default to the
+        boundaries of the heap containing the top chunk for the thread's arena.
+        """
+        arena = self.get_arena(addr)
+        if arena is not None and arena.address > 0:
+            region = self.get_region(addr) if addr else self.get_region(self.get_arena()['top'])
+        else:
+            # If we can't find an arena via heuristics, try to find it via vmmap
+            region = next(p for p in pwndbg.vmmap.get() if "heap]" in p.objfile)
+
+        # Occasionally, the [heap] vm region and the actual start of the heap are
+        # different, e.g. [heap] starts at 0x61f000 but mp_.sbrk_base is 0x620000.
+        # Return an adjusted Page object if this is the case.
+        if self._mp_addr:  # sometimes we can't find mp_ via heuristics
+            page = pwndbg.memory.Page(0, 0, 0, 0)
+            sbrk_base = int(self.mp['sbrk_base'])
+            if region == self.get_region(sbrk_base):
+                if sbrk_base != region.vaddr:
+                    page.vaddr = sbrk_base
+                    page.memsz = region.memsz - (sbrk_base - region.vaddr)
+                    return page
+        return region
+
+    def is_initialized(self):
+        # TODO/FIXME: If main_arena['top'] is been modified to 0, this will not work.
+        # try to use vmmap or main_arena.top to find the heap
+        return any("heap]" in x.objfile for x in pwndbg.vmmap.get()) or self.main_arena['top'] != 0

--- a/pwndbg/heap/structs.py
+++ b/pwndbg/heap/structs.py
@@ -1,3 +1,4 @@
+import ctypes
 import gdb
 
 import pwndbg.arch
@@ -5,7 +6,6 @@ import pwndbg.heap
 import pwndbg.typeinfo
 import pwndbg.memory
 import pwndbg.glibc
-import ctypes
 
 NBINS = 128
 BINMAPSIZE = 4
@@ -20,22 +20,76 @@ else:
     PTR = ctypes.c_uint64
     SIZE_T = ctypes.c_uint64
 
+class c_pvoid(PTR):
+    """
+    Represents a pointer.
+    """
+    pass
+
+class c_size_t(SIZE_T):
+    """
+    Represents a size_t.
+    """
+    pass
+
+C2GDB_MAPPING = {
+    ctypes.c_char: pwndbg.typeinfo.char,
+    ctypes.c_int8: pwndbg.typeinfo.int8,
+    ctypes.c_int16: pwndbg.typeinfo.int16,
+    ctypes.c_int32: pwndbg.typeinfo.int32,
+    ctypes.c_int64: pwndbg.typeinfo.int64,
+    ctypes.c_uint8: pwndbg.typeinfo.uint8,
+    ctypes.c_uint16: pwndbg.typeinfo.uint16,
+    ctypes.c_uint32: pwndbg.typeinfo.uint32,
+    ctypes.c_uint64: pwndbg.typeinfo.uint64,
+    c_pvoid: pwndbg.typeinfo.pvoid,
+    c_size_t: pwndbg.typeinfo.size_t
+}
+
 class CStruct2GDB:
+    _c_struct = None
+
     def __int__(self) -> int:
+        """
+        Returns the address of the C struct.
+        """
         return self.address
     
     def __getitem__(self, key: str) -> gdb.Value:
-        return getattr(self, key)
+        """
+        Returns the value of the specified field as a `gdb.Value`.
+        """
+        return self.read_field(key)
     
+    def __getattr__(self, key: str) -> gdb.Value:
+        """
+        Returns the value of the specified field as a `gdb.Value`.
+        """
+        return self.read_field(key)
+        
     def __eq__(self, other) -> bool:
         return self.address == int(other)
     
     def __str__(self) -> str:
+        """
+        Returns a string representation of the C struct like `gdb.Value` does.
+        """
         output = "{\n"
         for f in self._c_struct._fields_:
             output += "  %s = %s,\n" % (f[0], getattr(self, f[0]))
         output += "}"
         return output
+    
+    def read_field(self, field: str) -> gdb.Value:
+        """
+        Returns the value of the specified field as a `gdb.Value`.
+        """
+        field_offset = getattr(self._c_struct, field).offset
+        field_type = next((f for f in self._c_struct._fields_ if f[0] == field))[1]
+        if hasattr(field_type, "_length_"): # f is a ctypes Array
+            t = C2GDB_MAPPING[field_type._type_]
+            return pwndbg.memory.poi(t.array(field_type._length_ - 1), self.address + field_offset)
+        return pwndbg.memory.poi(C2GDB_MAPPING[field_type], self.address + field_offset)
 
     @property
     def type(self):
@@ -45,51 +99,84 @@ class CStruct2GDB:
         return self
     
     def field_address(self, field: str) -> int:
+        """
+        Returns the address of the specified field.
+        """
         return self.address + getattr(self._c_struct, field).offset
 
     def items(self) -> tuple:
+        """
+        Returns a tuple of (field name, field value) pairs.
+        """
         return tuple((field[0], getattr(self, field[0])) for field in self._c_struct._fields_)
 
 class c_malloc_state_2_26(ctypes.LittleEndianStructure):
+    """
+    This class represents malloc_state struct for GLIBC < 2.27 as a ctypes struct.
+
+    https://github.com/bminor/glibc/blob/1c9a5c270d8b66f30dcfaf1cb2d6cf39d3e18369/malloc/malloc.c#L1678-L1716
+
+    struct malloc_state
+    {
+        /* Serialize access.  */
+        __libc_lock_define (, mutex);
+
+        /* Flags (formerly in max_fast).  */
+        int flags;
+
+        /* Fastbins */
+        mfastbinptr fastbinsY[NFASTBINS];
+
+        /* Base of the topmost chunk -- not otherwise kept in a bin */
+        mchunkptr top;
+
+        /* The remainder from the most recent split of a small request */
+        mchunkptr last_remainder;
+
+        /* Normal bins packed as described above */
+        mchunkptr bins[NBINS * 2 - 2];
+
+        /* Bitmap of bins */
+        unsigned int binmap[BINMAPSIZE];
+
+        /* Linked list */
+        struct malloc_state *next;
+
+        /* Linked list for free arenas.  Access to this field is serialized
+            by free_list_lock in arena.c.  */
+        struct malloc_state *next_free;
+
+        /* Number of threads attached to this arena.  0 if the arena is on
+            the free list.  Access to this field is serialized by
+            free_list_lock in arena.c.  */
+        INTERNAL_SIZE_T attached_threads;
+
+        /* Memory allocated from the system in this arena.  */
+        INTERNAL_SIZE_T system_mem;
+        INTERNAL_SIZE_T max_system_mem;
+    };
+    """
     _fields_ = [
         ('mutex', ctypes.c_int32),
         ('flags', ctypes.c_int32),
-        ('fastbinsY', PTR * NFASTBINS),
-        ('top', PTR),
-        ('last_remainder', PTR),
-        ('bins', PTR * (NBINS * 2 - 2)),
+        ('fastbinsY', c_pvoid * NFASTBINS),
+        ('top', c_pvoid),
+        ('last_remainder', c_pvoid),
+        ('bins', c_pvoid * (NBINS * 2 - 2)),
         ('binmap', ctypes.c_int32 * BINMAPSIZE),
-        ('next', PTR),
-        ('next_free', PTR),
-        ('attached_threads', SIZE_T),
-        ('system_mem', SIZE_T),
-        ('max_system_mem', SIZE_T),
+        ('next', c_pvoid),
+        ('next_free', c_pvoid),
+        ('attached_threads', c_size_t),
+        ('system_mem', c_size_t),
+        ('max_system_mem', c_size_t),
     ]
 
 class c_malloc_state_2_27(ctypes.LittleEndianStructure):
-    _fields_ = [
-        ('mutex', ctypes.c_int32),
-        ('flags', ctypes.c_int32),
-        ('have_fastchunks', ctypes.c_int32),
-        ('fastbinsY', PTR * NFASTBINS),
-        ('top', PTR),
-        ('last_remainder', PTR),
-        ('bins', PTR * (NBINS * 2 - 2)),
-        ('binmap', ctypes.c_int32 * BINMAPSIZE),
-        ('next', PTR),
-        ('next_free', PTR),
-        ('attached_threads', SIZE_T),
-        ('system_mem', SIZE_T),
-        ('max_system_mem', SIZE_T),
-    ]
-
-class MallocState(CStruct2GDB):
     """
-    This class represents malloc_state struct.
+    This class represents malloc_state struct for GLIBC >= 2.27 as a ctypes struct.
 
     https://github.com/bminor/glibc/blob/glibc-2.34/malloc/malloc.c#L1831
 
-    Note: glibc < 2.27 does not have `have_fastchunks` field.
 
     struct malloc_state
     {
@@ -135,90 +222,47 @@ class MallocState(CStruct2GDB):
         INTERNAL_SIZE_T max_system_mem;
     };
     """
+    _fields_ = [
+        ('mutex', ctypes.c_int32),
+        ('flags', ctypes.c_int32),
+        ('have_fastchunks', ctypes.c_int32),
+        ('fastbinsY', c_pvoid * NFASTBINS),
+        ('top', c_pvoid),
+        ('last_remainder', c_pvoid),
+        ('bins', c_pvoid * (NBINS * 2 - 2)),
+        ('binmap', ctypes.c_int32 * BINMAPSIZE),
+        ('next', c_pvoid),
+        ('next_free', c_pvoid),
+        ('attached_threads', c_size_t),
+        ('system_mem', c_size_t),
+        ('max_system_mem', c_size_t),
+    ]
+
+class MallocState(CStruct2GDB):
+    """
+    This class represents malloc_state struct with interface compatible with `gdb.Value`.
+    """
     if pwndbg.glibc.get_version() >= (2, 27):
         _c_struct = c_malloc_state_2_27
-        sizeof = ctypes.sizeof(_c_struct)
     else:
         _c_struct = c_malloc_state_2_26
-        sizeof = ctypes.sizeof(_c_struct)
+    sizeof = ctypes.sizeof(_c_struct)
     
     def __init__(self, address: int) -> None:
         self.address = address
-    
-    @property
-    def mutex(self) -> gdb.Value:
-        return pwndbg.memory.poi(pwndbg.typeinfo.int32, self.address + self._c_struct.mutex.offset)
-    
-    @property
-    def flags(self) -> gdb.Value:
-        return pwndbg.memory.poi(pwndbg.typeinfo.int32, self.address + self._c_struct.flags.offset)
-
-    @property
-    def have_fastchunks(self) -> gdb.Value:
-        return pwndbg.memory.poi(pwndbg.typeinfo.int32, self.address + self._c_struct.have_fastchunks.offset)
-
-    @property
-    def fastbinsY(self) -> gdb.Value:
-        return pwndbg.memory.poi(pwndbg.typeinfo.pvoid.array(NFASTBINS - 1), self.address + self._c_struct.fastbinsY.offset)
-    
-    @property
-    def top(self) -> gdb.Value:
-        return pwndbg.memory.poi(pwndbg.typeinfo.pvoid, self.address + self._c_struct.top.offset)
-    
-    @property
-    def last_remainder(self) -> gdb.Value:
-        return pwndbg.memory.poi(pwndbg.typeinfo.pvoid, self.address + self._c_struct.last_remainder.offset)
-    
-    @property
-    def bins(self) -> gdb.Value:
-        return pwndbg.memory.poi(pwndbg.typeinfo.pvoid.array((NBINS * 2 - 2) - 1), self.address + self._c_struct.bins.offset)
-    
-    @property
-    def binmap(self) -> gdb.Value:
-        return pwndbg.memory.poi(pwndbg.typeinfo.int32.array(BINMAPSIZE - 1), self.address + self._c_struct.binmap.offset)
-    
-    @property
-    def next(self) -> gdb.Value:
-        return pwndbg.memory.poi(pwndbg.typeinfo.pvoid, self.address + self._c_struct.next.offset)
-    
-    @property
-    def next_free(self) -> gdb.Value:
-        return pwndbg.memory.poi(pwndbg.typeinfo.pvoid, self.address + self._c_struct.next_free.offset)
-    
-    @property
-    def attached_threads(self) -> gdb.Value:
-        return pwndbg.memory.poi(pwndbg.typeinfo.size_t, self.address + self._c_struct.attached_threads.offset)
-    
-    @property
-    def system_mem(self) -> gdb.Value:
-        return pwndbg.memory.poi(pwndbg.typeinfo.size_t, self.address + self._c_struct.system_mem.offset)
-    
-    @property
-    def max_system_mem(self) -> gdb.Value:
-        return pwndbg.memory.poi(pwndbg.typeinfo.size_t, self.address + self._c_struct.max_system_mem.offset)
 
     @staticmethod
     def keys() -> tuple:
         """
-        Use @staticmethod to make it compatible with the `gdb.Type` insterface.
+        Return a tuple of the names of the fields in the struct.
         """
         if pwndbg.glibc.get_version() >= (2, 27):
             return tuple(field[0] for field in c_malloc_state_2_27._fields_)
-        else:
-            return tuple(field[0] for field in c_malloc_state_2_26._fields_)
+        return tuple(field[0] for field in c_malloc_state_2_26._fields_)
 
 class c_heap_info(ctypes.LittleEndianStructure):
-    _fields_ = [
-        ('ar_ptr', PTR),
-        ('prev', PTR),
-        ('next', PTR),
-        ('size', SIZE_T),
-        ('pad', ctypes.c_uint8 * (8 if pwndbg.arch.ptrsize == 4 else 0)),
-    ]
-
-class HeapInfo(CStruct2GDB):
     """
-    This class represents _heap_info struct.
+    This class represents heap_info struct as a ctypes struct.
 
     https://github.com/bminor/glibc/blob/glibc-2.34/malloc/arena.c#L53
 
@@ -235,49 +279,34 @@ class HeapInfo(CStruct2GDB):
         char pad[-6 * SIZE_SZ & MALLOC_ALIGN_MASK];
     } heap_info;
     """
+    _fields_ = [
+        ('ar_ptr', c_pvoid),
+        ('prev', c_pvoid),
+        ('next', c_pvoid),
+        ('size', c_size_t),
+        ('pad', ctypes.c_uint8 * (8 if pwndbg.arch.ptrsize == 4 else 0)),
+    ]
+
+class HeapInfo(CStruct2GDB):
+    """
+    This class represents heap_info struct with interface compatible with `gdb.Value`.
+    """
     _c_struct = c_heap_info
     sizeof = ctypes.sizeof(_c_struct)
 
     def __init__(self, address: int) -> None:
         self.address = address
     
-    @property
-    def ar_ptr(self) -> gdb.Value:
-        return pwndbg.memory.poi(pwndbg.typeinfo.pvoid, self.address + self._c_struct.ar_ptr.offset)
-    
-    @property
-    def prev(self) -> gdb.Value:
-        return pwndbg.memory.poi(pwndbg.typeinfo.pvoid, self.address + self._c_struct.prev.offset)
-    
-    @property
-    def size(self) -> gdb.Value:
-        return pwndbg.memory.poi(pwndbg.typeinfo.size_t, self.address + self._c_struct.size.offset)
-    
-    @property
-    def mprotect_size(self) -> gdb.Value:
-        return pwndbg.memory.poi(pwndbg.typeinfo.size_t, self.address + self._c_struct.mprotect_size.offset)
-
-    @property
-    def pad(self) -> gdb.Value:
-        return pwndbg.memory.poi(pwndbg.typeinfo.char.array((8 if pwndbg.arch.ptrsize == 4 else 0) - 1), self.address + self._c_struct.pad.offset)
-    
     @staticmethod
     def keys() -> tuple:
+        """
+        Return a tuple of the names of the fields in the struct.
+        """
         return tuple(field[0] for field in c_heap_info._fields_)
 
 class c_malloc_chunk(ctypes.LittleEndianStructure):
-    _fields_ = [
-        ('prev_size', SIZE_T),
-        ('size', SIZE_T),
-        ('fd', PTR),
-        ('bk', PTR),
-        ('fd_nextsize', PTR),
-        ('bk_nextsize', PTR),
-    ]
-
-class MallocChunk(CStruct2GDB):
     """
-    This class represents malloc_chunk struct.
+    This class represents malloc_chunk struct as a ctypes struct.
 
     https://github.com/bminor/glibc/blob/glibc-2.34/malloc/malloc.c#L1154
     
@@ -294,49 +323,52 @@ class MallocChunk(CStruct2GDB):
         struct malloc_chunk* bk_nextsize;
     };
     """
+    _fields_ = [
+        ('prev_size', c_size_t),
+        ('size', c_size_t),
+        ('fd', c_pvoid),
+        ('bk', c_pvoid),
+        ('fd_nextsize', c_pvoid),
+        ('bk_nextsize', c_pvoid),
+    ]
+
+class MallocChunk(CStruct2GDB):
+    """
+    This class represents malloc_chunk struct with interface compatible with `gdb.Value`.
+    """
     _c_struct = c_malloc_chunk
     sizeof = ctypes.sizeof(_c_struct)
 
     def __init__(self, address: int) -> None:
         self.address = address
     
-    @property
-    def prev_size(self) -> gdb.Value:
-        return pwndbg.memory.poi(pwndbg.typeinfo.size_t, self.address + self._c_struct.prev_size.offset)
-    
-    @property
-    def size(self) -> gdb.Value:
-        return pwndbg.memory.poi(pwndbg.typeinfo.size_t, self.address + self._c_struct.size.offset)
-    
-    @property
-    def fd(self) -> gdb.Value:
-        return pwndbg.memory.poi(pwndbg.typeinfo.pvoid, self.address + self._c_struct.fd.offset)
-    
-    @property
-    def bk(self) -> gdb.Value:
-        return pwndbg.memory.poi(pwndbg.typeinfo.pvoid, self.address + self._c_struct.bk.offset)
-    
-    @property
-    def fd_nextsize(self) -> gdb.Value:
-        return pwndbg.memory.poi(pwndbg.typeinfo.pvoid, self.address + self._c_struct.fd_nextsize.offset)
-    
-    @property
-    def bk_nextsize(self) -> gdb.Value:
-        return pwndbg.memory.poi(pwndbg.typeinfo.pvoid, self.address + self._c_struct.bk_nextsize.offset)
-    
     @staticmethod
     def keys() -> tuple:
+        """
+        Return a tuple of the names of the fields in the struct.
+        """
         return tuple(field[0] for field in c_malloc_chunk._fields_)
 
-class c_tcache_perthread_struct(ctypes.LittleEndianStructure):
+class c_tcache_perthread_struct_2_29(ctypes.LittleEndianStructure):
+    """
+    This class represents tcache_perthread_struct for GLIBC < 2.30 as a ctypes struct.
+
+    https://github.com/bminor/glibc/blob/glibc-2.29/malloc/malloc.c#L2916
+
+    typedef struct tcache_perthread_struct
+    {
+        char counts[TCACHE_MAX_BINS];
+        tcache_entry *entries[TCACHE_MAX_BINS];
+    } tcache_perthread_struct;
+    """
     _fields_ = [
-        ('counts', ctypes.c_uint16 * TCACHE_MAX_BINS),
-        ('entries', PTR * TCACHE_MAX_BINS)
+        ('counts', ctypes.c_char * TCACHE_MAX_BINS),
+        ('entries', c_pvoid * TCACHE_MAX_BINS)
     ]
 
-class TcachePerthreadStruct(CStruct2GDB):
+class c_tcache_perthread_struct_2_30(ctypes.LittleEndianStructure):
     """
-    This class represents the tcache_perthread_struct struct.
+    This class represents the tcache_perthread_struct for GLIBC >= 2.30 as a ctypes struct.
 
     https://github.com/bminor/glibc/blob/glibc-2.34/malloc/malloc.c#L3025
 
@@ -346,42 +378,53 @@ class TcachePerthreadStruct(CStruct2GDB):
         tcache_entry *entries[TCACHE_MAX_BINS];
     } tcache_perthread_struct;
     """
-    _c_struct = c_tcache_perthread_struct
+    _fields_ = [
+        ('counts', ctypes.c_uint16 * TCACHE_MAX_BINS),
+        ('entries', c_pvoid * TCACHE_MAX_BINS)
+    ]
+
+class TcachePerthreadStruct(CStruct2GDB):
+    """
+    This class represents tcache_perthread_struct with interface compatible with `gdb.Value`.
+    """
+    if pwndbg.glibc.get_version() >= (2, 30):
+        _c_struct = c_tcache_perthread_struct_2_30
+    else:
+        _c_struct = c_tcache_perthread_struct_2_29
     sizeof = ctypes.sizeof(_c_struct)
 
     def __init__(self, address: int) -> None:
         self.address = address
 
-    @property
-    def counts(self) -> gdb.Value:
-        return pwndbg.memory.poi(pwndbg.typeinfo.uint16.array(TCACHE_MAX_BINS - 1), self.address + self._c_struct.counts.offset)
-    
-    @property
-    def entries(self) -> gdb.Value:
-        return pwndbg.memory.poi(pwndbg.typeinfo.pvoid.array(TCACHE_MAX_BINS - 1), self.address + self._c_struct.entries.offset)
-
     @staticmethod
     def keys() -> tuple:
-        return tuple(field[0] for field in c_tcache_perthread_struct._fields_)
+        """
+        Return a tuple of the names of the fields in the struct.
+        """
+        if pwndbg.glibc.get_version() >= (2, 30):
+            return tuple(field[0] for field in c_tcache_perthread_struct_2_30._fields_)
+        return tuple(field[0] for field in c_tcache_perthread_struct_2_29._fields_)
 
 class c_tcache_entry_2_28(ctypes.LittleEndianStructure):
+    """
+    This class represents the tcache_entry struct for GLIBC < 2.29 as a ctypes struct.
+
+    https://github.com/bminor/glibc/blob/glibc-2.28/malloc/malloc.c#L2888
+
+    typedef struct tcache_entry
+    {
+        struct tcache_entry *next;
+    } tcache_entry;
+    """
     _fields_ = [
-        ('next', PTR)
+        ('next', c_pvoid)
     ]
 
 class c_tcache_entry_2_29(ctypes.LittleEndianStructure):
-    _fields_ = [
-        ('next', PTR),
-        ('key', PTR)
-    ]
-
-class TcacheEntry:
     """
-    This class represents the tcache_entry struct.
+    This class represents the tcache_entry struct for GLIBC >= 2.29 as a ctypes struct.
 
     https://github.com/bminor/glibc/blob/glibc-2.34/malloc/malloc.c#L3013
-
-    Note: glibc < 2.29 does not have `key` field.
 
     typedef struct tcache_entry
     {
@@ -390,70 +433,84 @@ class TcacheEntry:
         uintptr_t key;
     } tcache_entry;
     """
+    _fields_ = [
+        ('next', c_pvoid),
+        ('key', c_pvoid)
+    ]
+
+class TcacheEntry:
+    """
+    This class represents the tcache_entry struct with interface compatible with `gdb.Value`.
+    """
     if pwndbg.glibc.get_version() >= (2, 29):
         _c_struct = c_tcache_entry_2_29
-        sizeof = ctypes.sizeof(_c_struct)
     else:
         _c_struct = c_tcache_entry_2_28
-        sizeof = ctypes.sizeof(_c_struct)
+    sizeof = ctypes.sizeof(_c_struct)
 
     def __init__(self, address: int) -> None:
         self.address = address
     
-    @property
-    def next(self) -> gdb.Value:
-        return pwndbg.memory.poi(pwndbg.typeinfo.pvoid, self.address + self._c_struct.next.offset)
-    
-    @property
-    def key(self) -> gdb.Value:
-        return pwndbg.memory.poi(pwndbg.typeinfo.pvoid, self.address + self._c_struct.key.offset)
-    
     @staticmethod
     def keys() -> tuple:
+        """
+        Return a tuple of the names of the fields in the struct.
+        """
         if pwndbg.glibc.get_version() >= (2, 29):
             return tuple(field[0] for field in c_tcache_entry_2_29._fields_)
-        else:
-            return tuple(field[0] for field in c_tcache_entry_2_28._fields_)
+        return tuple(field[0] for field in c_tcache_entry_2_28._fields_)
 
 class c_malloc_par_2_25(ctypes.LittleEndianStructure):
+    """
+    This class represents the malloc_par struct for GLIBC < 2.26 as a ctypes struct.
+
+    https://github.com/bminor/glibc/blob/glibc-2.25/malloc/malloc.c#L1690
+
+    struct malloc_par
+    {
+        /* Tunable parameters */
+        unsigned long trim_threshold;
+        INTERNAL_SIZE_T top_pad;
+        INTERNAL_SIZE_T mmap_threshold;
+        INTERNAL_SIZE_T arena_test;
+        INTERNAL_SIZE_T arena_max;
+
+        /* Memory map support */
+        int n_mmaps;
+        int n_mmaps_max;
+        int max_n_mmaps;
+        /* the mmap_threshold is dynamic, until the user sets
+            it manually, at which point we need to disable any
+            dynamic behavior. */
+        int no_dyn_threshold;
+
+        /* Statistics */
+        INTERNAL_SIZE_T mmapped_mem;
+        INTERNAL_SIZE_T max_mmapped_mem;
+
+        /* First address handed out by MORECORE/sbrk.  */
+        char *sbrk_base;
+    };
+    """
+    
     _fields_ = [
-        ('trim_threshold', SIZE_T),
-        ('top_pad', SIZE_T),
-        ('mmap_threshold', SIZE_T),
-        ('arena_test', SIZE_T),
-        ('arena_max', SIZE_T),
+        ('trim_threshold', c_size_t),
+        ('top_pad', c_size_t),
+        ('mmap_threshold', c_size_t),
+        ('arena_test', c_size_t),
+        ('arena_max', c_size_t),
         ('n_mmaps', ctypes.c_int32),
         ('n_mmaps_max', ctypes.c_int32),
         ('max_n_mmaps', ctypes.c_int32),
         ('no_dyn_threshold', ctypes.c_int32),
-        ('mmapped_mem', SIZE_T),
-        ('max_mmapped_mem', SIZE_T),
-        ('sbrk_base', PTR)
+        ('mmapped_mem', c_size_t),
+        ('max_mmapped_mem', c_size_t),
+        ('sbrk_base', c_pvoid)
     ]
 
 class c_malloc_par_2_26(ctypes.LittleEndianStructure):
-    _fields_ = [
-        ('trim_threshold', SIZE_T),
-        ('top_pad', SIZE_T),
-        ('mmap_threshold', SIZE_T),
-        ('arena_test', SIZE_T),
-        ('arena_max', SIZE_T),
-        ('n_mmaps', ctypes.c_int32),
-        ('n_mmaps_max', ctypes.c_int32),
-        ('max_n_mmaps', ctypes.c_int32),
-        ('no_dyn_threshold', ctypes.c_int32),
-        ('mmapped_mem', SIZE_T),
-        ('max_mmapped_mem', SIZE_T),
-        ('sbrk_base', PTR),
-        ('tcache_bins', SIZE_T),
-        ('tcache_max_bytes', SIZE_T),
-        ('tcache_count', ctypes.c_int32),
-        ('tcache_unsorted_limit', SIZE_T)
-    ]
-
-class MallocPar(CStruct2GDB):
     """
-    This class represents the malloc_par struct.
+    This class represents the malloc_par struct for GLIBC >= 2.26 as a ctypes struct.
 
     https://github.com/bminor/glibc/blob/glibc-2.34/malloc/malloc.c#L1875
 
@@ -482,7 +539,7 @@ class MallocPar(CStruct2GDB):
         /* First address handed out by MORECORE/sbrk.  */
         char *sbrk_base;
 
-        #if USE_TCACHE
+    #if USE_TCACHE
         /* Maximum number of buckets to use.  */
         size_t tcache_bins;
         size_t tcache_max_bytes;
@@ -491,86 +548,46 @@ class MallocPar(CStruct2GDB):
         /* Maximum number of chunks to remove from the unsorted list, which
             aren't used to prefill the cache.  */
         size_t tcache_unsorted_limit;
-        #endif
+    #endif
     };
+    """
+    _fields_ = [
+        ('trim_threshold', c_size_t),
+        ('top_pad', c_size_t),
+        ('mmap_threshold', c_size_t),
+        ('arena_test', c_size_t),
+        ('arena_max', c_size_t),
+        ('n_mmaps', ctypes.c_int32),
+        ('n_mmaps_max', ctypes.c_int32),
+        ('max_n_mmaps', ctypes.c_int32),
+        ('no_dyn_threshold', ctypes.c_int32),
+        ('mmapped_mem', c_size_t),
+        ('max_mmapped_mem', c_size_t),
+        ('sbrk_base', c_pvoid),
+        ('tcache_bins', c_size_t),
+        ('tcache_max_bytes', c_size_t),
+        ('tcache_count', ctypes.c_int32),
+        ('tcache_unsorted_limit', c_size_t)
+    ]
+
+class MallocPar(CStruct2GDB):
+    """
+    This class represents the malloc_par struct with interface compatible with `gdb.Value`.
     """
     if pwndbg.glibc.get_version() >= (2, 26):
         _c_struct = c_malloc_par_2_26
-        sizeof = ctypes.sizeof(_c_struct)
     else:
         _c_struct = c_malloc_par_2_25
-        sizeof = ctypes.sizeof(_c_struct)
+    sizeof = ctypes.sizeof(_c_struct)
 
     def __init__(self, address: int) -> None:
         self.address = address
     
-    @property
-    def trim_threshold(self) -> gdb.Value:
-        return pwndbg.memory.poi(pwndbg.typeinfo.ulong, self.address + self._c_struct.trim_threshold.offset)
-    
-    @property
-    def top_pad(self) -> gdb.Value:
-        return pwndbg.memory.poi(pwndbg.typeinfo.size_t, self.address + self._c_struct.top_pad.offset)
-    
-    @property
-    def mmap_threshold(self) -> gdb.Value:
-        return pwndbg.memory.poi(pwndbg.typeinfo.size_t, self.address + self._c_struct.mmap_threshold.offset)
-    
-    @property
-    def arena_test(self) -> gdb.Value:
-        return pwndbg.memory.poi(pwndbg.typeinfo.size_t, self.address + self._c_struct.arena_test.offset)
-    
-    @property
-    def arena_max(self) -> gdb.Value:
-        return pwndbg.memory.poi(pwndbg.typeinfo.size_t, self.address + self._c_struct.arena_max.offset)
-    
-    @property
-    def n_mmaps(self) -> gdb.Value:
-        return pwndbg.memory.poi(pwndbg.typeinfo.int32, self.address + self._c_struct.n_mmaps.offset)
-    
-    @property
-    def n_mmaps_max(self) -> gdb.Value:
-        return pwndbg.memory.poi(pwndbg.typeinfo.int32, self.address + self._c_struct.n_mmaps_max.offset)
-    
-    @property
-    def max_n_mmaps(self) -> gdb.Value:
-        return pwndbg.memory.poi(pwndbg.typeinfo.int32, self.address + self._c_struct.max_n_mmaps.offset)
-    
-    @property
-    def no_dyn_threshold(self) -> gdb.Value:
-        return pwndbg.memory.poi(pwndbg.typeinfo.int32, self.address + self._c_struct.no_dyn_threshold.offset)
-    
-    @property
-    def mmapped_mem(self) -> gdb.Value:
-        return pwndbg.memory.poi(pwndbg.typeinfo.size_t, self.address + self._c_struct.mmapped_mem.offset)
-    
-    @property
-    def max_mmapped_mem(self) -> gdb.Value:
-        return pwndbg.memory.poi(pwndbg.typeinfo.size_t, self.address + self._c_struct.max_mmapped_mem.offset)
-    
-    @property
-    def sbrk_base(self) -> gdb.Value:
-        return pwndbg.memory.poi(pwndbg.typeinfo.pvoid, self.address + self._c_struct.sbrk_base.offset)
-    
-    @property
-    def tcache_bins(self) -> gdb.Value:
-        return pwndbg.memory.poi(pwndbg.typeinfo.size_t, self.address + self._c_struct.tcache_bins.offset)
-    
-    @property
-    def tcache_max_bytes(self) -> gdb.Value:
-        return pwndbg.memory.poi(pwndbg.typeinfo.size_t, self.address + self._c_struct.tcache_max_bytes.offset)
-    
-    @property
-    def tcache_count(self) -> gdb.Value:
-        return pwndbg.memory.poi(pwndbg.typeinfo.size_t, self.address + self._c_struct.tcache_count.offset)
-    
-    @property
-    def tcache_unsorted_limit(self) -> gdb.Value:
-        return pwndbg.memory.poi(pwndbg.typeinfo.size_t, self.address + self._c_struct.tcache_unsorted_limit.offset)
-
     @staticmethod
     def keys() -> tuple:
+        """
+        Return a tuple of the names of the fields in the struct.
+        """
         if pwndbg.glibc.get_version() >= (2, 26):
             return tuple(field[0] for field in c_malloc_par_2_26._fields_)
-        else:
-            return tuple(field[0] for field in c_malloc_par_2_25._fields_)
+        return tuple(field[0] for field in c_malloc_par_2_25._fields_)

--- a/pwndbg/heap/structs.py
+++ b/pwndbg/heap/structs.py
@@ -426,8 +426,8 @@ class c_malloc_par_2_25(ctypes.LittleEndianStructure):
         ('n_mmaps_max', ctypes.c_int32),
         ('max_n_mmaps', ctypes.c_int32),
         ('no_dyn_threshold', ctypes.c_int32),
-        ('mmaped_mem', SIZE_T),
-        ('max_mmaped_mem', SIZE_T),
+        ('mmapped_mem', SIZE_T),
+        ('max_mmapped_mem', SIZE_T),
         ('sbrk_base', PTR)
     ]
 

--- a/pwndbg/heap/structs.py
+++ b/pwndbg/heap/structs.py
@@ -1,0 +1,576 @@
+import gdb
+
+import pwndbg.arch
+import pwndbg.heap
+import pwndbg.typeinfo
+import pwndbg.memory
+import pwndbg.glibc
+import ctypes
+
+NBINS = 128
+BINMAPSIZE = 4
+TCACHE_MAX_BINS = 64
+
+if pwndbg.arch.ptrsize == 4:
+    NFASTBINS = 11
+    PTR = ctypes.c_uint32
+    SIZE_T = ctypes.c_uint32
+else:
+    NFASTBINS = 10
+    PTR = ctypes.c_uint64
+    SIZE_T = ctypes.c_uint64
+
+class CStruct2GDB:
+    def __int__(self) -> int:
+        return self.address
+    
+    def __getitem__(self, key: str) -> gdb.Value:
+        return getattr(self, key)
+    
+    def __eq__(self, other) -> bool:
+        return self.address == int(other)
+    
+    def __str__(self) -> str:
+        output = "{\n"
+        for f in self._c_struct._fields_:
+            output += "  %s = %s,\n" % (f[0], getattr(self, f[0]))
+        output += "}"
+        return output
+
+    @property
+    def type(self):
+        """
+        Returns self to make it compatible with the `gdb.Value` interface.
+        """
+        return self
+    
+    def field_address(self, field: str) -> int:
+        return self.address + getattr(self._c_struct, field).offset
+
+    def items(self) -> tuple:
+        return tuple((field[0], getattr(self, field[0])) for field in self._c_struct._fields_)
+
+class c_malloc_state_2_26(ctypes.LittleEndianStructure):
+    _fields_ = [
+        ('mutex', ctypes.c_int32),
+        ('flags', ctypes.c_int32),
+        ('fastbinsY', PTR * NFASTBINS),
+        ('top', PTR),
+        ('last_remainder', PTR),
+        ('bins', PTR * (NBINS * 2 - 2)),
+        ('binmap', ctypes.c_int32 * BINMAPSIZE),
+        ('next', PTR),
+        ('next_free', PTR),
+        ('attached_threads', SIZE_T),
+        ('system_mem', SIZE_T),
+        ('max_system_mem', SIZE_T),
+    ]
+
+class c_malloc_state_2_27(ctypes.LittleEndianStructure):
+    _fields_ = [
+        ('mutex', ctypes.c_int32),
+        ('flags', ctypes.c_int32),
+        ('have_fastchunks', ctypes.c_int32),
+        ('fastbinsY', PTR * NFASTBINS),
+        ('top', PTR),
+        ('last_remainder', PTR),
+        ('bins', PTR * (NBINS * 2 - 2)),
+        ('binmap', ctypes.c_int32 * BINMAPSIZE),
+        ('next', PTR),
+        ('next_free', PTR),
+        ('attached_threads', SIZE_T),
+        ('system_mem', SIZE_T),
+        ('max_system_mem', SIZE_T),
+    ]
+
+class MallocState(CStruct2GDB):
+    """
+    This class represents malloc_state struct.
+
+    https://github.com/bminor/glibc/blob/glibc-2.34/malloc/malloc.c#L1831
+
+    Note: glibc < 2.27 does not have `have_fastchunks` field.
+
+    struct malloc_state
+    {
+        /* Serialize access.  */
+        __libc_lock_define (, mutex);
+
+        /* Flags (formerly in max_fast).  */
+        int flags;
+
+        /* Set if the fastbin chunks contain recently inserted free blocks.  */
+        /* Note this is a bool but not all targets support atomics on booleans.  */
+        int have_fastchunks;
+
+        /* Fastbins */
+        mfastbinptr fastbinsY[NFASTBINS];
+
+        /* Base of the topmost chunk -- not otherwise kept in a bin */
+        mchunkptr top;
+
+        /* The remainder from the most recent split of a small request */
+        mchunkptr last_remainder;
+
+        /* Normal bins packed as described above */
+        mchunkptr bins[NBINS * 2 - 2];
+
+        /* Bitmap of bins */
+        unsigned int binmap[BINMAPSIZE];
+
+        /* Linked list */
+        struct malloc_state *next;
+
+        /* Linked list for free arenas.  Access to this field is serialized
+            by free_list_lock in arena.c.  */
+        struct malloc_state *next_free;
+
+        /* Number of threads attached to this arena.  0 if the arena is on
+            the free list.  Access to this field is serialized by
+            free_list_lock in arena.c.  */
+        INTERNAL_SIZE_T attached_threads;
+
+        /* Memory allocated from the system in this arena.  */
+        INTERNAL_SIZE_T system_mem;
+        INTERNAL_SIZE_T max_system_mem;
+    };
+    """
+    if pwndbg.glibc.get_version() >= (2, 27):
+        _c_struct = c_malloc_state_2_27
+        sizeof = ctypes.sizeof(_c_struct)
+    else:
+        _c_struct = c_malloc_state_2_26
+        sizeof = ctypes.sizeof(_c_struct)
+    
+    def __init__(self, address: int) -> None:
+        self.address = address
+    
+    @property
+    def mutex(self) -> gdb.Value:
+        return pwndbg.memory.poi(pwndbg.typeinfo.int32, self.address + self._c_struct.mutex.offset)
+    
+    @property
+    def flags(self) -> gdb.Value:
+        return pwndbg.memory.poi(pwndbg.typeinfo.int32, self.address + self._c_struct.flags.offset)
+
+    @property
+    def have_fastchunks(self) -> gdb.Value:
+        return pwndbg.memory.poi(pwndbg.typeinfo.int32, self.address + self._c_struct.have_fastchunks.offset)
+
+    @property
+    def fastbinsY(self) -> gdb.Value:
+        return pwndbg.memory.poi(pwndbg.typeinfo.pvoid.array(NFASTBINS - 1), self.address + self._c_struct.fastbinsY.offset)
+    
+    @property
+    def top(self) -> gdb.Value:
+        return pwndbg.memory.poi(pwndbg.typeinfo.pvoid, self.address + self._c_struct.top.offset)
+    
+    @property
+    def last_remainder(self) -> gdb.Value:
+        return pwndbg.memory.poi(pwndbg.typeinfo.pvoid, self.address + self._c_struct.last_remainder.offset)
+    
+    @property
+    def bins(self) -> gdb.Value:
+        return pwndbg.memory.poi(pwndbg.typeinfo.pvoid.array((NBINS * 2 - 2) - 1), self.address + self._c_struct.bins.offset)
+    
+    @property
+    def binmap(self) -> gdb.Value:
+        return pwndbg.memory.poi(pwndbg.typeinfo.int32.array(BINMAPSIZE - 1), self.address + self._c_struct.binmap.offset)
+    
+    @property
+    def next(self) -> gdb.Value:
+        return pwndbg.memory.poi(pwndbg.typeinfo.pvoid, self.address + self._c_struct.next.offset)
+    
+    @property
+    def next_free(self) -> gdb.Value:
+        return pwndbg.memory.poi(pwndbg.typeinfo.pvoid, self.address + self._c_struct.next_free.offset)
+    
+    @property
+    def attached_threads(self) -> gdb.Value:
+        return pwndbg.memory.poi(pwndbg.typeinfo.size_t, self.address + self._c_struct.attached_threads.offset)
+    
+    @property
+    def system_mem(self) -> gdb.Value:
+        return pwndbg.memory.poi(pwndbg.typeinfo.size_t, self.address + self._c_struct.system_mem.offset)
+    
+    @property
+    def max_system_mem(self) -> gdb.Value:
+        return pwndbg.memory.poi(pwndbg.typeinfo.size_t, self.address + self._c_struct.max_system_mem.offset)
+
+    @staticmethod
+    def keys() -> tuple:
+        """
+        Use @staticmethod to make it compatible with the `gdb.Type` insterface.
+        """
+        if pwndbg.glibc.get_version() >= (2, 27):
+            return tuple(field[0] for field in c_malloc_state_2_27._fields_)
+        else:
+            return tuple(field[0] for field in c_malloc_state_2_26._fields_)
+
+class c_heap_info(ctypes.LittleEndianStructure):
+    _fields_ = [
+        ('ar_ptr', PTR),
+        ('prev', PTR),
+        ('next', PTR),
+        ('size', SIZE_T),
+        ('pad', ctypes.c_uint8 * (8 if pwndbg.arch.ptrsize == 4 else 0)),
+    ]
+
+class HeapInfo(CStruct2GDB):
+    """
+    This class represents _heap_info struct.
+
+    https://github.com/bminor/glibc/blob/glibc-2.34/malloc/arena.c#L53
+
+    typedef struct _heap_info
+    {
+        mstate ar_ptr; /* Arena for this heap. */
+        struct _heap_info *prev; /* Previous heap. */
+        size_t size;   /* Current size in bytes. */
+        size_t mprotect_size; /* Size in bytes that has been mprotected
+                                PROT_READ|PROT_WRITE.  */
+        /* Make sure the following data is properly aligned, particularly
+            that sizeof (heap_info) + 2 * SIZE_SZ is a multiple of
+            MALLOC_ALIGNMENT. */
+        char pad[-6 * SIZE_SZ & MALLOC_ALIGN_MASK];
+    } heap_info;
+    """
+    _c_struct = c_heap_info
+    sizeof = ctypes.sizeof(_c_struct)
+
+    def __init__(self, address: int) -> None:
+        self.address = address
+    
+    @property
+    def ar_ptr(self) -> gdb.Value:
+        return pwndbg.memory.poi(pwndbg.typeinfo.pvoid, self.address + self._c_struct.ar_ptr.offset)
+    
+    @property
+    def prev(self) -> gdb.Value:
+        return pwndbg.memory.poi(pwndbg.typeinfo.pvoid, self.address + self._c_struct.prev.offset)
+    
+    @property
+    def size(self) -> gdb.Value:
+        return pwndbg.memory.poi(pwndbg.typeinfo.size_t, self.address + self._c_struct.size.offset)
+    
+    @property
+    def mprotect_size(self) -> gdb.Value:
+        return pwndbg.memory.poi(pwndbg.typeinfo.size_t, self.address + self._c_struct.mprotect_size.offset)
+
+    @property
+    def pad(self) -> gdb.Value:
+        return pwndbg.memory.poi(pwndbg.typeinfo.char.array((8 if pwndbg.arch.ptrsize == 4 else 0) - 1), self.address + self._c_struct.pad.offset)
+    
+    @staticmethod
+    def keys() -> tuple:
+        return tuple(field[0] for field in c_heap_info._fields_)
+
+class c_malloc_chunk(ctypes.LittleEndianStructure):
+    _fields_ = [
+        ('prev_size', SIZE_T),
+        ('size', SIZE_T),
+        ('fd', PTR),
+        ('bk', PTR),
+        ('fd_nextsize', PTR),
+        ('bk_nextsize', PTR),
+    ]
+
+class MallocChunk(CStruct2GDB):
+    """
+    This class represents malloc_chunk struct.
+
+    https://github.com/bminor/glibc/blob/glibc-2.34/malloc/malloc.c#L1154
+    
+    struct malloc_chunk {
+
+        INTERNAL_SIZE_T      mchunk_prev_size;  /* Size of previous chunk (if free).  */
+        INTERNAL_SIZE_T      mchunk_size;       /* Size in bytes, including overhead. */
+
+        struct malloc_chunk* fd;         /* double links -- used only if free. */
+        struct malloc_chunk* bk;
+
+        /* Only used for large blocks: pointer to next larger size.  */
+        struct malloc_chunk* fd_nextsize; /* double links -- used only if free. */
+        struct malloc_chunk* bk_nextsize;
+    };
+    """
+    _c_struct = c_malloc_chunk
+    sizeof = ctypes.sizeof(_c_struct)
+
+    def __init__(self, address: int) -> None:
+        self.address = address
+    
+    @property
+    def prev_size(self) -> gdb.Value:
+        return pwndbg.memory.poi(pwndbg.typeinfo.size_t, self.address + self._c_struct.prev_size.offset)
+    
+    @property
+    def size(self) -> gdb.Value:
+        return pwndbg.memory.poi(pwndbg.typeinfo.size_t, self.address + self._c_struct.size.offset)
+    
+    @property
+    def fd(self) -> gdb.Value:
+        return pwndbg.memory.poi(pwndbg.typeinfo.pvoid, self.address + self._c_struct.fd.offset)
+    
+    @property
+    def bk(self) -> gdb.Value:
+        return pwndbg.memory.poi(pwndbg.typeinfo.pvoid, self.address + self._c_struct.bk.offset)
+    
+    @property
+    def fd_nextsize(self) -> gdb.Value:
+        return pwndbg.memory.poi(pwndbg.typeinfo.pvoid, self.address + self._c_struct.fd_nextsize.offset)
+    
+    @property
+    def bk_nextsize(self) -> gdb.Value:
+        return pwndbg.memory.poi(pwndbg.typeinfo.pvoid, self.address + self._c_struct.bk_nextsize.offset)
+    
+    @staticmethod
+    def keys() -> tuple:
+        return tuple(field[0] for field in c_malloc_chunk._fields_)
+
+class c_tcache_perthread_struct(ctypes.LittleEndianStructure):
+    _fields_ = [
+        ('counts', ctypes.c_uint16 * TCACHE_MAX_BINS),
+        ('entries', PTR * TCACHE_MAX_BINS)
+    ]
+
+class TcachePerthreadStruct(CStruct2GDB):
+    """
+    This class represents the tcache_perthread_struct struct.
+
+    https://github.com/bminor/glibc/blob/glibc-2.34/malloc/malloc.c#L3025
+
+    typedef struct tcache_perthread_struct
+    {
+        uint16_t counts[TCACHE_MAX_BINS];
+        tcache_entry *entries[TCACHE_MAX_BINS];
+    } tcache_perthread_struct;
+    """
+    _c_struct = c_tcache_perthread_struct
+    sizeof = ctypes.sizeof(_c_struct)
+
+    def __init__(self, address: int) -> None:
+        self.address = address
+
+    @property
+    def counts(self) -> gdb.Value:
+        return pwndbg.memory.poi(pwndbg.typeinfo.uint16.array(TCACHE_MAX_BINS - 1), self.address + self._c_struct.counts.offset)
+    
+    @property
+    def entries(self) -> gdb.Value:
+        return pwndbg.memory.poi(pwndbg.typeinfo.pvoid.array(TCACHE_MAX_BINS - 1), self.address + self._c_struct.entries.offset)
+
+    @staticmethod
+    def keys() -> tuple:
+        return tuple(field[0] for field in c_tcache_perthread_struct._fields_)
+
+class c_tcache_entry_2_28(ctypes.LittleEndianStructure):
+    _fields_ = [
+        ('next', PTR)
+    ]
+
+class c_tcache_entry_2_29(ctypes.LittleEndianStructure):
+    _fields_ = [
+        ('next', PTR),
+        ('key', PTR)
+    ]
+
+class TcacheEntry:
+    """
+    This class represents the tcache_entry struct.
+
+    https://github.com/bminor/glibc/blob/glibc-2.34/malloc/malloc.c#L3013
+
+    Note: glibc < 2.29 does not have `key` field.
+
+    typedef struct tcache_entry
+    {
+        struct tcache_entry *next;
+        /* This field exists to detect double frees.  */
+        uintptr_t key;
+    } tcache_entry;
+    """
+    if pwndbg.glibc.get_version() >= (2, 29):
+        _c_struct = c_tcache_entry_2_29
+        sizeof = ctypes.sizeof(_c_struct)
+    else:
+        _c_struct = c_tcache_entry_2_28
+        sizeof = ctypes.sizeof(_c_struct)
+
+    def __init__(self, address: int) -> None:
+        self.address = address
+    
+    @property
+    def next(self) -> gdb.Value:
+        return pwndbg.memory.poi(pwndbg.typeinfo.pvoid, self.address + self._c_struct.next.offset)
+    
+    @property
+    def key(self) -> gdb.Value:
+        return pwndbg.memory.poi(pwndbg.typeinfo.pvoid, self.address + self._c_struct.key.offset)
+    
+    @staticmethod
+    def keys() -> tuple:
+        if pwndbg.glibc.get_version() >= (2, 29):
+            return tuple(field[0] for field in c_tcache_entry_2_29._fields_)
+        else:
+            return tuple(field[0] for field in c_tcache_entry_2_28._fields_)
+
+class c_malloc_par_2_25(ctypes.LittleEndianStructure):
+    _fields_ = [
+        ('trim_threshold', SIZE_T),
+        ('top_pad', SIZE_T),
+        ('mmap_threshold', SIZE_T),
+        ('arena_test', SIZE_T),
+        ('arena_max', SIZE_T),
+        ('n_mmaps', ctypes.c_int32),
+        ('n_mmaps_max', ctypes.c_int32),
+        ('max_n_mmaps', ctypes.c_int32),
+        ('no_dyn_threshold', ctypes.c_int32),
+        ('mmaped_mem', SIZE_T),
+        ('max_mmaped_mem', SIZE_T),
+        ('sbrk_base', PTR)
+    ]
+
+class c_malloc_par_2_26(ctypes.LittleEndianStructure):
+    _fields_ = [
+        ('trim_threshold', SIZE_T),
+        ('top_pad', SIZE_T),
+        ('mmap_threshold', SIZE_T),
+        ('arena_test', SIZE_T),
+        ('arena_max', SIZE_T),
+        ('n_mmaps', ctypes.c_int32),
+        ('n_mmaps_max', ctypes.c_int32),
+        ('max_n_mmaps', ctypes.c_int32),
+        ('no_dyn_threshold', ctypes.c_int32),
+        ('mmapped_mem', SIZE_T),
+        ('max_mmapped_mem', SIZE_T),
+        ('sbrk_base', PTR),
+        ('tcache_bins', SIZE_T),
+        ('tcache_max_bytes', SIZE_T),
+        ('tcache_count', ctypes.c_int32),
+        ('tcache_unsorted_limit', SIZE_T)
+    ]
+
+class MallocPar(CStruct2GDB):
+    """
+    This class represents the malloc_par struct.
+
+    https://github.com/bminor/glibc/blob/glibc-2.34/malloc/malloc.c#L1875
+
+    struct malloc_par
+    {
+        /* Tunable parameters */
+        unsigned long trim_threshold;
+        INTERNAL_SIZE_T top_pad;
+        INTERNAL_SIZE_T mmap_threshold;
+        INTERNAL_SIZE_T arena_test;
+        INTERNAL_SIZE_T arena_max;
+
+        /* Memory map support */
+        int n_mmaps;
+        int n_mmaps_max;
+        int max_n_mmaps;
+        /* the mmap_threshold is dynamic, until the user sets
+            it manually, at which point we need to disable any
+            dynamic behavior. */
+        int no_dyn_threshold;
+
+        /* Statistics */
+        INTERNAL_SIZE_T mmapped_mem;
+        INTERNAL_SIZE_T max_mmapped_mem;
+
+        /* First address handed out by MORECORE/sbrk.  */
+        char *sbrk_base;
+
+        #if USE_TCACHE
+        /* Maximum number of buckets to use.  */
+        size_t tcache_bins;
+        size_t tcache_max_bytes;
+        /* Maximum number of chunks in each bucket.  */
+        size_t tcache_count;
+        /* Maximum number of chunks to remove from the unsorted list, which
+            aren't used to prefill the cache.  */
+        size_t tcache_unsorted_limit;
+        #endif
+    };
+    """
+    if pwndbg.glibc.get_version() >= (2, 26):
+        _c_struct = c_malloc_par_2_26
+        sizeof = ctypes.sizeof(_c_struct)
+    else:
+        _c_struct = c_malloc_par_2_25
+        sizeof = ctypes.sizeof(_c_struct)
+
+    def __init__(self, address: int) -> None:
+        self.address = address
+    
+    @property
+    def trim_threshold(self) -> gdb.Value:
+        return pwndbg.memory.poi(pwndbg.typeinfo.ulong, self.address + self._c_struct.trim_threshold.offset)
+    
+    @property
+    def top_pad(self) -> gdb.Value:
+        return pwndbg.memory.poi(pwndbg.typeinfo.size_t, self.address + self._c_struct.top_pad.offset)
+    
+    @property
+    def mmap_threshold(self) -> gdb.Value:
+        return pwndbg.memory.poi(pwndbg.typeinfo.size_t, self.address + self._c_struct.mmap_threshold.offset)
+    
+    @property
+    def arena_test(self) -> gdb.Value:
+        return pwndbg.memory.poi(pwndbg.typeinfo.size_t, self.address + self._c_struct.arena_test.offset)
+    
+    @property
+    def arena_max(self) -> gdb.Value:
+        return pwndbg.memory.poi(pwndbg.typeinfo.size_t, self.address + self._c_struct.arena_max.offset)
+    
+    @property
+    def n_mmaps(self) -> gdb.Value:
+        return pwndbg.memory.poi(pwndbg.typeinfo.int32, self.address + self._c_struct.n_mmaps.offset)
+    
+    @property
+    def n_mmaps_max(self) -> gdb.Value:
+        return pwndbg.memory.poi(pwndbg.typeinfo.int32, self.address + self._c_struct.n_mmaps_max.offset)
+    
+    @property
+    def max_n_mmaps(self) -> gdb.Value:
+        return pwndbg.memory.poi(pwndbg.typeinfo.int32, self.address + self._c_struct.max_n_mmaps.offset)
+    
+    @property
+    def no_dyn_threshold(self) -> gdb.Value:
+        return pwndbg.memory.poi(pwndbg.typeinfo.int32, self.address + self._c_struct.no_dyn_threshold.offset)
+    
+    @property
+    def mmapped_mem(self) -> gdb.Value:
+        return pwndbg.memory.poi(pwndbg.typeinfo.size_t, self.address + self._c_struct.mmapped_mem.offset)
+    
+    @property
+    def max_mmapped_mem(self) -> gdb.Value:
+        return pwndbg.memory.poi(pwndbg.typeinfo.size_t, self.address + self._c_struct.max_mmapped_mem.offset)
+    
+    @property
+    def sbrk_base(self) -> gdb.Value:
+        return pwndbg.memory.poi(pwndbg.typeinfo.pvoid, self.address + self._c_struct.sbrk_base.offset)
+    
+    @property
+    def tcache_bins(self) -> gdb.Value:
+        return pwndbg.memory.poi(pwndbg.typeinfo.size_t, self.address + self._c_struct.tcache_bins.offset)
+    
+    @property
+    def tcache_max_bytes(self) -> gdb.Value:
+        return pwndbg.memory.poi(pwndbg.typeinfo.size_t, self.address + self._c_struct.tcache_max_bytes.offset)
+    
+    @property
+    def tcache_count(self) -> gdb.Value:
+        return pwndbg.memory.poi(pwndbg.typeinfo.size_t, self.address + self._c_struct.tcache_count.offset)
+    
+    @property
+    def tcache_unsorted_limit(self) -> gdb.Value:
+        return pwndbg.memory.poi(pwndbg.typeinfo.size_t, self.address + self._c_struct.tcache_unsorted_limit.offset)
+
+    @staticmethod
+    def keys() -> tuple:
+        if pwndbg.glibc.get_version() >= (2, 26):
+            return tuple(field[0] for field in c_malloc_par_2_26._fields_)
+        else:
+            return tuple(field[0] for field in c_malloc_par_2_25._fields_)


### PR DESCRIPTION
I'm trying to make some features that #937 mentioned.

I use two classes to represent different heap resolving strategies(by debug symbols or heuristic), and use some classes in `pwndbg/heap/structs.py` to make some ctypes struct compatible with `gdb.Value` and `gdb.Type`.

We can use `set resolve-via-heuristic on/off` to enable/disable the feature in this PR.

Hope this PR is useful :)

----

P.S. ~Some features only work for i386 and x86-64 currently~, and their implements are a little bit dirty(but it seems to work). I'm sorry about that :(
Edit: It supports arm/aarch64 now
