### PR TITLE
Use `.data` instead of `.got.plt` in the heap heuristic

### DIFF
--- a/pwndbg/glibc.py
+++ b/pwndbg/glibc.py
@@ -63,16 +63,20 @@ def _get_version():
 @pwndbg.gdblib.proc.OnlyWhenRunning
 @pwndbg.lib.memoize.reset_on_start
 @pwndbg.lib.memoize.reset_on_objfile
-def get_got_plt_address():
-    # Try every possible object file, to find which one has `.got.plt` section showed in `info files`
+def get_data_address():
+    """
+    Find .data section address of libc
+    """
+    # Try every possible object file, to find which one has `.data` section showed in `info files`
     for libc_filename in (
         objfile.filename
         for objfile in gdb.objfiles()
         if re.search(r"^libc(\.|-.+\.)so", os.path.basename(objfile.filename))
     ):
+        # Will `info files` always work? If not, we should probably use `ELFFile` to parse libc file directly
         out = pwndbg.gdblib.info.files()
         for line in out.splitlines():
-            if libc_filename in line and ".got.plt" in line:
+            if libc_filename in line and " is .data in " in line:
                 return int(line.strip().split()[0], 16)
     return 0
 

--- a/pwndbg/heap/ptmalloc.py
+++ b/pwndbg/heap/ptmalloc.py
@@ -1274,9 +1274,9 @@ class HeuristicHeap(GlibcMemoryAllocator):
     @property
     def possible_page_of_symbols(self):
         if self._possible_page_of_symbols is None:
-            if pwndbg.glibc.get_got_plt_address() > 0:
+            if pwndbg.glibc.get_data_address() > 0:
                 self._possible_page_of_symbols = pwndbg.gdblib.vmmap.find(
-                    pwndbg.glibc.get_got_plt_address()
+                    pwndbg.glibc.get_data_address()
                 )
             elif pwndbg.gdblib.symbol.address("_IO_list_all"):
                 self._possible_page_of_symbols = pwndbg.gdblib.vmmap.find(


### PR DESCRIPTION
When libc has no symbols, to search the `main_arena` and `mp_` in the memory, we will need to find which page is possible to have those symbols first.

Before this PR, we used `.got.plt` to determine it, but it might find wrong page in some cases. Using the address of `.data` should be a better solution.

Some failing test about heuristic found in the archlinux tests in #1378 should pass after this PR.
