### PR TITLE
Integrate Chunk class into `malloc_chunk` command

### DIFF
--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -15,6 +15,7 @@ from pwndbg.color import message
 from pwndbg.commands.config import extend_value_with_default
 from pwndbg.commands.config import get_config_parameters
 from pwndbg.commands.config import print_row
+from pwndbg.heap.ptmalloc import Chunk
 
 
 def read_chunk(addr):
@@ -278,39 +279,33 @@ parser.add_argument(
 @pwndbg.commands.OnlyWhenHeapIsInitialized
 def malloc_chunk(addr, fake=False, verbose=False, simple=False):
     """Print a malloc_chunk struct's contents."""
-    # points to the real start of the chunk
-    cursor = int(addr)
+    chunk = Chunk(addr)
 
     allocator = pwndbg.heap.current
     ptr_size = allocator.size_sz
 
-    size_field = pwndbg.gdblib.memory.u(cursor + allocator.chunk_key_offset("size"))
-    real_size = size_field & ~allocator.malloc_align_mask
-
     headers_to_print = []  # both state (free/allocated) and flags
     fields_to_print = set()  # in addition to addr and size
-    out_fields = "Addr: {}\n".format(M.get(cursor))
+    out_fields = "Addr: {}\n".format(M.get(chunk.address))
 
     if fake:
         headers_to_print.append(message.on("Fake chunk"))
         verbose = True  # print all fields for fake chunks
 
     if simple:
-        chunk = read_chunk(cursor)
-
         if not headers_to_print:
-            headers_to_print.append(message.hint(M.get(cursor)))
+            headers_to_print.append(message.hint(M.get(chunk.address)))
 
         out_fields = ""
         verbose = True
     else:
-        arena = allocator.get_arena_for_chunk(cursor)
+        arena = allocator.get_arena_for_chunk(chunk.address)
         arena_address = None
         is_top = False
         if not fake and arena:
             arena_address = arena.address
             top_chunk = arena["top"]
-            if cursor == top_chunk:
+            if chunk.address == top_chunk:
                 headers_to_print.append(message.off("Top chunk"))
                 is_top = True
 
@@ -322,35 +317,35 @@ def malloc_chunk(addr, fake=False, verbose=False, simple=False):
             if allocator.has_tcache():
                 tcachebins = allocator.tcachebins(None)
 
-            if real_size in fastbins.keys() and cursor in fastbins[real_size]:
+            if chunk.size in fastbins.keys() and chunk.address in fastbins[chunk.size]:
                 headers_to_print.append(message.on("Free chunk (fastbins)"))
                 if not verbose:
                     fields_to_print.add("fd")
 
-            elif real_size in smallbins.keys() and cursor in bin_addrs(
-                smallbins[real_size], "smallbins"
+            elif chunk.size in smallbins.keys() and chunk.address in bin_addrs(
+                smallbins[chunk.size], "smallbins"
             ):
                 headers_to_print.append(message.on("Free chunk (smallbins)"))
                 if not verbose:
                     fields_to_print.update(["fd", "bk"])
 
-            elif real_size >= list(largebins.items())[0][0] and cursor in bin_addrs(
-                largebins[(list(largebins.items())[allocator.largebin_index(real_size) - 64][0])],
+            elif chunk.size >= list(largebins.items())[0][0] and chunk.address in bin_addrs(
+                largebins[(list(largebins.items())[allocator.largebin_index(chunk.size) - 64][0])],
                 "largebins",
             ):
                 headers_to_print.append(message.on("Free chunk (largebins)"))
                 if not verbose:
                     fields_to_print.update(["fd", "bk", "fd_nextsize", "bk_nextsize"])
 
-            elif cursor in bin_addrs(unsortedbin["all"], "unsortedbin"):
+            elif chunk.address in bin_addrs(unsortedbin["all"], "unsortedbin"):
                 headers_to_print.append(message.on("Free chunk (unsortedbin)"))
                 if not verbose:
                     fields_to_print.update(["fd", "bk"])
 
             elif (
                 allocator.has_tcache()
-                and real_size in tcachebins.keys()
-                and cursor + ptr_size * 2 in bin_addrs(tcachebins[real_size], "tcachebins")
+                and chunk.size in tcachebins.keys()
+                and chunk.address + ptr_size * 2 in bin_addrs(tcachebins[chunk.size], "tcachebins")
             ):
                 headers_to_print.append(message.on("Free chunk (tcache)"))
                 if not verbose:
@@ -362,9 +357,9 @@ def malloc_chunk(addr, fake=False, verbose=False, simple=False):
     if verbose:
         fields_to_print.update(["prev_size", "size", "fd", "bk", "fd_nextsize", "bk_nextsize"])
     else:
-        out_fields += "Size: 0x{:02x}\n".format(size_field)
+        out_fields += "Size: 0x{:02x}\n".format(chunk.size_field)
 
-    prev_inuse, is_mmapped, non_main_arena = allocator.chunk_flags(size_field)
+    prev_inuse, is_mmapped, non_main_arena = allocator.chunk_flags(chunk.size_field)
     if prev_inuse:
         headers_to_print.append(message.hint("PREV_INUSE"))
     if is_mmapped:
@@ -376,7 +371,7 @@ def malloc_chunk(addr, fake=False, verbose=False, simple=False):
     for field_to_print in fields_ordered:
         if field_to_print in fields_to_print:
             out_fields += message.system(field_to_print) + ": 0x{:02x}\n".format(
-                pwndbg.gdblib.memory.u(cursor + allocator.chunk_key_offset(field_to_print))
+                getattr(chunk, field_to_print)
             )
 
     print(" | ".join(headers_to_print) + "\n" + out_fields)

--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -301,74 +301,63 @@ def malloc_chunk(addr, fake=False, verbose=False, simple=False):
         if not headers_to_print:
             headers_to_print.append(message.hint(M.get(cursor)))
 
-        prev_inuse, is_mmapped, non_main_arena = allocator.chunk_flags(int(chunk["size"]))
-        if prev_inuse:
-            headers_to_print.append(message.hint("PREV_INUSE"))
-        if is_mmapped:
-            headers_to_print.append(message.hint("IS_MMAPED"))
-        if non_main_arena:
-            headers_to_print.append(message.hint("NON_MAIN_ARENA"))
+        out_fields = ""
+        verbose = True
+    else:
+        arena = allocator.get_arena_for_chunk(cursor)
+        arena_address = None
+        is_top = False
+        if not fake and arena:
+            arena_address = arena.address
+            top_chunk = arena["top"]
+            if cursor == top_chunk:
+                headers_to_print.append(message.off("Top chunk"))
+                is_top = True
 
-        print(" | ".join(headers_to_print))
-        for key, val in chunk.items():
-            print(message.system(key) + ": 0x{:02x}".format(int(val)))
-        print("")
-        return
+        if not is_top:
+            fastbins = allocator.fastbins(arena_address) or {}
+            smallbins = allocator.smallbins(arena_address) or {}
+            largebins = allocator.largebins(arena_address) or {}
+            unsortedbin = allocator.unsortedbin(arena_address) or {}
+            if allocator.has_tcache():
+                tcachebins = allocator.tcachebins(None)
 
-    arena = allocator.get_arena_for_chunk(cursor)
-    arena_address = None
-    is_top = False
-    if not fake and arena:
-        arena_address = arena.address
-        top_chunk = arena["top"]
-        if cursor == top_chunk:
-            headers_to_print.append(message.off("Top chunk"))
-            is_top = True
+            if real_size in fastbins.keys() and cursor in fastbins[real_size]:
+                headers_to_print.append(message.on("Free chunk (fastbins)"))
+                if not verbose:
+                    fields_to_print.add("fd")
 
-    if not is_top:
-        fastbins = allocator.fastbins(arena_address) or {}
-        smallbins = allocator.smallbins(arena_address) or {}
-        largebins = allocator.largebins(arena_address) or {}
-        unsortedbin = allocator.unsortedbin(arena_address) or {}
-        if allocator.has_tcache():
-            tcachebins = allocator.tcachebins(None)
+            elif real_size in smallbins.keys() and cursor in bin_addrs(
+                smallbins[real_size], "smallbins"
+            ):
+                headers_to_print.append(message.on("Free chunk (smallbins)"))
+                if not verbose:
+                    fields_to_print.update(["fd", "bk"])
 
-        if real_size in fastbins.keys() and cursor in fastbins[real_size]:
-            headers_to_print.append(message.on("Free chunk (fastbins)"))
-            if not verbose:
-                fields_to_print.add("fd")
+            elif real_size >= list(largebins.items())[0][0] and cursor in bin_addrs(
+                largebins[(list(largebins.items())[allocator.largebin_index(real_size) - 64][0])],
+                "largebins",
+            ):
+                headers_to_print.append(message.on("Free chunk (largebins)"))
+                if not verbose:
+                    fields_to_print.update(["fd", "bk", "fd_nextsize", "bk_nextsize"])
 
-        elif real_size in smallbins.keys() and cursor in bin_addrs(
-            smallbins[real_size], "smallbins"
-        ):
-            headers_to_print.append(message.on("Free chunk (smallbins)"))
-            if not verbose:
-                fields_to_print.update(["fd", "bk"])
+            elif cursor in bin_addrs(unsortedbin["all"], "unsortedbin"):
+                headers_to_print.append(message.on("Free chunk (unsortedbin)"))
+                if not verbose:
+                    fields_to_print.update(["fd", "bk"])
 
-        elif real_size >= list(largebins.items())[0][0] and cursor in bin_addrs(
-            largebins[(list(largebins.items())[allocator.largebin_index(real_size) - 64][0])],
-            "largebins",
-        ):
-            headers_to_print.append(message.on("Free chunk (largebins)"))
-            if not verbose:
-                fields_to_print.update(["fd", "bk", "fd_nextsize", "bk_nextsize"])
+            elif (
+                allocator.has_tcache()
+                and real_size in tcachebins.keys()
+                and cursor + ptr_size * 2 in bin_addrs(tcachebins[real_size], "tcachebins")
+            ):
+                headers_to_print.append(message.on("Free chunk (tcache)"))
+                if not verbose:
+                    fields_to_print.add("fd")
 
-        elif cursor in bin_addrs(unsortedbin["all"], "unsortedbin"):
-            headers_to_print.append(message.on("Free chunk (unsortedbin)"))
-            if not verbose:
-                fields_to_print.update(["fd", "bk"])
-
-        elif (
-            allocator.has_tcache()
-            and real_size in tcachebins.keys()
-            and cursor + ptr_size * 2 in bin_addrs(tcachebins[real_size], "tcachebins")
-        ):
-            headers_to_print.append(message.on("Free chunk (tcache)"))
-            if not verbose:
-                fields_to_print.add("fd")
-
-        else:
-            headers_to_print.append(message.hint("Allocated chunk"))
+            else:
+                headers_to_print.append(message.hint("Allocated chunk"))
 
     if verbose:
         fields_to_print.update(["prev_size", "size", "fd", "bk", "fd_nextsize", "bk_nextsize"])

--- a/pwndbg/heap/ptmalloc.py
+++ b/pwndbg/heap/ptmalloc.py
@@ -45,8 +45,9 @@ class Chunk:
         self._prev_inuse = None
         self._fd = None
         self._bk = None
+        self._fd_nextsize = None
 
-        # TODO fd_nextsize, bk_nextsize, key, REVEAL_PTR etc.
+        # TODO bk_nextsize, key, REVEAL_PTR
 
     # Some chunk fields were renamed in GLIBC 2.25 master branch.
     def __match_renamed_field(self, field):
@@ -152,6 +153,16 @@ class Chunk:
                 pass
 
         return self._bk
+
+    @property
+    def fd_nextsize(self):
+        if self._fd_nextsize is None:
+            try:
+                self._fd_nextsize = int(self._gdbValue["fd_nextsize"])
+            except gdb.MemoryError:
+                pass
+
+        return self._fd_nextsize
 
     # TODO Other useful methods e.g. next_chunk(), __iter__, __str__
 

--- a/pwndbg/heap/ptmalloc.py
+++ b/pwndbg/heap/ptmalloc.py
@@ -83,8 +83,7 @@ class Chunk:
     @property
     def flags(self):
         if self._flags is None:
-            sz = self.size
-            if sz is not None:
+            if self.size is not None:
                 self._flags = {
                     "non_main_arena": self.non_main_arena,
                     "is_mmapped": self.is_mmapped,

--- a/pwndbg/heap/ptmalloc.py
+++ b/pwndbg/heap/ptmalloc.py
@@ -38,6 +38,7 @@ class Chunk:
         self.address = int(self._gdbValue.address)
         self._prev_size = None
         self._size_field = None
+        self._size = None
         self._flags = None
         self._non_main_arena = None
         self._is_mmapped = None
@@ -79,6 +80,19 @@ class Chunk:
                 pass
 
         return self._size_field
+
+    @property
+    def size(self):
+        if self._size is None:
+            try:
+                self._size = int(
+                    self._gdbValue[self.__match_renamed_field("size")]
+                    & ~(ptmalloc.NON_MAIN_ARENA | ptmalloc.IS_MMAPPED | ptmalloc.PREV_INUSE)
+                )
+            except gdb.MemoryError:
+                pass
+
+        return self._size
 
     @property
     def flags(self):

--- a/pwndbg/heap/ptmalloc.py
+++ b/pwndbg/heap/ptmalloc.py
@@ -37,7 +37,7 @@ class Chunk:
         self._gdbValue = pwndbg.gdblib.memory.poi(pwndbg.heap.current.malloc_chunk, addr)
         self.address = int(self._gdbValue.address)
         self._prev_size = None
-        self._size = None
+        self._size_field = None
         self._flags = None
         self._non_main_arena = None
         self._is_mmapped = None
@@ -71,19 +71,19 @@ class Chunk:
         return self._prev_size
 
     @property
-    def size(self):
-        if self._size is None:
+    def size_field(self):
+        if self._size_field is None:
             try:
-                self._size = int(self._gdbValue[self.__match_renamed_field("size")])
+                self._size_field = int(self._gdbValue[self.__match_renamed_field("size")])
             except gdb.MemoryError:
                 pass
 
-        return self._size
+        return self._size_field
 
     @property
     def flags(self):
         if self._flags is None:
-            if self.size is not None:
+            if self.size_field is not None:
                 self._flags = {
                     "non_main_arena": self.non_main_arena,
                     "is_mmapped": self.is_mmapped,
@@ -95,7 +95,7 @@ class Chunk:
     @property
     def non_main_arena(self):
         if self._non_main_arena is None:
-            sz = self.size
+            sz = self.size_field
             if sz is not None:
                 self._non_main_arena = bool(sz & ptmalloc.NON_MAIN_ARENA)
 
@@ -104,7 +104,7 @@ class Chunk:
     @property
     def is_mmapped(self):
         if self._is_mmapped is None:
-            sz = self.size
+            sz = self.size_field
             if sz is not None:
                 self._is_mmapped = bool(sz & ptmalloc.IS_MMAPPED)
 
@@ -113,7 +113,7 @@ class Chunk:
     @property
     def prev_inuse(self):
         if self._prev_inuse is None:
-            sz = self.size
+            sz = self.size_field
             if sz is not None:
                 self._prev_inuse = bool(sz & ptmalloc.PREV_INUSE)
 

--- a/pwndbg/heap/ptmalloc.py
+++ b/pwndbg/heap/ptmalloc.py
@@ -46,8 +46,9 @@ class Chunk:
         self._fd = None
         self._bk = None
         self._fd_nextsize = None
+        self._bk_nextsize = None
 
-        # TODO bk_nextsize, key, REVEAL_PTR
+        # TODO key, REVEAL_PTR
 
     # Some chunk fields were renamed in GLIBC 2.25 master branch.
     def __match_renamed_field(self, field):
@@ -163,6 +164,16 @@ class Chunk:
                 pass
 
         return self._fd_nextsize
+
+    @property
+    def bk_nextsize(self):
+        if self._bk_nextsize is None:
+            try:
+                self._bk_nextsize = int(self._gdbValue["bk_nextsize"])
+            except gdb.MemoryError:
+                pass
+
+        return self._bk_nextsize
 
     # TODO Other useful methods e.g. next_chunk(), __iter__, __str__
 


### PR DESCRIPTION
The Chunk class is complete enough for use in the `malloc_chunk` command, where it can simplify a little code and provide some gdb module efficiency.
The `malloc_chunk` command output remains the same.