### PR TITLE
Add a header to the vmmap table

### DIFF
--- a/pwndbg/commands/vmmap.py
+++ b/pwndbg/commands/vmmap.py
@@ -29,6 +29,7 @@ def pages_filter(gdbval_or_str):
     else:
         raise argparse.ArgumentTypeError("Unknown vmmap argument type.")
 
+
 def print_vmmap_table_header():
     """
     Prints the table header for the vmmap command.
@@ -36,6 +37,7 @@ def print_vmmap_table_header():
     width = 2 + 2 * pwndbg.gdblib.arch.ptrsize
     fmt_string = "%#{}s %#{}s %#4s %#8s %#6s %s".format(width, width)
     print(fmt_string % ("Start", "End", "Perm", "Size", "Offset", "File"))
+
 
 parser = argparse.ArgumentParser()
 parser.description = """Print virtual memory map pages. Results can be filtered by providing address/module name.

--- a/pwndbg/commands/vmmap.py
+++ b/pwndbg/commands/vmmap.py
@@ -29,6 +29,13 @@ def pages_filter(gdbval_or_str):
     else:
         raise argparse.ArgumentTypeError("Unknown vmmap argument type.")
 
+def print_vmmap_table_header():
+    """
+    Prints the table header for the vmmap command.
+    """
+    width = 2 + 2 * pwndbg.gdblib.arch.ptrsize
+    fmt_string = "%#{}s %#{}s %#4s %#8s %#6s %s".format(width, width)
+    print(fmt_string % ("Start", "End", "Perm", "Size", "Offset", "File"))
 
 parser = argparse.ArgumentParser()
 parser.description = """Print virtual memory map pages. Results can be filtered by providing address/module name.
@@ -72,7 +79,7 @@ def vmmap(gdbval_or_str=None, writable=False, executable=False):
         return
 
     print(M.legend())
-
+    print_vmmap_table_header()
     if len(pages) == 1 and isinstance(gdbval_or_str, integer_types):
         page = pages[0]
         print(M.get(page.vaddr, text=str(page) + " +0x%x" % (int(gdbval_or_str) - page.vaddr)))

--- a/tests/gdb-tests/tests/test_command_vmmap.py
+++ b/tests/gdb-tests/tests/test_command_vmmap.py
@@ -69,7 +69,7 @@ def test_command_vmmap_on_coredump_on_crash_simple_binary(start_binary):
     vmmaps = gdb.execute("vmmap", to_string=True).splitlines()
 
     # Basic asserts
-    assert len(vmmaps) == len(expected_maps) + 1
+    assert len(vmmaps) == len(expected_maps) + 2 # +2 for header and legend
     assert vmmaps[0] == "LEGEND: STACK | HEAP | CODE | DATA | RWX | RODATA"
 
     # Split vmmaps

--- a/tests/gdb-tests/tests/test_command_vmmap.py
+++ b/tests/gdb-tests/tests/test_command_vmmap.py
@@ -73,7 +73,7 @@ def test_command_vmmap_on_coredump_on_crash_simple_binary(start_binary):
     assert vmmaps[0] == "LEGEND: STACK | HEAP | CODE | DATA | RWX | RODATA"
 
     # Split vmmaps
-    vmmaps = [i.split() for i in vmmaps[1:]]
+    vmmaps = [i.split() for i in vmmaps[2:]]
 
     # Assert that vmmap output matches expected one
     assert vmmaps == expected_maps

--- a/tests/gdb-tests/tests/test_command_vmmap.py
+++ b/tests/gdb-tests/tests/test_command_vmmap.py
@@ -69,7 +69,7 @@ def test_command_vmmap_on_coredump_on_crash_simple_binary(start_binary):
     vmmaps = gdb.execute("vmmap", to_string=True).splitlines()
 
     # Basic asserts
-    assert len(vmmaps) == len(expected_maps) + 2 # +2 for header and legend
+    assert len(vmmaps) == len(expected_maps) + 2  # +2 for header and legend
     assert vmmaps[0] == "LEGEND: STACK | HEAP | CODE | DATA | RWX | RODATA"
 
     # Split vmmaps
@@ -91,7 +91,7 @@ def test_command_vmmap_on_coredump_on_crash_simple_binary(start_binary):
 
     # Note: we will now see one less vmmap page as [vvar] will be missing
     assert vmmaps[0] == "LEGEND: STACK | HEAP | CODE | DATA | RWX | RODATA"
-    vmmaps = [i.split() for i in vmmaps[1:]]
+    vmmaps = [i.split() for i in vmmaps[2:]]
     assert len(vmmaps) == old_len_vmmaps - 1
 
     # Fix up expected maps
@@ -134,6 +134,6 @@ def test_command_vmmap_on_coredump_on_crash_simple_binary(start_binary):
     gdb.execute("file")
 
     vmmaps = gdb.execute("vmmap", to_string=True).splitlines()
-    vmmaps = [i.split() for i in vmmaps[1:]]
+    vmmaps = [i.split() for i in vmmaps[2:]]
 
     assert_maps()


### PR DESCRIPTION
A simple header has been added to the output of vmmap which helps new users identify the columns.

![image](https://user-images.githubusercontent.com/5400940/197078135-1b2598c1-decc-4dce-a262-730326798bfd.png)
