### PR TITLE
Add next_malloc_chunk command

### DIFF
--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -337,6 +337,30 @@ def malloc_chunk(addr, fake=False, verbose=False, simple=False):
 
 
 parser = argparse.ArgumentParser()
+parser.description = "Print the next chunk."
+parser.add_argument("addr", type=int, help="Address of the chunk (malloc_chunk struct start, prev_size field).")
+parser.add_argument("-f", "--fake", action="store_true", help="Is this a fake chunk?")
+parser.add_argument("-v", "--verbose", action="store_true", help="Print all chunk fields, even unused ones.")
+parser.add_argument("-s", "--simple", action="store_true", help="Simply print malloc_chunk struct's contents.")
+@pwndbg.commands.ArgparsedCommand(parser)
+@pwndbg.commands.OnlyWhenRunning
+@pwndbg.commands.OnlyWithLibcDebugSyms
+@pwndbg.commands.OnlyWhenHeapIsInitialized
+def next_malloc_chunk(addr, fake=False, verbose=False, simple=False):
+    """Print a the next malloc_chunk struct's contents."""
+    # points to the real start of the chunk
+    cursor = int(addr)
+
+    allocator = pwndbg.heap.current
+    ptr_size = allocator.size_sz
+
+    size_field = pwndbg.memory.u(cursor + allocator.chunk_key_offset('size'))
+    real_size = size_field & ~allocator.malloc_align_mask
+
+    malloc_chunk(addr + real_size, fake, verbose, simple)
+
+
+parser = argparse.ArgumentParser()
 parser.description = "Print the contents of all an arena's bins and a thread's tcache, default to the current thread's arena and tcache."
 parser.add_argument("addr", nargs="?", type=int, default=None, help="Address of the arena.")
 parser.add_argument("tcache_addr", nargs="?", type=int, default=None, help="Address of the tcache.")


### PR DESCRIPTION
The `malloc_chunk` command already exists to print a chunk at a particular address. But it's also useful to be able to easily print out the next chunk without having to do any additional pointer arithmetic inside GDB. To do this, I've added the `next_malloc_chunk` command.

My use case for this is the following situation. I've created a fake chunk here that I'm about to `free`:
```
pwndbg> malloc_chunk -v 0x56136f784340
Allocated chunk | PREV_INUSE
Addr: 0x56136f784340
prev_size: 0x00
size: 0x421
fd: 0x56136f784350
bk: 0x21
fd_nextsize: 0x56160e4eb400
bk_nextsize: 0x00
```

Everything looks good, but let me double check the next chunk:
```
pwndbg> next_malloc_chunk -v 0x56136f784340
Allocated chunk
Addr: 0x56136f784760
prev_size: 0x00
size: 0x00
fd: 0x00
bk: 0x00
fd_nextsize: 0x00
bk_nextsize: 0x00
```

We can see that my next chunk is actually invalid (`prev_inuse` bit should be set if we're freeing the original chunk), so doing the free will crash. Without this command, it's tedious to check things like this.