### PR TITLE
Fix #1197: stop displaying ctx on regs/mem changes

### DIFF
--- a/pwndbg/gdblib/events.py
+++ b/pwndbg/gdblib/events.py
@@ -136,7 +136,7 @@ class Pause:
 objfile_cache = dict()
 
 
-def connect(func, event_handler, name=""):
+def connect(func, event_handler, name="", receive_args=False):
     if debug:
         print("Connecting", func.__name__, event_handler)
 
@@ -161,7 +161,10 @@ def connect(func, event_handler, name=""):
             return
 
         try:
-            func()
+            if not receive_args:
+                func()
+            else:
+                func(*a)
         except Exception as e:
             import pwndbg.exception
 
@@ -197,15 +200,25 @@ before_prompt = partial(connect, event_handler=gdb.events.before_prompt, name="b
 
 
 def reg_changed(func):
+    """
+    Executed when registers are changed by GDB commands
+
+    Does not trigger when the debugged program execution changes registers
+    """
     try:
-        return connect(func, gdb.events.register_changed, "reg_changed")
+        return connect(func, gdb.events.register_changed, "reg_changed", receive_args=True)
     except AttributeError:
         return func
 
 
 def mem_changed(func):
+    """
+    Executed when memory is changed by GDB commands
+
+    Does not trigger when the debugged program execution changes memory
+    """
     try:
-        return connect(func, gdb.events.memory_changed, "mem_changed")
+        return connect(func, gdb.events.memory_changed, "mem_changed", receive_args=True)
     except AttributeError:
         return func
 

--- a/pwndbg/gdblib/prompt.py
+++ b/pwndbg/gdblib/prompt.py
@@ -63,6 +63,14 @@ def prompt_hook(*a):
 
 @pwndbg.lib.memoize.reset_on_stop
 def prompt_hook_on_stop(*a):
+    """
+    Displays context. We cache it so that it will be executed
+    if and only if the reset_on_stop cache was cleared and that
+    occurs whenever the stop event is triggered - through the
+    `memoize_on_stop` hook. This way, we properly display context
+    only on prompt hooks and only when the program state actually
+    advanced.
+    """
     pwndbg.commands.context.context()
 
 

--- a/pwndbg/gdblib/regs.py
+++ b/pwndbg/gdblib/regs.py
@@ -220,7 +220,10 @@ sys.modules[__name__] = module(__name__, "")
 
 @pwndbg.gdblib.events.cont
 @pwndbg.gdblib.events.stop
-def update_last():
+@pwndbg.gdblib.events.reg_changed
+def update_last(*arg):
+    # TODO/FIXME: arg is passed only on reg changed and we know which reg changed
+    # Could we use that info here?
     M = sys.modules[__name__]
     M.previous = M.last
     M.last = {k: M[k] for k in M.common}


### PR DESCRIPTION
This commit fixes a bug where we displayed context on registers or memory changes made by the user, so e.g. when user executed one of:

```
set *rax=1
set *(int*)0x<some address> = 0x1234
set *(unsigned long long*)$rsp+4=0x44444444
```

The fact that we displayed ctx on regs/mem changes was a result us clearing the cache of the `prompt_hook_on_stop` function:

```python
 @pwndbg.lib.memoize.reset_on_stop
 def prompt_hook_on_stop(*a):
     pwndbg.commands.context.context()
```

Where this function is called in `prompt_hook`, on each prompt display:

```python
def prompt_hook(*a):
    global cur

    new = (gdb.selected_inferior(), gdb.selected_thread())

    if cur != new:
        pwndbg.gdblib.events.after_reload(start=cur is None)
        cur = new

    if pwndbg.proc.alive and pwndbg.proc.thread_is_stopped:
        prompt_hook_on_stop(*a)
```

So, since we cleared this function cache on each register/memory changes, it resulted in us displaying context on each prompt hook.

So how did we clear this function cache? Through the `memoize_on_stop` function:

```
 @pwndbg.gdblib.events.stop
 @pwndbg.gdblib.events.mem_changed
 @pwndbg.gdblib.events.reg_changed
 def memoize_on_stop():
     reset_on_stop._reset()
```

But why? We need this to make sure that all of the executed commands, when they read memory or registry, get proper new (not cached) values!

So it makes sense to keep reseting the stop caches on mem/reg changed events. Otherwise, we would use incorrect (old) values if user set a register/memory and then used some commands like `context` or other that depend on register/memory state.

This commit fixes this situation with a hack. It makes so that the `memoize_on_stop` function will now only reset the `prompt_hook_on_stop` function cache if and only if the event that triggered `memoize_on_stop` is the stop event. Otherwise, it resets all other stop events cache except of the `prompt_hook_on_stop` function's cache.

This commit adds the `reg_changed` even to the `gdblib.regs.update_last` function so that we properly display only the registers the user has changed when `context regs` is displayed.