### PR TITLE
fix #1190: telescope -r with addr as count

### DIFF
--- a/pwndbg/commands/telescope.py
+++ b/pwndbg/commands/telescope.py
@@ -50,18 +50,20 @@ parser = argparse.ArgumentParser(
     """
 )
 parser.add_argument(
-    "address", nargs="?", default=None, type=int, help="The address to telescope at."
-)
-parser.add_argument(
-    "count", nargs="?", default=telescope_lines, type=int, help="The number of lines to show."
-)
-parser.add_argument(
     "-r",
     "--reverse",
     dest="reverse",
     action="store_true",
     default=False,
     help="Show <count> previous addresses instead of next ones",
+)
+
+parser.add_argument(
+    "address", nargs="?", default=None, type=int, help="The address to telescope at."
+)
+
+parser.add_argument(
+    "count", nargs="?", default=telescope_lines, type=int, help="The number of lines to show."
 )
 
 
@@ -84,14 +86,14 @@ def telescope(address=None, count=telescope_lines, to_string=False, reverse=Fals
     delimiter = T.delimiter(offset_delimiter)
     separator = T.separator(offset_separator)
 
-    # Allow invocation of telescope -r to dump previous addresses
-    if reverse:
-        address -= (count - 1) * ptrsize
-
     # Allow invocation of "telescope 20" to dump 20 bytes at the stack pointer
     if address < pwndbg.gdblib.memory.MMAP_MIN_ADDR and not pwndbg.gdblib.memory.peek(address):
         count = address
         address = pwndbg.gdblib.regs.sp
+
+    # Allow invocation of telescope -r to dump previous addresses
+    if reverse:
+        address -= (count - 1) * ptrsize
 
     # Allow invocation of "telescope a b" to dump all bytes from A to B
     if int(address) <= int(count):
@@ -103,7 +105,6 @@ def telescope(address=None, count=telescope_lines, to_string=False, reverse=Fals
     reg_values = collections.defaultdict(lambda: [])
     for reg in pwndbg.gdblib.regs.common:
         reg_values[pwndbg.gdblib.regs[reg]].append(reg)
-    # address    = pwndbg.gdblib.memory.poi(pwndbg.gdblib.typeinfo.ppvoid, address)
 
     start = address
     stop = address + (count * ptrsize)


### PR DESCRIPTION
Before:
```
pwndbg> telescope -r 3
Traceback (most recent call last):
  File "/home/gsgx/code/pwndbg/pwndbg/commands/__init__.py", line 145, in __call__
    return self.function(*args, **kwargs)
  File "/home/gsgx/code/pwndbg/pwndbg/commands/__init__.py", line 216, in _OnlyWhenRunning
    return function(*a, **kw)
  File "/home/gsgx/code/pwndbg/pwndbg/commands/telescope.py", line 191, in telescope
    telescope.offset += i
UnboundLocalError: local variable 'i' referenced before assignment
```

After:
```
pwndbg> telescope -r 3
00:0000│         0x7fffffffe2b0 ◂— 0x0
01:0008│         0x7fffffffe2b8 —▸ 0x7ffff7fe32ea (_dl_start_user+50) ◂— lea    rdx, [rip - 0x1a2b1]
02:0010│ r13 rsp 0x7fffffffe2c0 ◂— 0x1
```