### PR TITLE
small change to largebins() and contains_chunk()

### DIFF
--- a/pwndbg/heap/ptmalloc.py
+++ b/pwndbg/heap/ptmalloc.py
@@ -94,10 +94,7 @@ class Bins:
 
             # TODO: Refactor this, the bin should know how to calculate
             # largebin_index without calling into the allocator
-            if size < list(self.bins.items())[0][0]:
-                return False
             size = pwndbg.heap.current.largebin_index(size) - 64
-            return list(self.bins.items())[size][1].contains_chunk(chunk)
 
         elif self.bin_type == BinType.TCACHE:
             # Unlike fastbins, tcache bins don't store the chunk address in the
@@ -917,7 +914,9 @@ class Heap(pwndbg.heap.heap.BaseHeap):
                 return
 
             fd_chain, bk_chain, is_corrupted = chain
-            result.bins[size] = Bin(fd_chain, bk_chain, is_corrupted=is_corrupted)
+            result.bins[self.largebin_index(size) - 64] = Bin(
+                fd_chain, bk_chain, is_corrupted=is_corrupted
+            )
 
         return result
 

--- a/pwndbg/heap/ptmalloc.py
+++ b/pwndbg/heap/ptmalloc.py
@@ -27,6 +27,7 @@ NBINS = 128
 BINMAPSIZE = 4
 TCACHE_MAX_BINS = 64
 NFASTBINS = 10
+NSMALLBINS = 64
 
 
 # Note that we must inherit from `str` before `Enum`: https://stackoverflow.com/a/58608362/803801
@@ -94,7 +95,7 @@ class Bins:
 
             # TODO: Refactor this, the bin should know how to calculate
             # largebin_index without calling into the allocator
-            size = pwndbg.heap.current.largebin_index(size) - 64
+            size = pwndbg.heap.current.largebin_index(size) - NSMALLBINS
 
         elif self.bin_type == BinType.TCACHE:
             # Unlike fastbins, tcache bins don't store the chunk address in the
@@ -914,7 +915,7 @@ class Heap(pwndbg.heap.heap.BaseHeap):
                 return
 
             fd_chain, bk_chain, is_corrupted = chain
-            result.bins[self.largebin_index(size) - 64] = Bin(
+            result.bins[self.largebin_index(size) - NSMALLBINS] = Bin(
                 fd_chain, bk_chain, is_corrupted=is_corrupted
             )
 


### PR DESCRIPTION
small change to largebins() and contains_chunk() so that accessing a largebin uses the index (calculated from chunk size) as the key instead of the chunk size