### PR TITLE
Fix heap test binaries build

### DIFF
--- a/setup-test-tools.sh
+++ b/setup-test-tools.sh
@@ -25,6 +25,8 @@ install_apt() {
     gcc \
     libc6-dev
   test -f /usr/bin/go || sudo apt-get install -y golang
+  # We use zig to compile some test binaries as it is much easier than with gcc
+  sudo snap install zig --classic --edge
 }
 
 if linux; then

--- a/tests/binaries/makefile
+++ b/tests/binaries/makefile
@@ -1,3 +1,5 @@
+ZIGCC		=	   zig cc
+
 CC              =	   gcc
 DEBUG           =	   1
 CFLAGS         +=	   -Wall
@@ -29,7 +31,8 @@ CFLAGS		  +=	  -O1
 endif
 
 PWD=$(shell pwd)
-GLIBC=/glibc_versions/2.29/tcache_x64
+# Apparently we don't have this version? :(
+#GLIBC=/glibc_versions/2.29/tcache_x64
 GLIBC_2_33=$(PWD)/glibcs/2.33
 
 .PHONY : all clean
@@ -61,27 +64,30 @@ all: $(LINKED) $(LINKED_ASM) $(COMPILED_GO)
 
 heap_bugs.out: heap_bugs.c
 	@echo "[+] Building heap_bugs.out"
-	${CC} \
-	-Wl,-rpath=${GLIBC}:\
-	${GLIBC}/math:\
-	${GLIBC}/elf:\
-	${GLIBC}/dlfcn:\
-	${GLIBC}/nss:\
-	${GLIBC}/nis:\
-	${GLIBC}/rt:\
-	${GLIBC}/resolv:\
-	${GLIBC}/crypt:\
-	${GLIBC}/nptl_db:\
-	${GLIBC}/nptl:\
-	-Wl,--dynamic-linker=${GLIBC}/elf/ld.so \
+	${ZIGCC} \
+	-target native-native-gnu.2.33 \
+	-Wl,-rpath=${GLIBC_2_33}:\
+	${GLIBC_2_33}/math:\
+	${GLIBC_2_33}/elf:\
+	${GLIBC_2_33}/dlfcn:\
+	${GLIBC_2_33}/nss:\
+	${GLIBC_2_33}/nis:\
+	${GLIBC_2_33}/rt:\
+	${GLIBC_2_33}/resolv:\
+	${GLIBC_2_33}/crypt:\
+	${GLIBC_2_33}/nptl_db:\
+	${GLIBC_2_33}/nptl:\
+	-Wl,--dynamic-linker=${GLIBC_2_33}/ld-linux-x86-64.so.2 \
 	-g -o heap_bugs.out heap_bugs.c
 
-heap_bins.out: heap_bins.c
-	@echo "[+] Building heap_bins.out"
-	${CC} \
-	-Wl,-rpath=${GLIBC_2_33} \
-	-Wl,--dynamic-linker=${GLIBC_2_33}/ld-linux-x86-64.so.2 \
-	-g -O0 -o heap_bins.out heap_bins.c
+# TODO/FIXME: We should probably force this to 2.29? a version with tcache?
+#heap_bins.out: heap_bins.c
+#	@echo "[+] Building heap_bins.out"
+#	${ZIGCC} \
+#	-target native-native-gnu.2.33 \
+#	-Wl,-rpath=${GLIBC_2_33} \
+#	-Wl,--dynamic-linker=${GLIBC_2_33}/ld-linux-x86-64.so.2 \
+#	-g -O0 -o heap_bins.out heap_bins.c
 
 # Note: we use -pthread -lpthread because we hit this bug on CI builds:
 # https://sourceware.org/bugzilla/show_bug.cgi?id=24548

--- a/tests/binaries/makefile
+++ b/tests/binaries/makefile
@@ -59,7 +59,8 @@ all: $(LINKED) $(LINKED_ASM) $(COMPILED_GO)
 	@GOARCH=amd64 $(GO) build $?
 	@# Not stripped on purpose
 
-heap_bugs: heap_bugs.c
+heap_bugs.out: heap_bugs.c
+	@echo "[+] Building heap_bugs.out"
 	${CC} \
 	-Wl,-rpath=${GLIBC}:\
 	${GLIBC}/math:\
@@ -75,7 +76,8 @@ heap_bugs: heap_bugs.c
 	-Wl,--dynamic-linker=${GLIBC}/elf/ld.so \
 	-g -o heap_bugs.out heap_bugs.c
 
-heap_bins: heap_bins.c
+heap_bins.out: heap_bins.c
+	@echo "[+] Building heap_bins.out"
 	${CC} \
 	-Wl,-rpath=${GLIBC_2_33} \
 	-Wl,--dynamic-linker=${GLIBC_2_33}/ld-linux-x86-64.so.2 \


### PR DESCRIPTION
It turns out we never build the heap test binaries with their expected build flags. Instead, we always build and used the binaries build by wildcard rules in makefile: `%.out: %.c`

Ugh... and now I think some tests on CI will fail because we may not be able to load the binaries or have their dependencies? Let's see.