### PR TITLE
Linting/formatting improvements

### DIFF
--- a/gdbinit.py
+++ b/gdbinit.py
@@ -1,8 +1,8 @@
 import glob
 import locale
 import sys
-from os import path, environ
-
+from os import environ
+from os import path
 
 # Allow users to use packages from a virtualenv
 # That's not 100% supported, but they do it on their own,
@@ -70,4 +70,4 @@ if encoding != "UTF-8":
     print("Make sure that en_US.UTF-8 is activated in /etc/locale.gen and you called locale-gen")
     print("******")
 
-import pwndbg  # isort:skip
+import pwndbg

--- a/ida_script.py
+++ b/ida_script.py
@@ -5,8 +5,8 @@ from __future__ import print_function
 import datetime
 import threading
 import xmlrpc.client as xmlclient
-from xmlrpc.server import SimpleXMLRPCServer
 from xml.sax.saxutils import escape
+from xmlrpc.server import SimpleXMLRPCServer
 
 import idaapi
 import idc

--- a/lint.sh
+++ b/lint.sh
@@ -4,8 +4,8 @@ set -o xtrace
 set -o errexit
 
 isort --check-only --diff pwndbg tests
-black --diff --check pwndbg tests
-flake8 --show-source pwndbg tests
+black --diff --check .
+flake8 --show-source .
 
 # Indents are four spaces, binary ops can start a line, and indent switch cases
 shfmt -i 4 -bn -ci -d .

--- a/lint.sh
+++ b/lint.sh
@@ -3,7 +3,7 @@
 set -o xtrace
 set -o errexit
 
-isort --check-only --diff pwndbg tests
+isort --check-only --diff .
 black --diff --check .
 flake8 --show-source .
 

--- a/pwndbg/commands/nearpc.py
+++ b/pwndbg/commands/nearpc.py
@@ -1,7 +1,7 @@
 import argparse
 
 import gdb
-from capstone import *
+from capstone import *  # noqa: F403
 
 import pwndbg.arguments
 import pwndbg.color

--- a/pwndbg/disasm/__init__.py
+++ b/pwndbg/disasm/__init__.py
@@ -7,7 +7,7 @@ import collections
 
 import capstone
 import gdb
-from capstone import *
+from capstone import *  # noqa: F403
 
 import pwndbg.disasm.arch
 import pwndbg.gdblib.arch

--- a/pwndbg/disasm/arch.py
+++ b/pwndbg/disasm/arch.py
@@ -1,5 +1,5 @@
 import gdb
-from capstone import *
+from capstone import *  # noqa: F403
 
 import pwndbg.lib.memoize
 import pwndbg.symbol

--- a/pwndbg/disasm/arm.py
+++ b/pwndbg/disasm/arm.py
@@ -1,5 +1,5 @@
-from capstone import *
-from capstone.arm import *
+from capstone import *  # noqa: F403
+from capstone.arm import *  # noqa: F403
 
 import pwndbg.disasm.arch
 import pwndbg.gdblib.arch

--- a/pwndbg/disasm/x86.py
+++ b/pwndbg/disasm/x86.py
@@ -1,5 +1,5 @@
-from capstone import *
-from capstone.x86 import *
+from capstone import *  # noqa: F403
+from capstone.x86 import *  # noqa: F403
 
 import pwndbg.gdblib.arch
 import pwndbg.gdblib.memory

--- a/pytests_collect.py
+++ b/pytests_collect.py
@@ -3,7 +3,6 @@ import sys
 
 import pytest
 
-
 TESTS_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), "tests")
 
 

--- a/pytests_launcher.py
+++ b/pytests_launcher.py
@@ -1,6 +1,7 @@
 import os
-import pytest
 import sys
+
+import pytest
 
 use_pdb = os.environ.get("USE_PDB") == "1"
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,8 +53,6 @@ ignore =
     W505,
     # module imported but unused
     F401,
-    # 'from module import *' used; unable to detect undefined names
-    F403,
     # name may be undefined, or defined from star imports: module
     F405,
     # redefinition of unused name from line n

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,36 +1,7 @@
-[pep8]
-ignore = E203,E227,E251,E226,E501,E221,E241,E402,E261,E265,E704,W603,W503
-max-line-length=120
-exclude = capstone,unicorn,pwndbg/constants
-
 [flake8]
 ignore =
-    # continuation line under-indented for hanging indent (default)
-    E121,
-    # closing bracket does not match indentation of opening bracket's line (default)
-    E123,
-    # continuation line over-indented for hanging indent (default)
-    E126,
-    # continuation line under-indented for visual indent
-    E128,
-    # closing bracket is missing indentation (default)
-    E133,
     # whitespace before ‘:’
     E203,
-    # multiple spaces before operator
-    E221,
-    # missing whitespace around arithmetic operator (default)
-    E226,
-    # missing whitespace around bitwise or shift operator
-    E227,
-    # multiple spaces after ‘,’ (default)
-    E241,
-    # tab after ',' (default)
-    E242,
-    # unexpected spaces around keyword / parameter equals
-    E251,
-    # missing whitespace around arithmetic operator
-    E261,
     # too many leading '#' for block comment
     E266,
     # block comment should start with ‘# ‘
@@ -39,16 +10,10 @@ ignore =
     E402,
     # line too long (82 > 79 characters)
     E501,
-    # multiple statements on one line (def) (default)
-    E704,
-    # do not use bare except, specify exception instead
-    E722,
     # do not assign a lambda expression, use a def
     E731
     # line break before binary operator (default)
     W503,
-    # line break occurred after a binary operator (default)
-    W504,
     # doc line too long (82 > 79 characters) (default)
     W505,
     # module imported but unused
@@ -61,5 +26,6 @@ ignore =
     F821,
     # local variable name is assigned to but never used
     F841
-max-line-length=100
-exclude = capstone,unicorn,pwndbg/constants,gdb-pt-dump
+
+max-line-length = 100
+exclude = gdb-pt-dump


### PR DESCRIPTION
- Run `isort`, `black`, and `flake8` on the entire root directory
- Ignore F403 for lines where we do `from capstone import *` and remove F403 from the ignore list. This way we won't introduce wildcard imports in the future, but don't have to deal with changing any of the capstone code.
- Remove a bunch of warnings/errors from the ignore list in `setup.cfg` that required no code changes, and some other minor cleanup.