### PR TITLE
fix qemu vmmap showing coredump mappings

### DIFF
--- a/pwndbg/vmmap.py
+++ b/pwndbg/vmmap.py
@@ -63,7 +63,7 @@ def get():
         else:
             pages.extend(kernel_vmmap_via_monitor_info_mem())
 
-    if not pages:
+    if not pages and is_corefile():
         pages.extend(coredump_maps())
 
     # TODO/FIXME: Do we still need it after coredump_maps()?


### PR DESCRIPTION
Before:
```
pwndbg> vmmap
LEGEND: STACK | HEAP | CODE | DATA | RWX | RODATA
               0x0               0x34 r--p       34 20268  .gnu_debuglink
             0x238              0x254 rw-p       1c 238    .interp
             0x254              0x274 rw-p       20 254    .note.ABI-tag
             0x274              0x298 rw-p       24 274    .note.gnu.build-id
             0x298              0x384 rw-p       ec 298    .gnu.hash
             0x388             0x1180 rw-p      df8 388    .dynsym
            0x1180             0x1802 rw-p      682 1180   .dynstr
            0x1802             0x192c rw-p      12a 1802   .gnu.version
            0x1930             0x19a0 rw-p       70 1930   .gnu.version_r
            0x19a0             0x2cf0 rw-p     1350 19a0   .rela.dyn
            0x2cf0             0x3758 rw-p      a68 2cf0   .rela.plt
            0x3758             0x376f r-xp       17 3758   .init
            0x3770             0x3e70 r-xp      700 3770   .plt
            0x3e70             0x3e88 r-xp       18 3e70   .plt.got
            0x3e90            0x16369 r-xp    124d9 3e90   .text
           0x1636c            0x16375 r-xp        9 1636c  .fini
           0x16380            0x1b19d rw-p     4e1d 16380  .rodata
           0x1b1a0            0x1ba24 rw-p      884 1b1a0  .eh_frame_hdr
           0x1ba28            0x1e6e8 rw-p     2cc0 1ba28  .eh_frame
          0x21eff0           0x21eff8 -w-p        8 1eff0  .init_array
          0x21eff8           0x21f000 -w-p        8 1eff8  .fini_array
          0x21f000           0x21fa38 -w-p      a38 1f000  .data.rel.ro
          0x21fa38           0x21fc38 -w-p      200 1fa38  .dynamic
          0x21fc38           0x220000 -w-p      3c8 1fc38  .got
          0x220000           0x220268 -w-p      268 20000  .data
          0x220280           0x221560 ---p     12e0 20268  .bss
      0x4000622000       0x4000a4c000 rwxp   42a000 0      <explored>
      0x4000c4c000       0x4000c51000 rwxp     5000 0      <explored>

[QEMU target detected - vmmap result might not be accurate; see `help vmmap`]
```

After:
```
pwndbg> vmmap
LEGEND: STACK | HEAP | CODE | DATA | RWX | RODATA
               0x0 0xffffffffffffffff rwxp ffffffffffffffff 0      [qemu]

[QEMU target detected - vmmap result might not be accurate; see `help vmmap`]
```