### PR TITLE
Fix #1189: fixes patch command's arch=... value

### DIFF
--- a/pwndbg/commands/patch.py
+++ b/pwndbg/commands/patch.py
@@ -22,7 +22,7 @@ parser.add_argument("ins", type=str, help="instruction[s]")
 @pwndbg.commands.ArgparsedCommand(parser)
 @pwndbg.commands.OnlyWhenRunning
 def patch(address, ins):
-    new_mem = asm(ins, arch=pwndbg.gdblib.arch.current)
+    new_mem = asm(ins)
 
     old_mem = pwndbg.gdblib.memory.read(address, len(new_mem))
 
@@ -68,8 +68,8 @@ def patch_list():
 
     print(message.hint("Patches:"))
     for addr, (old, new) in patches.items():
-        old_insns = disasm(old, arch=pwndbg.gdblib.arch.current)
-        new_insns = disasm(new, arch=pwndbg.gdblib.arch.current)
+        old_insns = disasm(old)
+        new_insns = disasm(new)
 
         print(
             message.hint("Patch at"),


### PR DESCRIPTION
Before this commit we passed `pwndbg.gdblib.arch.current` as `arch=...` keyword argument to pwnlib functions like `asm` and `disasm`.

Since pwnlib has a concept of "context" that holds variables like currently set architecture or number of bits, this commit starts using those for the `patch` command implementation as we started to set pwnlib context recently in https://github.com/pwndbg/pwndbg/commit/9e84c18c44674307e4f830cf89c16c602f600a15