### PR TITLE
Add lint.sh script

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,7 +27,4 @@ jobs:
     - name: Run linters
       run: |
         git diff-index --quiet HEAD -- pwndbg tests
-        isort --check-only --diff pwndbg tests
-        black --diff --check pwndbg tests
-        flake8 --show-source pwndbg/ tests
-        python3 -m py_compile $(git ls-files 'pwndbg/*.py')
+        ./lint.sh

--- a/lint.sh
+++ b/lint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -o xtrace
+set -o errexit
+
+isort --check-only --diff pwndbg tests
+black --diff --check pwndbg tests
+flake8 --show-source pwndbg tests


### PR DESCRIPTION
This makes it easier to run all the linters at once during local development. The CI can reuse this script so when we add new linters, we only need to update it in one place.