### PR TITLE
Fix #1256: fixes next cmds hangs on segfaults

### DIFF
--- a/pwndbg/gdblib/proc.py
+++ b/pwndbg/gdblib/proc.py
@@ -42,6 +42,11 @@ class module(ModuleType):
 
     @property
     def alive(self):
+        """
+        Informs whether the process has a thread. However, note that it will
+        still return True for a segfaulted thread. To detect that, consider
+        using the `stopped_with_signal` method.
+        """
         return gdb.selected_thread() is not None
 
     @property
@@ -55,6 +60,15 @@ class module(ModuleType):
         :return: Whether gdb executes commands attached to bp with `command` command.
         """
         return gdb.selected_thread().is_stopped()
+
+    @property
+    def stopped_with_signal(self) -> bool:
+        """
+        Returns whether the program has stopped with a signal
+
+        Can be used to detect segfaults (but will also detect other signals)
+        """
+        return "It stopped with signal " in gdb.execute("info program", to_string=True)
 
     @property
     def exe(self):

--- a/tests/test_commands_next.py
+++ b/tests/test_commands_next.py
@@ -1,6 +1,6 @@
 import gdb
-
 import pytest
+
 import pwndbg.gdblib.regs
 import tests
 
@@ -46,7 +46,7 @@ def test_command_nextproginstr(start_binary):
 
 @pytest.mark.parametrize(
     "command",
-    ("nextcall", "nextjump", "nextproginstr", "nextret", "nextsyscall", "stepret", "stepsyscall")
+    ("nextcall", "nextjump", "nextproginstr", "nextret", "nextsyscall", "stepret", "stepsyscall"),
 )
 def test_next_command_doesnt_freeze_crashed_binary(start_binary, command):
     start_binary(REFERENCE_BINARY)


### PR DESCRIPTION
Before this commit the next/step commands like `nextret`, `stepret`, `nextsyscall`, `nextproginstr` etc. would hang if they approach a segfault. This commit fixes it by checking for ANY signals by executing the GDB's `info prog` command and parsing its output.