### PR TITLE
Fix context args crash on missing instruction

### DIFF
--- a/pwndbg/arguments.py
+++ b/pwndbg/arguments.py
@@ -73,6 +73,9 @@ def get(instruction):
     """
     n_args_default = 4
 
+    if instruction is None:
+        return []
+
     if instruction.address != pwndbg.regs.pc:
         return []
 


### PR DESCRIPTION
`context args` tries to disassemble instruction under RIP but gets `None` when it is in unmapped memory. Fixes https://github.com/pwndbg/pwndbg/issues/1008.