### PR TITLE
Develop Arena class

### DIFF
--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -299,21 +299,16 @@ def malloc_chunk(addr, fake=False, verbose=False, simple=False):
         out_fields = ""
         verbose = True
     else:
-        arena = allocator.get_arena_for_chunk(chunk.address)
-        arena_address = None
-        is_top = False
+        arena = chunk.arena
         if not fake and arena:
-            arena_address = arena.address
-            top_chunk = arena["top"]
-            if chunk.address == top_chunk:
+            if chunk.is_top_chunk:
                 headers_to_print.append(message.off("Top chunk"))
-                is_top = True
 
-        if not is_top:
-            fastbins = allocator.fastbins(arena_address) or {}
-            smallbins = allocator.smallbins(arena_address) or {}
-            largebins = allocator.largebins(arena_address) or {}
-            unsortedbin = allocator.unsortedbin(arena_address) or {}
+        if not chunk.is_top_chunk:
+            fastbins = allocator.fastbins(arena.address) or {}
+            smallbins = allocator.smallbins(arena.address) or {}
+            largebins = allocator.largebins(arena.address) or {}
+            unsortedbin = allocator.unsortedbin(arena.address) or {}
             if allocator.has_tcache():
                 tcachebins = allocator.tcachebins(None)
 

--- a/pwndbg/heap/ptmalloc.py
+++ b/pwndbg/heap/ptmalloc.py
@@ -32,6 +32,24 @@ def heap_for_ptr(ptr):
 
 
 class Chunk:
+    __slots__ = (
+        "_gdbValue",
+        "address",
+        "_prev_size",
+        "_size",
+        "_real_size",
+        "_flags",
+        "_non_main_arena",
+        "_is_mmapped",
+        "_prev_inuse",
+        "_fd",
+        "_bk",
+        "_fd_nextsize",
+        "_bk_nextsize",
+        "_arena",
+        "_is_top_chunk",
+    )
+
     def __init__(self, addr, arena=None):
         if isinstance(pwndbg.heap.current.malloc_chunk, gdb.Type):
             self._gdbValue = pwndbg.gdblib.memory.poi(pwndbg.heap.current.malloc_chunk, addr)
@@ -51,7 +69,6 @@ class Chunk:
         self._bk_nextsize = None
         self._arena = arena
         self._is_top_chunk = None
-
 
     # Some chunk fields were renamed in GLIBC 2.25 master branch.
     def __match_renamed_field(self, field):
@@ -206,6 +223,8 @@ class Chunk:
 
 
 class Arena:
+    __slots__ = ("_gdbValue", "address", "is_main_arena", "_top", "heaps")
+
     def __init__(self, addr, heaps=None):
         if isinstance(pwndbg.heap.current.malloc_state, gdb.Type):
             self._gdbValue = pwndbg.gdblib.memory.poi(pwndbg.heap.current.malloc_state, addr)

--- a/pwndbg/heap/ptmalloc.py
+++ b/pwndbg/heap/ptmalloc.py
@@ -246,11 +246,10 @@ class Arena:
         return self._top
 
     def __str__(self):
-        res = []
         prefix = "[%%%ds]    " % (pwndbg.gdblib.arch.ptrsize * 2)
         prefix_len = len(prefix % (""))
         arena_name = "main" if self.is_main_arena else hex(self.address)
-        res.append(message.hint(prefix % (arena_name)) + str(self.heaps[0]))
+        res = [message.hint(prefix % (arena_name)) + str(self.heaps[0])]
         for h in self.heaps[1:]:
             res.append(" " * prefix_len + str(h))
 

--- a/pwndbg/heap/ptmalloc.py
+++ b/pwndbg/heap/ptmalloc.py
@@ -52,7 +52,6 @@ class Chunk:
         self._arena = arena
         self._is_top_chunk = None
 
-        # TODO key, REVEAL_PTR
 
     # Some chunk fields were renamed in GLIBC 2.25 master branch.
     def __match_renamed_field(self, field):
@@ -204,8 +203,6 @@ class Chunk:
                 self._is_top_chunk = False
 
         return self._is_top_chunk
-
-    # TODO Other useful methods e.g. next_chunk(), __iter__, __str__
 
 
 class Arena:

--- a/pwndbg/heap/ptmalloc.py
+++ b/pwndbg/heap/ptmalloc.py
@@ -33,7 +33,7 @@ def heap_for_ptr(ptr):
 
 class Chunk:
     def __init__(self, addr, arena=None):
-        if type(pwndbg.heap.current.malloc_chunk) == gdb.Type:
+        if isinstance(pwndbg.heap.current.malloc_chunk, gdb.Type):
             self._gdbValue = pwndbg.gdblib.memory.poi(pwndbg.heap.current.malloc_chunk, addr)
         else:
             self._gdbValue = pwndbg.heap.current.malloc_chunk(addr)
@@ -207,7 +207,7 @@ class Chunk:
 
 class Arena:
     def __init__(self, addr, heaps=None):
-        if type(pwndbg.heap.current.malloc_state) == gdb.Type:
+        if isinstance(pwndbg.heap.current.malloc_state, gdb.Type):
             self._gdbValue = pwndbg.gdblib.memory.poi(pwndbg.heap.current.malloc_state, addr)
         else:
             self._gdbValue = pwndbg.heap.current.malloc_state(addr)


### PR DESCRIPTION
Add `Arena.top` and `Arena.is_main_arena`.
Add `Chunk.arena` and `Chunk.is_top_chunk`.

Above allows less complexity in `malloc_chunk` command.
Arena resolution via `Chunk.arena` is more accurate than existing `get_arena_for_chunk()` solution.