### PR TITLE
Refactor pwndbg.commands.windbg.dX and pwndbg.hexdump.hexdump

### DIFF
--- a/pwndbg/hexdump.py
+++ b/pwndbg/hexdump.py
@@ -3,16 +3,28 @@ Hexdump implementation, ~= stolen from pwntools.
 """
 
 import string
+import math
 
 import pwnlib.util.lists
+
+import gdb
 
 import pwndbg.color.hexdump as H
 import pwndbg.color.theme as theme
 import pwndbg.gdblib.config
+import pwndbg.gdblib.typeinfo
+from pwndbg.commands.windbg import enhex
 
 color_scheme = None
 printable = None
 
+def get_type(size):
+    return {
+        1: pwndbg.gdblib.typeinfo.uint8,
+        2: pwndbg.gdblib.typeinfo.uint16,
+        4: pwndbg.gdblib.typeinfo.uint32,
+        8: pwndbg.gdblib.typeinfo.uint64,
+    }[size]
 
 def groupby(width, array, fill=None):
     return pwnlib.util.lists.group(width, array, underfull_action="fill", fill_value=fill)
@@ -64,53 +76,146 @@ def load_color_scheme():
     color_scheme[-1] = "  "
     printable[-1] = " "
 
+def test_for_dx(size, address, count, to_string=False, repeat=False):
+    """
+    Traditionally, windbg will display 16 bytes of data per line.
+    """
+    values = []
 
-def hexdump(
-    data, address=0, width=16, group_width=4, flip_group_endianess=False, skip=True, offset=0
-):
-    if not color_scheme or not printable:
-        load_color_scheme()
+    if repeat:
+        count = test_for_dx.last_count
+        address = test_for_dx.last_address
+    else:
+        address = int(address) & pwndbg.gdblib.arch.ptrmask
+        count = int(count)
 
-    # If there's nothing to print, just print the offset and address and return
-    if len(data) == 0:
-        yield H.offset("+%04x " % len(data)) + H.address("%#08x  " % (address + len(data)))
+    type = get_type(size)
 
-        # Don't allow iterating over this generator again
+    for i in range(count):
+        try:
+            gval = pwndbg.gdblib.memory.poi(type, address + i * size)
+            # print(str(gval))
+            values.append(int(gval))
+        except gdb.MemoryError:
+            break
+
+    if not values:
+        print("Could not access the provided address")
         return
 
-    data = list(bytearray(data))
-    last_line = None
-    skipping = False
-    for i, line in enumerate(groupby(width, data, fill=-1)):
-        if skip and line == last_line:
-            if skipping:
-                continue
+    n_rows = int(math.ceil(count * size / float(16)))
+    row_sz = int(16 / size)
+    rows = [values[i * row_sz : (i + 1) * row_sz] for i in range(n_rows)]
+    lines = []
 
-            skipping = True
-            yield "..."
-        else:
-            skipping = False
-            last_line = line
+    # sys.stdout.write(repr(rows) + '\n')
 
-        hexline = []
+    for i, row in enumerate(rows):
+        if not row:
+            continue
+        line = [enhex(pwndbg.gdblib.arch.ptrsize, address + (i * 16)), "   "]
+        for value in row:
+            line.append(enhex(size, value))
+        lines.append(" ".join(line))
 
-        hexline.append(H.offset("+%04x " % ((i + offset) * width)))
-        hexline.append(H.address("%#08x  " % (address + (i * width))))
+    test_for_dx.last_count = count
+    test_for_dx.last_address = address + len(rows) * 16
 
-        for group in groupby(group_width, line):
-            group = reversed(group) if flip_group_endianess else group
-            for idx, char in enumerate(group):
-                if flip_group_endianess and idx == group_width - 1:
-                    hexline.append(H.highlight_group_lsb(color_scheme[char]))
-                else:
-                    hexline.append(color_scheme[char])
-                hexline.append(str(config_byte_separator))
-            hexline.append(" ")
+    return lines
 
-        hexline.append(H.separator("%s" % config_separator))
-        for group in groupby(group_width, line):
-            for char in group:
-                hexline.append(printable[char])
+def hexdump(data,address=0,width=16,group_width=4,flip_group_endianess=False,skip=True,offset=0,size=0,count=0,repeat=False,dX_call=False):
+    if (not dX_call):
+        if not color_scheme or not printable:
+            load_color_scheme()
+
+        # If there's nothing to print, just print the offset and address and return
+        if len(data) == 0:
+            yield H.offset("+%04x " % len(data)) + H.address("%#08x  " % (address + len(data)))
+
+            # Don't allow iterating over this generator again
+            return
+
+        data = list(bytearray(data))
+        last_line = None
+        skipping = False
+        for i, line in enumerate(groupby(width, data, fill=-1)):
+            if skip and line == last_line:
+                if skipping:
+                    continue
+
+                skipping = True
+                yield "..."
+            else:
+                skipping = False
+                last_line = line
+
+            hexline = []
+
+            hexline.append(H.offset("+%04x " % ((i + offset) * width)))
+            hexline.append(H.address("%#08x  " % (address + (i * width))))
+
+            for group in groupby(group_width, line):
+                group = reversed(group) if flip_group_endianess else group
+                for idx, char in enumerate(group):
+                    if flip_group_endianess and idx == group_width - 1:
+                        hexline.append(H.highlight_group_lsb(color_scheme[char]))
+                    else:
+                        hexline.append(color_scheme[char])
+                    hexline.append(str(config_byte_separator))
+                hexline.append(" ")
+
             hexline.append(H.separator("%s" % config_separator))
+            for group in groupby(group_width, line):
+                for char in group:
+                    hexline.append(printable[char])
+                hexline.append(H.separator("%s" % config_separator))
 
-        yield "".join(hexline)
+            yield "".join(hexline)
+
+    else:
+
+        """
+        Traditionally, windbg will display 16 bytes of data per line.
+        """
+        values = []
+
+        if repeat:
+            count = hexdump.last_count
+            address = hexdump.last_address
+        else:
+            address = int(address) & pwndbg.gdblib.arch.ptrmask
+            count = int(count)
+
+        type = get_type(size)
+
+        for i in range(count):
+            try:
+                gval = pwndbg.gdblib.memory.poi(type, address + i * size)
+                # print(str(gval))
+                values.append(int(gval))
+            except gdb.MemoryError:
+                break
+
+        if not values:
+            print("Could not access the provided address")
+            return
+
+        n_rows = int(math.ceil(count * size / float(16)))
+        row_sz = int(16 / size)
+        rows = [values[i * row_sz : (i + 1) * row_sz] for i in range(n_rows)]
+        lines = []
+
+        # sys.stdout.write(repr(rows) + '\n')
+
+        for i, row in enumerate(rows):
+            if not row:
+                continue
+            line = [enhex(pwndbg.gdblib.arch.ptrsize, address + (i * 16)), "   "]
+            for value in row:
+                line.append(enhex(size, value))
+            lines.append(" ".join(line))
+
+        hexdump.last_count = count
+        hexdump.last_address = address + len(rows) * 16
+
+        yield lines


### PR DESCRIPTION
Replace the implementation of pwndbg.commands.windbg.dX with pwndbg.hexdump.hexdump, see issue #1280. The code in dX has been moved to dexdump. Some optional options have been added to the function signature of hexdump such that dX is implemented using a single call to hexdump.