### PR TITLE
Avoid bare catch-all except blocks

### DIFF
--- a/pwndbg/__init__.py
+++ b/pwndbg/__init__.py
@@ -89,7 +89,7 @@ try:
     import unicorn
 
     import pwndbg.emu
-except:
+except Exception:
     pass
 
 __all__ = [

--- a/pwndbg/argv.py
+++ b/pwndbg/argv.py
@@ -34,7 +34,7 @@ def update():
 
     try:
         argc = pwndbg.memory.u(sp, ptrbits)
-    except:
+    except Exception:
         return
 
     sp += ptrsize

--- a/pwndbg/auxv.py
+++ b/pwndbg/auxv.py
@@ -86,7 +86,7 @@ class AUXV(dict):
                 value = gdb.Value(value)
                 value = value.cast(pwndbg.typeinfo.pchar)
                 value = value.string()
-            except:
+            except Exception:
                 value = 'couldnt read AUXV!'
 
         self[name] = value

--- a/pwndbg/commands/comments.py
+++ b/pwndbg/commands/comments.py
@@ -27,7 +27,7 @@ def comm(addr=None, comment=None):
                 if not pwndbg.proc.exe in file_lists.keys():
                     file_lists[pwndbg.proc.exe] = {}
                 file_lists[pwndbg.proc.exe][hex(target)] = comment
-    except:
+    except Exception:
         print(message.error("Permission denied to create file"))
 
 def init():
@@ -47,5 +47,5 @@ def init():
 
                 file_lists[filename][addr_comm[0]] = addr_comm[1]
 
-    except:
+    except Exception:
         pass 

--- a/pwndbg/commands/defcon.py
+++ b/pwndbg/commands/defcon.py
@@ -52,12 +52,12 @@ def heap_freebins(addr=0x0602558):
 
         try:
             bk = pwndbg.memory.u64(linkedlist)
-        except:
+        except Exception:
             bk = None
 
         try:
             fd = pwndbg.memory.u64(linkedlist+8)
-        except:
+        except Exception:
             fd = None
 
         print('    %#x %#x %s' % (addr, size, '*' if in_use else ''))

--- a/pwndbg/commands/nearpc.py
+++ b/pwndbg/commands/nearpc.py
@@ -165,7 +165,7 @@ def nearpc(pc=None, lines=None, to_string=False, emulate=False):
         # For Comment Function
         try:
             line += " "*10 + C.comment(pwndbg.commands.comments.file_lists[pwndbg.proc.exe][hex(instr.address)])
-        except:
+        except Exception:
             pass
 
         result.append(line)

--- a/pwndbg/commands/p2p.py
+++ b/pwndbg/commands/p2p.py
@@ -41,7 +41,7 @@ def address_range_explicit(section):
         end = int(end, guess_numbers_base(end))
 
         return AddrRange(begin, end)
-    except:
+    except Exception:
         parser.error('\"%s\" - Bad format of explicit address range!' \
                 ' Expected format: \"BEGIN_ADDRESS:END_ADDRESS\"' % pwndbg.color.red(section))
 
@@ -72,7 +72,7 @@ parser.add_argument('mapping_names', type=address_range, nargs='+', help='Mappin
 def maybe_points_to_ranges(ptr: int, rs: [AddrRange]):
     try:
         pointee = pwndbg.memory.pvoid(ptr)
-    except:
+    except Exception:
         return None
 
     for r in rs:

--- a/pwndbg/commands/procinfo.py
+++ b/pwndbg/commands/procinfo.py
@@ -11,7 +11,7 @@ import pwndbg.proc
 
 try:
     import psutil
-except:
+except Exception:
     psutil = None
 
 """

--- a/pwndbg/commands/reload.py
+++ b/pwndbg/commands/reload.py
@@ -9,7 +9,7 @@ import pwndbg.memoize
 
 try:
     from __builtins__ import reload as _reload
-except:
+except Exception:
     from imp import reload as _reload
 
 

--- a/pwndbg/commands/search.py
+++ b/pwndbg/commands/search.py
@@ -150,7 +150,7 @@ def search(type, hex, string, executable, writable, value, mapping_name, save, n
         for addr in saved:
             try:
                 val = pwndbg.memory.read(addr, val_len)
-            except:
+            except Exception:
                 continue
             if val == value:
                 new_saved.add(addr)

--- a/pwndbg/commands/version.py
+++ b/pwndbg/commands/version.py
@@ -174,7 +174,7 @@ If it is somehow unavailable, use:
     if run_browser:
         try:
             check_output(['xdg-open', github_issue_url + github_issue_body])
-        except:
+        except Exception:
             print(please_please_submit + github_issue_url)
     else:
         print(please_please_submit + github_issue_url)

--- a/pwndbg/disasm/__init__.py
+++ b/pwndbg/disasm/__init__.py
@@ -18,7 +18,7 @@ import pwndbg.symbol
 
 try:
     import pwndbg.emu.emulator
-except:
+except Exception:
     pwndbg.emu = None
 
 CapstoneArch = {
@@ -86,7 +86,7 @@ def get_disassembler_cached(arch, ptrsize, endian, extra=None):
         cs.syntax = CapstoneSyntax[flavor]
     except CsError as ex:
         pass
-    except:
+    except Exception:
         raise
     cs.detail = True
     return cs

--- a/pwndbg/file.py
+++ b/pwndbg/file.py
@@ -69,7 +69,7 @@ def get(path):
     try:
         with open(local_path,'rb') as f:
             return f.read()
-    except:
+    except Exception:
         return b''
 
 def readlink(path):

--- a/pwndbg/heap/ptmalloc.py
+++ b/pwndbg/heap/ptmalloc.py
@@ -277,7 +277,7 @@ class Heap(pwndbg.heap.heap.BaseHeap):
         chunk_keys = [renames[key] if key in renames else key for key in val.keys()]
         try:
             return chunk_keys.index(key) * pwndbg.arch.ptrsize
-        except:
+        except Exception:
             return None
 
     @property

--- a/pwndbg/memory.py
+++ b/pwndbg/memory.py
@@ -110,7 +110,7 @@ def peek(address):
         address cannot be read.
     """
     try:    return read(address, 1)
-    except: pass
+    except Exception: pass
     return None
 
 
@@ -128,7 +128,7 @@ def poke(address):
     c = peek(address)
     if c is None: return False
     try:    write(address, c)
-    except: return False
+    except Exception: return False
     return True
 
 

--- a/pwndbg/symbol.py
+++ b/pwndbg/symbol.py
@@ -194,7 +194,7 @@ def address(symbol, allow_unmapped=False):
 
     try:
         return int(symbol, 0)
-    except:
+    except Exception:
         pass
 
     try:

--- a/pwndbg/ui.py
+++ b/pwndbg/ui.py
@@ -57,6 +57,6 @@ def get_window_size(target=sys.stdin):
     try:
         # get terminal size and force ret buffer len of 4 bytes for safe unpacking by passing equally long arg
         rows, cols = struct.unpack('hh', fcntl.ioctl(target.fileno(), termios.TIOCGWINSZ, '1234'))
-    except:
+    except Exception:
         rows, cols = fallback
     return rows, cols

--- a/pwndbg/vmmap.py
+++ b/pwndbg/vmmap.py
@@ -307,7 +307,7 @@ def proc_pid_maps():
         
         try:
             inode, objfile = inode_objfile.split(None, 1)
-        except:
+        except Exception:
             # Name unnamed anonymous pages so they can be used e.g. with search commands
             objfile = '[anon_' + start[:-3] + ']'
 
@@ -579,7 +579,7 @@ def check_aslr():
             data = pwndbg.file.get('/proc/%i/personality' % pwndbg.proc.pid)
             personality = int(data, 16)
             return (personality & 0x40000 == 0), 'read status from process\' personality'
-        except:
+        except Exception:
             print("Could not check ASLR: can't read process' personality")
             pass
 


### PR DESCRIPTION
`except:` by default catches not only exceptions, but also special cases like SystemExit and KeyboardInterrupt.  Suppressing them is probably the worst thing that can be done, but it is most likely a mistake to catch them anyway.  Most of these exceptions can be narrowed down even further, to ValueError, ImportError, TypeError etc., but I have not put much thought into it yet.

This was done with

```sh
grep -rl 'except:' | xargs sed -i 's/except:/except Exception:/'
```

Not tested, but I believe it carries no harm, and this alone could be useful already.
@disconnect3d  WDYT?