### PR TITLE
Fix parameter default values

### DIFF
--- a/pwndbg/commands/config.py
+++ b/pwndbg/commands/config.py
@@ -39,7 +39,7 @@ def get_config_parameters(scope, filter_pattern):
         values = [
             v
             for v in values
-            if filter_pattern in v.optname.lower() or filter_pattern in v.docstring.lower()
+            if filter_pattern in v.name.lower() or filter_pattern in v.docstring.lower()
         ]
 
     return values

--- a/pwndbg/gdblib/config.py
+++ b/pwndbg/gdblib/config.py
@@ -37,19 +37,17 @@ PARAM_CLASSES = {
 # https://sourceware.org/gdb/onlinedocs/gdb/Parameters-In-Python.html
 class Parameter(gdb.Parameter):
     def __init__(self, param: pwndbg.lib.config.Parameter):
+        param_class = PARAM_CLASSES[type(param.value)]
+        super().__init__(param.name, gdb.COMMAND_SUPPORT, param_class)
+
         self.param = param
+        self.value = param.value
 
         # `set_doc` and `show_doc` must be set before `gdb.Parameter.__init__`.
         # They will be used for `help set <param>` and `help show <param>`,
         # respectively
         self.set_doc = "Set " + self.param.docstring
         self.show_doc = "Show " + self.param.docstring
-        super().__init__(self.param.name, gdb.COMMAND_SUPPORT, self._param_class())
-
-    def _param_class(self):
-        for k, v in PARAM_CLASSES.items():
-            if isinstance(self.param.value, k):
-                return v
 
     @property
     def native_value(self):

--- a/pwndbg/gdblib/config.py
+++ b/pwndbg/gdblib/config.py
@@ -37,17 +37,17 @@ PARAM_CLASSES = {
 # https://sourceware.org/gdb/onlinedocs/gdb/Parameters-In-Python.html
 class Parameter(gdb.Parameter):
     def __init__(self, param: pwndbg.lib.config.Parameter):
+        # `set_doc` and `show_doc` must be set before `gdb.Parameter.__init__`.
+        # They will be used for `help set <param>` and `help show <param>`,
+        # respectively
+        self.set_doc = "Set " + param.docstring
+        self.show_doc = "Show " + param.docstring
+
         param_class = PARAM_CLASSES[type(param.value)]
         super().__init__(param.name, gdb.COMMAND_SUPPORT, param_class)
 
         self.param = param
         self.value = param.value
-
-        # `set_doc` and `show_doc` must be set before `gdb.Parameter.__init__`.
-        # They will be used for `help set <param>` and `help show <param>`,
-        # respectively
-        self.set_doc = "Set " + self.param.docstring
-        self.show_doc = "Show " + self.param.docstring
 
     @property
     def native_value(self):

--- a/tests/gdb-tests/tests/test_command_config.py
+++ b/tests/gdb-tests/tests/test_command_config.py
@@ -18,10 +18,10 @@ def test_config():
 def test_config_filtering():
     out = gdb.execute("config context-code-lines", to_string=True).splitlines()
 
-    assert re.match("Name\s+Value\s+\(Def\)\s+Documentation", out[0])
-    assert re.match("-+", out[1])
+    assert re.match(r"Name\s+Value\s+\(Def\)\s+Documentation", out[0])
+    assert re.match(r"-+", out[1])
     assert re.match(
-        "context-code-lines\s+10\s+number of additional lines to print in the code context", out[2]
+        r"context-code-lines\s+10\s+number of additional lines to print in the code context", out[2]
     )
     assert out[3] == "You can set config variable with `set <config-var> <value>`"
     assert (

--- a/tests/gdb-tests/tests/test_command_config.py
+++ b/tests/gdb-tests/tests/test_command_config.py
@@ -1,3 +1,5 @@
+import re
+
 import gdb
 
 
@@ -11,3 +13,23 @@ def test_config():
 
     gdb.execute("set global-max-fast 0x80")
     assert "'0x80' ('0')" in gdb.execute("heap_config", to_string=True)
+
+
+def test_config_filtering():
+    out = gdb.execute("config context-code-lines", to_string=True).splitlines()
+
+    assert re.match("Name\s+Value\s+\(Def\)\s+Documentation", out[0])
+    assert re.match("-+", out[1])
+    assert re.match(
+        "context-code-lines\s+10\s+number of additional lines to print in the code context", out[2]
+    )
+    assert out[3] == "You can set config variable with `set <config-var> <value>`"
+    assert (
+        out[4]
+        == "You can generate configuration file using `configfile` - then put it in your .gdbinit after initializing pwndbg"
+    )
+
+
+def test_config_filtering_missing():
+    out = gdb.execute("config asdasdasdasd", to_string=True)
+    assert out == 'No config parameter found with filter "asdasdasdasd"\n'

--- a/tests/gdb-tests/tests/test_gdblib_parameter.py
+++ b/tests/gdb-tests/tests/test_gdblib_parameter.py
@@ -19,14 +19,15 @@ def test_gdb_parameter_default_value_works(start_binary, params):
     pwndbg.gdblib.config_mod.Parameter(param)
 
     out = gdb.execute(f"show {param_name}", to_string=True)
-    assert out == f"""The current value of '{param_name}' is "{displayed_value}".\n"""
+    assert out in (
+        f"""The current value of '{param_name}' is "{displayed_value}".\n""",  # GDB 12.x
+        f"Show some show string {displayed_value}\n",  # GDB 9.x
+    )
     assert gdb.parameter(param_name) == default_value
 
     # TODO/FIXME: We need to add documentation
-    assert (
-        gdb.execute(f"help show {param_name}", to_string=True)
-        == "Show some show string\nThis command is not documented.\n"
-    )
+    out = gdb.execute(f"help show {param_name}", to_string=True)
+    assert out == "Show some show string\nThis command is not documented.\n"
     assert (
         gdb.execute(f"help set {param_name}", to_string=True)
         == "Set some show string\nThis command is not documented.\n"

--- a/tests/gdb-tests/tests/test_gdblib_parameter.py
+++ b/tests/gdb-tests/tests/test_gdblib_parameter.py
@@ -25,8 +25,14 @@ def test_gdb_parameter_default_value_works(start_binary, params):
     assert gdb.parameter(param_name) == default_value
 
     # TODO/FIXME: We need to add documentation
-    assert gdb.execute(f"help show {param_name}", to_string=True) == 'Show some show string\nThis command is not documented.\n'
-    assert gdb.execute(f"help set {param_name}", to_string=True) == 'Set some show string\nThis command is not documented.\n'
+    assert (
+        gdb.execute(f"help show {param_name}", to_string=True)
+        == "Show some show string\nThis command is not documented.\n"
+    )
+    assert (
+        gdb.execute(f"help set {param_name}", to_string=True)
+        == "Set some show string\nThis command is not documented.\n"
+    )
 
     # TODO/FIXME: Is there a way to unregister a GDB parameter defined in Python?
     # Probably no? If the fact that we register params above ever causes issues,

--- a/tests/gdb-tests/tests/test_gdblib_parameter.py
+++ b/tests/gdb-tests/tests/test_gdblib_parameter.py
@@ -3,7 +3,6 @@ import pytest
 
 import pwndbg.gdblib.config
 import tests
-from pwndbg.gdblib import config_mod
 
 
 @pytest.mark.parametrize(

--- a/tests/gdb-tests/tests/test_gdblib_parameter.py
+++ b/tests/gdb-tests/tests/test_gdblib_parameter.py
@@ -24,6 +24,10 @@ def test_gdb_parameter_default_value_works(start_binary, params):
     assert out == f"""The current value of '{param_name}' is "{displayed_value}".\n"""
     assert gdb.parameter(param_name) == default_value
 
+    # TODO/FIXME: We need to add documentation
+    assert gdb.execute(f"help show {param_name}", to_string=True) == 'Show some show string\nThis command is not documented.\n'
+    assert gdb.execute(f"help set {param_name}", to_string=True) == 'Set some show string\nThis command is not documented.\n'
+
     # TODO/FIXME: Is there a way to unregister a GDB parameter defined in Python?
     # Probably no? If the fact that we register params above ever causes issues,
     # then we should just not test it via gdb.* APIs and only check if the added param

--- a/tests/gdb-tests/tests/test_gdblib_parameter.py
+++ b/tests/gdb-tests/tests/test_gdblib_parameter.py
@@ -2,7 +2,6 @@ import gdb
 import pytest
 
 import pwndbg.gdblib.config
-import tests
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Before this commit the created gdb.Parameter default values were not set properly. Now, we set the object's .value field properly with the provided default value.