### PR TITLE
Cleanup dependencies

### DIFF
--- a/pwndbg/color/syntax_highlight.py
+++ b/pwndbg/color/syntax_highlight.py
@@ -1,19 +1,15 @@
 import os.path
 import re
 
+import pygments
+import pygments.formatters
+import pygments.lexers
+
 import pwndbg.config
 from pwndbg.color import disable_colors
 from pwndbg.color import message
 from pwndbg.color import theme
-
-try:
-    import pygments
-    import pygments.formatters
-    import pygments.lexers
-
-    from pwndbg.color.lexer import PwntoolsLexer
-except ImportError:
-    pygments = None
+from pwndbg.color.lexer import PwntoolsLexer
 
 pwndbg.config.Parameter("syntax-highlight", True, "Source code / assembly syntax highlight")
 style = theme.Parameter(
@@ -48,7 +44,7 @@ def check_style():
 
 def syntax_highlight(code, filename=".asm"):
     # No syntax highlight if pygment is not installed
-    if not pygments or disable_colors:
+    if disable_colors:
         return code
 
     filename = os.path.basename(filename)

--- a/pwndbg/commands/procinfo.py
+++ b/pwndbg/commands/procinfo.py
@@ -7,11 +7,6 @@ import pwndbg.lib.memoize
 import pwndbg.lib.net
 import pwndbg.proc
 
-try:
-    import psutil
-except Exception:
-    psutil = None
-
 """
 PEDA prints it out like this:
 
@@ -195,10 +190,6 @@ def procinfo():
     """
     Display information about the running process.
     """
-    if not psutil:
-        print("psutil required but not installed")
-        return
-
     exe = str(pwndbg.auxv.get()["AT_EXECFN"])
     print("%-10s %r" % ("exe", exe))
 

--- a/pwndbg/exception.py
+++ b/pwndbg/exception.py
@@ -1,5 +1,4 @@
 import functools
-import pdb
 import sys
 import traceback
 
@@ -14,7 +13,7 @@ with pwndbg.lib.stdio.stdio:
     try:
         import ipdb as pdb
     except ImportError:
-        pass
+        import pdb
 
 verbose = pwndbg.config.Parameter(
     "exception-verbose",

--- a/pwndbg/gdblib/regs.py
+++ b/pwndbg/gdblib/regs.py
@@ -73,11 +73,6 @@ class module(ModuleType):
     def __getitem__(self, item):
         if not isinstance(item, str):
             print("Unknown register type: %r" % (item))
-            import pdb
-            import traceback
-
-            traceback.print_stack()
-            pdb.set_trace()
             return None
 
         # e.g. if we're looking for register "$rax", turn it into "rax"

--- a/pwndbg/lib/memoize.py
+++ b/pwndbg/lib/memoize.py
@@ -6,17 +6,11 @@ new library/objfile are loaded, etc.
 
 import functools
 import sys
+from collections.abc import Hashable
 from typing import Any
 from typing import Callable
 from typing import Dict
 from typing import List
-
-try:
-    # Python >= 3.10
-    from collections.abc import Hashable
-except ImportError:
-    # Python < 3.10
-    from collections import Hashable  # type: ignore
 
 debug = False
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,5 +5,5 @@ extend-exclude = "gdb-pt-dump"
 [tool.isort]
 profile = "black"
 force_single_line = true
-known_third_party = ["capstone", "unicorn", "six", "psutil", "pycparser", "gdb"]
+known_third_party = ["capstone", "unicorn", "psutil", "pycparser", "gdb"]
 extend_skip_glob = ["gdb-pt-dump/*"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,22 +1,11 @@
-attrs==21.4.0
 capstone==4.0.2
-enum34==1.1.10
+# This can be removed after ida_script.py upgrades to Python 3
 future==0.18.2
-iniconfig==1.1.1
-packaging==21.3
-pbr==5.9.0
-pluggy==1.0.0
-psutil==5.9.1
-py==1.11.0
+psutil==5.9.2
+pwntools==4.8.0
 pycparser==2.21
-pyelftools==0.28
-Pygments==2.12.0
-pyparsing==3.0.9
-python-ptrace==0.9.8
-ROPGadget==6.8
-six==1.16.0
-tomli==2.0.1; python_version >= '3.7'
-tomli==1.2.3; python_version < '3.7'
+pyelftools==0.29
+Pygments==2.13.0
+ROPGadget==7.1
 unicorn==2.0.0; python_version >= '3.7'
 unicorn==2.0.0rc7; python_version < '3.7'
-pwntools==4.8.0


### PR DESCRIPTION
Remove dependencies we're not actually using from `requirements.txt`. Make some dependencies that were optional in the code, no longer optional, as they should always be installed (`psutil` and `Pygments`). The last remaining dependencies that are "optional" in the code are `unicorn` and `r2pipe`, and I'm not sure if those were intentionally made optional so I've left that in for now.