### PR TITLE
Fix the error when trying to read thread-local variables

### DIFF
--- a/pwndbg/gdblib/symbol.py
+++ b/pwndbg/gdblib/symbol.py
@@ -211,7 +211,7 @@ def address(symbol: str) -> int:
         # If we try to look up a TLS variable when there is no TLS, this
         # exception occurs. Ideally we should come up with a way to check for
         # this case before calling `gdb.lookup_symbol`
-        skipped_exceptions.append("Cannot find thread-local variables")
+        skipped_exceptions.append("Cannot find thread-local")
 
         if all(x not in str(e) for x in skipped_exceptions):
             raise e


### PR DESCRIPTION
This PR fix the typo in the check at:

https://github.com/pwndbg/pwndbg/blob/478a569cb3bef11f7011cd0a2f374d53ce5997fd/pwndbg/gdblib/symbol.py#L214-L217

See #1271 