### PR TITLE
Make `CStruct2GDB` support `gdb.types.has_field()`

### DIFF
--- a/pwndbg/heap/structs.py
+++ b/pwndbg/heap/structs.py
@@ -101,6 +101,7 @@ class FakeGDBField:
 
 
 class CStruct2GDB:
+    code = gdb.TYPE_CODE_STRUCT
     _c_struct = None
 
     def __init__(self, address: int) -> None:
@@ -154,6 +155,13 @@ class CStruct2GDB:
         Returns type(self) to make it compatible with the `gdb.Value` interface.
         """
         return type(self)
+
+    @classmethod
+    def unqualified(cls):
+        """
+        Returns cls to make it compatible with the `gdb.types.has_field()` interface.
+        """
+        return cls
 
     @classmethod
     def fields(cls):


### PR DESCRIPTION
According to the suggestion from @CptGibbon in Discord, `gdb.types.has_field()` might be useful in the future, so this commit is trying to make `CStruct2GDB` support it.

<img width="721" alt="截圖 2022-10-05 上午9 07 01" src="https://user-images.githubusercontent.com/61896187/193957780-5eee8396-b9a0-4a93-b68a-0328694029cd.png">
