### PR TITLE
Add smoke test

### DIFF
--- a/pwndbg/commands/shell.py
+++ b/pwndbg/commands/shell.py
@@ -10,7 +10,7 @@ import pwndbg.commands
 import pwndbg.which
 
 pwncmds = ["asm", "constgrep", "cyclic", "disasm", "pwn", "unhex"]
-shellcmds = [
+shellcmd_names = [
     "awk",
     "bash",
     "cat",
@@ -63,7 +63,7 @@ shellcmds = [
 ]
 
 pwncmds = filter(pwndbg.which.which, pwncmds)
-shellcmds = filter(pwndbg.which.which, shellcmds)
+shellcmds = filter(pwndbg.which.which, shellcmd_names)
 
 
 def register_shell_function(cmd, deprecated=False):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,7 @@ def start_binary():
 
     def _start_binary(path, *args):
         gdb.execute("file " + path)
+        gdb.execute("set exception-verbose on")
         gdb.execute("starti " + " ".join(args))
 
         global _start_binary_called

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,0 +1,55 @@
+import gdb
+import pytest
+
+import tests
+from pwndbg.commands import command_names
+from pwndbg.commands import commands
+from pwndbg.commands.shell import shellcmd_names
+
+BINARY = tests.binaries.get("heap_bins.out")
+
+# TODO: See if we can reduce the number of commands we need to skip
+blacklisted_commands = set(
+    [
+        "disasm",
+        "unhex",
+        "bugreport",
+        "try_free",
+        "errno",
+        "nextproginstr",
+    ]
+)
+
+# Don't run any shell commands
+blacklisted_commands.update(shellcmd_names)
+
+# TODO: Figure out why these are being thrown and then remove this
+whitelisted_exceptions = [
+    "Cannot access memory at address",
+    "Cannot insert breakpoint",
+    "Warning:",
+    "The program is not being run",
+]
+
+
+@pytest.mark.skip(reason="flaky test")
+def test_commands(start_binary):
+    for name in command_names:
+        print("Running command", name)
+        try:
+            start_binary(BINARY)
+
+            if name in blacklisted_commands:
+                continue
+
+            gdb.execute(name)
+        except gdb.error as e:
+            ignore = False
+            for ex in whitelisted_exceptions:
+                if ex in str(e):
+                    ignore = True
+                    print("Ignoring exception in command", name)
+                    break
+
+            if not ignore:
+                raise e


### PR DESCRIPTION
Add a smoke test that runs every command to make sure that no errors are thrown. This catches the bug in #1111. The test is currently skipped because it can be flaky, but until we improve it we can at least run it locally while developing.

We run the commands right after `starti` and without passing in any additional args. In the future we can improve this by getting the argparser object for the command and generating some default arguments.

We skip running shell commands, as those don't really need testing, and running all of those commands on a user's system could lead to issues. Some of them wait on user input as well, which blocks the test.

A few additional commands needed to be removed, mostly because they either blocked waiting for user input, or just took too long executing every instruction. `errno` and `try_free` seem to be throwing legitimate errors, so for now they're added to this list but should be fixed eventually.

Finally, there was a strange issue where `start_binary` itself was throwing exceptions when it was calling `starti`, but the exception was just "Warning:". Some commands randomly threw a few additional exceptions, all seem to be related to accessing memory or setting a breakpoint at address 0x318 (at least on my system). For now I've whitelisted these exceptions, but they should eventually be removed.