### PR TITLE
GDB Refactor [11/N]: Move elftypes.py to lib/

### DIFF
--- a/pwndbg/elf.py
+++ b/pwndbg/elf.py
@@ -16,12 +16,12 @@ from elftools.elf.constants import SH_FLAGS
 from elftools.elf.elffile import ELFFile
 
 import pwndbg.auxv
-import pwndbg.elftypes
 import pwndbg.gdblib.abi
 import pwndbg.gdblib.arch
 import pwndbg.gdblib.events
 import pwndbg.gdblib.info
 import pwndbg.gdblib.memory
+import pwndbg.lib.elftypes
 import pwndbg.lib.memoize
 import pwndbg.proc
 import pwndbg.stack
@@ -51,14 +51,14 @@ class ELFInfo(namedtuple("ELFInfo", "header sections segments")):
 @pwndbg.gdblib.events.start
 @pwndbg.gdblib.events.new_objfile
 def update():
-    importlib.reload(pwndbg.elftypes)
+    importlib.reload(pwndbg.lib.elftypes)
 
     if pwndbg.gdblib.arch.ptrsize == 4:
-        Ehdr = pwndbg.elftypes.Elf32_Ehdr
-        Phdr = pwndbg.elftypes.Elf32_Phdr
+        Ehdr = pwndbg.lib.elftypes.Elf32_Ehdr
+        Phdr = pwndbg.lib.elftypes.Elf32_Phdr
     else:
-        Ehdr = pwndbg.elftypes.Elf64_Ehdr
-        Phdr = pwndbg.elftypes.Elf64_Phdr
+        Ehdr = pwndbg.lib.elftypes.Elf64_Ehdr
+        Phdr = pwndbg.lib.elftypes.Elf64_Phdr
 
     module.__dict__.update(locals())
 

--- a/pwndbg/lib/elftypes.py
+++ b/pwndbg/lib/elftypes.py
@@ -29,9 +29,7 @@
 #
 import ctypes
 
-import pwndbg.gdblib.arch
 import pwndbg.gdblib.ctypes
-import pwndbg.gdblib.events
 
 Elf32_Addr = ctypes.c_uint32
 Elf32_Half = ctypes.c_uint16


### PR DESCRIPTION
Note that while the goal of moving code to `lib/` is to not depend on GDB, for now we will have a small dependency on `pwndbg.gdblib.arch`/`pwndbg.gdblib.typeinfo` for sizes of types (which is fine for now because this is easy to mock). Because `pwndbg.gdblib.ctypes` is a small file with just a dependency on `pwndbg.gdblib.arch.ptrsize`, for now it should be OK to reference this in `lib/`, and if we can sort out how to get rid of the dependency on `arch` it will get cleaned up then.