### PR TITLE
Minor test cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ __pycache__/
 
 # C extensions
 *.so
-!tests/binaries/glibcs/**/*.so
+!tests/**/binaries/glibcs/**/*.so
 
 # Distribution / packaging
 .Python
@@ -66,12 +66,11 @@ venv/
 
 # PyTest files
 .pytest_cache/
-tests/.pytest_cache/
-tests/binaries/*.o
-tests/binaries/*.out
-tests/binaries/gosample.x*
-/tests/binaries/div_zero_binary/core
-/tests/binaries/div_zero_binary/binary
+tests/**/binaries/*.o
+tests/**/binaries/*.out
+tests/**/binaries/gosample.x*
+tests/**/binaries/div_zero_binary/core
+tests/**/binaries/div_zero_binary/binary
 
 # VS Code files
 .vscode/

--- a/pytests_launcher.py
+++ b/pytests_launcher.py
@@ -1,7 +1,6 @@
 import os
 import pytest
 import sys
-print(sys.argv)
 
 use_pdb = os.environ.get('USE_PDB') == '1'
 

--- a/tests.sh
+++ b/tests.sh
@@ -1,41 +1,44 @@
 #!/bin/bash
 
+ROOT_DIR="$(pwd)"
+GDB_INIT_PATH="$ROOT_DIR/gdbinit.py"
+
 help_and_exit() {
     echo "Usage: ./tests.sh [-p|--pdb] [<test-name-filter>]"
-    echo "  -p,  --pdb	       enable pdb (Python debugger) post mortem debugger on failed tests"
+    echo "  -p,  --pdb         enable pdb (Python debugger) post mortem debugger on failed tests"
     echo "  <test-name-filter> run only tests that match the regex"
-    exit 1;
+    exit 1
 }
 
 if [[ $# -gt 2 ]]; then
-	help_and_exit
+    help_and_exit
 fi
 
 USE_PDB=0
 TEST_NAME_FILTER=""
 
 while [[ $# -gt 0 ]]; do
-  case $1 in
-    -p|--pdb)
-      USE_PDB=1
-      echo "Will run tests with Python debugger"
-      shift
-      ;;
-    *)
-      if [[ ! -z "${TEST_NAME_FILTER}" ]]; then
-          help_and_exit
-      fi
-      TEST_NAME_FILTER="$1"
-      shift
-      ;;
-  esac
+    case $1 in
+        -p|--pdb)
+            USE_PDB=1
+            echo "Will run tests with Python debugger"
+            shift
+            ;;
+        *)
+            if [[ ! -z "${TEST_NAME_FILTER}" ]]; then
+                help_and_exit
+            fi
+            TEST_NAME_FILTER="$1"
+            shift
+            ;;
+    esac
 done
 
 
 if [[ -z "$ZIGPATH" ]]; then
     # If ZIGPATH is not set, set it to $pwd/.zig
     # In Docker environment this should by default be set to /opt/zig
-    export ZIGPATH="$(pwd)/.zig"
+    export ZIGPATH="$ROOT_DIR/.zig"
 fi
 echo "ZIGPATH set to $ZIGPATH"
 
@@ -44,14 +47,17 @@ cd ./tests/binaries || exit 1
 make clean && make all || exit 2
 cd ../../
 
+run_gdb() {
+    gdb --silent --nx --nh $1 --eval-command quit
+}
 
 # NOTE: We run tests under GDB sessions and because of some cleanup/tests dependencies problems
 # we decided to run each test in a separate GDB session
-TESTS_COLLECT_OUTPUT=$(gdb --silent --nx --nh --command gdbinit.py --command pytests_collect.py --eval-command quit)
+TESTS_COLLECT_OUTPUT=$(run_gdb "--command $GDB_INIT_PATH --command pytests_collect.py")
 
 if [ $? -eq 1 ]; then
-    echo -E "$TESTS_COLLECT_OUTPUT";
-    exit 1;
+    echo -E "$TESTS_COLLECT_OUTPUT"
+    exit 1
 fi
 
 TESTS_LIST=$(echo -E "$TESTS_COLLECT_OUTPUT" | grep -o "tests/.*::.*" | grep "${TEST_NAME_FILTER}")
@@ -60,9 +66,13 @@ tests_passed_or_skipped=0
 tests_failed=0
 
 for test_case in ${TESTS_LIST}; do
-    COVERAGE_PROCESS_START=.coveragerc USE_PDB="${USE_PDB}" PWNDBG_LAUNCH_TEST="${test_case}" PWNDBG_DISABLE_COLORS=1 gdb --silent --nx --nh -ex 'py import coverage;coverage.process_startup()' --command gdbinit.py --command pytests_launcher.py --eval-command quit
-    exit_status=$?
+    COVERAGE_PROCESS_START=.coveragerc \
+        USE_PDB="${USE_PDB}" \
+        PWNDBG_LAUNCH_TEST="${test_case}" \
+        PWNDBG_DISABLE_COLORS=1 \
+        run_gdb "-ex 'py import coverage;coverage.process_startup()' --command $GDB_INIT_PATH --command pytests_launcher.py"
 
+    exit_status=$?
     if [ ${exit_status} -eq 0 ]; then
         (( ++tests_passed_or_skipped ))
     else

--- a/tests/binaries/makefile
+++ b/tests/binaries/makefile
@@ -93,7 +93,7 @@ heap_bugs.out: heap_bugs.c
 # https://sourceware.org/bugzilla/show_bug.cgi?id=24548
 heap_vis.out: heap_vis.c
 	@echo "[+] Building heap_vis.out"
-	${CC} -g -O0 -o heap_vis.out heap_vis.c -pthread -lpthread
+	${CC} -g -O0 -Wno-nonnull -o heap_vis.out heap_vis.c -pthread -lpthread
 
 clean :
 	@echo "[+] Cleaning stuff"

--- a/tests/test_attachp.py
+++ b/tests/test_attachp.py
@@ -17,7 +17,9 @@ if os.getuid() == 0:
 else:
     # see `man ptrace`
     with open('/proc/sys/kernel/yama/ptrace_scope') as f:
-        can_attach = f.read() == '0'
+        result = f.read()
+        if len(result) >= 1 and result[0] == '0':
+            can_attach = True
 
 REASON_CANNOT_ATTACH = 'Test skipped due to inability to attach (needs sudo or sysctl -w kernel.yama.ptrace_scope=0'
 


### PR DESCRIPTION
Changes in this PR:
- Silences a warning when building the `heap_vis.c` test binary. I can alternatively just fix the warning if that's preferred, but I don't think it matters in this case.
- When I check the value in `/proc/sys/kernel/yama/ptrace_scope` on my Ubuntu 22.04 machine, I see that the value is '0\n'. The logic for skipping tests was only checking for '0'. This is fixed now.
- Makes the .gitignore more flexible for where the test binaries are stored, as there may be some changes to this in the future when we add a new folder for unit tests
- Cleans up some small things in tests.sh: formatting, setting the $ROOT_DIR variable to allow for easily changing this in the future if the location of the script changes, and putting the call to GDB in a function so we can reuse most of the logic.