### PR TITLE
added cymbol command

### DIFF
--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -458,6 +458,7 @@ def load_commands():
     import pwndbg.commands.config
     import pwndbg.commands.context
     import pwndbg.commands.cpsr
+    import pwndbg.commands.cymbol
     import pwndbg.commands.dt
     import pwndbg.commands.dumpargs
     import pwndbg.commands.elf
@@ -498,4 +499,3 @@ def load_commands():
     import pwndbg.commands.windbg
     import pwndbg.commands.xinfo
     import pwndbg.commands.xor
-    import pwndbg.commands.cymbol

--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -498,3 +498,4 @@ def load_commands():
     import pwndbg.commands.windbg
     import pwndbg.commands.xinfo
     import pwndbg.commands.xor
+    import pwndbg.commands.cymbol

--- a/pwndbg/commands/cymbol.py
+++ b/pwndbg/commands/cymbol.py
@@ -187,9 +187,10 @@ def load_custom_structure(custom_structure_name, custom_structure_path):
 
 @OnlyWhenStructureExists
 def show_custom_structure(custom_structure_name, custom_structure_path):
-    # Clear the memoization cache.
-    pwndbg.pwndbg.commands.context.get_highlight_source.clear()
-    highlighted_source = pwndbg.pwndbg.commands.context.get_highlight_source(custom_structure_path)
+    # Call wrapper .func() to avoid memoization.
+    highlighted_source = pwndbg.pwndbg.commands.context.get_highlight_source.func(
+        custom_structure_path
+    )
     print("\n".join(highlighted_source))
 
 

--- a/pwndbg/commands/cymbol.py
+++ b/pwndbg/commands/cymbol.py
@@ -6,7 +6,7 @@ Add, load, show, edit, or delete symbols for custom structures.
 
 For the generation of the symbols g++/gcc is being used under the hood.
 
-In case of remote debugging a binary which is not native to your architecture it 
+In case of remote debugging a binary which is not native to your architecture it
 is advised to configure the 'gcc-config-path' config parameter to your own cross-platform
 gnu gcc compiled toolchain for your target architecture.
 
@@ -15,71 +15,88 @@ favorite text editor. Otherwise cymbol exapnds $EDITOR and $VISUAL environement 
 to find the path to the default text editor.
 """
 
-import tempfile
 import argparse
+import os
 import subprocess
-import os, sys, gdb
+import sys
+import tempfile
+
+import gdb
 
 import pwndbg
-import pwndbg.lib.gcc
-import pwndbg.gdblib.arch
-import pwndbg.lib.tempfile
 import pwndbg.commands
+import pwndbg.gdblib.arch
+import pwndbg.lib.gcc
+import pwndbg.lib.tempfile
 from pwndbg.color import message
 
 gcc_compiler_path = pwndbg.gdblib.config.add_param(
-    "gcc-compiler-path", '', "Path to your own gnu gcc/g++ toolchain for generating imported symbols."
+    "gcc-compiler-path",
+    "",
+    "Path to your own gnu gcc/g++ toolchain for generating imported symbols.",
 )
 
 cymbol_editor = pwndbg.gdblib.config.add_param(
-    "cymbol-editor", '', "Path to your editor of your choice for editing custom structures."
+    "cymbol-editor", "", "Path to your editor of your choice for editing custom structures."
 )
+
 
 def OnlyWhenStructureExists(func):
     def wrapper(custom_structure_name):
-        pwndbg_cachedir = pwndbg.lib.tempfile.cachedir('custom-symbols')
-        pwndbg_custom_structure_path = os.path.join(pwndbg_cachedir, custom_structure_name) + '.c'
+        pwndbg_cachedir = pwndbg.lib.tempfile.cachedir("custom-symbols")
+        pwndbg_custom_structure_path = os.path.join(pwndbg_cachedir, custom_structure_name) + ".c"
 
         if not os.path.exists(pwndbg_custom_structure_path):
-            print(
-                message.error('No custom structure was found with the given name!')
-            )
+            print(message.error("No custom structure was found with the given name!"))
             return
 
         return func(custom_structure_name, pwndbg_custom_structure_path)
+
     return wrapper
+
 
 def PromptForOverwrite(func):
     def wrapper(custom_structure_name):
-        pwndbg_cachedir = pwndbg.lib.tempfile.cachedir('custom-symbols')
-        pwndbg_custom_structure_path = os.path.join(pwndbg_cachedir, custom_structure_name) + '.c'
+        pwndbg_cachedir = pwndbg.lib.tempfile.cachedir("custom-symbols")
+        pwndbg_custom_structure_path = os.path.join(pwndbg_cachedir, custom_structure_name) + ".c"
 
         if not os.path.exists(pwndbg_custom_structure_path):
             return func(custom_structure_name)
-    
+
         option = input(
-            message.notice('A custom structure was found with the given name, would you like to overwrite it? [y/n] ')
+            message.notice(
+                "A custom structure was found with the given name, would you like to overwrite it? [y/n] "
+            )
         )
 
-        if option != 'y':
+        if option != "y":
             return
-        
-        return func(custom_structure_name)
-    return wrapper  
 
-def generate_debug_symbols(custom_structure_path, pwndbg_debug_symbols_output_file = None):
+        return func(custom_structure_name)
+
+    return wrapper
+
+
+def generate_debug_symbols(custom_structure_path, pwndbg_debug_symbols_output_file=None):
     if not pwndbg_debug_symbols_output_file:
-        _, pwndbg_debug_symbols_output_file = tempfile.mkstemp(prefix='custom-', suffix='.dbg')
-    
+        _, pwndbg_debug_symbols_output_file = tempfile.mkstemp(prefix="custom-", suffix=".dbg")
+
     # -fno-eliminate-unused-debug-types is a handy gcc flag that lets us extract debug symbols from non-used defined structures.
-    gcc_extra_flags = [custom_structure_path, '-c', '-g', '-fno-eliminate-unused-debug-types', '-o', pwndbg_debug_symbols_output_file]
+    gcc_extra_flags = [
+        custom_structure_path,
+        "-c",
+        "-g",
+        "-fno-eliminate-unused-debug-types",
+        "-o",
+        pwndbg_debug_symbols_output_file,
+    ]
     gcc_flags = None
 
-    if gcc_compiler_path != '':
+    if gcc_compiler_path != "":
         if pwndbg.gdblib.arch.ptrsize == 8:
-            gcc_flags = [gcc_compiler_path, '-m64']
+            gcc_flags = [gcc_compiler_path, "-m64"]
         elif pwndbg.gdblib.arch.ptrsize == 4:
-            gcc_flags = [gcc_compiler_path, '-m32']
+            gcc_flags = [gcc_compiler_path, "-m32"]
     else:
         # Should we check for exceptions here?
         gcc_flags = pwndbg.lib.gcc.which(pwndbg.gdblib.arch)
@@ -89,116 +106,104 @@ def generate_debug_symbols(custom_structure_path, pwndbg_debug_symbols_output_fi
     try:
         subprocess.run(gcc_cmd, capture_output=False, check=True)
     except subprocess.CalledProcessError as exepction:
-        print(
-            message.error(exepction)
-        )
-        print(
-            message.error('Parsing failed, try to fix any syntax errors first.')
-        )
+        print(message.error(exepction))
+        print(message.error("Parsing failed, try to fix any syntax errors first."))
         return None
     except Exception as exepction:
-        print(
-            message.error(exepction)
-        )
-        print(
-            message.error('An error occured while generating the debug symbols.')
-        )
+        print(message.error(exepction))
+        print(message.error("An error occured while generating the debug symbols."))
         return None
-    
+
     return pwndbg_debug_symbols_output_file
+
 
 @PromptForOverwrite
 def add_custom_structure(custom_structure_name):
     print(
-        message.notice('Enter your custom structure in a C header style, press Ctrl+D to save:\n')
+        message.notice("Enter your custom structure in a C header style, press Ctrl+D to save:\n")
     )
 
     custom_structures_source = sys.stdin.read().strip()
-    if custom_structures_source == '':
-        print(
-            message.notice('An empty structure is entered, skipping ...')
-        )
+    if custom_structures_source == "":
+        print(message.notice("An empty structure is entered, skipping ..."))
         return
 
-    pwndbg_cachedir = pwndbg.lib.tempfile.cachedir('custom-symbols')
-    pwndbg_custom_structure_path = os.path.join(pwndbg_cachedir, custom_structure_name) + '.c'
+    pwndbg_cachedir = pwndbg.lib.tempfile.cachedir("custom-symbols")
+    pwndbg_custom_structure_path = os.path.join(pwndbg_cachedir, custom_structure_name) + ".c"
 
     with open(pwndbg_custom_structure_path, "w") as f:
         f.write(custom_structures_source)
-    
+
     pwndbg_debug_symbols_output_file = generate_debug_symbols(pwndbg_custom_structure_path)
     if not pwndbg_debug_symbols_output_file:
         return
-    
-    gdb.execute(f'add-symbol-file {pwndbg_debug_symbols_output_file}', to_string=True)
-    print(
-        message.success('Symbols are added!')
-    )
+
+    gdb.execute(f"add-symbol-file {pwndbg_debug_symbols_output_file}", to_string=True)
+    print(message.success("Symbols are added!"))
+
 
 @OnlyWhenStructureExists
 def edit_custom_structure(custom_structure_name, custom_structure_path):
 
     # Lookup an editor to use for editing the custom structure.
-    editor_preference = os.getenv('EDITOR')
+    editor_preference = os.getenv("EDITOR")
     if not editor_preference:
-        editor_preference = os.getenv('VISUAL')
+        editor_preference = os.getenv("VISUAL")
     if not editor_preference:
-        editor_preference = 'vi'
-    
-    if cymbol_editor != '':
+        editor_preference = "vi"
+
+    if cymbol_editor != "":
         editor_preference = cymbol_editor
-    
+
     try:
         subprocess.run([editor_preference, custom_structure_path], capture_output=False, check=True)
     except Exception as exepction:
+        print(message.error("An error occured during opening the source file."))
+        print(message.error(f"Path to the custom structure: {custom_structure_path}"))
+        print(message.error("Please try to manually edit the structure."))
         print(
-            message.error('An error occured during opening the source file.')
-        )
-        print(
-            message.error(f'Path to the custom structure: {custom_structure_path}')
-        )
-        print(
-            message.error('Please try to manually edit the structure.')
-        )
-        print(
-            message.error('\nTry to set a path to an editor with:\n\tset "cymbol-editor" /usr/bin/nano')
+            message.error(
+                '\nTry to set a path to an editor with:\n\tset "cymbol-editor" /usr/bin/nano'
+            )
         )
         return
-    
-    input(
-        message.notice('Press enter to continue.')
-    )
+
+    input(message.notice("Press enter to continue."))
 
     load_custom_structure(custom_structure_name)
+
 
 @OnlyWhenStructureExists
 def remove_custom_structure(custom_structure_name, custom_structure_path):
     os.remove(custom_structure_path)
+    print(message.success("Symbols are removed!"))
     print(
-        message.success('Symbols are removed!')
+        message.notice(
+            "If the symbols are already loaded, please restart pwndbg to unload them from memory."
+        )
     )
-    print(
-        message.notice('If the symbols are already loaded, please restart pwndbg to unload them from memory.')
-    )
+
 
 @OnlyWhenStructureExists
 def load_custom_structure(custom_structure_name, custom_structure_path):
     pwndbg_debug_symbols_output_file = generate_debug_symbols(custom_structure_path)
     if not pwndbg_debug_symbols_output_file:
         return
-    gdb.execute(f'add-symbol-file {pwndbg_debug_symbols_output_file}', to_string=True)
-    print(
-        message.success('Symbols are loaded!')
-    )
+    gdb.execute(f"add-symbol-file {pwndbg_debug_symbols_output_file}", to_string=True)
+    print(message.success("Symbols are loaded!"))
+
 
 @OnlyWhenStructureExists
 def show_custom_structure(custom_structure_name, custom_structure_path):
     print()
-    with open(custom_structure_path, 'r') as f:
+    with open(custom_structure_path, "r") as f:
         print(f.read())
     print()
 
-parser = argparse.ArgumentParser(description="Add, show, load, edit, or delete custom structures in plain C")
+
+parser = argparse.ArgumentParser(
+    description="Add, show, load, edit, or delete custom structures in plain C"
+)
 parser.add_argument(
     "-a",
     "--add",
@@ -240,6 +245,7 @@ parser.add_argument(
     type=str,
 )
 
+
 @pwndbg.commands.ArgparsedCommand(parser)
 @pwndbg.commands.OnlyAmd64
 @pwndbg.commands.OnlyWhenRunning
@@ -247,21 +253,21 @@ def cymbol(add, remove, edit, load, show):
     if add:
         add_custom_structure(add)
         return
-    
+
     if remove:
         remove_custom_structure(remove)
         return
-    
+
     if edit:
         edit_custom_structure(edit)
         return
-    
+
     if load:
         load_custom_structure(load)
         return
-    
+
     if show:
         show_custom_structure(show)
         return
-    
+
     parser.print_help()

--- a/pwndbg/commands/cymbol.py
+++ b/pwndbg/commands/cymbol.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+Add, load, show, edit, or delete symbols for custom structures.
+
+For the generation of the symbols g++/gcc is being used under the hood.
+
+In case of remote debugging a binary which is not native to your architecture it 
+is advised to configure the 'gcc-config-path' config parameter to your own cross-platform
+gnu gcc compiled toolchain for your target architecture.
+
+You are advised to configure the 'cymbol-editor' config parameter to the path of your
+favorite text editor. Otherwise cymbol exapnds $EDITOR and $VISUAL environement varialbes
+to find the path to the default text editor.
+"""
+
+import tempfile
+import argparse
+import subprocess
+import os, sys, gdb
+
+import pwndbg
+import pwndbg.lib.gcc
+import pwndbg.gdblib.arch
+import pwndbg.lib.tempfile
+import pwndbg.commands
+from pwndbg.color import message
+
+gcc_compiler_path = pwndbg.gdblib.config.add_param(
+    "gcc-compiler-path", '', "Path to your own gnu gcc/g++ toolchain for generating imported symbols."
+)
+
+cymbol_editor = pwndbg.gdblib.config.add_param(
+    "cymbol-editor", '', "Path to your editor of your choice for editing custom structures."
+)
+
+def OnlyWhenStructureExists(func):
+    def wrapper(custom_structure_name):
+        pwndbg_cachedir = pwndbg.lib.tempfile.cachedir('custom-symbols')
+        pwndbg_custom_structure_path = os.path.join(pwndbg_cachedir, custom_structure_name) + '.c'
+
+        if not os.path.exists(pwndbg_custom_structure_path):
+            print(
+                message.error('No custom structure was found with the given name!')
+            )
+            return
+
+        return func(custom_structure_name, pwndbg_custom_structure_path)
+    return wrapper
+
+def PromptForOverwrite(func):
+    def wrapper(custom_structure_name):
+        pwndbg_cachedir = pwndbg.lib.tempfile.cachedir('custom-symbols')
+        pwndbg_custom_structure_path = os.path.join(pwndbg_cachedir, custom_structure_name) + '.c'
+
+        if not os.path.exists(pwndbg_custom_structure_path):
+            return func(custom_structure_name)
+    
+        option = input(
+            message.notice('A custom structure was found with the given name, would you like to overwrite it? [y/n] ')
+        )
+
+        if option != 'y':
+            return
+        
+        return func(custom_structure_name)
+    return wrapper  
+
+def generate_debug_symbols(custom_structure_path, pwndbg_debug_symbols_output_file = None):
+    if not pwndbg_debug_symbols_output_file:
+        _, pwndbg_debug_symbols_output_file = tempfile.mkstemp(prefix='custom-', suffix='.dbg')
+    
+    # -fno-eliminate-unused-debug-types is a handy gcc flag that lets us extract debug symbols from non-used defined structures.
+    gcc_extra_flags = [custom_structure_path, '-c', '-g', '-fno-eliminate-unused-debug-types', '-o', pwndbg_debug_symbols_output_file]
+    gcc_flags = None
+
+    if gcc_compiler_path != '':
+        if pwndbg.gdblib.arch.ptrsize == 8:
+            gcc_flags = [gcc_compiler_path, '-m64']
+        elif pwndbg.gdblib.arch.ptrsize == 4:
+            gcc_flags = [gcc_compiler_path, '-m32']
+    else:
+        # Should we check for exceptions here?
+        gcc_flags = pwndbg.lib.gcc.which(pwndbg.gdblib.arch)
+
+    gcc_cmd = gcc_flags + gcc_extra_flags
+
+    try:
+        subprocess.run(gcc_cmd, capture_output=False, check=True)
+    except subprocess.CalledProcessError as exepction:
+        print(
+            message.error(exepction)
+        )
+        print(
+            message.error('Parsing failed, try to fix any syntax errors first.')
+        )
+        return None
+    except Exception as exepction:
+        print(
+            message.error(exepction)
+        )
+        print(
+            message.error('An error occured while generating the debug symbols.')
+        )
+        return None
+    
+    return pwndbg_debug_symbols_output_file
+
+@PromptForOverwrite
+def add_custom_structure(custom_structure_name):
+    print(
+        message.notice('Enter your custom structure in a C header style, press Ctrl+D to save:\n')
+    )
+
+    custom_structures_source = sys.stdin.read().strip()
+    if custom_structures_source == '':
+        print(
+            message.notice('An empty structure is entered, skipping ...')
+        )
+        return
+
+    pwndbg_cachedir = pwndbg.lib.tempfile.cachedir('custom-symbols')
+    pwndbg_custom_structure_path = os.path.join(pwndbg_cachedir, custom_structure_name) + '.c'
+
+    with open(pwndbg_custom_structure_path, "w") as f:
+        f.write(custom_structures_source)
+    
+    pwndbg_debug_symbols_output_file = generate_debug_symbols(pwndbg_custom_structure_path)
+    if not pwndbg_debug_symbols_output_file:
+        return
+    
+    gdb.execute(f'add-symbol-file {pwndbg_debug_symbols_output_file}', to_string=True)
+    print(
+        message.success('Symbols are added!')
+    )
+
+@OnlyWhenStructureExists
+def edit_custom_structure(custom_structure_name, custom_structure_path):
+
+    # Lookup an editor to use for editing the custom structure.
+    editor_preference = os.getenv('EDITOR')
+    if not editor_preference:
+        editor_preference = os.getenv('VISUAL')
+    if not editor_preference:
+        editor_preference = 'vi'
+    
+    if cymbol_editor != '':
+        editor_preference = cymbol_editor
+    
+    try:
+        subprocess.run([editor_preference, custom_structure_path], capture_output=False, check=True)
+    except Exception as exepction:
+        print(
+            message.error('An error occured during opening the source file.')
+        )
+        print(
+            message.error(f'Path to the custom structure: {custom_structure_path}')
+        )
+        print(
+            message.error('Please try to manually edit the structure.')
+        )
+        print(
+            message.error('\nTry to set a path to an editor with:\n\tset "cymbol-editor" /usr/bin/nano')
+        )
+        return
+    
+    input(
+        message.notice('Press enter to continue.')
+    )
+
+    load_custom_structure(custom_structure_name)
+
+@OnlyWhenStructureExists
+def remove_custom_structure(custom_structure_name, custom_structure_path):
+    os.remove(custom_structure_path)
+    print(
+        message.success('Symbols are removed!')
+    )
+    print(
+        message.notice('If the symbols are already loaded, please restart pwndbg to unload them from memory.')
+    )
+
+@OnlyWhenStructureExists
+def load_custom_structure(custom_structure_name, custom_structure_path):
+    pwndbg_debug_symbols_output_file = generate_debug_symbols(custom_structure_path)
+    if not pwndbg_debug_symbols_output_file:
+        return
+    gdb.execute(f'add-symbol-file {pwndbg_debug_symbols_output_file}', to_string=True)
+    print(
+        message.success('Symbols are loaded!')
+    )
+
+@OnlyWhenStructureExists
+def show_custom_structure(custom_structure_name, custom_structure_path):
+    print()
+    with open(custom_structure_path, 'r') as f:
+        print(f.read())
+    print()
+
+parser = argparse.ArgumentParser(description="Add, show, load, edit, or delete custom structures in plain C")
+parser.add_argument(
+    "-a",
+    "--add",
+    metavar="name",
+    help="Add a new custom structure",
+    default=None,
+    type=str,
+)
+parser.add_argument(
+    "-r",
+    "--remove",
+    metavar="name",
+    help="Remove an existing custom structure",
+    default=None,
+    type=str,
+)
+parser.add_argument(
+    "-e",
+    "--edit",
+    metavar="name",
+    help="Edit an existing custom structure",
+    default=None,
+    type=str,
+)
+parser.add_argument(
+    "-l",
+    "--load",
+    metavar="name",
+    help="Load an existing custom structure",
+    default=None,
+    type=str,
+)
+parser.add_argument(
+    "-s",
+    "--show",
+    metavar="name",
+    help="Show the source code of an existing custom structure",
+    default=None,
+    type=str,
+)
+
+@pwndbg.commands.ArgparsedCommand(parser)
+@pwndbg.commands.OnlyAmd64
+@pwndbg.commands.OnlyWhenRunning
+def cymbol(add, remove, edit, load, show):
+    if add:
+        add_custom_structure(add)
+        return
+    
+    if remove:
+        remove_custom_structure(remove)
+        return
+    
+    if edit:
+        edit_custom_structure(edit)
+        return
+    
+    if load:
+        load_custom_structure(load)
+        return
+    
+    if show:
+        show_custom_structure(show)
+        return
+    
+    parser.print_help()

--- a/pwndbg/commands/cymbol.py
+++ b/pwndbg/commands/cymbol.py
@@ -104,7 +104,7 @@ def generate_debug_symbols(custom_structure_path, pwndbg_debug_symbols_output_fi
     gcc_cmd = gcc_flags + gcc_extra_flags
 
     try:
-        subprocess.run(gcc_cmd, capture_output=False, check=True)
+        subprocess.run(gcc_cmd, stdout = subprocess.PIPE, stderr = subprocess.PIPE, check=True)
     except subprocess.CalledProcessError as exepction:
         print(message.error(exepction))
         print(message.error("Parsing failed, try to fix any syntax errors first."))
@@ -156,7 +156,7 @@ def edit_custom_structure(custom_structure_name, custom_structure_path):
         editor_preference = cymbol_editor
 
     try:
-        subprocess.run([editor_preference, custom_structure_path], capture_output=False, check=True)
+        subprocess.run([editor_preference, custom_structure_path], stdout = subprocess.PIPE, stderr = subprocess.PIPE, check=True)
     except Exception as exepction:
         print(message.error("An error occured during opening the source file."))
         print(message.error(f"Path to the custom structure: {custom_structure_path}"))

--- a/pwndbg/commands/cymbol.py
+++ b/pwndbg/commands/cymbol.py
@@ -104,7 +104,7 @@ def generate_debug_symbols(custom_structure_path, pwndbg_debug_symbols_output_fi
     gcc_cmd = gcc_flags + gcc_extra_flags
 
     try:
-        subprocess.run(gcc_cmd, stdout = subprocess.PIPE, stderr = subprocess.PIPE, check=True)
+        subprocess.run(gcc_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True)
     except subprocess.CalledProcessError as exepction:
         print(message.error(exepction))
         print(message.error("Parsing failed, try to fix any syntax errors first."))
@@ -156,7 +156,12 @@ def edit_custom_structure(custom_structure_name, custom_structure_path):
         editor_preference = cymbol_editor
 
     try:
-        subprocess.run([editor_preference, custom_structure_path], stdout = subprocess.PIPE, stderr = subprocess.PIPE, check=True)
+        subprocess.run(
+            [editor_preference, custom_structure_path],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=True,
+        )
     except Exception as exepction:
         print(message.error("An error occured during opening the source file."))
         print(message.error(f"Path to the custom structure: {custom_structure_path}"))

--- a/pwndbg/commands/cymbol.py
+++ b/pwndbg/commands/cymbol.py
@@ -257,22 +257,13 @@ parser.add_argument(
 def cymbol(add, remove, edit, load, show):
     if add:
         add_custom_structure(add)
-        return
-
-    if remove:
+    elif remove:
         remove_custom_structure(remove)
-        return
-
-    if edit:
+    elif edit:
         edit_custom_structure(edit)
-        return
-
-    if load:
+    elif load:
         load_custom_structure(load)
-        return
-
-    if show:
+    elif show:
         show_custom_structure(show)
-        return
-
-    parser.print_help()
+    else:
+        parser.print_help()

--- a/tests/gdb-tests/tests/test_cymbol.py
+++ b/tests/gdb-tests/tests/test_cymbol.py
@@ -1,59 +1,64 @@
-import os, sys
+import os
+import sys
+
 import pwndbg.commands.cymbol
 import pwndbg.gdblib.dt
 import tests
 
 REFERENCE_BINARY = tests.binaries.get("reference-binary.out")
 
+
 def test_cymbol(start_binary):
     start_binary(REFERENCE_BINARY)
 
-    pwndbg_cachedir = pwndbg.lib.tempfile.cachedir('custom-symbols')
-    custom_structure_example = '''
+    pwndbg_cachedir = pwndbg.lib.tempfile.cachedir("custom-symbols")
+    custom_structure_example = """
         typedef struct example_struct {
             int a;
             char b[16];
             char* c;
             void* d;
         } example_t;
-    '''
-    custom_structure_example_path = os.path.join(pwndbg_cachedir, 'example.c')
-    with open(custom_structure_example_path, 'w') as f:
+    """
+    custom_structure_example_path = os.path.join(pwndbg_cachedir, "example.c")
+    with open(custom_structure_example_path, "w") as f:
         f.write(custom_structure_example)
 
     # Test whether OnlyWhenStructureExists decorator works properly
-    assert pwndbg.commands.cymbol.OnlyWhenStructureExists(lambda x, y: True)('dummy') == None
-    assert pwndbg.commands.cymbol.OnlyWhenStructureExists(lambda x, y: True)('example') == True
+    assert pwndbg.commands.cymbol.OnlyWhenStructureExists(lambda x, y: True)("dummy") is None
+    assert pwndbg.commands.cymbol.OnlyWhenStructureExists(lambda x, y: True)("example") is True
 
     # Test whether PromptForOverwrite decorator works properly
     # Returns True when the custom structure 'dummy' does not exist and there is no need for an overwrite prompt.
-    assert pwndbg.commands.cymbol.PromptForOverwrite(lambda x: True)('dummy') == True
+    assert pwndbg.commands.cymbol.PromptForOverwrite(lambda x: True)("dummy") is True
 
     # Test whether generate_debug_symbols() works properly
-    assert pwndbg.commands.cymbol.generate_debug_symbols(custom_structure_example_path) != None
+    assert pwndbg.commands.cymbol.generate_debug_symbols(custom_structure_example_path) is not None
 
     # Test whether load_custom_structure() works properly
-    pwndbg.commands.cymbol.load_custom_structure('example')
+    pwndbg.commands.cymbol.load_custom_structure("example")
     # Not much but honest work.
-    assert '+0x0004 b' in pwndbg.gdblib.dt.dt('example_t').strip()
+    assert "+0x0004 b" in pwndbg.gdblib.dt.dt("example_t").strip()
 
     # Test whether add_custom_structure() works properly.
     saved_read = sys.stdin.read
     saved_exists = os.path.exists
     # We do a little hack here :)
-    sys.stdin.read = lambda: '''
+    sys.stdin.read = (
+        lambda: """
         typedef struct example_struct2 {
             long a;
             int b[16];
             int** c;
             void* d;
         } example2_t;
-    '''
+    """
+    )
     # Always overwrite files which exist.
     os.path.exists = lambda x: False
-    pwndbg.commands.cymbol.add_custom_structure('example2')
+    pwndbg.commands.cymbol.add_custom_structure("example2")
     # Not much but honest work.
-    assert ': int [16]' in pwndbg.gdblib.dt.dt('example2_t').strip()
+    assert ": int [16]" in pwndbg.gdblib.dt.dt("example2_t").strip()
 
     # Restore
     sys.stdin.read = saved_read

--- a/tests/gdb-tests/tests/test_cymbol.py
+++ b/tests/gdb-tests/tests/test_cymbol.py
@@ -1,0 +1,60 @@
+import os, sys
+import pwndbg.commands.cymbol
+import pwndbg.gdblib.dt
+import tests
+
+REFERENCE_BINARY = tests.binaries.get("reference-binary.out")
+
+def test_cymbol(start_binary):
+    start_binary(REFERENCE_BINARY)
+
+    pwndbg_cachedir = pwndbg.lib.tempfile.cachedir('custom-symbols')
+    custom_structure_example = '''
+        typedef struct example_struct {
+            int a;
+            char b[16];
+            char* c;
+            void* d;
+        } example_t;
+    '''
+    custom_structure_example_path = os.path.join(pwndbg_cachedir, 'example.c')
+    with open(custom_structure_example_path, 'w') as f:
+        f.write(custom_structure_example)
+
+    # Test whether OnlyWhenStructureExists decorator works properly
+    assert pwndbg.commands.cymbol.OnlyWhenStructureExists(lambda x, y: True)('dummy') == None
+    assert pwndbg.commands.cymbol.OnlyWhenStructureExists(lambda x, y: True)('example') == True
+
+    # Test whether PromptForOverwrite decorator works properly
+    # Returns True when the custom structure 'dummy' does not exist and there is no need for an overwrite prompt.
+    assert pwndbg.commands.cymbol.PromptForOverwrite(lambda x: True)('dummy') == True
+
+    # Test whether generate_debug_symbols() works properly
+    assert pwndbg.commands.cymbol.generate_debug_symbols(custom_structure_example_path) != None
+
+    # Test whether load_custom_structure() works properly
+    pwndbg.commands.cymbol.load_custom_structure('example')
+    # Not much but honest work.
+    assert '+0x0004 b' in pwndbg.gdblib.dt.dt('example_t').strip()
+
+    # Test whether add_custom_structure() works properly.
+    saved_read = sys.stdin.read
+    saved_exists = os.path.exists
+    # We do a little hack here :)
+    sys.stdin.read = lambda: '''
+        typedef struct example_struct2 {
+            long a;
+            int b[16];
+            int** c;
+            void* d;
+        } example2_t;
+    '''
+    # Always overwrite files which exist.
+    os.path.exists = lambda x: False
+    pwndbg.commands.cymbol.add_custom_structure('example2')
+    # Not much but honest work.
+    assert ': int [16]' in pwndbg.gdblib.dt.dt('example2_t').strip()
+
+    # Restore
+    sys.stdin.read = saved_read
+    os.path.exists = saved_exists

--- a/tests/gdb-tests/tests/test_cymbol.py
+++ b/tests/gdb-tests/tests/test_cymbol.py
@@ -28,10 +28,6 @@ def test_cymbol(start_binary):
     assert pwndbg.commands.cymbol.OnlyWhenStructureExists(lambda x, y: True)("dummy") is None
     assert pwndbg.commands.cymbol.OnlyWhenStructureExists(lambda x, y: True)("example") is True
 
-    # Test whether PromptForOverwrite decorator works properly
-    # Returns True when the custom structure 'dummy' does not exist and there is no need for an overwrite prompt.
-    assert pwndbg.commands.cymbol.PromptForOverwrite(lambda x: True)("dummy") is True
-
     # Test whether generate_debug_symbols() works properly
     assert pwndbg.commands.cymbol.generate_debug_symbols(custom_structure_example_path) is not None
 
@@ -63,3 +59,11 @@ def test_cymbol(start_binary):
     # Restore
     sys.stdin.read = saved_read
     os.path.exists = saved_exists
+
+    # Test whether remove_custom_structure() works properly.
+    pwndbg.commands.cymbol.remove_custom_structure("example2")
+    try:
+        pwndbg.gdblib.dt.dt("example2_t")
+    except Exception as exception:
+        # In case it is an AttributeError remove_custom_structure() successfully removed the loaded symbol.
+        assert isinstance(exception, AttributeError)

--- a/tests/gdb-tests/tests/test_cymbol.py
+++ b/tests/gdb-tests/tests/test_cymbol.py
@@ -1,5 +1,4 @@
 import os
-import sys
 
 import pwndbg.commands.cymbol
 import pwndbg.gdblib.dt
@@ -8,10 +7,27 @@ import tests
 REFERENCE_BINARY = tests.binaries.get("reference-binary.out")
 
 
+# Might be useful for future expansion of the test case
+def create_symbol_file(symbol, source):
+    custom_structure_example_path = (
+        os.path.join(pwndbg.commands.cymbol.pwndbg_cachedir, symbol) + ".c"
+    )
+    with open(custom_structure_example_path, "w") as f:
+        f.write(source)
+    return custom_structure_example_path
+
+
+def check_symbol_existance(symbol_type):
+    try:
+        pwndbg.gdblib.dt.dt(symbol_type)
+    except Exception as exception:
+        # In case it is an AttributeError symbol_type doesn't exists.
+        assert isinstance(exception, AttributeError)
+
+
 def test_cymbol(start_binary):
     start_binary(REFERENCE_BINARY)
 
-    pwndbg_cachedir = pwndbg.lib.tempfile.cachedir("custom-symbols")
     custom_structure_example = """
         typedef struct example_struct {
             int a;
@@ -20,50 +36,35 @@ def test_cymbol(start_binary):
             void* d;
         } example_t;
     """
-    custom_structure_example_path = os.path.join(pwndbg_cachedir, "example.c")
-    with open(custom_structure_example_path, "w") as f:
-        f.write(custom_structure_example)
+    custom_structure_example_path = create_symbol_file("example", custom_structure_example)
 
-    # Test whether OnlyWhenStructureExists decorator works properly
-    assert pwndbg.commands.cymbol.OnlyWhenStructureExists(lambda x, y: True)("dummy") is None
-    assert pwndbg.commands.cymbol.OnlyWhenStructureExists(lambda x, y: True)("example") is True
+    # Test whether OnlyWhenStructFileExists decorator works properly
+    assert pwndbg.commands.cymbol.OnlyWhenStructFileExists(lambda x, y: True)("dummy") is None
+    assert pwndbg.commands.cymbol.OnlyWhenStructFileExists(lambda x, y: True)("example") is True
 
-    # Test whether generate_debug_symbols() works properly
+    # Test whether generate_debug_symbols() works properly.
     assert pwndbg.commands.cymbol.generate_debug_symbols(custom_structure_example_path) is not None
 
     # Test whether load_custom_structure() works properly
     pwndbg.commands.cymbol.load_custom_structure("example")
-    # Not much but honest work.
-    assert "+0x0004 b" in pwndbg.gdblib.dt.dt("example_t").strip()
-
-    # Test whether add_custom_structure() works properly.
-    saved_read = sys.stdin.read
-    saved_exists = os.path.exists
-    # We do a little hack here :)
-    sys.stdin.read = (
-        lambda: """
-        typedef struct example_struct2 {
-            long a;
-            int b[16];
-            int** c;
-            void* d;
-        } example2_t;
-    """
+    # Test whether the symbol is loaded on the lookup loaded_symbols dict.
+    assert pwndbg.commands.cymbol.loaded_symbols.get("example") is not None
+    # Test whether the returned type is what we expect (on x86-64).
+    assert (
+        "example_t\n    +0x0000 a                    : int\n    +0x0004 b                    : char [16]\n    +0x0018 c                    : char *\n    +0x0020 d                    : void *"
+        in pwndbg.gdblib.dt.dt("example_t").strip()
     )
-    # Always overwrite files which exist.
-    os.path.exists = lambda x: False
-    pwndbg.commands.cymbol.add_custom_structure("example2")
-    # Not much but honest work.
-    assert ": int [16]" in pwndbg.gdblib.dt.dt("example2_t").strip()
 
-    # Restore
-    sys.stdin.read = saved_read
-    os.path.exists = saved_exists
+    # Test whether unload_loaded_symbol() works properly.
+    pwndbg.commands.cymbol.unload_loaded_symbol("example")
+    # Ensure the symbol is removed from the lookup loaded_symbols dict.
+    assert pwndbg.commands.cymbol.loaded_symbols.get("example") is None
+    # Ensure the symbol is no longer present in gdb.
+    check_symbol_existance("example_t")
+
+    # Load the symbol again for the next test case.
+    pwndbg.commands.cymbol.load_custom_structure("example")
 
     # Test whether remove_custom_structure() works properly.
-    pwndbg.commands.cymbol.remove_custom_structure("example2")
-    try:
-        pwndbg.gdblib.dt.dt("example2_t")
-    except Exception as exception:
-        # In case it is an AttributeError remove_custom_structure() successfully removed the loaded symbol.
-        assert isinstance(exception, AttributeError)
+    pwndbg.commands.cymbol.remove_custom_structure("example")
+    check_symbol_existance("example_t")


### PR DESCRIPTION
A first implementation for a command importing symbols from objects defined in a C header like style.

I've currently restricted the implementation to `OnlyAmd64` only, cause remote debugging a binary in a non native architecture could be a little bit challenging.

Improvements that can be made:
* Move generated symbols away from `.cache/pwndbg` to a `.local/pwndbg` directory? For a more safe keep.
* Save and load the generated symbol files instead of recompiling the `.c` definition again and again. (Should we load them when pwndbg loads?)
* Implement a `-u/--unload` flag, for unloading loaded symbols in runtime.
* Implement a `--list-loaded` flag, for listing all currently loaded custom structures.