### PR TITLE
Try fs/gs_base registers before ptrace'ing

### DIFF
--- a/pwndbg/regs.py
+++ b/pwndbg/regs.py
@@ -389,12 +389,24 @@ class module(ModuleType):
     @property
     @pwndbg.memoize.reset_on_stop
     def fsbase(self):
-        return self._fs_gs_helper(ARCH_GET_FS)
+        try:
+            # We can try fs_base register in GDB >= 8.
+            assert get_register == gdb79_get_register
+            fs_base = get_register("fs_base")
+            return fs_base
+        except (ValueError, AssertionError):
+            return self._fs_gs_helper(ARCH_GET_FS)
 
     @property
     @pwndbg.memoize.reset_on_stop
     def gsbase(self):
-        return self._fs_gs_helper(ARCH_GET_GS)
+        try:
+            # We can try gs_base register in GDB >= 8.
+            assert get_register == gdb79_get_register
+            gs_base = get_register("gs_base")
+            return gs_base
+        except (ValueError, AssertionError):
+            return self._fs_gs_helper(ARCH_GET_GS)
 
     @pwndbg.memoize.reset_on_stop
     def _fs_gs_helper(self, which):


### PR DESCRIPTION
`fsbase()` and `gsbase()` in `pwndbg/regs.py` will use ptrace by ourself to find segment base, but it doesn't work on remote debugging.

But GDB >= 8 can use `fs_base` and `gs_base` register to get the same result for x86-64 processes, and this feature works when remote debugging.

So by checking these two registers, even if we are using gdbserver to debug a x86-64 process, we can still use `fsbase`/`gsbase` without any problems if our GDB version >= 8