### PR TITLE
ArgparsedCommand: fix `help cmd` and `cmd --help` behavior

### DIFF
--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -326,6 +326,8 @@ class _ArgparsedCommand(Command):
         self.parser.print_help(file)
         file.seek(0)
         self.__doc__ = file.read()
+        # Note: function.__doc__ is used in the `pwndbg [filter]` command display
+        function.__doc__ = self.parser.description.strip()
 
         super(_ArgparsedCommand, self).__init__(function, command_name=command_name, *a, **kw)
 

--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -1,5 +1,6 @@
 import argparse
 import functools
+import io
 
 import gdb
 
@@ -321,13 +322,10 @@ class _ArgparsedCommand(Command):
         else:
             self.parser.prog = command_name
 
-        # TODO/FIXME: Can we also append the generated positional args?
-        # E.g. "-f --flag  This does something"
-        doc = self.parser.description.strip()
-        if self.parser.epilog:
-            doc += "\n" + self.parser.epilog
-
-        self.__doc__ = function.__doc__ = doc
+        file = io.StringIO()
+        self.parser.print_help(file)
+        file.seek(0)
+        self.__doc__ = file.read()
 
         super(_ArgparsedCommand, self).__init__(function, command_name=command_name, *a, **kw)
 


### PR DESCRIPTION
Before this commit there was always a mismatch of what was displayed
when the user did `<command> --help` or `help <command>`.

With those changes, we fetch the help string from the argument parser
and render it as the command object's `self.__doc__`, so that it will be
displayed during `help <command>`.

Previously, we only displayed the command description during help.