### PR TITLE
Support Arch Linux docker test

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        images: [ubuntu18.04, ubuntu20.04, ubuntu22.04, debian10, debian11]
+        images: [ubuntu18.04, ubuntu20.04, ubuntu22.04, debian10, debian11, archlinux]
 
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,7 +19,7 @@ jobs:
       continue-on-error: true
       with:
         path: ~/.cache/images
-        key: ${{ matrix.images }}-cache-images
+        key: ${{ matrix.images }}-cache-images-{hash}
 
     - name: Docker Build ${{ matrix.images }}
       run: docker-compose pull ${{ matrix.images }}

--- a/Dockerfile.arch
+++ b/Dockerfile.arch
@@ -1,6 +1,6 @@
-# This dockerfile was created for development & testing purposes, for APT-based distro.
+# This dockerfile was created for development & testing purposes, for Pacman-based distro.
 #
-# Build as:             docker build -t pwndbg .
+# Build as:             docker build -f Dockerfile.arch -t pwndbg .
 #
 # For testing use:      docker run --rm -it --cap-add=SYS_PTRACE --security-opt seccomp=unconfined pwndbg bash
 #
@@ -8,23 +8,22 @@
 #   docker run -it --cap-add=SYS_PTRACE --security-opt seccomp=unconfined -v `pwd`:/pwndbg pwndbg bash
 #
 
-ARG image=ubuntu:20.04
+ARG image=archlinux:latest
 FROM $image
 
 WORKDIR /pwndbg
 
 ENV LANG en_US.utf8
 ENV TZ=America/New_York
-ENV ZIGPATH=/opt/zig
+# install zig with pacman
+ENV ZIGPATH=/usr/bin
 
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && \
     echo $TZ > /etc/timezone && \
-    apt-get update && \
-    apt-get install -y locales && \
-    rm -rf /var/lib/apt/lists/* && \
+    pacman -Syu --noconfirm && \
     localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8 && \
-    apt-get update && \
-    apt-get install -y vim
+    pacman -S --noconfirm vim && \
+    pacman -Scc --noconfirm
 
 ADD ./setup.sh /pwndbg/
 ADD ./requirements.txt /pwndbg/
@@ -32,7 +31,7 @@ ADD ./dev-requirements.txt /pwndbg/
 # The `git submodule` is commented because it refreshes all the sub-modules in the project
 # but at this time we only need the essentials for the set up. It will execute at the end.
 RUN sed -i "s/^git submodule/#git submodule/" ./setup.sh && \
-    DEBIAN_FRONTEND=noninteractive ./setup.sh
+    ./setup.sh
 
 # Comment these lines if you won't run the tests.
 ADD ./setup-dev.sh /pwndbg/

--- a/Dockerfile.arch
+++ b/Dockerfile.arch
@@ -15,8 +15,7 @@ WORKDIR /pwndbg
 
 ENV LANG en_US.utf8
 ENV TZ=America/New_York
-# install zig with pacman
-ENV ZIGPATH=/usr/bin
+ENV ZIGPATH=/opt/zig
 
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && \
     echo $TZ > /etc/timezone && \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
     <<: *base-spec
     build:
       context: .
+      dockerfile: Dockerfile
       args:
         image: ubuntu:18.04
 
@@ -21,6 +22,7 @@ services:
     <<: *base-spec
     build:
       context: .
+      dockerfile: Dockerfile
       args:
         image: ubuntu:20.04
 
@@ -28,6 +30,7 @@ services:
     <<: *base-spec
     build:
       context: .
+      dockerfile: Dockerfile
       args:
         image: ubuntu:22.04
 
@@ -35,6 +38,7 @@ services:
     <<: *base-spec
     build:
       context: .
+      dockerfile: Dockerfile
       args:
         image: debian:10
 
@@ -42,5 +46,6 @@ services:
     <<: *base-spec
     build:
       context: .
+      dockerfile: Dockerfile
       args:
         image: debian:11

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,3 +49,11 @@ services:
       dockerfile: Dockerfile
       args:
         image: debian:11
+
+  archlinux:
+    <<: *base-spec
+    build:
+      context: .
+      dockerfile: Dockerfile.arch
+      args:
+        image: archlinux:latest

--- a/setup-dev.sh
+++ b/setup-dev.sh
@@ -50,13 +50,17 @@ linux() {
     uname | grep -i Linux &> /dev/null
 }
 
-install_apt() {
+set_zigpath() {
     if [[ -z "$ZIGPATH" ]]; then
-        # If ZIGPATH is not set, set it to $pwd/.zig
-        # In Docker environment this should by default be set to /opt/zig
-        export ZIGPATH="$(pwd)/.zig"
+        # If ZIGPATH is not set, set it
+        # In Docker environment this should by default be set to /opt/zig (APT) or /usr/bin (Pacman)
+        export ZIGPATH="$1"
     fi
     echo "ZIGPATH set to $ZIGPATH"
+}
+
+install_apt() {
+    set_zigpath "$(pwd)/.zig"
 
     sudo apt-get update || true
     sudo apt-get install -y \
@@ -95,12 +99,7 @@ install_apt() {
 }
 
 install_pacman() {
-    if [[ -z "$ZIGPATH" ]]; then
-        # If ZIGPATH is not set, set it to /usr/bin to use the system one
-        # In Docker environment this should by default be set to /usr/bin
-        export ZIGPATH="/usr/bin"
-    fi
-    echo "ZIGPATH set to $ZIGPATH"
+    set_zigpath /usr/bin
 
     # add debug repo for glibc-debug
     cat <<EOF | sudo tee -a /etc/pacman.conf

--- a/setup-dev.sh
+++ b/setup-dev.sh
@@ -59,25 +59,7 @@ set_zigpath() {
     echo "ZIGPATH set to $ZIGPATH"
 }
 
-install_apt() {
-    set_zigpath "$(pwd)/.zig"
-
-    sudo apt-get update || true
-    sudo apt-get install -y \
-        nasm \
-        gcc \
-        libc6-dev \
-        curl \
-        build-essential \
-        gdb \
-        parallel
-
-    if [[ "$1" == "22.04" ]]; then
-        sudo apt install shfmt
-    fi
-
-    test -f /usr/bin/go || sudo apt-get install -y golang
-
+download_zig_binary() {
     # Install zig to current directory
     # We use zig to compile some test binaries as it is much easier than with gcc
 
@@ -98,8 +80,30 @@ install_apt() {
     echo "Zig installed to ${ZIGPATH}"
 }
 
+install_apt() {
+    set_zigpath "$(pwd)/.zig"
+
+    sudo apt-get update || true
+    sudo apt-get install -y \
+        nasm \
+        gcc \
+        libc6-dev \
+        curl \
+        build-essential \
+        gdb \
+        parallel
+
+    if [[ "$1" == "22.04" ]]; then
+        sudo apt install shfmt
+    fi
+
+    test -f /usr/bin/go || sudo apt-get install -y golang
+
+    download_zig_binary
+}
+
 install_pacman() {
-    set_zigpath /usr/bin
+    set_zigpath "$(pwd)/.zig"
 
     # add debug repo for glibc-debug
     cat <<EOF | sudo tee -a /etc/pacman.conf
@@ -128,9 +132,7 @@ EOF
 
     test -f /usr/bin/go || sudo pacman -S --noconfirm go
 
-    # Install zig to system
-    # We use zig to compile some test binaries as it is much easier than with gcc
-    sudo pacman -S --noconfirm zig
+    download_zig_binary
 }
 
 if linux; then

--- a/setup-dev.sh
+++ b/setup-dev.sh
@@ -152,13 +152,13 @@ if linux; then
             install_pacman
             ;;
         *) # we can add more install command for each distros.
-            echo "\"$distro\" is not supported distro. Will search for 'apt' or 'dnf' package managers."
+            echo "\"$distro\" is not supported distro. Will search for 'apt' or 'pacman' package managers."
             if hash apt; then
                 install_apt
             elif hash pacman; then
                 install_pacman
             else
-                echo "\"$distro\" is not supported and your distro don't have apt or dnf that we support currently."
+                echo "\"$distro\" is not supported and your distro don't have apt or pacman that we support currently."
                 exit
             fi
             ;;


### PR DESCRIPTION
~~Use zig from Pacman.~~ Use zig from upstream (like what we do for Ubuntu) because of unexpected stripped binary output.
Add debug repos to install `glibc-debug` in case of debuginfod not working.

fix #1212 

<!-- Please make sure to read the testing and linting instructions at https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md before creating a PR -->
