### PR TITLE
fix #1098: dX cmds trunc out on x86 binaries

### DIFF
--- a/pwndbg/commands/windbg.py
+++ b/pwndbg/commands/windbg.py
@@ -190,7 +190,7 @@ def dX(size, address, count, to_string=False, repeat=False):
 
 
 def enhex(size, value):
-    value = value & pwndbg.arch.ptrmask
+    value = value & ((1 << 8*size) - 1)
     x = "%x" % abs(value)
     x = x.rjust(size * 2, "0")
     return x

--- a/pwndbg/commands/windbg.py
+++ b/pwndbg/commands/windbg.py
@@ -190,7 +190,7 @@ def dX(size, address, count, to_string=False, repeat=False):
 
 
 def enhex(size, value):
-    value = value & ((1 << 8*size) - 1)
+    value = value & ((1 << 8 * size) - 1)
     x = "%x" % abs(value)
     x = x.rjust(size * 2, "0")
     return x

--- a/tests/test_windbg.py
+++ b/tests/test_windbg.py
@@ -4,6 +4,8 @@ import pwndbg
 import tests
 
 MEMORY_BINARY = tests.binaries.get("memory.out")
+X86_BINARY = tests.binaries.get("gosample.x86")
+
 data_addr = "0x400081"
 
 
@@ -299,3 +301,67 @@ def test_windbg_eX_commands(start_binary):
 
     # Check if the write actually occurred
     assert pwndbg.memory.read(stack_last_qword_ea, 8) == b"\xef\xbe\xad\xde\xbe\xba\xfe\xca"
+
+
+def test_windbg_commands_x86(start_binary):
+    """
+    Tests windbg compatibility commands that dump memory
+    like dq, dw, db, ds etc.
+    """
+    start_binary(X86_BINARY)
+
+    # Prepare memory
+    pwndbg.memory.write(pwndbg.regs.esp, b'1234567890abcdef_')
+    pwndbg.memory.write(pwndbg.regs.esp+16, b'\x00'*16)
+    pwndbg.memory.write(pwndbg.regs.esp+32, bytes(range(16)))
+    pwndbg.memory.write(pwndbg.regs.esp+48, b'Z'*16)
+
+    #################################################
+    #### dX command tests
+    #################################################
+    db = gdb.execute("db $esp", to_string=True).splitlines()
+    assert db == [
+        '%x     31 32 33 34 35 36 37 38 39 30 61 62 63 64 65 66' % pwndbg.regs.esp,
+        '%x     00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00' % (pwndbg.regs.esp+16),
+        '%x     00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f' % (pwndbg.regs.esp+32),
+        '%x     5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a' % (pwndbg.regs.esp+48),
+    ]
+
+    dw = gdb.execute("dw $esp", to_string=True).splitlines()
+    assert dw == [
+        '%x     3231 3433 3635 3837 3039 6261 6463 6665' % pwndbg.regs.esp,
+        '%x     0000 0000 0000 0000 0000 0000 0000 0000' % (pwndbg.regs.esp+16),
+        '%x     0100 0302 0504 0706 0908 0b0a 0d0c 0f0e' % (pwndbg.regs.esp+32),
+        '%x     5a5a 5a5a 5a5a 5a5a 5a5a 5a5a 5a5a 5a5a' % (pwndbg.regs.esp+48),
+    ]
+
+    dd = gdb.execute("dd $esp", to_string=True).splitlines()
+    assert dd == [
+        '%x     34333231 38373635 62613039 66656463' % pwndbg.regs.esp,
+        '%x     00000000 00000000 00000000 00000000' % (pwndbg.regs.esp+16),
+        '%x     03020100 07060504 0b0a0908 0f0e0d0c' % (pwndbg.regs.esp+32),
+        '%x     5a5a5a5a 5a5a5a5a 5a5a5a5a 5a5a5a5a' % (pwndbg.regs.esp+48),
+    ]
+
+    dq = gdb.execute("dq $esp", to_string=True).splitlines()
+    assert dq == [
+        '%x     3837363534333231 6665646362613039' % pwndbg.regs.esp,
+        '%x     0000000000000000 0000000000000000' % (pwndbg.regs.esp+16),
+        '%x     0706050403020100 0f0e0d0c0b0a0908' % (pwndbg.regs.esp+32),
+        '%x     5a5a5a5a5a5a5a5a 5a5a5a5a5a5a5a5a' % (pwndbg.regs.esp+48),
+    ]
+
+    #################################################
+    #### eX command tests
+    #################################################
+    gdb.execute('eb $esp 00')
+    assert pwndbg.memory.read(pwndbg.regs.esp, 1) == b'\x00'
+
+    gdb.execute('ew $esp 4141')
+    assert pwndbg.memory.read(pwndbg.regs.esp, 2) == b'\x41\x41'
+
+    gdb.execute('ed $esp 5252525252')
+    assert pwndbg.memory.read(pwndbg.regs.esp, 4) == b'\x52'*4
+
+    gdb.execute('eq $esp 1122334455667788')
+    assert pwndbg.memory.read(pwndbg.regs.esp, 8) == b'\x88\x77\x66\x55\x44\x33\x22\x11'

--- a/tests/test_windbg.py
+++ b/tests/test_windbg.py
@@ -311,57 +311,57 @@ def test_windbg_commands_x86(start_binary):
     start_binary(X86_BINARY)
 
     # Prepare memory
-    pwndbg.memory.write(pwndbg.regs.esp, b'1234567890abcdef_')
-    pwndbg.memory.write(pwndbg.regs.esp+16, b'\x00'*16)
-    pwndbg.memory.write(pwndbg.regs.esp+32, bytes(range(16)))
-    pwndbg.memory.write(pwndbg.regs.esp+48, b'Z'*16)
+    pwndbg.memory.write(pwndbg.regs.esp, b"1234567890abcdef_")
+    pwndbg.memory.write(pwndbg.regs.esp + 16, b"\x00" * 16)
+    pwndbg.memory.write(pwndbg.regs.esp + 32, bytes(range(16)))
+    pwndbg.memory.write(pwndbg.regs.esp + 48, b"Z" * 16)
 
     #################################################
     #### dX command tests
     #################################################
     db = gdb.execute("db $esp", to_string=True).splitlines()
     assert db == [
-        '%x     31 32 33 34 35 36 37 38 39 30 61 62 63 64 65 66' % pwndbg.regs.esp,
-        '%x     00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00' % (pwndbg.regs.esp+16),
-        '%x     00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f' % (pwndbg.regs.esp+32),
-        '%x     5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a' % (pwndbg.regs.esp+48),
+        "%x     31 32 33 34 35 36 37 38 39 30 61 62 63 64 65 66" % pwndbg.regs.esp,
+        "%x     00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00" % (pwndbg.regs.esp + 16),
+        "%x     00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f" % (pwndbg.regs.esp + 32),
+        "%x     5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a" % (pwndbg.regs.esp + 48),
     ]
 
     dw = gdb.execute("dw $esp", to_string=True).splitlines()
     assert dw == [
-        '%x     3231 3433 3635 3837 3039 6261 6463 6665' % pwndbg.regs.esp,
-        '%x     0000 0000 0000 0000 0000 0000 0000 0000' % (pwndbg.regs.esp+16),
-        '%x     0100 0302 0504 0706 0908 0b0a 0d0c 0f0e' % (pwndbg.regs.esp+32),
-        '%x     5a5a 5a5a 5a5a 5a5a 5a5a 5a5a 5a5a 5a5a' % (pwndbg.regs.esp+48),
+        "%x     3231 3433 3635 3837 3039 6261 6463 6665" % pwndbg.regs.esp,
+        "%x     0000 0000 0000 0000 0000 0000 0000 0000" % (pwndbg.regs.esp + 16),
+        "%x     0100 0302 0504 0706 0908 0b0a 0d0c 0f0e" % (pwndbg.regs.esp + 32),
+        "%x     5a5a 5a5a 5a5a 5a5a 5a5a 5a5a 5a5a 5a5a" % (pwndbg.regs.esp + 48),
     ]
 
     dd = gdb.execute("dd $esp", to_string=True).splitlines()
     assert dd == [
-        '%x     34333231 38373635 62613039 66656463' % pwndbg.regs.esp,
-        '%x     00000000 00000000 00000000 00000000' % (pwndbg.regs.esp+16),
-        '%x     03020100 07060504 0b0a0908 0f0e0d0c' % (pwndbg.regs.esp+32),
-        '%x     5a5a5a5a 5a5a5a5a 5a5a5a5a 5a5a5a5a' % (pwndbg.regs.esp+48),
+        "%x     34333231 38373635 62613039 66656463" % pwndbg.regs.esp,
+        "%x     00000000 00000000 00000000 00000000" % (pwndbg.regs.esp + 16),
+        "%x     03020100 07060504 0b0a0908 0f0e0d0c" % (pwndbg.regs.esp + 32),
+        "%x     5a5a5a5a 5a5a5a5a 5a5a5a5a 5a5a5a5a" % (pwndbg.regs.esp + 48),
     ]
 
     dq = gdb.execute("dq $esp", to_string=True).splitlines()
     assert dq == [
-        '%x     3837363534333231 6665646362613039' % pwndbg.regs.esp,
-        '%x     0000000000000000 0000000000000000' % (pwndbg.regs.esp+16),
-        '%x     0706050403020100 0f0e0d0c0b0a0908' % (pwndbg.regs.esp+32),
-        '%x     5a5a5a5a5a5a5a5a 5a5a5a5a5a5a5a5a' % (pwndbg.regs.esp+48),
+        "%x     3837363534333231 6665646362613039" % pwndbg.regs.esp,
+        "%x     0000000000000000 0000000000000000" % (pwndbg.regs.esp + 16),
+        "%x     0706050403020100 0f0e0d0c0b0a0908" % (pwndbg.regs.esp + 32),
+        "%x     5a5a5a5a5a5a5a5a 5a5a5a5a5a5a5a5a" % (pwndbg.regs.esp + 48),
     ]
 
     #################################################
     #### eX command tests
     #################################################
-    gdb.execute('eb $esp 00')
-    assert pwndbg.memory.read(pwndbg.regs.esp, 1) == b'\x00'
+    gdb.execute("eb $esp 00")
+    assert pwndbg.memory.read(pwndbg.regs.esp, 1) == b"\x00"
 
-    gdb.execute('ew $esp 4141')
-    assert pwndbg.memory.read(pwndbg.regs.esp, 2) == b'\x41\x41'
+    gdb.execute("ew $esp 4141")
+    assert pwndbg.memory.read(pwndbg.regs.esp, 2) == b"\x41\x41"
 
-    gdb.execute('ed $esp 5252525252')
-    assert pwndbg.memory.read(pwndbg.regs.esp, 4) == b'\x52'*4
+    gdb.execute("ed $esp 5252525252")
+    assert pwndbg.memory.read(pwndbg.regs.esp, 4) == b"\x52" * 4
 
-    gdb.execute('eq $esp 1122334455667788')
-    assert pwndbg.memory.read(pwndbg.regs.esp, 8) == b'\x88\x77\x66\x55\x44\x33\x22\x11'
+    gdb.execute("eq $esp 1122334455667788")
+    assert pwndbg.memory.read(pwndbg.regs.esp, 8) == b"\x88\x77\x66\x55\x44\x33\x22\x11"


### PR DESCRIPTION
Before:
```
pwndbg> hexdump $esp
+0000 0xffffd260  01 00 00 00  c8 d3 ff ff  00 00 00 00  da d3 ff ff  │....│....│....│....│
+0010 0xffffd270  ed d3 ff ff  d9 d9 ff ff  0b da ff ff  2d da ff ff  │....│....│....│-...│
+0020 0xffffd280  3c da ff ff  49 da ff ff  ff db ff ff  0f dc ff ff  │<...│I...│....│....│
+0030 0xffffd290  26 dc ff ff  34 dc ff ff  49 dc ff ff  51 dc ff ff  │&...│4...│I...│Q...│
pwndbg> dq $esp
ffffd260     0000000000000001 0000000000000000
ffffd270     00000000ffffd3ed 00000000ffffda0b
ffffd280     00000000ffffda3c 00000000ffffdbff
ffffd290     00000000ffffdc26 00000000ffffdc49
```

After:
```
pwndbg> hexdump $esp
+0000 0xffffd260  01 00 00 00  c8 d3 ff ff  00 00 00 00  da d3 ff ff  │....│....│....│....│
+0010 0xffffd270  ed d3 ff ff  d9 d9 ff ff  0b da ff ff  2d da ff ff  │....│....│....│-...│
+0020 0xffffd280  3c da ff ff  49 da ff ff  ff db ff ff  0f dc ff ff  │<...│I...│....│....│
+0030 0xffffd290  26 dc ff ff  34 dc ff ff  49 dc ff ff  51 dc ff ff  │&...│4...│I...│Q...│
pwndbg> dq $esp
ffffd260     ffffd3c800000001 ffffd3da00000000
ffffd270     ffffd9d9ffffd3ed ffffda2dffffda0b
ffffd280     ffffda49ffffda3c ffffdc0fffffdbff
ffffd290     ffffdc34ffffdc26 ffffdc51ffffdc49
```