### PR TITLE
Remove instr operands padding in enhance

### DIFF
--- a/pwndbg/enhance.py
+++ b/pwndbg/enhance.py
@@ -89,7 +89,7 @@ def enhance(value, code=True, safe_linking=False):
     if exe:
         instr = pwndbg.disasm.one(value)
         if instr:
-            instr = "%-6s %s" % (instr.mnemonic, instr.op_str)
+            instr = "%s %s" % (instr.mnemonic, instr.op_str)
             if pwndbg.gdblib.config.syntax_highlight:
                 instr = syntax_highlight(instr)
 


### PR DESCRIPTION
The current display of instructions outside DISASM window adds padding before operands however it doesn't serve any purpose. This PR removed this padding.

Before:
![Screenshot from 2022-11-11 17-15-26](https://user-images.githubusercontent.com/4679721/201383894-8416cf49-2aff-4040-ba7d-9445e5d14f8c.png)

After:
![Screenshot from 2022-11-11 17-15-49](https://user-images.githubusercontent.com/4679721/201383899-16ab5fca-fbc6-431a-bee9-ae8fa47a1ab8.png)
