### PR TITLE
improve start and entry commands description

### DIFF
--- a/pwndbg/commands/start.py
+++ b/pwndbg/commands/start.py
@@ -3,6 +3,7 @@ Launches the target process after setting a breakpoint at a convenient
 entry point.
 """
 import argparse
+from argparse import RawTextHelpFormatter
 from shlex import quote
 
 import gdb
@@ -24,11 +25,28 @@ def on_start():
         break_on_first_instruction = False
 
 
+# Starting from 3rd paragraph, the description is
+# taken from the GDB's `starti` command description
 parser = argparse.ArgumentParser(
     description="""
-    Set a breakpoint at a convenient location in the binary,
-    generally 'main', 'init', or the entry point."""
+Start the debugged program stopping at the first convenient location 
+from this list: main, _main, start, _start, init or _init.
+You may specify arguments to give it.
+
+Args may include "*", or "[...]"; they are expanded using the
+shell that will start the program (specified by the "$SHELL" environment
+variable).  Input and output redirection with ">", "<", or ">>"
+are also allowed.
+
+With no arguments, uses arguments last specified (with "run" or
+"set args").  To cancel previous arguments and run with no arguments,
+use "set args" without arguments.
+
+To start the inferior without using a shell, use "set startup-with-shell off".
+""",
+    formatter_class=RawTextHelpFormatter,
 )
+
 parser.add_argument(
     "args", nargs="*", type=str, default=None, help="The arguments to run the binary with."
 )
@@ -38,10 +56,6 @@ parser.add_argument(
 def start(args=None):
     if args is None:
         args = []
-    """
-    Set a breakpoint at a convenient location in the binary,
-    generally 'main', 'init', or the entry point.
-    """
     run = "run " + " ".join(args)
 
     symbols = ["main", "_main", "start", "_start", "init", "_init"]
@@ -60,11 +74,29 @@ def start(args=None):
     entry(args)
 
 
+# Starting from 3rd paragraph, the description is
+# taken from the GDB's `starti` command description
 parser = argparse.ArgumentParser(
     description="""
-    Set a breakpoint at the first instruction executed in
-    the target binary.
-    """
+Start the debugged program stopping at its entrypoint address.
+You may specify arguments to give it.
+
+Note that the entrypoint may not be the first instruction executed
+by the program. If you want to stop on the first executed instruction,
+use the GDB's `starti` command (added in GDB 8.1).
+
+Args may include "*", or "[...]"; they are expanded using the
+shell that will start the program (specified by the "$SHELL" environment
+variable).  Input and output redirection with ">", "<", or ">>"
+are also allowed.
+
+With no arguments, uses arguments last specified (with "run" or
+"set args").  To cancel previous arguments and run with no arguments,
+use "set args" without arguments.
+
+To start the inferior without using a shell, use "set startup-with-shell off".
+""",
+    formatter_class=RawTextHelpFormatter,
 )
 parser.add_argument(
     "args", nargs="*", type=str, default=None, help="The arguments to run the binary with."
@@ -76,10 +108,6 @@ parser.add_argument(
 def entry(args=None):
     if args is None:
         arg = []
-    """
-    Set a breakpoint at the first instruction executed in
-    the target binary.
-    """
     global break_on_first_instruction
     break_on_first_instruction = True
     run = "run " + " ".join(map(quote, args))

--- a/pwndbg/commands/start.py
+++ b/pwndbg/commands/start.py
@@ -29,7 +29,7 @@ def on_start():
 # taken from the GDB's `starti` command description
 parser = argparse.ArgumentParser(
     description="""
-Start the debugged program stopping at the first convenient location 
+Start the debugged program stopping at the first convenient location
 from this list: main, _main, start, _start, init or _init.
 You may specify arguments to give it.
 


### PR DESCRIPTION
Now, those commands will display proper description, describing when
they actually stop and what else can you do (e.g. run `starti` command
if u need to stop on first stop!).