### PR TITLE
Fix #1153 nextproginstr command

### DIFF
--- a/pwndbg/commands/next.py
+++ b/pwndbg/commands/next.py
@@ -67,9 +67,7 @@ def stepret():
 )
 @pwndbg.commands.OnlyWhenRunning
 def nextproginstr():
-    """Breaks at the next instruction that belongs to the running program"""
-    if pwndbg.gdblib.next.break_on_program_code():
-        pwndbg.commands.context.context()
+    pwndbg.gdblib.next.break_on_program_code()
 
 
 parser = argparse.ArgumentParser(

--- a/pwndbg/proc.py
+++ b/pwndbg/proc.py
@@ -69,10 +69,6 @@ class module(ModuleType):
         """
         return gdb.current_progspace().filename
 
-    @property
-    def mem_page(self):
-        return next(p for p in pwndbg.vmmap.get() if p.objfile == self.exe)
-
     def OnlyWhenRunning(self, func):
         @functools.wraps(func)
         def wrapper(*a, **kw):

--- a/tests/test_commands_next.py
+++ b/tests/test_commands_next.py
@@ -29,8 +29,7 @@ def test_command_nextproginstr(start_binary):
     gdb.execute("continue")
 
     # Sanity check that we are in libc
-    libc = "libc.so.6"
-    assert pwndbg.vmmap.find(pwndbg.gdblib.regs.rip).objfile.endswith(libc)
+    assert "libc" in pwndbg.vmmap.find(pwndbg.gdblib.regs.rip).objfile
 
     # Execute nextproginstr and see if we came back to the same vmmap page
     gdb.execute("nextproginstr")

--- a/tests/test_commands_next.py
+++ b/tests/test_commands_next.py
@@ -1,0 +1,41 @@
+import gdb
+
+import pwndbg.gdblib.regs
+import tests
+
+REFERENCE_BINARY = tests.binaries.get("reference-binary.out")
+
+
+def test_command_nextproginstr_binary_not_running():
+    out = gdb.execute("nextproginstr", to_string=True)
+    assert out == "nextproginstr: The program is not being run.\n"
+
+
+def test_command_nextproginstr(start_binary):
+    start_binary(REFERENCE_BINARY)
+
+    gdb.execute("break main")
+    gdb.execute("continue")
+
+    out = gdb.execute("nextproginstr", to_string=True)
+    assert out == "The pc is already at the binary objfile code. Not stepping.\n"
+
+    # Sanity check
+    exec_bin_pages = [p for p in pwndbg.vmmap.get() if p.objfile == pwndbg.proc.exe and p.execute]
+    assert any(pwndbg.gdblib.regs.pc in p for p in exec_bin_pages)
+    main_page = pwndbg.vmmap.find(pwndbg.gdblib.regs.pc)
+
+    gdb.execute("break puts")
+    gdb.execute("continue")
+
+    # Sanity check that we are in libc
+    libc = "libc.so.6"
+    assert pwndbg.vmmap.find(pwndbg.gdblib.regs.rip).objfile.endswith(libc)
+
+    # Execute nextproginstr and see if we came back to the same vmmap page
+    gdb.execute("nextproginstr")
+    assert pwndbg.gdblib.regs.pc in main_page
+
+    # Ensure that nextproginstr won't jump now
+    out = gdb.execute("nextproginstr", to_string=True)
+    assert out == "The pc is already at the binary objfile code. Not stepping.\n"


### PR DESCRIPTION
Fixes issues with the `nextproginst` command described in #1153 and adds two simple tests for it.

The command had two following issues:
1) It assumed that the program vmmap was always the first vmmap with
   proc.exe objfile name -- this assumption has two flaws. First, newer
linkers will create the first memory page for the binary file as read-only. This is because you do not need the ELF header content to be executable, and that was the case in old linkers or linux distributions. As an example, see those vmmap from a simple hello world binary compiled on Ubuntu 18.04 vs Ubuntu 22.04:

Ubuntu 18.04:
```
  pwndbg> vmmap
  LEGEND: STACK | HEAP | CODE | DATA | RWX | RODATA
      0x555555554000     0x555555555000 r-xp     1000 0      /home/dc/a.out
      0x555555754000     0x555555755000 r--p     1000 0      /home/dc/a.out
      0x555555755000     0x555555756000 rw-p     1000 1000   /home/dc/a.out
      [...]
```

Ubuntu 22.04:
```
  pwndbg> vmmap
  LEGEND: STACK | HEAP | CODE | DATA | RWX | RODATA
      0x555555554000     0x555555555000 r--p     1000 0      /home/user/a.out
      0x555555555000     0x555555556000 r-xp     1000 1000   /home/user/a.out
      0x555555556000     0x555555557000 r--p     1000 2000   /home/user/a.out
      0x555555557000     0x555555558000 r--p     1000 2000   /home/user/a.out
      0x555555558000     0x555555559000 rw-p     1000 3000   /home/user/a.out
```

So, before this commit on Ubuntu 22.04 we ended up taking the first vmmap which was non-executable and we compared the program counter register against it after each instruction step executed by the nextproginstr command. As a result, we ended up never getting back to the user and just finishing the debugged program this way!

Now, after this commit, we will grab only and all the executable pages for the binary that we debug and compare and compare against them.

2) The second problem was that we printed out the current Pwndbg context
   after executing nextproginstr succesfully. This does not seem to make
much sense because the context should be printed by the prompt hook. (Without removing this, we ended up printing the context twice)