### PR TITLE
Show less error when trying to load a non-exist type

### DIFF
--- a/pwndbg/gdblib/typeinfo.py
+++ b/pwndbg/gdblib/typeinfo.py
@@ -171,7 +171,7 @@ def load(name):
         for path in glob.glob(os.path.join(dirname, "*.h")):
             if any(b in path for b in blacklist):
                 continue
-            print(path)
+            # print(path)
             source += '#include "%s"\n' % path
 
     source += """
@@ -208,7 +208,7 @@ def compile(filename=None, address=0):
         gcc = pwndbg.lib.gcc.which(pwndbg.gdblib.arch)
         gcc += ["-w", "-c", "-g", filename, "-o", objectname]
         try:
-            subprocess.check_output(gcc)
+            subprocess.check_output(gcc, stderr=subprocess.STDOUT)
         except subprocess.CalledProcessError as e:
             return
 


### PR DESCRIPTION
Show less error when trying to load a non-exist type, because seems like the user doesn't need that much information when loading a non-exist type.

Before:

<img width="1142" alt="截圖 2022-09-27 下午10 59 50" src="https://user-images.githubusercontent.com/61896187/192562654-e8377810-d88e-4ae6-a7e9-59c57d761966.png">

After:

<img width="717" alt="截圖 2022-09-27 下午11 02 14" src="https://user-images.githubusercontent.com/61896187/192563063-4d3d20d0-3bad-4fb8-8b0a-3228d2a137a7.png">
