### PR TITLE
Add flake8-builtins to linters

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,6 +2,7 @@ black==22.8.0
 coverage==6.2; python_version < '3.7'
 coverage==6.4.4; python_version >= '3.7'
 flake8==5.0.4
+flake8-builtins==1.5.3
 testresources==2.0.1
 isort==5.10.1
 pytest==7.0.1; python_version < '3.7'

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,7 +2,7 @@ black==22.8.0
 coverage==6.2; python_version < '3.7'
 coverage==6.4.4; python_version >= '3.7'
 flake8==5.0.4
-flake8-builtins==1.5.3
+flake8-builtins==2.0.0
 testresources==2.0.1
 isort==5.10.1
 pytest==7.0.1; python_version < '3.7'

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,9 @@ ignore =
     # undefined name name
     F821,
     # local variable name is assigned to but never used
-    F841
+    F841,
+    # class attribute is shadowing a python builtin
+    A003
 
 per-file-ignores =
     # Unused imports in __init__.py are fine
@@ -31,3 +33,18 @@ per-file-ignores =
 
 max-line-length = 100
 exclude = gdb-pt-dump
+
+# flake8-builtins should allow these builtins to be shadowed
+builtins-ignorelist =
+    all,
+    breakpoint,
+    copyright,
+    dir,
+    exit,
+    format,
+    hex,
+    map,
+    max,
+    min,
+    next,
+    type


### PR DESCRIPTION
flake8-builtins adds lint warnings if you create variables that shadow Python builtins. Once it's installed, `flake8` picks it up automatically. I added the `builtins-ignorelist` feature upstream, and I've added all of the builtins we're currently shadowing there, as I'd like to prevent any more builtins from being shadows but don't have time to fix the current issues at the moment.

Fixes #1181 