### PR TITLE
Add unstrip command

### DIFF
--- a/pwndbg/__init__.py
+++ b/pwndbg/__init__.py
@@ -49,6 +49,7 @@ import pwndbg.commands.start
 import pwndbg.commands.telescope
 import pwndbg.commands.theme
 import pwndbg.commands.tls
+import pwndbg.commands.unstrip
 import pwndbg.commands.version
 import pwndbg.commands.vmmap
 import pwndbg.commands.windbg

--- a/pwndbg/commands/unstrip.py
+++ b/pwndbg/commands/unstrip.py
@@ -1,0 +1,28 @@
+import os.path
+
+from pwnlib.libcdb import unstrip_libc
+
+import pwndbg.commands
+from pwndbg.color import message
+from pwndbg.vmmap import info_sharedlibrary
+
+
+def _is_libc(path):
+    filename = os.path.basename(path)
+    # TODO: this will lead to false positives
+    if filename == "libc.so.6" or (filename.startswith("libc") and filename.endswith(".so")):
+        return True
+
+
+@pwndbg.commands.ArgparsedCommand("Unstrips the current libc")
+def unstrip():
+    mappings = info_sharedlibrary()
+    for mapping in mappings:
+        path = mapping.objfile
+        if _is_libc(path):
+            print(message.notice("Attempting to unstrip %s" % path))
+            if unstrip_libc(mapping.objfile):
+                print(message.success("Successfully unstripped libc"))
+                break
+            else:
+                print(message.error("Failed to unstrip libc"))


### PR DESCRIPTION
Use `pwntools` to unstrip the currently loaded libc.

Fixes #1169 