### PR TITLE
Fix tests reporting in parallel execution

### DIFF
--- a/tests/gdb-tests/tests.sh
+++ b/tests/gdb-tests/tests.sh
@@ -111,10 +111,10 @@ run_test() {
         PWNDBG_LAUNCH_TEST="${test_case}" \
         PWNDBG_DISABLE_COLORS=1 \
         run_gdb "${gdb_args[@]}"
-        exit $?
+    retval=$?
 
     if [ "$SERIAL" -ne 1 ]; then
-        exit $?
+        exit $retval
     fi
 }
 

--- a/tests/gdb-tests/tests.sh
+++ b/tests/gdb-tests/tests.sh
@@ -111,6 +111,7 @@ run_test() {
         PWNDBG_LAUNCH_TEST="${test_case}" \
         PWNDBG_DISABLE_COLORS=1 \
         run_gdb "${gdb_args[@]}"
+        exit $?
 
     if [ "$SERIAL" -ne 1 ]; then
         exit $?


### PR DESCRIPTION
Fix issue where parallel test execution was unable to track failed tests and inform about their number.

When we had a test failing, that is the output before/after this PR.

Before:
```
*********************************
********* TESTS SUMMARY *********
*********************************
Tests passed or skipped: 1
Tests failed: 0
```

After:
```
*********************************
********* TESTS SUMMARY *********
*********************************
Tests passed or skipped: 0
Tests failed: 1
```

<!-- Please make sure to read the testing and linting instructions at https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md before creating a PR -->
