### PR TITLE
allow setting gdblib.regs.<reg>=<val>

### DIFF
--- a/pwndbg/commands/mprotect.py
+++ b/pwndbg/commands/mprotect.py
@@ -69,12 +69,6 @@ def mprotect(addr, length, prot):
     # restore registers and memory
     pwndbg.gdblib.memory.write(saved_rip, saved_instruction_bytes)
 
-    gdb.execute("set $rax={}".format(saved_rax))
-    gdb.execute("set $rbx={}".format(saved_rbx))
-    gdb.execute("set $rcx={}".format(saved_rcx))
-    gdb.execute("set $rdx={}".format(saved_rdx))
-    gdb.execute("set $rip={}".format(saved_rip))
-
     pwndbg.gdblib.regs.rax = saved_rax
     pwndbg.gdblib.regs.rbx = saved_rbx
     pwndbg.gdblib.regs.rcx = saved_rcx

--- a/pwndbg/gdblib/regs.py
+++ b/pwndbg/gdblib/regs.py
@@ -68,6 +68,14 @@ class module(ModuleType):
         except (ValueError, gdb.error):
             return None
 
+    def __setattr__(self, attr, val):
+        if attr == "last" or attr == "previous":
+            return super().__setattr__(attr, val)
+        else:
+            # Not catching potential gdb.error as this should never
+            # be called in a case when this can throw
+            gdb.execute(f"set ${attr} = {val}")
+
     @pwndbg.lib.memoize.reset_on_stop
     @pwndbg.lib.memoize.reset_on_prompt
     def __getitem__(self, item):


### PR DESCRIPTION
This commit allows for setting the selected thread's registers by using the pwndbg.gdblib.regs.<register-name> = <new-value> expressions. Before this commit invoking such Python code would set the internal Pwndbg register value, but not really the inferior value. This could lead to weird issues when the displayed context shows the new register value but e.g. `info reg rax` displays the old value.