### PR TITLE
Add feature to deprecate config options and refactor pwndbg.color.context

### DIFF
--- a/pwndbg/color/context.py
+++ b/pwndbg/color/context.py
@@ -1,107 +1,43 @@
-import pwndbg.color.theme as theme
-from pwndbg.color import generateColorFunction
+from pwndbg.color import ColorConfig
+from pwndbg.color import ColorParamSpec
 from pwndbg.gdblib import config
 
-config_prefix_color = theme.add_color_param(
-    "code-prefix-color", "none", "color for 'context code' command (prefix marker)"
+# TODO: Should probably change - to .
+c = ColorConfig(
+    "context",
+    [
+        ColorParamSpec("register", "bold", "color for registers label"),
+        ColorParamSpec("register-changed", "red", "color for registers label (change marker)"),
+        ColorParamSpec("flag-value", "none", "color for flags register (register value)"),
+        ColorParamSpec("flag-bracket", "none", "color for flags register (bracket)"),
+        ColorParamSpec("flag-set", "green,bold", "color for flags register (flag set)"),
+        ColorParamSpec("flag-unset", "red", "color for flags register (flag unset)"),
+        ColorParamSpec("flag-changed", "underline", "color for flags register (flag changed)"),
+        ColorParamSpec("banner", "blue", "color for banner line"),
+        ColorParamSpec("banner-title", "none", "color for banner title"),
+        ColorParamSpec("code-prefix", "none", "color for 'context code' command (prefix marker)"),
+        ColorParamSpec("highlight", "green,bold", "color added to highlights like source/pc"),
+        ColorParamSpec("comment", "gray", "color for comment"),
+        ColorParamSpec("backtrace-prefix", "none", "color for prefix of current backtrace label"),
+        ColorParamSpec("backtrace-address", "none", "color for backtrace (address)"),
+        ColorParamSpec("backtrace-symbol", "none", "color for backtrace (symbol)"),
+        ColorParamSpec("backtrace-frame-label", "none", "color for backtrace (frame label)"),
+    ],
 )
-config_highlight_color = theme.add_color_param(
-    "highlight-color", "green,bold", "color added to highlights like source/pc"
+
+# Deprecated 2022-10-23
+config.add_deprecated_param("code-prefix-color", "context-code-prefix-color", scope="theme")
+config.add_deprecated_param("highlight-color", "context-highlight-color", scope="theme")
+config.add_deprecated_param("comment-color", "context-comment-color", scope="theme")
+config.add_deprecated_param(
+    "backtrace-prefix-color", "context-backtrace-prefix-color", scope="theme"
 )
-config_register_color = theme.add_color_param(
-    "context-register-color", "bold", "color for registers label"
+config.add_deprecated_param(
+    "backtrace-address-color", "context-backtrace-address-color", scope="theme"
 )
-config_flag_value_color = theme.add_color_param(
-    "context-flag-value-color", "none", "color for flags register (register value)"
+config.add_deprecated_param(
+    "backtrace-symbol-color", "context-backtrace-symbol-color", scope="theme"
 )
-config_flag_bracket_color = theme.add_color_param(
-    "context-flag-bracket-color", "none", "color for flags register (bracket)"
+config.add_deprecated_param(
+    "backtrace-frame-label-color", "context-backtrace-frame-label-color", scope="theme"
 )
-config_flag_set_color = theme.add_color_param(
-    "context-flag-set-color", "green,bold", "color for flags register (flag set)"
-)
-config_flag_unset_color = theme.add_color_param(
-    "context-flag-unset-color", "red", "color for flags register (flag unset)"
-)
-config_flag_changed_color = theme.add_color_param(
-    "context-flag-changed-color", "underline", "color for flags register (flag changed)"
-)
-config_banner_color = theme.add_color_param("banner-color", "blue", "color for banner line")
-config_banner_title = theme.add_color_param("banner-title-color", "none", "color for banner title")
-config_register_changed_color = theme.add_color_param(
-    "context-register-changed-color", "red", "color for registers label (change marker)"
-)
-config_register_changed_marker = theme.add_param(
-    "context-register-changed-marker", "*", "change marker for registers label"
-)
-config_comment = theme.add_color_param("comment-color", "gray", "color for comment")
-
-
-def prefix(x):
-    return generateColorFunction(config.code_prefix_color)(x)
-
-
-def highlight(x):
-    return generateColorFunction(config.highlight_color)(x)
-
-
-def register(x):
-    return generateColorFunction(config.context_register_color)(x)
-
-
-def register_changed(x):
-    return generateColorFunction(config.context_register_changed_color)(x)
-
-
-def flag_bracket(x):
-    return generateColorFunction(config.context_flag_bracket_color)(x)
-
-
-def flag_value(x):
-    return generateColorFunction(config.context_flag_value_color)(x)
-
-
-def flag_set(x):
-    return generateColorFunction(config.context_flag_set_color)(x)
-
-
-def flag_unset(x):
-    return generateColorFunction(config.context_flag_unset_color)(x)
-
-
-def flag_changed(x):
-    return generateColorFunction(config.context_flag_changed_color)(x)
-
-
-def banner(x):
-    return generateColorFunction(config.banner_color)(x)
-
-
-def banner_title(x):
-    return generateColorFunction(config.banner_title_color)(x)
-
-
-def comment(x):
-    return generateColorFunction(config.comment_color)(x)
-
-
-def format_flags(value, flags, last=None):
-    desc = flag_value("%#x" % value)
-    if not flags:
-        return desc
-
-    names = []
-    for name, bit in flags.items():
-        bit = 1 << bit
-        if value & bit:
-            name = name.upper()
-            name = flag_set(name)
-        else:
-            name = name.lower()
-            name = flag_unset(name)
-
-        if last is not None and value & bit != last & bit:
-            name = flag_changed(name)
-        names.append(name)
-
-    return "%s %s %s %s" % (desc, flag_bracket("["), " ".join(names), flag_bracket("]"))

--- a/pwndbg/color/disasm.py
+++ b/pwndbg/color/disasm.py
@@ -1,13 +1,13 @@
 import capstone
 
 import pwndbg.chain
-import pwndbg.color.context as C
 import pwndbg.color.memory as M
 import pwndbg.color.syntax_highlight as H
 import pwndbg.disasm.jump
 from pwndbg.color import ColorConfig
 from pwndbg.color import ColorParamSpec
 from pwndbg.color import ljust_colored
+from pwndbg.color.context import c as C
 from pwndbg.color.message import on
 
 capstone_branch_groups = set((capstone.CS_GRP_CALL, capstone.CS_GRP_JUMP))

--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -3,7 +3,6 @@ import ctypes
 
 import gdb
 
-import pwndbg.color.context as C
 import pwndbg.color.memory as M
 import pwndbg.commands
 import pwndbg.gdblib.config
@@ -12,6 +11,7 @@ import pwndbg.glibc
 import pwndbg.lib.heap.helpers
 from pwndbg.color import generateColorFunction
 from pwndbg.color import message
+from pwndbg.color.context import c as C
 from pwndbg.commands import CommandCategory
 from pwndbg.commands.config import display_config
 from pwndbg.heap.ptmalloc import Arena

--- a/pwndbg/commands/nearpc.py
+++ b/pwndbg/commands/nearpc.py
@@ -1,9 +1,23 @@
 import argparse
 
+import pwndbg.arguments
+import pwndbg.color
+import pwndbg.color.theme
+import pwndbg.commands.comments
+import pwndbg.disasm
+import pwndbg.gdblib.config
 import pwndbg.gdblib.nearpc
+import pwndbg.gdblib.regs
+import pwndbg.gdblib.strings
+import pwndbg.gdblib.symbol
+import pwndbg.gdblib.vmmap
+import pwndbg.ida
+import pwndbg.lib.functions
+import pwndbg.ui
 from pwndbg.commands import CommandCategory
 
 parser = argparse.ArgumentParser(description="Disassemble near a specified address.")
+
 parser.add_argument("pc", type=int, nargs="?", default=None, help="Address to disassemble near.")
 parser.add_argument(
     "lines",

--- a/pwndbg/gdblib/config.py
+++ b/pwndbg/gdblib/config.py
@@ -80,9 +80,11 @@ class Parameter(gdb.Parameter):
 
     def get_show_string(self, svalue) -> str:
         """Handles the GDB `show <param>` command"""
-        more_information_hint = " See `help set %s` for more information." % self.param.name
+        param = self._get_replacement_param()
+
+        more_information_hint = " See `help set %s` for more information." % param.name
         return "%s is %r.%s" % (
-            self.param.set_show_doc.capitalize(),
+            param.set_show_doc.capitalize(),
             svalue,
             more_information_hint if self.__doc__ else "",
         )

--- a/pwndbg/gdblib/config.py
+++ b/pwndbg/gdblib/config.py
@@ -87,6 +87,11 @@ class Parameter(gdb.Parameter):
             param.set_show_doc.capitalize(),
             svalue,
             more_information_hint if self.__doc__ else "",
+            # TODO: Convert above to code below
+            # param = self._get_replacement_param()
+            # return "The current value of %r is %s" % (
+            #     param.name,
+            #     Parameter._value_to_gdb_native(param.value, param.param_class),
         )
 
     @staticmethod

--- a/pwndbg/gdblib/nearpc.py
+++ b/pwndbg/gdblib/nearpc.py
@@ -5,7 +5,6 @@ from capstone import *  # noqa: F403
 
 import pwndbg.arguments
 import pwndbg.color
-import pwndbg.color.context as C
 import pwndbg.color.disasm as D
 import pwndbg.color.theme
 import pwndbg.commands.comments
@@ -21,6 +20,7 @@ import pwndbg.ui
 from pwndbg.color import ColorConfig
 from pwndbg.color import ColorParamSpec
 from pwndbg.color import message
+from pwndbg.color.context import c as C
 
 
 def ljust_padding(lst):

--- a/pwndbg/ghidra.py
+++ b/pwndbg/ghidra.py
@@ -2,10 +2,10 @@ import os
 
 import gdb
 
-import pwndbg.color.context as C
 import pwndbg.color.syntax_highlight as H
 import pwndbg.gdblib.regs
 import pwndbg.radare2
+from pwndbg.color.context import c
 
 
 def decompile(func=None):
@@ -73,5 +73,5 @@ def decompile(func=None):
         source = H.syntax_highlight(source, src_filename)
 
     # Replace code prefix marker after syntax highlighting
-    source = source.replace(current_line_marker, C.prefix(pwndbg.gdblib.config.code_prefix), 1)
+    source = source.replace(current_line_marker, c.prefix(pwndbg.gdblib.config.code_prefix), 1)
     return source

--- a/pwndbg/lib/config.py
+++ b/pwndbg/lib/config.py
@@ -157,7 +157,7 @@ class Config:
         )
         return self.add_param_obj(p)
 
-    def add_deprecated_param(self, old_name: str, new_name: str):
+    def add_deprecated_param(self, old_name: str, new_name: str, scope="TODO"):
         self.deprecated_params[old_name] = (new_name, False)
 
     def add_param_obj(self, p: Parameter):

--- a/pwndbg/ui.py
+++ b/pwndbg/ui.py
@@ -8,13 +8,13 @@ import struct
 import sys
 import termios
 
-import pwndbg.color.context as C
 import pwndbg.gdblib.arch
 from pwndbg.color import ljust_colored
 from pwndbg.color import message
 from pwndbg.color import rjust_colored
 from pwndbg.color import strip
 from pwndbg.color import theme
+from pwndbg.color.context import c
 from pwndbg.gdblib import config
 
 theme.add_param("banner-separator", "─", "repeated banner separator character")
@@ -45,7 +45,7 @@ def banner(title, target=sys.stdin, width=None, extra=""):
     if title:
         title = "%s%s%s%s" % (
             config.banner_title_surrounding_left,
-            C.banner_title(title),
+            c.banner_title(title),
             extra,
             config.banner_title_surrounding_right,
         )
@@ -56,7 +56,7 @@ def banner(title, target=sys.stdin, width=None, extra=""):
     else:
         banner = rjust_colored(title, (width + len(strip(title))) // 2, config.banner_separator)
         banner = ljust_colored(banner, width, config.banner_separator)
-    return C.banner(banner)
+    return c.banner(banner)
 
 
 def addrsz(address) -> str:

--- a/tests/gdb-tests/tests/test_gdblib_parameter.py
+++ b/tests/gdb-tests/tests/test_gdblib_parameter.py
@@ -53,6 +53,9 @@ def test_gdb_parameter_default_value_works(start_binary, params):
         out
         == f"{set_show_doc.capitalize()} is {displayed_value!r}. See `help set {param_name}` for more information.\n"
     )
+    # TODO: Fix merge conflict, below is new code
+    # assert out == f"The current value of {param_name!r} is {displayed_value}\n"
+
     if (
         optional_kwargs.get("param_class") in (gdb.PARAM_UINTEGER, gdb.PARAM_INTEGER)
         and default_value == 0


### PR DESCRIPTION
The changes to lib/config.py and gdblib/config.py add a way to deprecate configuration parameters. When a configuration parameter is deprecated, the first time a user tries to set it, they'll see a warning telling them the new parameter name. Any time a user tries to set a deprecated parameter, we forward it to the new parameter.

This PR also refactors pwndbg.color.context to use `ColorConfig`, and makes use of the configuration deprecation.