### PR TITLE
Add types for some modules in lib/

### DIFF
--- a/pwndbg/lib/arch.py
+++ b/pwndbg/lib/arch.py
@@ -3,7 +3,7 @@ import sys
 
 
 class Arch:
-    def __init__(self, arch_name, ptrsize, endian):
+    def __init__(self, arch_name: str, ptrsize: int, endian: str) -> None:
         self.name = arch_name
         # TODO: `current` is the old name for the arch name, and it's now an
         # alias for `name`. It's used throughout the codebase, do we want to
@@ -29,10 +29,10 @@ class Arch:
 
         self.native_endian = str(sys.byteorder)
 
-    def pack(self, integer):
+    def pack(self, integer: int) -> bytes:
         return struct.pack(self.fmt, integer & self.ptrmask)
 
-    def unpack(self, data):
+    def unpack(self, data: bytearray) -> int:
         return struct.unpack(self.fmt, data)[0]
 
     def signed(self, integer):

--- a/pwndbg/lib/memoize.py
+++ b/pwndbg/lib/memoize.py
@@ -6,6 +6,8 @@ new library/objfile are loaded, etc.
 
 import functools
 import sys
+from typing import Any
+from typing import Callable
 
 try:
     # Python >= 3.10
@@ -24,13 +26,13 @@ class memoize:
 
     caching = True
 
-    def __init__(self, func):
+    def __init__(self, func: Callable) -> None:
         self.func = func
         self.cache = {}
         self.caches.append(self)  # must be provided by base class
         functools.update_wrapper(self, func)
 
-    def __call__(self, *args, **kwargs):
+    def __call__(self, *args: Any, **kwargs: Any) -> int:
         how = None
 
         if not isinstance(args, Hashable):
@@ -59,10 +61,10 @@ class memoize:
         funcname = self.func.__module__ + "." + self.func.__name__
         return "<%s-memoized function %s>" % (self.kind, funcname)
 
-    def __get__(self, obj, objtype):
+    def __get__(self, obj, objtype: type) -> Callable:
         return functools.partial(self.__call__, obj)
 
-    def clear(self):
+    def clear(self) -> None:
         if debug:
             print("Clearing %s %r" % (self, self.cache))
         self.cache.clear()
@@ -86,7 +88,7 @@ class reset_on_stop(memoize):
     kind = "stop"
 
     @staticmethod
-    def __reset_on_stop():
+    def __reset_on_stop() -> None:
         for obj in reset_on_stop.caches:
             obj.cache.clear()
 
@@ -110,7 +112,7 @@ class reset_on_exit(memoize):
     kind = "exit"
 
     @staticmethod
-    def __reset_on_exit():
+    def __reset_on_exit() -> None:
         for obj in reset_on_exit.caches:
             obj.clear()
 
@@ -122,7 +124,7 @@ class reset_on_objfile(memoize):
     kind = "objfile"
 
     @staticmethod
-    def __reset_on_objfile():
+    def __reset_on_objfile() -> None:
         for obj in reset_on_objfile.caches:
             obj.clear()
 
@@ -134,7 +136,7 @@ class reset_on_start(memoize):
     kind = "start"
 
     @staticmethod
-    def __reset_on_start():
+    def __reset_on_start() -> None:
         for obj in reset_on_start.caches:
             obj.clear()
 
@@ -146,7 +148,7 @@ class reset_on_cont(memoize):
     kind = "cont"
 
     @staticmethod
-    def __reset_on_cont():
+    def __reset_on_cont() -> None:
         for obj in reset_on_cont.caches:
             obj.clear()
 
@@ -159,11 +161,11 @@ class while_running(memoize):
     caching = False
 
     @staticmethod
-    def _start_caching():
+    def _start_caching() -> None:
         while_running.caching = True
 
     @staticmethod
-    def __reset_while_running():
+    def __reset_while_running() -> None:
         for obj in while_running.caches:
             obj.clear()
         while_running.caching = False

--- a/pwndbg/lib/memory.py
+++ b/pwndbg/lib/memory.py
@@ -12,7 +12,7 @@ PAGE_SIZE = 0x1000
 PAGE_MASK = ~(PAGE_SIZE - 1)
 
 
-def round_down(address, align):
+def round_down(address: int, align: int) -> int:
     """round_down(address, align) -> int
 
     Round down ``address`` to the nearest increment of ``align``.
@@ -20,7 +20,7 @@ def round_down(address, align):
     return address & ~(align - 1)
 
 
-def round_up(address, align):
+def round_up(address: int, align: int) -> int:
     """round_up(address, align) -> int
 
     Round up ``address`` to the nearest increment of ``align``.
@@ -32,7 +32,7 @@ align_down = round_down
 align_up = round_up
 
 
-def page_align(address):
+def page_align(address: int) -> int:
     """page_align(address) -> int
 
     Round down ``address`` to the nearest page boundary.
@@ -40,7 +40,7 @@ def page_align(address):
     return round_down(address, PAGE_SIZE)
 
 
-def page_size_align(address):
+def page_size_align(address: int) -> int:
     return round_up(address, PAGE_SIZE)
 
 
@@ -65,7 +65,7 @@ class Page:
     offset = 0  #: Offset into the original ELF file that the data is loaded from
     objfile = ""  #: Path to the ELF on disk
 
-    def __init__(self, start, size, flags, offset, objfile=""):
+    def __init__(self, start: int, size: int, flags: int, offset: int, objfile: str = "") -> None:
         self.vaddr = start
         self.memsz = size
         self.flags = flags
@@ -76,14 +76,14 @@ class Page:
         # self.flags = self.flags ^ 1
 
     @property
-    def start(self):
+    def start(self) -> int:
         """
         Mapping start address.
         """
         return self.vaddr
 
     @property
-    def end(self):
+    def end(self) -> int:
         """
         Address beyond mapping. So the last effective address is self.end-1
         It is the same as displayed in /proc/<pid>/maps
@@ -99,15 +99,15 @@ class Page:
         return len(self.objfile) > 0 and self.objfile[0] != "[" and self.objfile != "<pt>"
 
     @property
-    def read(self):
+    def read(self) -> bool:
         return bool(self.flags & 4)
 
     @property
-    def write(self):
+    def write(self) -> bool:
         return bool(self.flags & 2)
 
     @property
-    def execute(self):
+    def execute(self) -> bool:
         return bool(self.flags & 1)
 
     @property
@@ -115,7 +115,7 @@ class Page:
         return self.read and self.write
 
     @property
-    def rwx(self):
+    def rwx(self) -> bool:
         return self.read and self.write and self.execute
 
     @property
@@ -146,13 +146,13 @@ class Page:
     def __repr__(self):
         return "%s(%r)" % (self.__class__.__name__, self.__str__())
 
-    def __contains__(self, addr):
+    def __contains__(self, addr: int) -> bool:
         return self.start <= addr < self.end
 
-    def __eq__(self, other):
+    def __eq__(self, other) -> bool:
         return self.vaddr == getattr(other, "vaddr", other)
 
-    def __lt__(self, other):
+    def __lt__(self, other) -> bool:
         return self.vaddr < getattr(other, "vaddr", other)
 
     def __hash__(self):


### PR DESCRIPTION
Autogenerated typehints from [pyannotate](https://github.com/dropbox/pyannotate). None of these should cause problems in Python 3.6.