### PR TITLE
feature: Add highlighting of freed chunks in vis_heap_chunks

### DIFF
--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -10,9 +10,10 @@ import pwndbg.commands
 import pwndbg.config
 import pwndbg.glibc
 import pwndbg.typeinfo
+from pwndbg.color import NORMAL
 from pwndbg.color import generateColorFunction
 from pwndbg.color import message
-from pwndbg.color import underline, NORMAL
+from pwndbg.color import underline
 from pwndbg.commands.config import extend_value_with_default
 from pwndbg.commands.config import get_config_parameters
 from pwndbg.commands.config import print_row


### PR DESCRIPTION
Adds highlighting to known-free chunks in vis_heap_chunks,
unfortunately not all freed chunks will be highlighted, only those marked by the Heap class, which by default is limited to 8 chunks per bin type.

<img width="898" alt="image" src="https://user-images.githubusercontent.com/5400940/186277666-d8952c2d-9bb7-4028-837c-2ae8b7db0ced.png">
