### PR TITLE
Add black to CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,7 @@ jobs:
         pip install isort
         pip install black
 
-    - name: Run tests
+    - name: Run linters
       run: |
         git diff-index --quiet HEAD -- pwndbg tests
         isort --check-only --diff pwndbg tests

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,9 +21,11 @@ jobs:
     - name: Install linters
       run: |
         pip install isort
+        pip install black
 
     - name: Run tests
       run: |
         git diff-index --quiet HEAD -- pwndbg tests
         isort --check-only --diff pwndbg tests
-        python3   -m py_compile               $(git ls-files 'pwndbg/*.py')
+        black --diff --check pwndbg tests
+        python3 -m py_compile $(git ls-files 'pwndbg/*.py')

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,4 @@
+black
 coverage==6.4.4; python_version >= '3.7'
 coverage==6.2; python_version < '3.7'
 pytest==7.1.2; python_version >= '3.7'


### PR DESCRIPTION
Run black during the CI linter checks and fail if the code is not formatted.