### PR TITLE
Update CI to test 18.04, 20.04, and 22.04

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,8 +4,9 @@ on: [push, pull_request]
 jobs:
   tests:
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-22.04, ubuntu-20.04, ubuntu-18.04]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     steps:

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,2 @@
+coverage==6.4.4; python_version >= '3.7'
+coverage==6.2; python_version < '3.7'

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,10 +13,13 @@ pycparser==2.21
 pyelftools==0.28
 Pygments==2.12.0
 pyparsing==3.0.9
-pytest==7.1.2
+pytest==7.1.2; python_version >= '3.7'
+pytest==7.0.1; python_version < '3.7'
 python-ptrace==0.9.8
 ROPGadget==6.8
 six==1.16.0
 testresources==2.0.1
-tomli==2.0.1
-unicorn==2.0.0
+tomli==2.0.1; python_version >= '3.7'
+tomli==1.2.3; python_version < '3.7'
+unicorn==2.0.0; python_version >= '3.7'
+unicorn==2.0.0rc7; python_version < '3.7'

--- a/setup-test-tools.sh
+++ b/setup-test-tools.sh
@@ -54,7 +54,6 @@ install_apt() {
 
   mv /tmp/zig-linux-x86_64-* ${ZIGPATH} 2>/dev/null >/dev/null || true
   echo "Zig installed to ${ZIGPATH}"
-  
 }
 
 if linux; then
@@ -74,4 +73,6 @@ if linux; then
     fi
     ;;
   esac
+
+  python3 -m pip install -r dev-requirements.txt
 fi


### PR DESCRIPTION
After investigating the test failures in https://github.com/pwndbg/pwndbg/pull/1076, I figured out a way to install different dependencies in Python versions lower than 3.7 and greater than or equal to 3.7, which fixed those test failures. However, the `vis_heap_chunk` test was recently introduced, which is now breaking on 18.04.

I also added a `dev-requirements.txt` with the `coverage` package and install it from `setup-test-tools.sh`.