### PR TITLE
Make the heap heuristic compatible with new heap code

### DIFF
--- a/pwndbg/heap/ptmalloc.py
+++ b/pwndbg/heap/ptmalloc.py
@@ -34,7 +34,10 @@ def heap_for_ptr(ptr):
 
 class Chunk:
     def __init__(self, addr):
-        self._gdbValue = pwndbg.gdblib.memory.poi(pwndbg.heap.current.malloc_chunk, addr)
+        if type(pwndbg.heap.current.malloc_chunk) == gdb.Type:
+            self._gdbValue = pwndbg.gdblib.memory.poi(pwndbg.heap.current.malloc_chunk, addr)
+        else:
+            self._gdbValue = pwndbg.heap.current.malloc_chunk(addr)
         self.address = int(self._gdbValue.address)
         self._prev_size = None
         self._size = None


### PR DESCRIPTION
Some bugs were introduced by some new code about `Chunk`, and this PR is trying to make heap heuristic compatible with them.

And also, I refactor some code in `structs.py` to make it cleaner.