### PR TITLE
refactor: use .format() properly for displaying vmmap rows

### DIFF
--- a/pwndbg/commands/vmmap.py
+++ b/pwndbg/commands/vmmap.py
@@ -34,9 +34,17 @@ def print_vmmap_table_header():
     """
     Prints the table header for the vmmap command.
     """
-    width = 2 + 2 * pwndbg.gdblib.arch.ptrsize
-    fmt_string = "%#{}s %#{}s %#4s %#8s %#6s %s".format(width, width)
-    print(fmt_string % ("Start", "End", "Perm", "Size", "Offset", "File"))
+    print(
+        "{start:>{width}} {end:>{width}} {permstr} {size:>8} {offset:>6} {objfile}".format(
+            start="Start",
+            end="End",
+            permstr="Perm",
+            size="Size",
+            offset="Offset",
+            objfile="File",
+            width=2 + 2 * pwndbg.gdblib.arch.ptrsize,
+        )
+    )
 
 
 parser = argparse.ArgumentParser()

--- a/pwndbg/lib/memory.py
+++ b/pwndbg/lib/memory.py
@@ -129,16 +129,14 @@ class Page:
         )
 
     def __str__(self):
-        width = 2 + 2 * pwndbg.gdblib.arch.ptrsize
-        fmt_string = "%#{}x %#{}x %s %8x %-6x %s"
-        fmt_string = fmt_string.format(width, width)
-        return fmt_string % (
-            self.vaddr,
-            self.vaddr + self.memsz,
-            self.permstr,
-            self.memsz,
-            self.offset,
-            self.objfile or "",
+        return "{start:#{width}x} {end:#{width}x} {permstr} {size:8x} {offset:6x} {objfile}".format(
+            start=self.vaddr,
+            end=self.vaddr + self.memsz,
+            permstr=self.permstr,
+            size=self.memsz,
+            offset=self.offset,
+            objfile=self.objfile or "",
+            width=2 + 2 * pwndbg.gdblib.arch.ptrsize,
         )
 
     def __repr__(self):


### PR DESCRIPTION
Fixes the comments in #1311