### PR TITLE
add max display size for vis_heap_chunks

### DIFF
--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -594,6 +594,12 @@ def find_fake_fast(addr, size=None):
                     malloc_chunk(start + offset - psize, fake=True)
 
 
+pwndbg.config.Parameter(
+    "max-visualize-chunk-size",
+    0,
+    "max display size for heap chunks visualization (0 for display all)",
+)
+
 parser = argparse.ArgumentParser()
 parser.description = "Visualize chunks on a heap, default to the current arena's active heap."
 parser.add_argument(
@@ -611,13 +617,20 @@ parser.add_argument(
     default=False,
     help="Attempt to keep printing beyond the top chunk.",
 )
+parser.add_argument(
+    "--display_all",
+    "-a",
+    action="store_true",
+    default=False,
+    help="Display all the chunk contents (Ignore the `max-visualize-chunk-size` configuration).",
+)
 
 
 @pwndbg.commands.ArgparsedCommand(parser)
 @pwndbg.commands.OnlyWhenRunning
 @pwndbg.commands.OnlyWithResolvedHeapSyms
 @pwndbg.commands.OnlyWhenHeapIsInitialized
-def vis_heap_chunks(addr=None, count=None, naive=None):
+def vis_heap_chunks(addr=None, count=None, naive=None, display_all=None):
     """Visualize chunks on a heap, default to the current arena's active heap."""
     allocator = pwndbg.heap.current
     heap_region = allocator.get_heap_boundaries(addr)
@@ -704,10 +717,35 @@ def vis_heap_chunks(addr=None, count=None, naive=None):
 
     cursor = cursor_backup
 
+    has_huge_chunk = False
+    # round up to align with 4*ptr_size and get half
+    half_max_size = (
+        pwndbg.lib.memory.round_up(pwndbg.config.max_visualize_chunk_size, ptr_size << 2) >> 1
+    )
+
     for c, stop in enumerate(chunk_delims):
         color_func = color_funcs[c % len(color_funcs)]
 
+        if stop - cursor > 0x10000:
+            has_huge_chunk = True
+        first_cut = True
+        # round down to align with 2*ptr_size
+        begin_addr = pwndbg.lib.memory.round_down(cursor, ptr_size << 1)
+        end_addr = pwndbg.lib.memory.round_down(stop, ptr_size << 1)
+
         while cursor != stop:
+            # skip the middle part of a huge chunk
+            if (
+                not display_all
+                and half_max_size > 0
+                and begin_addr + half_max_size <= cursor < end_addr - half_max_size
+            ):
+                if first_cut:
+                    out += "\n" + "." * len(hex(cursor))
+                    first_cut = False
+                cursor += ptr_size
+                continue
+
             if printed % 2 == 0:
                 out += "\n0x%x" % cursor
 
@@ -732,6 +770,13 @@ def vis_heap_chunks(addr=None, count=None, naive=None):
             cursor += ptr_size
 
     print(out)
+
+    if has_huge_chunk and max_visualize_chunk_size == 0:
+        print(
+            message.warn(
+                "You can try `set max-visualize-chunk-size 0x500` and re-run this command.\n"
+            )
+        )
 
 
 def bin_ascii(bs):


### PR DESCRIPTION
https://github.com/pwndbg/pwndbg/issues/1072

A test case:
```c
#include <stdio.h>
#include <stdlib.h>
#include <string.h>

int main() {
  void *p, *q;
  p = malloc(0x10);
  free(p);
  p = malloc(0x2000);
  q = malloc(0x100);
  free(p);
  free(q);

  asm("int $3");

  p = malloc(0x20);
  memset(p, 'A', 0x30);

  asm("int $3");

  return 0;
}
```

```sh
gcc -m64 -g -o heap64 heap.c
gcc -m32 -g -o heap32 heap.c
```

```
pwndbg> set max-visualize-chunk-size 0x500
pwndbg> vis
```

<img width="669" alt="image" src="https://user-images.githubusercontent.com/20320324/195406324-1c16f3d2-5c26-4fc6-ac5e-4d564712e512.png">

<img width="807" alt="image" src="https://user-images.githubusercontent.com/20320324/195407124-bb9ab567-04da-4f45-9b25-1b88a04608c9.png">

