### PR TITLE
Remove unused imports

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -16,7 +16,6 @@
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
 import os
-import subprocess
 import sys
 
 # These paths are relative to the 'source' directory
@@ -24,7 +23,7 @@ os.environ["SPHINX"] = "1"
 sys.path.insert(0, os.path.abspath(".."))  # <-- For 'gdb'
 sys.path.insert(0, os.path.abspath("../.."))  # <-- For 'pwndbg'
 
-import pwndbg
+import pwndbg  # noqa: F401
 
 # -- General configuration ------------------------------------------------
 

--- a/gdbinit.py
+++ b/gdbinit.py
@@ -70,4 +70,4 @@ if encoding != "UTF-8":
     print("Make sure that en_US.UTF-8 is activated in /etc/locale.gen and you called locale-gen")
     print("******")
 
-import pwndbg
+import pwndbg  # noqa: F401

--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -202,7 +202,6 @@ def fix(arg, sloppy=False, quiet=True, reraise=False):
             print(e)
         if reraise:
             raise e
-        pass
 
     if sloppy:
         return arg

--- a/pwndbg/commands/defcon.py
+++ b/pwndbg/commands/defcon.py
@@ -1,7 +1,5 @@
 import argparse
 
-import gdb
-
 import pwndbg.commands
 import pwndbg.gdblib.memory
 import pwndbg.symbol
@@ -25,13 +23,11 @@ def defcon_heap(addr=0x2AAAAAAD5000):
         free = heap_freebins()
     except Exception as e:
         print(e)
-        pass
 
     try:
         heap_allocations(addr, free)
     except Exception as e:
         print(e)
-        pass
 
 
 def heap_freebins(addr=0x0602558):

--- a/pwndbg/commands/dt.py
+++ b/pwndbg/commands/dt.py
@@ -1,7 +1,5 @@
 import argparse
 
-import gdb
-
 import pwndbg.color
 import pwndbg.commands
 import pwndbg.gdblib.dt

--- a/pwndbg/commands/misc.py
+++ b/pwndbg/commands/misc.py
@@ -5,7 +5,6 @@ import gdb
 
 import pwndbg.auxv
 import pwndbg.commands
-import pwndbg.gdblib.arch as _arch
 import pwndbg.gdblib.regs
 import pwndbg.symbol
 

--- a/pwndbg/commands/mprotect.py
+++ b/pwndbg/commands/mprotect.py
@@ -9,7 +9,6 @@ import pwndbg.file
 import pwndbg.lib.which
 import pwndbg.wrappers.checksec
 import pwndbg.wrappers.readelf
-from pwndbg.color import message
 
 parser = argparse.ArgumentParser(description="Calls mprotect. x86_64 only.")
 parser.add_argument("addr", help="Page-aligned address to all mprotect on.", type=int)

--- a/pwndbg/commands/p2p.py
+++ b/pwndbg/commands/p2p.py
@@ -1,7 +1,5 @@
 import argparse
 
-import gdb
-
 import pwndbg.color
 import pwndbg.commands
 import pwndbg.gdblib.arch

--- a/pwndbg/commands/procinfo.py
+++ b/pwndbg/commands/procinfo.py
@@ -1,7 +1,5 @@
 import string
 
-import gdb
-
 import pwndbg.auxv
 import pwndbg.commands
 import pwndbg.file

--- a/pwndbg/commands/reload.py
+++ b/pwndbg/commands/reload.py
@@ -1,7 +1,5 @@
 import types
 
-import gdb
-
 import pwndbg
 import pwndbg.commands
 import pwndbg.gdblib.events

--- a/pwndbg/commands/shell.py
+++ b/pwndbg/commands/shell.py
@@ -4,8 +4,6 @@ Wrapper for shell commands.
 
 import os
 
-import gdb
-
 import pwndbg.commands
 import pwndbg.lib.which
 

--- a/pwndbg/commands/tls.py
+++ b/pwndbg/commands/tls.py
@@ -1,7 +1,6 @@
 """
 Command to print the information of the current Thread Local Storage (TLS).
 """
-import argparse
 
 import pwndbg.commands
 import pwndbg.tls

--- a/pwndbg/commands/windbg.py
+++ b/pwndbg/commands/windbg.py
@@ -5,7 +5,6 @@ Compatibility functionality for Windbg users.
 import argparse
 import codecs
 import math
-import sys
 from builtins import str
 
 import gdb

--- a/pwndbg/commands/xinfo.py
+++ b/pwndbg/commands/xinfo.py
@@ -1,7 +1,5 @@
 import argparse
 
-import gdb
-
 import pwndbg.color.memory as M
 import pwndbg.commands
 import pwndbg.config

--- a/pwndbg/constants/ptmalloc.py
+++ b/pwndbg/constants/ptmalloc.py
@@ -1,9 +1,3 @@
-import platform
-
-import gdb
-
-import pwndbg.gdblib.arch
-
 # Heap flags
 PREV_INUSE = 1
 IS_MMAPPED = 2

--- a/pwndbg/enhance.py
+++ b/pwndbg/enhance.py
@@ -9,8 +9,6 @@ supplemental information sources (e.g. active IDA Pro connection).
 
 import string
 
-import gdb
-
 import pwndbg.color as color
 import pwndbg.color.enhance as E
 import pwndbg.config

--- a/pwndbg/gdblib/hooks.py
+++ b/pwndbg/gdblib/hooks.py
@@ -1,7 +1,6 @@
 import pwndbg.gdblib.events
 import pwndbg.gdblib.typeinfo
 from pwndbg.gdblib import arch_mod
-from pwndbg.lib.memoize import forever
 from pwndbg.lib.memoize import reset_on_cont
 from pwndbg.lib.memoize import reset_on_exit
 from pwndbg.lib.memoize import reset_on_objfile

--- a/pwndbg/gdblib/memory.py
+++ b/pwndbg/gdblib/memory.py
@@ -2,7 +2,6 @@
 Reading, writing, and describing memory.
 """
 
-import os
 
 import gdb
 

--- a/pwndbg/gdblib/regs.py
+++ b/pwndbg/gdblib/regs.py
@@ -2,7 +2,6 @@
 Reading register value from the inferior, and provides a
 standardized interface to registers like "sp" and "pc".
 """
-import collections
 import ctypes
 import re
 import sys

--- a/pwndbg/glibc.py
+++ b/pwndbg/glibc.py
@@ -5,8 +5,6 @@ Get information about the GLibc
 import functools
 import re
 
-import gdb
-
 import pwndbg.config
 import pwndbg.gdblib.memory
 import pwndbg.heap

--- a/pwndbg/lib/memory.py
+++ b/pwndbg/lib/memory.py
@@ -4,8 +4,6 @@ Reading, writing, and describing memory.
 
 import os
 
-import gdb
-
 import pwndbg.gdblib.arch
 
 PAGE_SIZE = 0x1000

--- a/pwndbg/vmmap.py
+++ b/pwndbg/vmmap.py
@@ -7,7 +7,6 @@ system has /proc/$$/maps, which backs 'info proc mapping'.
 """
 import bisect
 import os
-import sys
 
 import gdb
 
@@ -604,7 +603,6 @@ def check_aslr():
             return False, "kernel.randomize_va_space == 0"
     except Exception as e:
         print("Could not check ASLR: can't read randomize_va_space")
-        pass
 
     # Check the personality of the process
     if pwndbg.proc.alive:
@@ -614,7 +612,6 @@ def check_aslr():
             return (personality & 0x40000 == 0), "read status from process' personality"
         except Exception:
             print("Could not check ASLR: can't read process' personality")
-            pass
 
     # Just go with whatever GDB says it did.
     #

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,8 +16,6 @@ ignore =
     W503,
     # doc line too long (82 > 79 characters) (default)
     W505,
-    # module imported but unused
-    F401,
     # name may be undefined, or defined from star imports: module
     F405,
     # redefinition of unused name from line n
@@ -26,6 +24,10 @@ ignore =
     F821,
     # local variable name is assigned to but never used
     F841
+
+per-file-ignores =
+    # Unused imports in __init__.py are fine
+    __init__.py:F401
 
 max-line-length = 100
 exclude = gdb-pt-dump

--- a/tests/test_attachp.py
+++ b/tests/test_attachp.py
@@ -1,12 +1,8 @@
-import codecs
 import os
 import re
 import subprocess
 
-import gdb
 import pytest
-
-import tests
 
 from .utils import run_gdb_with_script
 

--- a/tests/test_command_errno.py
+++ b/tests/test_command_errno.py
@@ -1,8 +1,5 @@
 import gdb
 
-import pwndbg
-import pwndbg.gdblib.memory
-import pwndbg.gdblib.regs
 import tests
 
 # We use the heap_vis binary as it enforces pthreads and so will have TLS on all distros

--- a/tests/test_command_xor.py
+++ b/tests/test_command_xor.py
@@ -4,7 +4,6 @@ import pwndbg.gdblib.memory
 import pwndbg.gdblib.regs
 import tests
 from pwndbg.commands.xor import memfrob
-from pwndbg.commands.xor import xor
 
 REFERENCE_BINARY = tests.binaries.get("reference-binary.out")
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -3,7 +3,6 @@ import pytest
 
 import tests
 from pwndbg.commands import command_names
-from pwndbg.commands import commands
 from pwndbg.commands.shell import shellcmd_names
 
 BINARY = tests.binaries.get("heap_bins.out")

--- a/tests/test_heap.py
+++ b/tests/test_heap.py
@@ -1,5 +1,4 @@
 import os
-import stat
 import tempfile
 
 import gdb

--- a/tests/test_loads.py
+++ b/tests/test_loads.py
@@ -1,12 +1,9 @@
 import os
 import re
 
-import pytest
-
 import tests
 
 from .utils import compile_binary
-from .utils import launched_locally
 from .utils import run_gdb_with_script
 
 HELLO = [


### PR DESCRIPTION
Should be merged after #1138.

This PR removes unused imports, mainly with this command:
```
autoflake -i -r --remove-all-unused-imports --ignore-init-module-imports .
```

The `setup.cfg` is updated to now check for unused imports (`F401`), other than from `__init__.py` files.

This might help with some of the circular import issues I've been running into while refactoring.
