### PR TITLE
Fix coredump debugging

### DIFF
--- a/pwndbg/elf.py
+++ b/pwndbg/elf.py
@@ -240,6 +240,11 @@ def get_ehdr(pointer):
     vmmap = pwndbg.vmmap.find(pointer)
     base = None
 
+    # If there is no vmmap for the requested address, we can't do much
+    # (e.g. it could have been unmapped for whatever reason)
+    if vmmap is None:
+        return None, None
+
     # We first check if the beginning of the page contains the ELF magic
     if pwndbg.memory.read(vmmap.start, 4) == b'\x7fELF':
         base = vmmap.start

--- a/pwndbg/vmmap.py
+++ b/pwndbg/vmmap.py
@@ -165,7 +165,6 @@ def clear_custom_page():
     # TODO: avoid flush all caches
     pwndbg.memoize.reset()
 
-KNOWN_DATA_SECTS = ('.auxv',)
 
 @pwndbg.memoize.reset_on_objfile
 @pwndbg.memoize.reset_on_start
@@ -203,7 +202,7 @@ def coredump_maps():
         flags = 0
         if 'READONLY' in flags_list: flags |= 4
         if 'DATA' in flags_list: flags |= 2
-        if 'CODE' in flags_list or name in KNOWN_DATA_SECTS: flags |= 1
+        if 'CODE' in flags_list: flags |= 1
 
         # Now, if the section is already in pages, just add its perms
         known_page = False
@@ -234,7 +233,6 @@ def coredump_maps():
             try:
                 stack_addr = int(line.split()[-2], 16)
             except Exception as e:
-                print("AA", e)
                 pass
             break
 

--- a/pwndbg/vmmap.py
+++ b/pwndbg/vmmap.py
@@ -205,9 +205,6 @@ def coredump_maps():
         if 'DATA' in flags_list: flags |= 2
         if 'CODE' in flags_list or name in KNOWN_DATA_SECTS: flags |= 1
 
-        # Main thread stack detection heuristic
-        0x7ffffffff000
-
         # Now, if the section is already in pages, just add its perms
         known_page = False
 


### PR DESCRIPTION
This commit fixes our headaches with core files debugging.

The TL;DR is that we will now try to parse `info proc mappings` and
`maintenance info sections` to give users best possible UX/vmmaps
information.

Related:
* https://sourceware.org/bugzilla/show_bug.cgi?id=29508
* https://github.com/pwndbg/pwndbg/issues/985
* https://github.com/pwndbg/pwndbg/issues/954