### PR TITLE
Add dev-requirements.txt to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && \
 
 ADD ./setup.sh /pwndbg/
 ADD ./requirements.txt /pwndbg/
+ADD ./dev-requirements.txt /pwndbg/
 # The `git submodule` is commented because it refreshes all the sub-modules in the project
 # but at this time we only need the essentials for the set up. It will execute at the end.
 RUN sed -i "s/^git submodule/#git submodule/" ./setup.sh && \


### PR DESCRIPTION
Building the Docker image currently fails because `./setup.sh` references `dev-requirements.txt`, but this was never added to the repo.

This PR fixes the issue with the least amount of modification, but I'm wondering if we can just move the `ADD . /pwndbg` higher up so that everything in the repo is copied over and we don't have to worry about adding any new files that are needed for setup? Why are we copying individual setup files over in the first place?