### PR TITLE
fix #1364: update unicorn to 2.0.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ pycparser==2.21
 pyelftools==0.29
 Pygments==2.13.0
 ROPGadget==7.1
-unicorn==2.0.0; python_version >= '3.7'
+unicorn==2.0.1; python_version >= '3.7'
 unicorn==2.0.0rc7; python_version < '3.7'


### PR DESCRIPTION
Removed version lib unicorn in file requirements.txt. This change allow run pwndbg in Parallels MacBook with M1

<!-- Please make sure to read the testing and linting instructions at https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md before creating a PR -->
