### PR TITLE
Fix #1165: set context-clear-screen on resetting scrollback

### DIFF
--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -33,9 +33,24 @@ from pwndbg.color import theme
 def clear_screen(out=sys.stdout):
     """
     Clear the screen by moving the cursor to top-left corner and
-    clear the content
+    clearing the content. Different terminals may act differently
     """
-    out.write("\x1b[H\x1b[J")
+    ## The ANSI escape codes we use here are described e.g. on:
+    # https://en.wikipedia.org/wiki/ANSI_escape_code#CSIsection
+    #
+    ## To sum up the escape codes used below:
+    # \x1b - Escape | Starts all the escape sequences
+    # [ - Control Sequence Introducer | Starts most of the useful sequences
+    # H - Cursor Position | Moves the cursor to row n, column m (default=1)
+    # \x1b - Escape | Starts all the escape sequences
+    # <n> J - Erase in Display | Clears part of the screen.
+    # If n is 0 (or missing), clear from cursor to end of screen.
+    # If n is 1, clear from cursor to beginning of the screen.
+    # If n is 2, clear entire screen (and moves cursor to upper left on DOS ANSI.SYS).
+    # If n is 3, clear entire screen and delete all lines saved in the
+    # scrollback buffer (this feature was added for xterm and is supported
+    # by other terminal applications
+    out.write("\x1b[H\x1b[2J")
 
 
 config_clear_screen = pwndbg.config.Parameter(

--- a/pwndbg/lib/tips.py
+++ b/pwndbg/lib/tips.py
@@ -9,6 +9,7 @@ TIPS = [
     "Use GDB's `pi` command to run an interactive Python console where you can use Pwndbg APIs like `pwndbg.gdblib.memory.read(addr, len)`, `pwndbg.gdblib.memory.write(addr, data)`, `pwndbg.gdb.vmmap.get()` and so on!",
     "GDB's `set directories <path>` parameter can be used to debug e.g. glibc sources like the malloc/free functions!",
     # Pwndbg hints
+    "If you want Pwndbg to clear screen on each command (but still save previous output in history) use `set context-clear-screen on`.",
     "GDB and Pwndbg parameters can be shown or set with `show <param>` and `set <param> <value>` GDB commands",
     "Use Pwndbg's `config` and `theme` commands to tune its configuration and theme colors!",
     "Pwndbg mirrors some of Windbg commands like `eq`, `ew`, `ed`, `eb`, `es`, `dq`, `dw`, `dd`, `db`, `ds` for writing and reading memory",


### PR DESCRIPTION
This commit tries to fix the issue of our `set context-clear-screen on` option resetting the scrollback buffer on some terminals like gnome-terminal (fwiw it did not happen on terminator or on tmux).

It also adds info to tips about that option.

More details in #1165