### PR TITLE
`set history expansion off` by default (Fix #1227)

### DIFF
--- a/pwndbg/__init__.py
+++ b/pwndbg/__init__.py
@@ -138,7 +138,7 @@ set confirm off
 set verbose off
 set pagination off
 set height 0
-set history expansion on
+set history expansion off
 set history save on
 set follow-fork-mode child
 set backtrace past-main on

--- a/pwndbg/lib/tips.py
+++ b/pwndbg/lib/tips.py
@@ -5,6 +5,7 @@ TIPS = [
     # GDB hints
     "GDB's `apropos <topic>` command displays all registered commands that are related to the given <topic>",
     "GDB's `follow-fork-mode` parameter can be used to set whether to trace parent or child after fork() calls",
+    "GDB's `history expansion` is been turn off to avoid conflicts with `!command-string` syntax, turn it on again with `set history expansion on` if you want to use it",
     'Use GDB\'s `dprintf` command to print all calls to given function. E.g. `dprintf malloc, "malloc(%p)\\n", (void*)$rdi` will print all malloc calls',
     "Use GDB's `pi` command to run an interactive Python console where you can use Pwndbg APIs like `pwndbg.gdblib.memory.read(addr, len)`, `pwndbg.gdblib.memory.write(addr, data)`, `pwndbg.gdb.vmmap.get()` and so on!",
     "GDB's `set directories <path>` parameter can be used to debug e.g. glibc sources like the malloc/free functions!",


### PR DESCRIPTION
After this fix:

<img width="335" alt="截圖 2022-10-05 下午4 37 16" src="https://user-images.githubusercontent.com/61896187/194017895-733fdca8-2af6-426b-9150-1a527b02f0c6.png">
