### PR TITLE
Add Heap class

### DIFF
--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -127,7 +127,7 @@ def heap(addr=None, verbose=False, simple=False):
     active heap.
     """
     allocator = pwndbg.heap.current
-    heap_region = allocator.get_heap_boundaries(addr)
+    heap_region = pwndbg.heap.ptmalloc.Heap(addr)
     arena = allocator.get_arena_for_chunk(addr) if addr else allocator.get_arena()
     top_chunk = arena["top"]
     ptr_size = allocator.size_sz
@@ -142,15 +142,8 @@ def heap(addr=None, verbose=False, simple=False):
     # struct and possibly an arena.
     if addr:
         cursor = int(addr)
-    elif arena == allocator.main_arena:
-        cursor = heap_region.start
     else:
-        cursor = heap_region.start + allocator.heap_info.sizeof
-        if pwndbg.gdblib.vmmap.find(allocator.get_heap(heap_region.start)["ar_ptr"]) == heap_region:
-            # Round up to a 2-machine-word alignment after an arena to
-            # compensate for the presence of the have_fastchunks variable
-            # in GLIBC versions >= 2.27.
-            cursor += (allocator.malloc_state.sizeof + ptr_size) & ~allocator.malloc_align_mask
+        cursor = heap_region.start
 
     # i686 alignment heuristic
     first_chunk_size = pwndbg.gdblib.arch.unpack(

--- a/pwndbg/heap/heap.py
+++ b/pwndbg/heap/heap.py
@@ -1,4 +1,4 @@
-class BaseHeap:
+class MemoryAllocator:
     """Heap abstraction layer."""
 
     def breakpoint(event):

--- a/pwndbg/heap/ptmalloc.py
+++ b/pwndbg/heap/ptmalloc.py
@@ -317,16 +317,20 @@ class Heap:
         allocator = pwndbg.heap.current
         if addr is not None:
             try:
+                # Can fail if any part of the struct is unmapped (due to corruption/fake struct).
                 ar_ptr = allocator.get_heap(addr)["ar_ptr"]
                 ar_ptr.fetch_lazy()
             except Exception:
                 ar_ptr = None
 
+            # This is probably a non-main arena if a legitimate ar_ptr exists.
             if ar_ptr is not None and ar_ptr in (ar.address for ar in allocator.arenas):
                 self.arena = Arena(ar_ptr)
             else:
+                # Use the main arena as a fallback
                 self.arena = Arena(allocator.main_arena.address)
         else:
+            # Get the thread arena under default conditions.
             self.arena = Arena(allocator.get_arena().address)
 
         if self.arena.address == allocator.main_arena.address:

--- a/pwndbg/heap/ptmalloc.py
+++ b/pwndbg/heap/ptmalloc.py
@@ -485,7 +485,7 @@ class HeapInfo:
         )
 
 
-class Heap(pwndbg.heap.heap.BaseHeap):
+class GlibcMemoryAllocator(pwndbg.heap.heap.MemoryAllocator):
     def __init__(self):
         # Global ptmalloc objects
         self._global_max_fast_addr = None
@@ -984,8 +984,8 @@ class Heap(pwndbg.heap.heap.BaseHeap):
         )
 
 
-class DebugSymsHeap(Heap):
-    can_be_resolved = Heap.libc_has_debug_syms
+class DebugSymsHeap(GlibcMemoryAllocator):
+    can_be_resolved = GlibcMemoryAllocator.libc_has_debug_syms
 
     @property
     def main_arena(self):
@@ -1158,7 +1158,7 @@ class SymbolUnresolvableError(Exception):
         return "`%s` can not be resolved via heuristic" % self.symbol
 
 
-class HeuristicHeap(Heap):
+class HeuristicHeap(GlibcMemoryAllocator):
     def __init__(self):
         super().__init__()
         self._thread_arena_offset = None


### PR DESCRIPTION
Add a `Heap` class to the heap inspection code, plus:
* Rename the existing `Heap` class to `GlibcMemoryAllocator` and the `BaseHeap` class to `MemoryAllocator`, which I think is more descriptive.
* Integrate the new `Heap` class into the `heap` command.

Hopefully this is the last heap-related class pwndbg needs for now, along with the recent Chunk, Arena & Bins classes.
This is a bare-bones implementation for now, just enough to for use in the `heap` command and there is some redundancy with existing classes & functions, which I plan to iron out in subsequent PRs. The end goal is to move most of the existing heap logic into the heap classes.