### PR TITLE
Fix test runner script for parallel make builds

### DIFF
--- a/tests.sh
+++ b/tests.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 cd ./tests/binaries || exit 1
-make clean all || exit 2
+make clean && make all || exit 2
 cd ../../
 
 # NOTE: We run tests under GDB sessions and because of some cleanup/tests dependencies problems


### PR DESCRIPTION
Makefile targets don't necessarily run in the order they're specified on the command line, so with `make clean all` it may be possible for `all` to get run before `clean`. This probably wasn't noticed by many people because it doesn't happen when running with a single thread, but I set `MAKEFLAGS="-j 16"` in my .bashrc, and this issue gets triggered.