### PR TITLE
lint.sh: lint only pwndbg files

### DIFF
--- a/lint.sh
+++ b/lint.sh
@@ -31,7 +31,8 @@ set -o xtrace
 LINT_FILES="pwndbg tests *.py"
 
 if [[ $FORMAT == 1 ]]; then
-    isort     black ${LINT_FILES}
+    isort ${LINT_FILES}
+    black ${LINT_FILES}
 else
     isort --check-only --diff ${LINT_FILES}
     black --check --diff ${LINT_FILES}

--- a/lint.sh
+++ b/lint.sh
@@ -28,15 +28,16 @@ done
 
 set -o xtrace
 
+LINT_FILES="pwndbg tests *.py"
+
 if [[ $FORMAT == 1 ]]; then
-    isort .
-    black .
+    isort     black ${LINT_FILES}
 else
-    isort --check-only --diff .
-    black --check --diff .
+    isort --check-only --diff ${LINT_FILES}
+    black --check --diff ${LINT_FILES}
 fi
 
-flake8 --show-source .
+flake8 --show-source ${LINT_FILES}
 
 # Indents are four spaces, binary ops can start a line, and indent switch cases
 shfmt -i 4 -bn -ci -d .


### PR DESCRIPTION
This change makes it so that if one has e.g. a venv/ dir in their pwndbg dir, the linters will not lint that.

...kinda helpful if someone uses PyCharm or other tools that may create a venv ;).