### PR TITLE
Set security_opt to seccomp:unconfined in docker-compose.yml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,10 @@
 #
 # Build as:             docker build -t pwndbg .
 #
-# For testing use:      docker run --rm -it --cap-add=SYS_PTRACE pwndbg bash
+# For testing use:      docker run --rm -it --cap-add=SYS_PTRACE --security-opt seccomp=unconfined pwndbg bash
 #
 # For development, mount the directory so the host changes are reflected into container:
-#   docker run -it --cap-add=SYS_PTRACE -v `pwd`:/pwndbg pwndbg bash
+#   docker run -it --cap-add=SYS_PTRACE --security-opt seccomp=unconfined -v `pwd`:/pwndbg pwndbg bash
 #
 FROM ubuntu:20.04
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,5 +5,7 @@ services:
     volumes:
       - .:/pwndbg
     platform: linux/amd64
+    security_opt:
+      - seccomp:unconfined
     cap_add:
       - SYS_PTRACE


### PR DESCRIPTION
Without this we see `Error disabling address space randomization: Operation not permitted` messages when running `docker-compose run main ./tests.sh`.