### PR TITLE
Show arch and emulation status on disasm banner

### DIFF
--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -569,8 +569,11 @@ def context_disasm(target=sys.stdout, with_banner=True, width=None):
     if cs is not None and cs.syntax != syntax:
         pwndbg.lib.memoize.reset()
 
-    banner = [pwndbg.ui.banner("disasm", target=target, width=width)]
+    arch = pwndbg.gdblib.arch.current
     emulate = bool(pwndbg.config.emulate)
+
+    info = ' / %s / set emulate %s' % (arch, 'on' if emulate else 'off')
+    banner = [pwndbg.ui.banner("disasm", target=target, width=width, extra=info)]
     result = pwndbg.commands.nearpc.nearpc(to_string=True, emulate=emulate, lines=code_lines // 2)
 
     # If we didn't disassemble backward, try to make sure

--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -572,7 +572,7 @@ def context_disasm(target=sys.stdout, with_banner=True, width=None):
     arch = pwndbg.gdblib.arch.current
     emulate = bool(pwndbg.config.emulate)
 
-    info = ' / %s / set emulate %s' % (arch, 'on' if emulate else 'off')
+    info = " / %s / set emulate %s" % (arch, "on" if emulate else "off")
     banner = [pwndbg.ui.banner("disasm", target=target, width=width, extra=info)]
     result = pwndbg.commands.nearpc.nearpc(to_string=True, emulate=emulate, lines=code_lines // 2)
 

--- a/pwndbg/ui.py
+++ b/pwndbg/ui.py
@@ -38,7 +38,7 @@ def check_title_position():
         title_position.revert_default()
 
 
-def banner(title, target=sys.stdin, width=None, extra=''):
+def banner(title, target=sys.stdin, width=None, extra=""):
     title = title.upper()
     if width is None:  # auto width. In case of stdout, it's better to use stdin (b/c GdbOutputFile)
         _height, width = get_window_size(target=target if target != sys.stdout else sys.stdin)

--- a/pwndbg/ui.py
+++ b/pwndbg/ui.py
@@ -38,14 +38,15 @@ def check_title_position():
         title_position.revert_default()
 
 
-def banner(title, target=sys.stdin, width=None):
+def banner(title, target=sys.stdin, width=None, extra=''):
     title = title.upper()
     if width is None:  # auto width. In case of stdout, it's better to use stdin (b/c GdbOutputFile)
         _height, width = get_window_size(target=target if target != sys.stdout else sys.stdin)
     if title:
-        title = "%s%s%s" % (
+        title = "%s%s%s%s" % (
             config.banner_title_surrounding_left,
             C.banner_title(title),
+            extra,
             config.banner_title_surrounding_right,
         )
     if "left" == title_position:


### PR DESCRIPTION
Before:
```
───────[ DISASM ]───────
```
After:
```
───────[ DISASM / x86-64 / set emulate on ]───────
```