### PR TITLE
CI: run tests on Ubuntu 22.04, 20.04 and 18.04

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,7 @@ jobs:
   tests:
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-22.04, ubuntu-20.04, ubuntu-18.04]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,7 @@ on: [push, pull_request]
 jobs:
   tests:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-22.04, ubuntu-20.04, ubuntu-18.04]
     runs-on: ${{ matrix.os }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,10 +13,10 @@ pycparser==2.21
 pyelftools==0.28
 Pygments==2.12.0
 pyparsing==3.0.9
-pytest==7.1.2
 python-ptrace==0.9.8
 ROPGadget==6.8
 six==1.16.0
 testresources==2.0.1
-tomli==2.0.1
 unicorn==2.0.0
+pytest
+tomli


### PR DESCRIPTION
Let's see if we can get CI running on other Ubuntu versions :)

AFAIU this should work, based on:
* https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs
* https://github.com/actions/runner-images#available-images