### PR TITLE
add show-flags and show-compact-regs to ctx regs banner

### DIFF
--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -482,7 +482,11 @@ def context_regs(target=sys.stdout, with_banner=True, width=None):
     if pwndbg.config.show_compact_regs:
         regs = compact_regs(regs, target=target, width=width)
 
-    banner = [pwndbg.ui.banner("registers", target=target, width=width)]
+    info = " / show-flags %s / show-compact-regs %s" % (
+        "on" if pwndbg.config.show_flags else "off",
+        "on" if pwndbg.config.show_compact_regs else "off",
+    )
+    banner = [pwndbg.ui.banner("registers", target=target, width=width, extra=info)]
     return banner + regs if with_banner else regs
 
 


### PR DESCRIPTION
Hopefully his will improve the discoverability/UX for users who are not aware of those options.

This is how the new registers banner looks like:
```
[ REGISTERS / show-flags off / show-compact-regs off ]
```

Fwiw it is 54 chars long (without "---" before and after) so its length should be fine.

Screenshot of current ctx:
<img width="889" alt="image" src="https://user-images.githubusercontent.com/10009354/193496729-c291aadc-8e6d-4d58-9b96-ded97f24456d.png">
Compact + flags on:
<img width="833" alt="image" src="https://user-images.githubusercontent.com/10009354/193496757-6761b49e-6f37-4109-b20e-0b7c137955b8.png">
