### PR TITLE
Fix #1197: dont display ctx on reg/mem changes

### DIFF
--- a/pwndbg/gdblib/prompt.py
+++ b/pwndbg/gdblib/prompt.py
@@ -52,6 +52,7 @@ def initial_hook(*a):
 
 context_shown = False
 
+
 def prompt_hook(*a):
     global cur, context_shown
 
@@ -70,7 +71,6 @@ def prompt_hook(*a):
 def reset_context_shown(*a):
     global context_shown
     context_shown = False
-
 
 
 @pwndbg.config.Trigger([message.config_prompt_color, disable_colors])


### PR DESCRIPTION
This commit fixes a bug where we displayed context on registers or memory changes made by the user, so e.g. when user executed one of:

```
set *rax=1
set *(int*)0x<some address> = 0x1234
set *(unsigned long long*)$rsp+4=0x44444444
```

It fixes it by just... setting a flag after the context is displayed for the first time and resetting it on a continue GDB event.

There was a previous attempt to fix this bug in #1226 but it was rather a hack than a proper fix. This current commit should be a proper fix :P.

Below is some more explanation of this bug.

The fact that we displayed ctx on regs/mem changes was a result us clearing the cache of the `prompt_hook_on_stop` function:

```python
 @pwndbg.lib.memoize.reset_on_stop
 def prompt_hook_on_stop(*a):
     pwndbg.commands.context.context()
```

Where this function is called in `prompt_hook`, on each prompt display:

```python
def prompt_hook(*a):
    global cur

    new = (gdb.selected_inferior(), gdb.selected_thread())

    if cur != new:
        pwndbg.gdblib.events.after_reload(start=cur is None)
        cur = new

    if pwndbg.proc.alive and pwndbg.proc.thread_is_stopped:
        prompt_hook_on_stop(*a)
```

So, since we cleared this function cache on each register/memory changes, it resulted in us displaying context on each prompt hook.

So how did we clear this function cache? Through the `memoize_on_stop` function:

```
 @pwndbg.gdblib.events.stop
 @pwndbg.gdblib.events.mem_changed
 @pwndbg.gdblib.events.reg_changed
 def memoize_on_stop():
     reset_on_stop._reset()
```

But why? We need this to make sure that all of the executed commands, when they read memory or registry, get proper new (not cached) values!

So it makes sense to keep reseting the stop caches on mem/reg changed events. Otherwise, we would use incorrect (old) values if user set a register/memory and then used some commands like `context` or other that depend on register/memory state.