### PR TITLE
Fix some issues about GDB < 9.x

### DIFF
--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -278,10 +278,12 @@ def OnlyWithResolvedHeapSyms(function):
                     f"You can try to determine the libc symbols addresses manually and set them appropriately. For this, see the `heap_config` command output and set the config about `{err.symbol}`."
                 )
                 if (
-                    pwndbg.gdblib.config.exception_verbose.value
-                    or pwndbg.gdblib.config.exception_debugger.value
+                    pwndbg.gdblib.config.exception_verbose
+                    or pwndbg.gdblib.config.exception_debugger
                 ):
                     raise err
+                else:
+                    pwndbg.exception.inform_verbose_and_debug()
             except Exception as err:
                 e(f"{function.__name__}: An unknown error occurred when running this command.")
                 if pwndbg.gdblib.config.resolve_heap_via_heuristic:
@@ -295,6 +297,8 @@ def OnlyWithResolvedHeapSyms(function):
                     or pwndbg.gdblib.config.exception_debugger
                 ):
                     raise err
+                else:
+                    pwndbg.exception.inform_verbose_and_debug()
         else:
             print(message.error(f"{function.__name__}: "), end="")
             if not pwndbg.gdblib.config.resolve_heap_via_heuristic:

--- a/pwndbg/exception.py
+++ b/pwndbg/exception.py
@@ -42,6 +42,16 @@ def inform_report_issue(exception_msg):
     )
 
 
+def inform_verbose_and_debug():
+    print(
+        message.notice("For more info invoke `")
+        + message.hint("set exception-verbose on")
+        + message.notice("` and rerun the command\nor debug it by yourself with `")
+        + message.hint("set exception-debugger on")
+        + message.notice("`")
+    )
+
+
 def handle(name="Error"):
     """Displays an exception to the user, optionally displaying a full traceback
     and spawning an interactive post-moretem debugger.
@@ -69,13 +79,7 @@ def handle(name="Error"):
 
         print(message.error("Exception occurred: {}: {} ({})".format(name, exc_value, exc_type)))
 
-        print(
-            message.notice("For more info invoke `")
-            + message.hint("set exception-verbose on")
-            + message.notice("` and rerun the command\nor debug it by yourself with `")
-            + message.hint("set exception-debugger on")
-            + message.notice("`")
-        )
+        inform_verbose_and_debug()
 
     # Break into the interactive debugger
     if debug:

--- a/pwndbg/gdblib/symbol.py
+++ b/pwndbg/gdblib/symbol.py
@@ -243,14 +243,14 @@ def address(symbol: str) -> int:
 
 @pwndbg.lib.memoize.reset_on_objfile
 @pwndbg.lib.memoize.reset_on_thread
-def static_linkage_symbol_address(symbol):
-    if isinstance(symbol, int):
-        return symbol
+def static_linkage_symbol_address(symbol: str) -> int:
+    """
+    Get the address for static linkage `symbol`
+    """
 
-    try:
-        return int(symbol, 0)
-    except Exception:
-        pass
+    # GDB < 9.x does not have `gdb.lookup_static_symbol`
+    if not hasattr(gdb, "lookup_static_symbol"):
+        return None
 
     try:
         symbol_obj = gdb.lookup_static_symbol(symbol)

--- a/pwndbg/heap/ptmalloc.py
+++ b/pwndbg/heap/ptmalloc.py
@@ -2083,13 +2083,15 @@ class HeuristicHeap(Heap):
         """Find the boundaries of the heap containing `addr`, default to the
         boundaries of the heap containing the top chunk for the thread's arena.
         """
+        region = None
         try:
             region = self.get_region(addr) if addr else self.get_region(self.get_arena()["top"])
         except Exception:
             # Although `self.get_arena` should only raise `SymbolUnresolvableError`, we catch all exceptions here to avoid some bugs in main_arena's heuristics break this function :)
             pass
         # If we can't use arena to find the heap region, we use vmmap to find the heap region
-        region = next((p for p in pwndbg.gdblib.vmmap.get() if "[heap]" == p.objfile), None)
+        if region is None and not self.multithreaded:
+            region = next((p for p in pwndbg.gdblib.vmmap.get() if "[heap]" == p.objfile), None)
         if region is not None and addr is not None:
             region = None if addr not in region else region
 

--- a/tests/gdb-tests/tests/heap/test_heap.py
+++ b/tests/gdb-tests/tests/heap/test_heap.py
@@ -179,7 +179,7 @@ class mock_for_heuristic:
             mock_symbols  # every symbol's address in the list will be mocked to `None`
         )
         self.mock_all = mock_all  # all symbols will be mocked to `None`
-        # Save `pwndbg.gdblib.symbol.address` and `pwndbg.gdblib.symbol.addresses` before mocking
+        # Save `pwndbg.gdblib.symbol.address` and `pwndbg.gdblib.symbol.static_linkage_symbol_address` before mocking
         self.saved_address_func = pwndbg.gdblib.symbol.address
         self.saved_static_linkage_symbol_address_func = (
             pwndbg.gdblib.symbol.static_linkage_symbol_address
@@ -203,7 +203,7 @@ class mock_for_heuristic:
 
             return _mock
 
-        # Mock `pwndbg.gdblib.symbol.address` and `pwndbg.gdblib.symbol.addresses`
+        # Mock `pwndbg.gdblib.symbol.address` and `pwndbg.gdblib.symbol.static_linkage_symbol_address`
         pwndbg.gdblib.symbol.address = mock(pwndbg.gdblib.symbol.address)
         pwndbg.gdblib.symbol.static_linkage_symbol_address = mock(
             pwndbg.gdblib.symbol.static_linkage_symbol_address
@@ -213,7 +213,7 @@ class mock_for_heuristic:
             pwndbg.gdblib.memory.write(self.page.vaddr, b"\xff" * self.page.memsz)
 
     def __exit__(self, exc_type, exc_value, traceback):
-        # Restore `pwndbg.gdblib.symbol.address` and `pwndbg.gdblib.symbol.addresses`
+        # Restore `pwndbg.gdblib.symbol.address` and `pwndbg.gdblib.symbol.static_linkage_symbol_address`
         pwndbg.gdblib.symbol.address = self.saved_address_func
         pwndbg.gdblib.symbol.static_linkage_symbol_address = (
             self.saved_static_linkage_symbol_address_func

--- a/tests/gdb-tests/tests/test_gdblib_parameter.py
+++ b/tests/gdb-tests/tests/test_gdblib_parameter.py
@@ -14,7 +14,10 @@ import pwndbg.gdblib.config
         ("auto-bool", None, "auto", {"param_class": gdb.PARAM_AUTO_BOOLEAN}),
         ("unlimited-uint", 0, "unlimited", {"param_class": gdb.PARAM_UINTEGER}),
         ("unlimited-int", 0, "unlimited", {"param_class": gdb.PARAM_INTEGER}),
-        ("unlimited-zuint", -1, "unlimited", {"param_class": gdb.PARAM_ZUINTEGER_UNLIMITED}),
+        # GDB < 9.x does not support PARAM_ZUINTEGER_UNLIMITED
+        ("unlimited-zuint", -1, "unlimited", {"param_class": gdb.PARAM_ZUINTEGER_UNLIMITED})
+        if hasattr(gdb, "PARAM_ZUINTEGER_UNLIMITED")
+        else (),
         (
             "enum",
             "enum1",
@@ -24,6 +27,9 @@ import pwndbg.gdblib.config
     ),
 )
 def test_gdb_parameter_default_value_works(start_binary, params):
+    if not params:
+        pytest.skip("Current GDB version does not support this testcase")
+
     name_suffix, default_value, displayed_value, optional_kwargs = params
 
     param_name = f"test-param-{name_suffix}"


### PR DESCRIPTION
This PR fixes some issues found in #1327 by:

* Return `None` if gdb doesn't have `gdb.lookup_static_symbol` when calling `pwndbg.gdblib.symbol.static_linkage_symbol_address`.

* Skip the tests for `gdb.PARAM_ZUINTEGER_UNLIMITED` if gdb doesn't have this attribute.

* Inform the user to `set exception-* on` when there's an error occurred when running the heap commands.

* A bug fix for `get_heap_boundaries()` of `HeuristicHeap` (found this in the fail test about the heap heuristics in that container)
