### PR TITLE
Minor linter/formatter configuration changes

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,4 +1,0 @@
-[settings]
-indent='    '
-force_single_line = 1
-known_third_party=capstone,unicorn,six,psutil,pycparser,gdb

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,3 +4,6 @@ extend-exclude = "gdb-pt-dump"
 
 [tool.isort]
 profile = "black"
+force_single_line = true
+known_third_party = ["capstone", "unicorn", "six", "psutil", "pycparser", "gdb"]
+extend_skip_glob = ["gdb-pt-dump/*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 100
+extend-exclude = "gdb-pt-dump"
 
 [tool.isort]
 profile = "black"
-

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,4 +64,4 @@ ignore =
     # local variable name is assigned to but never used
     F841
 max-line-length=120
-exclude = capstone,unicorn,pwndbg/constants
+exclude = capstone,unicorn,pwndbg/constants,gdb-pt-dump

--- a/setup.cfg
+++ b/setup.cfg
@@ -63,5 +63,5 @@ ignore =
     F821,
     # local variable name is assigned to but never used
     F841
-max-line-length=120
+max-line-length=100
 exclude = capstone,unicorn,pwndbg/constants,gdb-pt-dump


### PR DESCRIPTION
- Don't attempt to format `gdb-pt-dump` submodules when running `black` or `isort`, and don't lint it with `flake8`
- Remove `.isort.cfg` and put the configuration in `pyproject.toml`. Also remove the `indent` setting, which is handled by black and is the default isort setting anyway
- Set the flake8 max line length to 100