### PR TITLE
Enhance heap with for static-linked binaries & remove typeinfo bloat

### DIFF
--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -280,14 +280,37 @@ def OnlyAmd64(function):
     return _OnlyAmd64
 
 
+# TODO/FIXME: Move this elsewhere? Have better logic for that? Maybe caching?
+def _is_statically_linked():
+    out = gdb.execute("info dll", to_string=True)
+    return "No shared libraries loaded at this time." in out
+
+
 def OnlyWithResolvedHeapSyms(function):
     @functools.wraps(function)
     def _OnlyWithResolvedHeapSyms(*a, **kw):
         if pwndbg.heap.current.libc_has_debug_syms() or pwndbg.config.resolve_heap_via_heuristic:
             return function(*a, **kw)
         else:
-            print(
-                """%s: This command only works with libc debug symbols.
+            e = lambda s: print(message.error(s))
+            w = lambda s: print(message.warn(s))
+
+            if _is_statically_linked():
+                e(
+                    f"{function.__name__}: Can't find libc symbols addresses required for this command to work since this is a statically linked binary"
+                )
+                w(
+                    """Invoking the `set resolve-heap-via-heuristic on` command to resolve libc symbols via heuristics.
+Please set the GLIBC version you think the target binary was compiled (using `set glibc <version>` command; e.g. 2.32) and re-run this command.
+If this does not work, the only thing left is to determine the libc symbols addresses manually and set them appropriately. For this, see the `heap_config` command output and set the `main_arena`, `mp_`, `global_max_fast`, `tcache` and `thread_arena` addresses."""
+                )
+                gdb.execute("set resolve-heap-via-heuristic on", to_string=True)
+                return
+
+            else:
+                print(
+                    """%s: This command only works with libc debug symbols which are missing.
+
 They can probably be installed via the package manager of your choice.
 See also: https://sourceware.org/gdb/onlinedocs/gdb/Separate-Debug-Files.html
 
@@ -296,19 +319,19 @@ sudo apt-get install libc6-dbg
 sudo dpkg --add-architecture i386
 sudo apt-get install libc-dbg:i386
 """
-                % function.__name__
-            )
-            print(
-                message.warn(
-                    "pwndbg can still try to use this command without debug symbols by `set resolve-heap-via-heuristic on`."
+                    % function.__name__
                 )
-            )
-            print(message.warn("You can show your current config about heap by `heap_config`."))
-            print(
-                message.warn(
-                    "Then pwndbg will resolve some missing symbols via heuristics, but the results of those commands may be incorrect in some cases."
+                print(
+                    message.warn(
+                        "pwndbg can still try to use this command without debug symbols by `set resolve-heap-via-heuristic on`."
+                    )
                 )
-            )
+                print(message.warn("You can show your current config about heap by `heap_config`."))
+                print(
+                    message.warn(
+                        "Then pwndbg will resolve some missing symbols via heuristics, but the results of those commands may be incorrect in some cases."
+                    )
+                )
 
     return _OnlyWithResolvedHeapSyms
 

--- a/pwndbg/gdblib/typeinfo.py
+++ b/pwndbg/gdblib/typeinfo.py
@@ -3,9 +3,6 @@ Common types, and routines for manually loading types from file
 via GCC.
 """
 
-import glob
-import os
-import subprocess
 import sys
 
 import gdb
@@ -16,16 +13,6 @@ import pwndbg.lib.memoize
 import pwndbg.lib.tempfile
 
 module = sys.modules[__name__]
-
-
-def is_pointer(value):
-    type = value
-
-    if isinstance(value, gdb.Value):
-        type = value.type
-
-    type = type.strip_typedefs()
-    return type.code == gdb.TYPE_CODE_PTR
 
 
 def lookup_types(*types):
@@ -86,147 +73,13 @@ def update():
 # Call it once so we load all of the types
 update()
 
-# Trial and error until things work
-blacklist = [
-    "regexp.h",
-    "xf86drm.h",
-    "libxl_json.h",
-    "xf86drmMode.h",
-    "caca0.h",
-    "xenguest.h",
-    "_libxl_types_json.h",
-    "term_entry.h",
-    "slcurses.h",
-    "pcreposix.h",
-    "sudo_plugin.h",
-    "tic.h",
-    "sys/elf.h",
-    "sys/vm86.h",
-    "xenctrlosdep.h",
-    "xenctrl.h",
-    "cursesf.h",
-    "cursesm.h",
-    "gdbm.h",
-    "dbm.h",
-    "gcrypt-module.h",
-    "term.h",
-    "gmpxx.h",
-    "pcap/namedb.h",
-    "pcap-namedb.h",
-    "evr.h",
-    "mpc.h",
-    "fdt.h",
-    "mpfr.h",
-    "evrpc.h",
-    "png.h",
-    "zlib.h",
-    "pngconf.h",
-    "libelfsh.h",
-    "libmjollnir.h",
-    "hwloc.h",
-    "ares.h",
-    "revm.h",
-    "ares_rules.h",
-    "libunwind-ptrace.h",
-    "libui.h",
-    "librevm-color.h",
-    "libedfmt.h",
-    "revm-objects.h",
-    "libetrace.h",
-    "revm-io.h",
-    "libasm-mips.h",
-    "libstderesi.h",
-    "libasm.h",
-    "libaspect.h",
-    "libunwind.h",
-    "libmjollnir-objects.h",
-    "libunwind-coredump.h",
-    "libunwind-dynamic.h",
-]
-
 
 def load(name):
-    """Load symbol by name from headers in standard system include directory"""
+    """Load a GDB symbol; note that new symbols can be added with `add-symbol-file` functionality"""
     try:
         return gdb.lookup_type(name)
     except gdb.error:
-        pass
-
-    # s, _ = gdb.lookup_symbol(name)
-
-    # Try to find an architecture-specific include path
-    arch = pwndbg.gdblib.arch.current.split(":")[0]
-
-    include_dir = glob.glob("/usr/%s*/include" % arch)
-
-    if include_dir:
-        include_dir = include_dir[0]
-    else:
-        include_dir = "/usr/include"
-
-    source = "#include <fstream>\n"
-
-    for subdir in ["", "sys", "netinet"]:
-        dirname = os.path.join(include_dir, subdir)
-        for path in glob.glob(os.path.join(dirname, "*.h")):
-            if any(b in path for b in blacklist):
-                continue
-            # print(path)
-            source += '#include "%s"\n' % path
-
-    source += """
-{name} foo;
-""".format(
-        **locals()
-    )
-
-    filename = "%s/%s_%s.cc" % (
-        pwndbg.lib.tempfile.cachedir("typeinfo"),
-        arch,
-        "-".join(name.split()),
-    )
-
-    with open(filename, "w+") as f:
-        f.write(source)
-        f.flush()
-        os.fsync(f.fileno())
-
-    compile(filename)
-
-    return gdb.lookup_type(name)
-
-
-def compile(filename=None, address=0):
-    """Compile and extract symbols from specified file"""
-    if filename is None:
-        print("Specify a filename to compile.")
-        return
-
-    objectname = os.path.splitext(filename)[0] + ".o"
-
-    if not os.path.exists(objectname):
-        gcc = pwndbg.lib.gcc.which(pwndbg.gdblib.arch)
-        gcc += ["-w", "-c", "-g", filename, "-o", objectname]
-        try:
-            subprocess.check_output(gcc, stderr=subprocess.STDOUT)
-        except subprocess.CalledProcessError as e:
-            return
-
-    add_symbol_file(objectname, address)
-
-
-def add_symbol_file(filename=None, address=0):
-    """Read additional symbol table information from the object file filename"""
-    if filename is None:
-        print("Specify a symbol file to add.")
-        return
-
-    with pwndbg.gdblib.events.Pause():
-        gdb.execute(
-            "add-symbol-file %s %s" % (filename, address),
-            from_tty=False,
-            to_string=True,
-        )
+        return None
 
 
 def read_gdbvalue(type_name, addr):

--- a/pwndbg/heap/ptmalloc.py
+++ b/pwndbg/heap/ptmalloc.py
@@ -538,7 +538,13 @@ class Heap(pwndbg.heap.heap.BaseHeap):
         raise NotImplementedError()
 
     def libc_has_debug_syms(self):
-        return pwndbg.symbol.address("global_max_fast") is not None
+        """
+        The `struct malloc_chunk` comes from debugging symbols and it will not be there
+        for statically linked binaries
+        """
+        return pwndbg.gdblib.typeinfo.load("struct malloc_chunk") and pwndbg.symbol.address(
+            "global_max_fast"
+        )
 
 
 class DebugSymsHeap(Heap):


### PR DESCRIPTION
This commit enhances the heap commands UX for statically linked binaries and removes typeinfo module bloat.

The typeinfo module had this typeinfo.load function that was looking up a given type. If it didn't find the type, it fallbacked to compiling many many system headers in order to add a symbol for a given type into the program. This was supposed to be used for missing glibc malloc symbols like malloc_chunk.

However, the exact reason it was used: the struct malloc_chunk was never defined in a header file and was always defined in a malloc.c or another .c file in glibc sources.

Another place the typeinfo.load logic of compiling headers was/is used is the `dt` command, which is a windbg alias for getting struct layout type information, e.g.:
```
pwndbg> dt 'struct malloc_chunk'
struct malloc_chunk
    +0x0000 mchunk_prev_size     : size_t
    +0x0008 mchunk_size          : size_t
    +0x0010 fd                   : struct malloc_chunk *
    +0x0018 bk                   : struct malloc_chunk *
    +0x0020 fd_nextsize          : struct malloc_chunk *
    +0x0028 bk_nextsize          : struct malloc_chunk *
pwndbg>
```

However, the whole big issue with typeinfo.load compilation of headers was that most of the time it didn't work because e.g. some headers defined in other paths were missing or that two different headers used the same struct/function name and the compilation failed.

Since this logic almost never gave good results, I am removing it.

Regarding UX for statically linked binaries: we use `info dll` command to see if a binary is statically linked. While this method is not robust, as it may give us wrong results if the statically linked binary used `dlopen(...)` it is probably good enough.

Now, if a heap related command is executed on statically linked binaries, it will inform the user and set the resolving of libc heap symbols via heuristics. Then, it also says to the user they have to set the glibc version and re-run the command.