### PR TITLE
Refactor heap code

### DIFF
--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -232,21 +232,25 @@ def mp():
 
 parser = argparse.ArgumentParser()
 parser.description = "Print relevant information about an arena's top chunk, default to current thread's arena."
-parser.add_argument("addr", nargs="?", type=int, default=None, help="Address of the arena.")
+parser.add_argument(
+    "addr", nargs="?", type=int, default=None, help="Address of the arena."
+)
 @pwndbg.commands.ArgparsedCommand(parser)
 @pwndbg.commands.OnlyWhenRunning
 @pwndbg.commands.OnlyWithResolvedHeapSyms
 @pwndbg.commands.OnlyWhenHeapIsInitialized
-def top_chunk(addr=None):
+def top_chunk(addr: Optional[int] = None):
     """Print relevant information about an arena's top chunk, default to the
     current thread's arena.
     """
     allocator = pwndbg.heap.current
     arena = allocator.get_arena(addr)
     address = arena['top']
-    size = pwndbg.memory.u(int(address) + allocator.chunk_key_offset('size'))
+    size = allocator.chunk_size_nomask(int(address))
 
-    out = message.off("Top chunk\n") + "Addr: {}\nSize: 0x{:02x}".format(M.get(address), size)
+    out = message.off("Top chunk\n") + "Addr: {}\nSize: 0x{:02x}".format(
+        M.get(address), size
+    )
     print(out)
 
 

--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -1,7 +1,6 @@
 import argparse
 import ctypes
 import struct
-from typing import Optional
 
 import gdb
 
@@ -23,7 +22,7 @@ from pwndbg.heap.ptmalloc import BinType
 from pwndbg.heap.ptmalloc import read_chunk_from_gdb
 
 
-def format_bin(bins: Bins, verbose=False, offset=None) -> list[str]:
+def format_bin(bins, verbose=False, offset=None):
     allocator = pwndbg.heap.current
     if offset is None:
         offset = allocator.chunk_key_offset('fd')
@@ -103,7 +102,7 @@ parser.add_argument(
 @pwndbg.commands.OnlyWhenRunning
 @pwndbg.commands.OnlyWithResolvedHeapSyms
 @pwndbg.commands.OnlyWhenHeapIsInitialized
-def heap(addr: int = None, verbose=False, simple=False):
+def heap(addr=None, verbose=False, simple=False):
     """Iteratively print chunks on a heap, default to the current thread's
     active heap.
     """
@@ -192,7 +191,7 @@ parser.add_argument(
 @pwndbg.commands.OnlyWhenRunning
 @pwndbg.commands.OnlyWithResolvedHeapSyms
 @pwndbg.commands.OnlyWhenHeapIsInitialized
-def top_chunk(addr: Optional[int] = None):
+def top_chunk(addr=None):
     """Print relevant information about an arena's top chunk, default to the
     current thread's arena.
     """
@@ -207,7 +206,7 @@ def top_chunk(addr: Optional[int] = None):
     print(out)
 
 
-def get_chunk_bin(addr: int) -> list[BinType]:
+def get_chunk_bin(addr):
     # points to the real start of the chunk
     cursor = int(addr)
 
@@ -265,7 +264,7 @@ parser.add_argument(
 @pwndbg.commands.OnlyWhenRunning
 @pwndbg.commands.OnlyWithResolvedHeapSyms
 @pwndbg.commands.OnlyWhenHeapIsInitialized
-def malloc_chunk(addr: int, fake=False, verbose=False, simple=False):
+def malloc_chunk(addr, fake=False, verbose=False, simple=False):
     """Print a malloc_chunk struct's contents."""
     # points to the real start of the chunk
     cursor = int(addr)
@@ -362,7 +361,7 @@ parser.add_argument(
 @pwndbg.commands.OnlyWhenRunning
 @pwndbg.commands.OnlyWithResolvedHeapSyms
 @pwndbg.commands.OnlyWhenHeapIsInitialized
-def bins(addr: Optional[int] = None, tcache_addr: Optional[int] = None):
+def bins(addr=None, tcache_addr=None):
     """Print the contents of all an arena's bins and a thread's tcache,
     default to the current thread's arena and tcache.
     """
@@ -374,9 +373,7 @@ def bins(addr: Optional[int] = None, tcache_addr: Optional[int] = None):
     largebins(addr)
 
 
-def print_bins(
-    bin_type: BinType, addr: Optional[int] = None, verbose: bool = False
-):
+def print_bins(bin_type, addr=None, verbose=False):
     allocator = pwndbg.heap.current
     offset = None
 
@@ -409,7 +406,7 @@ parser.add_argument(
 @pwndbg.commands.OnlyWhenRunning
 @pwndbg.commands.OnlyWithResolvedHeapSyms
 @pwndbg.commands.OnlyWhenHeapIsInitialized
-def fastbins(addr: Optional[int] = None, verbose=True):
+def fastbins(addr=None, verbose=True):
     """Print the contents of an arena's fastbins, default to the current
     thread's arena.
     """
@@ -428,7 +425,7 @@ parser.add_argument(
 @pwndbg.commands.OnlyWhenRunning
 @pwndbg.commands.OnlyWithResolvedHeapSyms
 @pwndbg.commands.OnlyWhenHeapIsInitialized
-def unsortedbin(addr: Optional[int] = None, verbose=True):
+def unsortedbin(addr=None, verbose=True):
     """Print the contents of an arena's unsortedbin, default to the current
     thread's arena.
     """
@@ -447,7 +444,7 @@ parser.add_argument(
 @pwndbg.commands.OnlyWhenRunning
 @pwndbg.commands.OnlyWithResolvedHeapSyms
 @pwndbg.commands.OnlyWhenHeapIsInitialized
-def smallbins(addr: Optional[int] = None, verbose=False):
+def smallbins(addr=None, verbose=False):
     """Print the contents of an arena's smallbins, default to the current
     thread's arena.
     """
@@ -466,7 +463,7 @@ parser.add_argument(
 @pwndbg.commands.OnlyWhenRunning
 @pwndbg.commands.OnlyWithResolvedHeapSyms
 @pwndbg.commands.OnlyWhenHeapIsInitialized
-def largebins(addr: Optional[int] = None, verbose=False):
+def largebins(addr=None, verbose=False):
     """Print the contents of an arena's largebins, default to the current
     thread's arena.
     """
@@ -494,7 +491,7 @@ parser.add_argument(
 @pwndbg.commands.OnlyWithResolvedHeapSyms
 @pwndbg.commands.OnlyWhenHeapIsInitialized
 @pwndbg.commands.OnlyWithTcache
-def tcachebins(addr: Optional[int] = None, verbose=False):
+def tcachebins(addr=None, verbose=False):
     """Print the contents of a tcache, default to the current thread's tcache."""
     print_bins(BinType.TCACHE, addr, verbose)
 
@@ -568,7 +565,7 @@ parser.add_argument(
 @pwndbg.commands.OnlyWhenRunning
 @pwndbg.commands.OnlyWithResolvedHeapSyms
 @pwndbg.commands.OnlyWhenHeapIsInitialized
-def vis_heap_chunks(addr: Optional[int] = None, count=None, naive=False):
+def vis_heap_chunks(addr=None, count=None, naive=False):
     """Visualize chunks on a heap, default to the current arena's active heap."""
     allocator = pwndbg.heap.current
     heap_region = allocator.get_heap_boundaries(addr)
@@ -680,7 +677,7 @@ def vis_heap_chunks(addr: Optional[int] = None, count=None, naive=False):
     print(out)
 
 
-def bin_labels(addr: int, bin_type: BinType) -> list[str]:
+def bin_labels(addr, bin_type):
     labels = []
     allocator = pwndbg.heap.current
 

--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -843,7 +843,7 @@ def try_free(addr):
     if chunk_size_unmasked <= allocator.global_max_fast:
         print(message.notice('Fastbin checks'))
         chunk_fastbin_idx = allocator.fastbin_index(chunk_size_unmasked)
-        fastbin_list = allocator.fastbins(int(arena.address))[(chunk_fastbin_idx+2)*(ptr_size*2)]
+        fastbin_list = allocator.fastbins(int(arena.address)).bins[(chunk_fastbin_idx+2)*(ptr_size*2)]
 
         try:
             next_chunk = read_chunk_from_gdb(addr + chunk_size_unmasked)
@@ -862,7 +862,7 @@ def try_free(addr):
             errors_found += 1
 
         # chunk is not the same as the one on top of fastbin[idx]
-        if int(fastbin_list[0]) == addr:
+        if int(fastbin_list.fd_chain[0]) == addr:
             err = 'double free or corruption (fasttop) -> chunk already is on top of fastbin list\n'
             err += '    fastbin idx == {}'
             err = err.format(chunk_fastbin_idx)
@@ -870,7 +870,7 @@ def try_free(addr):
             errors_found += 1
 
         # chunk's size is ~same as top chunk's size
-        fastbin_top_chunk = int(fastbin_list[0])
+        fastbin_top_chunk = int(fastbin_list.fd_chain[0])
         if fastbin_top_chunk != 0:
             try:
                 fastbin_top_chunk = read_chunk_from_gdb(fastbin_top_chunk)

--- a/pwndbg/heap/ptmalloc.py
+++ b/pwndbg/heap/ptmalloc.py
@@ -753,7 +753,6 @@ class DebugSymsHeap(Heap):
                 break
 
     def chunk_size_nomask(self, addr: int) -> int:
-        print(hex(addr + self.chunk_key_offset('size')))
         return pwndbg.memory.u(addr + self.chunk_key_offset('size'))
 
     def chunk_size(self, addr: int) -> int:

--- a/pwndbg/heap/ptmalloc.py
+++ b/pwndbg/heap/ptmalloc.py
@@ -2,6 +2,7 @@ import importlib
 from collections import OrderedDict
 from enum import Enum
 from functools import wraps
+from typing import Optional
 
 import gdb
 
@@ -388,6 +389,20 @@ class Heap(pwndbg.heap.heap.BaseHeap):
     def get_region(self, addr):
         """Find the memory map containing 'addr'."""
         return pwndbg.vmmap.find(addr)
+
+    def get_bins(self, bin_type: BinType, addr: Optional[int] = None) -> Bins:
+        if bin_type == BinType.TCACHE:
+            return self.tcachebins(addr)
+        elif bin_type == BinType.FAST:
+            return self.fastbins(addr)
+        elif bin_type == BinType.UNSORTED:
+            return self.unsortedbin(addr)
+        elif bin_type == BinType.SMALL:
+            return self.smallbins(addr)
+        elif bin_type == BinType.LARGE:
+            return self.largebins(addr)
+        else:
+            return None
 
     def fastbin_index(self, size):
         if pwndbg.arch.ptrsize == 8:

--- a/pwndbg/heap/ptmalloc.py
+++ b/pwndbg/heap/ptmalloc.py
@@ -765,6 +765,10 @@ class DebugSymsHeap(Heap):
     def next_chunk(self, addr: int) -> int:
         return addr + self.chunk_size(addr)
 
+    def prev_inuse(self, addr: int) -> bool:
+        prev_inuse, _, _ = self.chunk_flags(self.chunk_size(addr))
+        return prev_inuse == ptmalloc.PREV_INUSE
+
     def get_tcache(self, tcache_addr=None):
         if tcache_addr is None:
             return self.thread_cache

--- a/pwndbg/heap/ptmalloc.py
+++ b/pwndbg/heap/ptmalloc.py
@@ -396,6 +396,7 @@ class Heap(pwndbg.heap.heap.BaseHeap):
         start_addr = heap_start
         if arena != self.main_arena:
             start_addr += self.heap_info.sizeof
+            heap_region = self.get_heap_boundaries(heap_start)
             if pwndbg.vmmap.find(self.get_heap(heap_start)['ar_ptr']) == heap_region:
                 # Round up to a 2-machine-word alignment after an arena to
                 # compensate for the presence of the have_fastchunks variable

--- a/tests/test_heap_bins.py
+++ b/tests/test_heap_bins.py
@@ -5,6 +5,7 @@ import pwndbg.memory
 import pwndbg.symbol
 import pwndbg.vmmap
 import tests
+from pwndbg.heap.ptmalloc import BinType
 
 BINARY = tests.binaries.get('heap_bins.out')
 
@@ -39,94 +40,94 @@ def test_heap_bins(start_binary):
     largebin_count = pwndbg.memory.u64(addr)
 
     result = allocator.tcachebins()
-    assert result['type'] == 'tcachebins'
-    assert tcache_size in result
-    assert result[tcache_size][1] == 0 and len(result[tcache_size][0]) == 1
+    assert result.bin_type == BinType.TCACHE
+    assert tcache_size in result.bins
+    assert result.bins[tcache_size].count == 0 and len(result.bins[tcache_size].fd_chain) == 1
 
     result = allocator.fastbins()
-    assert result['type'] == 'fastbins'
-    assert fastbin_size in result
-    assert len(result[fastbin_size]) == 1
+    assert result.bin_type == BinType.FAST
+    assert fastbin_size in result.bins
+    assert len(result.bins[fastbin_size].fd_chain) == 1
 
     result = allocator.unsortedbin()
-    assert result['type'] == 'unsortedbin'
-    assert len(result['all'][0]) == 1
-    assert not result['all'][2]
+    assert result.bin_type == BinType.UNSORTED
+    assert len(result.bins['all'].fd_chain) == 1
+    assert not result.bins['all'].is_corrupted
 
     result = allocator.smallbins()
-    assert result['type'] == 'smallbins'
-    assert smallbin_size in result
-    assert len(result[smallbin_size][0]) == 1 and len(result[smallbin_size][1]) == 1
-    assert not result[smallbin_size][2]
+    assert result.bin_type == BinType.SMALL
+    assert smallbin_size in result.bins
+    assert len(result.bins[smallbin_size].fd_chain) == 1 and len(result.bins[smallbin_size].bk_chain) == 1
+    assert not result.bins[smallbin_size].is_corrupted
 
     result = allocator.largebins()
-    assert result['type'] == 'largebins'
-    largebin_size = list(result.items())[allocator.largebin_index(largebin_size) - 64][0]
-    assert largebin_size in result
-    assert len(result[largebin_size][0]) == 1 and len(result[largebin_size][1]) == 1
-    assert not result[largebin_size][2]
+    assert result.bin_type == BinType.LARGE
+    largebin_size = list(result.bins.items())[allocator.largebin_index(largebin_size) - 64][0]
+    assert largebin_size in result.bins
+    assert len(result.bins[largebin_size].fd_chain) == 1 and len(result.bins[largebin_size].bk_chain) == 1
+    assert not result.bins[largebin_size].is_corrupted
 
     # check tcache
     gdb.execute('continue')
 
     result = allocator.tcachebins()
-    assert result['type'] == 'tcachebins'
-    assert tcache_size in result
-    assert result[tcache_size][1] == tcache_count and len(result[tcache_size][0]) == tcache_count + 1
-    for addr in result[tcache_size][0][:-1]:
+    assert result.bin_type == BinType.TCACHE
+    assert tcache_size in result.bins
+    assert result.bins[tcache_size].count == tcache_count and len(result.bins[tcache_size].fd_chain) == tcache_count + 1
+    for addr in result.bins[tcache_size].fd_chain[:-1]:
         assert pwndbg.vmmap.find(addr)
 
     # check fastbin
     gdb.execute('continue')
 
     result = allocator.fastbins()
-    assert result['type'] == 'fastbins'
-    assert (fastbin_size in result) and (len(result[fastbin_size]) == fastbin_count + 1)
-    for addr in result[fastbin_size][:-1]:
+    assert result.bin_type == BinType.FAST
+    assert (fastbin_size in result.bins) and (len(result.bins[fastbin_size].fd_chain) == fastbin_count + 1)
+    for addr in result.bins[fastbin_size].fd_chain[:-1]:
         assert pwndbg.vmmap.find(addr)
 
     # check unsortedbin
     gdb.execute('continue')
 
     result = allocator.unsortedbin()
-    assert result['type'] == 'unsortedbin'
-    assert len(result['all'][0]) == smallbin_count + 2 and len(result['all'][1]) == smallbin_count + 2
-    assert not result['all'][2]
-    for addr in result['all'][0][:-1]:
+    assert result.bin_type == BinType.UNSORTED
+    assert len(result.bins['all'].fd_chain) == smallbin_count + 2 and len(result.bins['all'].bk_chain) == smallbin_count + 2
+    assert not result.bins['all'].is_corrupted
+    for addr in result.bins['all'].fd_chain[:-1]:
         assert pwndbg.vmmap.find(addr)
-    for addr in result['all'][1][:-1]:
+    for addr in result.bins['all'].bk_chain[:-1]:
         assert pwndbg.vmmap.find(addr)
 
     # check smallbins
     gdb.execute('continue')
 
     result = allocator.smallbins()
-    assert result['type'] == 'smallbins'
-    assert len(result[smallbin_size][0]) == smallbin_count + 2 and len(result[smallbin_size][1]) == smallbin_count + 2
-    assert not result[smallbin_size][2]
-    for addr in result[smallbin_size][0][:-1]:
+    assert result.bin_type == BinType.SMALL
+    assert len(result.bins[smallbin_size].fd_chain) == smallbin_count + 2 and len(result.bins[smallbin_size].bk_chain) == smallbin_count + 2
+    assert not result.bins[smallbin_size].is_corrupted
+    for addr in result.bins[smallbin_size].fd_chain[:-1]:
         assert pwndbg.vmmap.find(addr)
-    for addr in result[smallbin_size][1][:-1]:
+    for addr in result.bins[smallbin_size].bk_chain[:-1]:
         assert pwndbg.vmmap.find(addr)
 
     # check largebins
     gdb.execute('continue')
 
     result = allocator.largebins()
-    assert result['type'] == 'largebins'
-    assert len(result[largebin_size][0]) == largebin_count + 2 and len(result[largebin_size][1]) == largebin_count + 2
-    assert not result[largebin_size][2]
-    for addr in result[largebin_size][0][:-1]:
+    assert result.bin_type == BinType.LARGE
+    assert len(result.bins[largebin_size].fd_chain) == largebin_count + 2 and len(result.bins[largebin_size].bk_chain) == largebin_count + 2
+    assert not result.bins[largebin_size].is_corrupted
+    for addr in result.bins[largebin_size].fd_chain[:-1]:
         assert pwndbg.vmmap.find(addr)
-    for addr in result[largebin_size][1][:-1]:
+    for addr in result.bins[largebin_size].bk_chain[:-1]:
         assert pwndbg.vmmap.find(addr)
 
     # check corrupted
     gdb.execute('continue')
     result = allocator.smallbins()
-    assert result['type'] == 'smallbins'
-    assert result[smallbin_size][2]
+    assert result.bin_type == BinType.SMALL
+    assert result.bins[smallbin_size].is_corrupted
 
     result = allocator.largebins()
-    assert result['type'] == 'largebins'
-    assert result[largebin_size][2]
+    assert result.bin_type == BinType.LARGE
+    assert result.bins[largebin_size].is_corrupted


### PR DESCRIPTION
This is a large PR that refactors a lot of the heap code in `commands/heap.py` and `heap/ptmalloc.py`. The main goal of refactoring was to make it easier to add new functionality. While adding some new functionality, I was frustrated with the amount of implementation details I needed to learn, for `example` I shouldn't have to add `2*sizeof(size_t)` to a tcache chunk before searching for it in bins. And because we're duplicating so much code, it's more time consuming to make changes because you need to change multiple locations in the code you're not familiar with, as each duplication needs to be updated.

To improve this, I've created a `Bins` and `Bin` class, which can help abstract all of these implementation details and allow us to reuse code more often. I've also made some small improvements to `ptmalloc.py`, such as making it easier to iterate over all heap chunks.

This is a large PR, and it's still a work in progress. I have some TODOs to finish, more manual testing to do, I need to fix the existing unit tests and lint issues, and I want to add more automated tests as well. I'm putting it up early so I can get some early feedback if people think this is going in completely the wrong direction, as well as to give a heads up that this is happening so we can coordinate around merging new heap PRs so I don't have to fix as many merge conflicts.

The best way to review this will be commit by commit, as opposed to the whole PR at once.