### PR TITLE
Try to install missing lint dependencies

### DIFF
--- a/lint.sh
+++ b/lint.sh
@@ -53,4 +53,4 @@ flake8 --show-source ${LINT_FILES}
 shfmt -i 4 -bn -ci -d .
 
 # Checking minimum python version
-vermin -t=3.6 --violations ./pwndbg/
+vermin -q -t=3.6 --violations ./pwndbg/

--- a/lint.sh
+++ b/lint.sh
@@ -29,6 +29,15 @@ done
 set -o xtrace
 
 LINT_FILES="pwndbg tests *.py"
+LINT_TOOLS="isort black flake8 vermin"
+
+if ! type ${LINT_TOOLS} &>/dev/null; then
+    PIP_CMD="pip install -Ur dev-requirements.txt"
+    echo "Missing one of the following tools: ${LINT_TOOLS}"
+    echo "Running '${PIP_CMD}'"
+
+    $PIP_CMD
+fi
 
 if [[ $FORMAT == 1 ]]; then
     isort ${LINT_FILES}


### PR DESCRIPTION
We just added `vermin` to the lint script. I want to make sure running lint isn't frustrating for developers, so if any of the python dependencies aren't installed (like if we add a new one after the user already installed dependencies), it will try to install the missing ones.

Also add the quiet flag to `vermin`