### PR TITLE
Add regression test for `find_fake_fast` command

### DIFF
--- a/tests/binaries/heap_find_fake_fast.c
+++ b/tests/binaries/heap_find_fake_fast.c
@@ -1,0 +1,26 @@
+/* Test the find_fake_fast command.
+ *
+ * No need to test the output as find_fake_fast wraps malloc_chunk,
+ * which can be tested separately.
+ *
+ * Just test for the command completing without a crash.
+ * Purposefully pass a fake chunk with no parent arena, with a set
+ * NON_MAIN_ARENA flag to ensure no error occurs when attempting to read
+ * the non-existent heap_info struct - issue #1142
+ */
+
+#include <stdlib.h>
+
+void break_here(void) {}
+
+// Fake chunk size field with a set NON_MAIN_ARENA flag.
+// Enough space afterwards to ensure only this fake size field is a candidate.
+char fake_chunk[0x80] __attribute__((aligned(0x10))) = "XXXXXXXX\x7f";
+
+int main(void)
+{
+    // Initialize malloc so heap commands can run.
+    void* m = malloc(0x18);
+
+    break_here();
+}

--- a/tests/test_heap.py
+++ b/tests/test_heap.py
@@ -12,6 +12,7 @@ HEAP_CODE = tests.binaries.get("heap_bugs.c")
 _, OUTPUT_FILE = tempfile.mkstemp()
 
 HEAP_VIS = tests.binaries.get("heap_vis.out")
+HEAP_FIND_FAKE_FAST = tests.binaries.get("heap_find_fake_fast.out")
 
 
 def binary_parse_breakpoints(binary_code):
@@ -399,3 +400,19 @@ def test_vis_heap_chunk_command(start_binary):
     expected_all3.append(vis_heap_line(suffix="\t <-- Top chunk"))
 
     assert result_all3 == expected_all3
+
+
+# Ensure find_fake_fast command doesn't error when fake chunk's heap_info
+# struct isn't mapped.
+def test_find_fake_fast_command(start_binary):
+    start_binary(HEAP_FIND_FAKE_FAST)
+    gdb.execute("break break_here")
+    gdb.execute("continue")
+
+    # Ensure memory at fake_chunk's heap_info struct isn't mapped.
+    unmapped_heap_info = pwndbg.heap.ptmalloc.heap_for_ptr(pwndbg.symbol.address("fake_chunk"))
+    assert pwndbg.gdblib.memory.peek(unmapped_heap_info) is None
+
+    # A gdb.MemoryError raised here indicates a regression from PR #1145
+    gdb.execute("find_fake_fast (void*)&fake_chunk+0x70")
+

--- a/tests/test_heap.py
+++ b/tests/test_heap.py
@@ -415,4 +415,3 @@ def test_find_fake_fast_command(start_binary):
 
     # A gdb.MemoryError raised here indicates a regression from PR #1145
     gdb.execute("find_fake_fast (void*)&fake_chunk+0x70")
-


### PR DESCRIPTION
The test program creates a fake chunk size field in its .data section with a set NON_MAIN_ARENA flag.
The Python test runs the find_fake_fast command on an address succeeding the fake chunk.
A gdb.MemoryError indicates regression - issue #1142