### PR TITLE
Fix lexer for coloring negative numbers in asm

### DIFF
--- a/pwndbg/color/lexer.py
+++ b/pwndbg/color/lexer.py
@@ -27,7 +27,7 @@ class PwntoolsLexer(RegexLexer):
     string = r'"(\\"|[^"])*"'
     char = r"[\w$.@-]"
     identifier = r"(?:[a-zA-Z$_]" + char + r"*|\." + char + r"+|or)"
-    number = r"(?:0[xX][a-zA-Z0-9]+|\d+)"
+    number = r"(?:\-?0[xX][a-zA-Z0-9]+|\d+)"
     memory = r"(?:[\]\[])"
 
     eol = r"[\r\n]+"


### PR DESCRIPTION
This particularly affected arm asm coloring which displayed negative numbers as comments.
Before:
<img width="661" alt="Screenshot 2022-11-10 at 22 20 20" src="https://user-images.githubusercontent.com/4679721/201208706-526c20b8-3d54-4262-9d87-7bfb4f2bea1c.png">
After:
<img width="660" alt="Screenshot 2022-11-10 at 22 19 48" src="https://user-images.githubusercontent.com/4679721/201208723-09999857-9176-4fd2-b26b-84cdb583da2c.png">
