### PR TITLE
Fix symbol resolution issue

### DIFF
--- a/pwndbg/gdblib/info.py
+++ b/pwndbg/gdblib/info.py
@@ -1,14 +1,15 @@
 """
 Runs a few useful commands which are available under "info".
-
-We probably don't need this anymore.
 """
+
+import re
+from typing import Optional
 
 import gdb
 
 import pwndbg.lib.memoize
 
-# TODO: Add address, symbol, threads, dll, program
+# TODO: Add symbol, threads, dll, program
 
 
 @pwndbg.lib.memoize.reset_on_exit
@@ -47,3 +48,11 @@ def sharedlibrary():
         return gdb.execute("info sharedlibrary", to_string=True)
     except gdb.error:
         return ""
+
+
+def address(symbol: str) -> Optional[int]:
+    try:
+        res = gdb.execute(f"info address {symbol}", to_string=True)
+        return int(re.search("0x[0-9a-fA-F]+", res).group(), 0)
+    except gdb.error:
+        return None

--- a/pwndbg/gdblib/symbol.py
+++ b/pwndbg/gdblib/symbol.py
@@ -19,6 +19,7 @@ import pwndbg.gdblib.arch
 import pwndbg.gdblib.elf
 import pwndbg.gdblib.events
 import pwndbg.gdblib.file
+import pwndbg.gdblib.info
 import pwndbg.gdblib.memory
 import pwndbg.gdblib.qemu
 import pwndbg.gdblib.remote
@@ -215,6 +216,19 @@ def address(symbol: str) -> int:
 
         if all(x not in str(e) for x in skipped_exceptions):
             raise e
+
+    try:
+        # Unfortunately, `gdb.lookup_symbol` does not seem to handle all
+        # symbols, so we need to fallback to using `info address`. See
+        # https://sourceware.org/pipermail/gdb/2022-October/050362.html
+        address = pwndbg.gdblib.info.address(symbol)
+        if address is None or not pwndbg.gdblib.vmmap.find(address):
+            return None
+
+        return address
+
+    except gdb.error:
+        return None
 
     try:
         # TODO: We should properly check if we have a connection to the IDA server first


### PR DESCRIPTION
In https://github.com/pwndbg/pwndbg/pull/1259 I removed the code using `info address` to resolve symbols, as `gdb.lookup_symbol` should have covered this. However, there seems to be some issue with `gdb.lookup_symbol`: https://sourceware.org/pipermail/gdb/2022-October/050362.html

The main place this broke things was in heap heuristics. Since this was missed by the tests, new tests were added in https://github.com/pwndbg/pwndbg/pull/1283, and this PR is based on top of that one.

This PR adds back in the `info address` lookup, with a comment explaining why we need it.