### PR TITLE
nearpc: convert pc to pointer

### DIFF
--- a/pwndbg/commands/nearpc.py
+++ b/pwndbg/commands/nearpc.py
@@ -1,5 +1,6 @@
 import argparse
 
+import gdb
 from capstone import *
 
 import pwndbg.arguments
@@ -51,6 +52,9 @@ def nearpc(pc=None, lines=None, to_string=False, emulate=False):
         pc = nearpc.next_pc
 
     result = []
+
+    if pc is not None:
+        pc = gdb.Value(pc).cast(pwndbg.typeinfo.pvoid)
 
     # Fix the case where we only have one argument, and
     # it's a small value.

--- a/pwndbg/prompt.py
+++ b/pwndbg/prompt.py
@@ -1,4 +1,5 @@
 import re
+
 import gdb
 
 import pwndbg.decorators


### PR DESCRIPTION
This PR fixes https://github.com/pwndbg/pwndbg/issues/120 by casting `pc` to `pwndbg.typeinfo.pvoid` beforehand

Reference: https://github.com/pwndbg/pwndbg/commit/668e53f5279cfb86b75d852061d3b32b44b69408