### PR TITLE
tests zig cc: silence unused vars warnings

### DIFF
--- a/tests/gdb-tests/tests/binaries/makefile
+++ b/tests/gdb-tests/tests/binaries/makefile
@@ -66,11 +66,12 @@ all: $(LINKED) $(LINKED_ASM) $(COMPILED_GO)
 heap_bugs.out: heap_bugs.c
 	@echo "[+] Building heap_bugs.out"
 	${ZIGCC} \
-    -Wno-int-to-pointer-cast -Wno-int-conversion -Wno-unused-variable \
+	${CFLAGS} \
+	-Wno-int-to-pointer-cast -Wno-int-conversion -Wno-unused-variable \
 	-target native-native-gnu.2.33 \
 	-Wl,-rpath=${GLIBC_2_33}:\
 	-Wl,--dynamic-linker=${GLIBC_2_33}/ld-linux-x86-64.so.2 \
-	${CFLAGS} -o heap_bugs.out heap_bugs.c
+	-o heap_bugs.out heap_bugs.c
 
 # TODO/FIXME: We should probably force this to 2.29? a version with tcache?
 #heap_bins.out: heap_bins.c


### PR DESCRIPTION
This should silence the unused vars from zig cc compilations and make our tests outputs MUCH smaller