### PR TITLE
fix distance command

### DIFF
--- a/pwndbg/commands/misc.py
+++ b/pwndbg/commands/misc.py
@@ -87,12 +87,15 @@ parser.add_argument("b", type=int, help="The second address.")
 @pwndbg.commands.ArgparsedCommand(parser)
 def distance(a, b):
     """Print the distance between the two arguments"""
-    a = int(a) & pwndbg.arch.ptrmask
-    b = int(b) & pwndbg.arch.ptrmask
+    a = int(a) & pwndbg.gdblib.arch.ptrmask
+    b = int(b) & pwndbg.gdblib.arch.ptrmask
 
     distance = b - a
 
-    print("%#x->%#x is %#x bytes (%#x words)" % (a, b, distance, distance // pwndbg.arch.ptrsize))
+    print(
+        "%#x->%#x is %#x bytes (%#x words)"
+        % (a, b, distance, distance // pwndbg.gdblib.arch.ptrsize)
+    )
 
 
 def list_and_filter_commands(filter_str):

--- a/tests/test_command_distance.py
+++ b/tests/test_command_distance.py
@@ -1,9 +1,7 @@
 import gdb
 
-import pwndbg.gdblib.memory
 import pwndbg.gdblib.regs
 import tests
-from pwndbg.commands.xor import memfrob
 
 REFERENCE_BINARY = tests.binaries.get("reference-binary.out")
 

--- a/tests/test_command_distance.py
+++ b/tests/test_command_distance.py
@@ -1,0 +1,17 @@
+import gdb
+
+import pwndbg.gdblib.memory
+import pwndbg.gdblib.regs
+import tests
+from pwndbg.commands.xor import memfrob
+
+REFERENCE_BINARY = tests.binaries.get("reference-binary.out")
+
+
+def test_command_distance(start_binary):
+    start_binary(REFERENCE_BINARY)
+
+    rsp = pwndbg.gdblib.regs.rsp
+    result = gdb.execute("distance $rsp $rsp+0x10", to_string=True)
+
+    assert result == "%#x->%#x is 0x10 bytes (0x2 words)\n" % (rsp, rsp + 0x10)


### PR DESCRIPTION
The recent refactoring broke the distance command (`pwndbg.arch` -> `pwndbg.gdblib.arch`). This PR fixes this command and adds a test for it.