### PR TITLE
fix vis_heap_chunk test on CI?

### DIFF
--- a/setup-test-tools.sh
+++ b/setup-test-tools.sh
@@ -20,7 +20,10 @@ linux() {
 
 install_apt() {
   sudo apt-get update || true
-  sudo apt-get install -y nasm gcc
+  sudo apt-get install -y \
+    nasm \
+    gcc \
+    libc6-dev
   test -f /usr/bin/go || sudo apt-get install -y golang
 }
 

--- a/tests/binaries/heap_vis.c
+++ b/tests/binaries/heap_vis.c
@@ -1,6 +1,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include <pthread.h>
+
 void break_here() {}
 
 int main() {
@@ -18,4 +20,11 @@ int main() {
     free(allocs[1]);
 
     break_here();
+
+    // We do not really need it for our test
+    // but we need it so that our CI test pass can get TLS variables
+    // See:
+    // - https://github.com/pwndbg/pwndbg/pull/1086
+    // - https://sourceware.org/bugzilla/show_bug.cgi?id=24548
+    pthread_create(0,0,0,0);
 }

--- a/tests/binaries/makefile
+++ b/tests/binaries/makefile
@@ -83,7 +83,8 @@ heap_bins: heap_bins.c
 
 # Note: we use -pthread -lpthread because we hit this bug on CI builds:
 # https://sourceware.org/bugzilla/show_bug.cgi?id=24548
-heap_vis: heap_vis.c
+heap_vis.out: heap_vis.c
+	@echo "[+] Building heap_vis.out"
 	${CC} -g -O0 -o heap_vis.out heap_vis.c -pthread -lpthread
 
 clean :

--- a/tests/binaries/makefile
+++ b/tests/binaries/makefile
@@ -81,8 +81,10 @@ heap_bins: heap_bins.c
 	-Wl,--dynamic-linker=${GLIBC_2_33}/ld-linux-x86-64.so.2 \
 	-g -O0 -o heap_bins.out heap_bins.c
 
+# Note: we use -pthread -lpthread because we hit this bug on CI builds:
+# https://sourceware.org/bugzilla/show_bug.cgi?id=24548
 heap_vis: heap_vis.c
-	${CC} -g -O0 -o heap_vis.out heap_vis.c
+	${CC} -g -O0 -o heap_vis.out heap_vis.c -pthread -lpthread
 
 clean :
 	@echo "[+] Cleaning stuff"


### PR DESCRIPTION
I've commited a test for vis_heap_chunk to dev, but apparently it fails on CI, likely due to the https://sourceware.org/bugzilla/show_bug.cgi?id=24548 bug.

The TL;DR for its failing is that we are fetching `tcache` variable from GDB commands and this variable is a thread-local-storage (TLS) variable and... GDB can't fetch it on CI due to reasons described in the post above.

Linking with `libpthread` should fix this issue and that's what this PR adds.

Below you can see part of the pytest stack trace why this test failed on CI:
```
        # The tcache chunks have two fields: next and key
        # We are fetching it from the glibc's TLS tcache variable :)
>       tcache_next = int(gdb.parse_and_eval('tcache->entries[0]->next'))
E       gdb.error: Cannot find thread-local storage for process 5323, shared library /usr/lib/debug/.build-id/18/78e6b475720c7c51969e69ab2d276fae6d1dee.debug:
E       Cannot find thread-local variables on this target
```