### PR TITLE
Pwndbg configuration: do not set history expansion

### DIFF
--- a/pwndbg/__init__.py
+++ b/pwndbg/__init__.py
@@ -65,7 +65,6 @@ set confirm off
 set verbose off
 set pagination off
 set height 0
-set history expansion on
 set history save on
 set follow-fork-mode child
 set backtrace past-main on


### PR DESCRIPTION
The `set history expansion on` setting we set seems to cause troubles if users want to execute a shell command by using the exclamation mark.

I do not like it, especially taking into account the recent shell command deprecation we did.