### PR TITLE
Remove QuietSloppyParsedCommand once and for all

### DIFF
--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -274,12 +274,6 @@ sudo apt-get install libc-dbg:i386
             print(message.warn("Then pwndbg will resolve some missing symbols via heuristics, but the results of those commands may be incorrect in some cases."))
     return _OnlyWithResolvedHeapSyms
 
-class QuietSloppyParsedCommand(ParsedCommand):
-    def __init__(self, *a, **kw):
-        super(QuietSloppyParsedCommand, self).__init__(*a, **kw)
-        self.quiet = True
-        self.sloppy = True
-
 
 class _ArgparsedCommand(Command):
     def __init__(self, parser, function, command_name=None, *a, **kw):

--- a/pwndbg/commands/pie.py
+++ b/pwndbg/commands/pie.py
@@ -94,7 +94,7 @@ parser.add_argument('offset', nargs='?', default=0,
 parser.add_argument('module', type=str, nargs='?', default='',
                     help='Module to choose as base. Defaults to the target executable.')
 
-@pwndbg.commands.ArgparsedCommand(parser)
+@pwndbg.commands.ArgparsedCommand(parser, aliases=['brva'])
 @pwndbg.commands.OnlyWhenRunning
 def breakrva(offset=0, module=None):
     offset = int(offset)
@@ -109,10 +109,3 @@ def breakrva(offset=0, module=None):
         gdb.Breakpoint(spec)
     else:
         print(message.error('Could not determine rebased breakpoint address on current target'))
-
-
-@pwndbg.commands.QuietSloppyParsedCommand #TODO should this just be an alias or does the QuietSloppy have an effect?
-@pwndbg.commands.OnlyWhenRunning
-def brva(*args):
-    """Alias for breakrva."""
-    return breakrva(*args)


### PR DESCRIPTION
This commit cleans up the commands/__init__.py a bit by removing the
`QuietSloppyParsedCommand` that we do not use anymore.

The last command that used it was `brva` which was just an alias for
`breakrva`, so now we just set it as an alias using the
`ArgparsedCommand` as it should be done.