### PR TITLE
Add Chunk class & template_heap_command

### DIFF
--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -122,6 +122,16 @@ def template_heap_command(addr):
     if chunk.size is not None:
         print(f"chunk.size: 0x{chunk.size:02x}")
 
+    # Flags may be retrieved individually or as a dictionary of all 3.
+    if chunk.non_main_arena is not None:
+        print(f"chunk.non_main_arena: {chunk.non_main_arena}")
+
+    if chunk.is_mmapped is not None:
+        print(f"chunk.is_mmapped: {chunk.is_mmapped}")
+
+    if chunk.prev_inuse is not None:
+        print(f"chunk.prev_inuse: {chunk.prev_inuse}")
+
     if chunk.flags is not None:
         print(f"chunk.flags: {chunk.flags}")
 

--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -96,7 +96,7 @@ def format_bin(bins, verbose=False, offset=None):
 
 
 parser = argparse.ArgumentParser()
-parser.description = ("Template heap command. You can ignore this.")
+parser.description = "Template heap command. You can ignore this."
 parser.add_argument("addr", type=int, help="Address of a chunk header.")
 
 

--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -96,53 +96,6 @@ def format_bin(bins, verbose=False, offset=None):
 
 
 parser = argparse.ArgumentParser()
-parser.description = "Template heap command. You can ignore this."
-parser.add_argument("addr", type=int, help="Address of a chunk header.")
-
-
-@pwndbg.commands.ArgparsedCommand(parser)
-@pwndbg.commands.OnlyWhenRunning
-@pwndbg.commands.OnlyWithResolvedHeapSyms
-@pwndbg.commands.OnlyWhenHeapIsInitialized
-def template_heap_command(addr):
-    """Template heap command with example uses of pwndbg's heap classes."""
-
-    # `addr` is a gdb.Value of one of several types, depending on how the user invoked this command
-    # e.g. template_heap_command <address> vs. template_heap_command <symbol>
-
-    # The `Chunk` class abstracts away many heap & gdb module internals.
-    chunk = pwndbg.heap.ptmalloc.Chunk(addr)
-
-    print(f"chunk.address: 0x{chunk.address:02x}")
-
-    # Be aware that if a chunk field is unreadable (e.g. a fake chunk straddling an unmapped page boundary) it will be None, always check.
-    if chunk.prev_size is not None:
-        print(f"chunk.prev_size: 0x{chunk.prev_size:02x}")
-
-    if chunk.size is not None:
-        print(f"chunk.size: 0x{chunk.size:02x}")
-
-    # Flags may be retrieved individually or as a dictionary of all 3.
-    if chunk.non_main_arena is not None:
-        print(f"chunk.non_main_arena: {chunk.non_main_arena}")
-
-    if chunk.is_mmapped is not None:
-        print(f"chunk.is_mmapped: {chunk.is_mmapped}")
-
-    if chunk.prev_inuse is not None:
-        print(f"chunk.prev_inuse: {chunk.prev_inuse}")
-
-    if chunk.flags is not None:
-        print(f"chunk.flags: {chunk.flags}")
-
-    if chunk.fd is not None:
-        print(f"chunk.fd: 0x{chunk.fd:02x}")
-
-    if chunk.bk is not None:
-        print(f"chunk.bk: 0x{chunk.bk:02x}")
-
-
-parser = argparse.ArgumentParser()
 parser.description = (
     "Iteratively print chunks on a heap, default to the current thread's active heap."
 )

--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -96,6 +96,43 @@ def format_bin(bins, verbose=False, offset=None):
 
 
 parser = argparse.ArgumentParser()
+parser.description = ("Template heap command. You can ignore this.")
+parser.add_argument("addr", type=int, help="Address of a chunk header.")
+
+
+@pwndbg.commands.ArgparsedCommand(parser)
+@pwndbg.commands.OnlyWhenRunning
+@pwndbg.commands.OnlyWithResolvedHeapSyms
+@pwndbg.commands.OnlyWhenHeapIsInitialized
+def template_heap_command(addr):
+    """Template heap command with example uses of pwndbg's heap classes."""
+
+    # `addr` is a gdb.Value of one of several types, depending on how the user invoked this command
+    # e.g. template_heap_command <address> vs. template_heap_command <symbol>
+
+    # The `Chunk` class abstracts away many heap & gdb module internals.
+    chunk = pwndbg.heap.ptmalloc.Chunk(addr)
+
+    print(f"chunk.address: 0x{chunk.address:02x}")
+
+    # Be aware that if a chunk field is unreadable (e.g. a fake chunk straddling an unmapped page boundary) it will be None, always check.
+    if chunk.prev_size is not None:
+        print(f"chunk.prev_size: 0x{chunk.prev_size:02x}")
+
+    if chunk.size is not None:
+        print(f"chunk.size: 0x{chunk.size:02x}")
+
+    if chunk.flags is not None:
+        print(f"chunk.flags: {chunk.flags}")
+
+    if chunk.fd is not None:
+        print(f"chunk.fd: 0x{chunk.fd:02x}")
+
+    if chunk.bk is not None:
+        print(f"chunk.bk: 0x{chunk.bk:02x}")
+
+
+parser = argparse.ArgumentParser()
 parser.description = (
     "Iteratively print chunks on a heap, default to the current thread's active heap."
 )

--- a/pwndbg/heap/ptmalloc.py
+++ b/pwndbg/heap/ptmalloc.py
@@ -39,6 +39,9 @@ class Chunk:
         self._prev_size = None
         self._size = None
         self._flags = None
+        self._non_main_arena = None
+        self._is_mmapped = None
+        self._prev_inuse = None
         self._fd = None
         self._bk = None
         # TODO fd_nextsize, bk_nextsize, key, REVEAL_PTR etc.
@@ -79,12 +82,39 @@ class Chunk:
             sz = self.size
             if sz is not None:
                 self._flags = {
-                    "non_main_arena": bool(sz & ptmalloc.NON_MAIN_ARENA),
-                    "is_mmapped": bool(sz & ptmalloc.IS_MMAPPED),
-                    "prev_inuse": bool(sz & ptmalloc.PREV_INUSE),
+                    "non_main_arena": self.non_main_arena,
+                    "is_mmapped": self.is_mmapped,
+                    "prev_inuse": self.prev_inuse,
                 }
 
         return self._flags
+
+    @property
+    def non_main_arena(self):
+        if self._non_main_arena is None:
+            sz = self.size
+            if sz is not None:
+                self._non_main_arena = bool(sz & ptmalloc.NON_MAIN_ARENA)
+
+        return self._non_main_arena
+
+    @property
+    def is_mmapped(self):
+        if self._is_mmapped is None:
+            sz = self.size
+            if sz is not None:
+                self._is_mmapped = bool(sz & ptmalloc.IS_MMAPPED)
+
+        return self._is_mmapped
+
+    @property
+    def prev_inuse(self):
+        if self._prev_inuse is None:
+            sz = self.size
+            if sz is not None:
+                self._prev_inuse = bool(sz & ptmalloc.PREV_INUSE)
+
+        return self._prev_inuse
 
     @property
     def fd(self):


### PR DESCRIPTION
The Chunk class abstracts developers from some heap & gdb internals and makes use of the gdb module's lazy fetching.
The `template_heap_command` command serves as an example of how to use the Chunk class (and hopefully future classes).