### PR TITLE
Add tabstop config for context source code

### DIFF
--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -627,6 +627,9 @@ theme.add_param("highlight-source", True, "whether to highlight the closest sour
 source_code_lines = pwndbg.gdblib.config.add_param(
     "context-source-code-lines", 10, "number of source code lines to print by the context command"
 )
+pwndbg.gdblib.config.add_param(
+    "context-source-code-tabstop", 8, "number of spaces that a <tab> in the source code counts for"
+)
 theme.add_param("code-prefix", "►", "prefix marker for 'context code' command")
 
 
@@ -684,6 +687,8 @@ def get_filename_and_formatted_source():
     # Format the output
     formatted_source = []
     for line_number, code in enumerate(source, start=start + 1):
+        if pwndbg.gdblib.config.context_source_code_tabstop > 0:
+            code = code.replace("\t", " " * pwndbg.gdblib.config.context_source_code_tabstop)
         fmt = " {prefix_sign:{prefix_width}} {line_number:>{num_width}} {code}"
         if pwndbg.gdblib.config.highlight_source and line_number == closest_line:
             fmt = C.highlight(fmt)


### PR DESCRIPTION
* The c code `test.c`:
```c
#include <stdio.h>

int main() {
  puts("Hello, World!");
  return 0;
}
```

* The gdb script `script.txt`:
```
dir /usr/src/glibc/glibc-2.35
set context-source-code-lines 30
b main
r
b _IO_flush_all_lockp
c
n 6
```

* The libc source code is misalignment:
```sh
gcc -g test.c
gdb -x script.txt ./a.out
```
<img width="1019" alt="0327fab1-b15c-4e0d-b66a-258978115a63" src="https://user-images.githubusercontent.com/20320324/201943879-703fe440-2f0d-4061-8f6c-e2b5c60ac57c.png">

* `set context-source-code-tabstop 8` to make it looks better:
<img width="1023" alt="0d2cce01-7e7d-4652-bd8b-9b1401f879b3" src="https://user-images.githubusercontent.com/20320324/201944251-39cedcdb-5d43-45e9-89de-e82901c737ea.png">