### PR TITLE
Support starting the IPython interactive prompt with `ipi` command

### DIFF
--- a/pwndbg/__init__.py
+++ b/pwndbg/__init__.py
@@ -25,6 +25,7 @@ import pwndbg.commands.got
 import pwndbg.commands.heap
 import pwndbg.commands.hexdump
 import pwndbg.commands.ida
+import pwndbg.commands.ipython_interactive
 import pwndbg.commands.leakfind
 import pwndbg.commands.memoize
 import pwndbg.commands.misc

--- a/pwndbg/commands/ipython_interactive.py
+++ b/pwndbg/commands/ipython_interactive.py
@@ -1,0 +1,40 @@
+"""
+Command to start an interactive IPython prompt.
+"""
+import sys
+from contextlib import contextmanager
+
+import gdb
+
+import pwndbg.commands
+
+
+@contextmanager
+def switch_to_ipython_env():
+    """We need to change stdout/stderr to the default ones, otherwise we can't use tab or autocomplete"""
+    # Save GDB's stdout and stderr
+    saved_stdout = sys.stdout
+    saved_stderr = sys.stderr
+    # Use Python's default stdout and stderr
+    sys.stdout = sys.__stdout__
+    sys.stderr = sys.__stderr__
+    yield
+    # Restore GDB's stdout and stderr
+    sys.stdout = saved_stdout
+    sys.stderr = saved_stderr
+    # Restore Python's default ps1 and ps2 for GDB's `pi` command
+    sys.ps1 = ">>> "
+    sys.ps2 = "... "
+
+
+@pwndbg.commands.ArgparsedCommand("Start an interactive IPython prompt.")
+def ipi():
+    with switch_to_ipython_env():
+        # Use `gdb.execute` to embed IPython into GDB's variable scope
+        code4ipython = """import IPython
+import pwn
+IPython.embed(colors='neutral',banner1='',confirm_exit=False,simple_prompt=False)
+""".strip().replace(
+            "\n", ";"
+        )
+        gdb.execute(f"pi {code4ipython}")

--- a/pwndbg/commands/ipython_interactive.py
+++ b/pwndbg/commands/ipython_interactive.py
@@ -32,7 +32,9 @@ def ipi():
     with switch_to_ipython_env():
         # Use `gdb.execute` to embed IPython into GDB's variable scope
         code4ipython = """import IPython
+import jedi
 import pwn
+jedi.Interpreter._allow_descriptor_getattr_default = False
 IPython.embed(colors='neutral',banner1='',confirm_exit=False,simple_prompt=False)
 """.strip().replace(
             "\n", ";"

--- a/pwndbg/commands/ipython_interactive.py
+++ b/pwndbg/commands/ipython_interactive.py
@@ -15,6 +15,7 @@ def switch_to_ipython_env():
     # Save GDB's stdout and stderr
     saved_stdout = sys.stdout
     saved_stderr = sys.stderr
+    saved_excepthook = sys.excepthook
     # Use Python's default stdout and stderr
     sys.stdout = sys.__stdout__
     sys.stderr = sys.__stderr__
@@ -22,9 +23,10 @@ def switch_to_ipython_env():
     # Restore GDB's stdout and stderr
     sys.stdout = saved_stdout
     sys.stderr = saved_stderr
-    # Restore Python's default ps1 and ps2 for GDB's `pi` command
+    # Restore Python's default ps1, ps2, and excepthook for GDB's `pi` command
     sys.ps1 = ">>> "
     sys.ps2 = "... "
+    sys.excepthook = saved_excepthook
 
 
 @pwndbg.commands.ArgparsedCommand("Start an interactive IPython prompt.")


### PR DESCRIPTION
This `ipi` command can help us to start the IPython interactive prompt instead of the Python interactive prompt provided by the `pi` command.

![截圖 2022-09-27 下午12 15 43](https://user-images.githubusercontent.com/61896187/192445550-66be799d-0b7a-4d95-95bb-92ea39ee8922.png)
