### PR TITLE
Fix debian10 ci

### DIFF
--- a/tests/gdb-tests/tests/binaries/makefile
+++ b/tests/gdb-tests/tests/binaries/makefile
@@ -51,7 +51,7 @@ all: $(LINKED) $(LINKED_ASM) $(COMPILED_GO)
 
 %.out : %.o
 	@echo "[+] Linking '$@'"
-	@$(LD) -Ttext 0x400080 -o $@ $?
+	@$(LD) -Ttext 0x400080 --section-start .note.gnu.property=0x8000000 -o $@ $?
 
 %.x86 : %.x86.go
 	@echo "[+] Building '$@'"


### PR DESCRIPTION
This fixes the weird error that appeared on debian10 CI:
```
root@98cc3841eab9:/pwndbg/tests/gdb-tests/tests/binaries# ld -Ttext 0x400000 -o memory.out memory.o
ld: section .note.gnu.property LMA [00000000004000e8,0000000000400107] overlaps section .text LMA [0000000000400000,00000000004001a4]
```

It turned out that the .note.gnu.property address was choosen to be the same as our hardcoded .text address and so we got into this issue.

This PR hardcodes the gnu section address.

<!-- Please make sure to read the testing and linting instructions at https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md before creating a PR -->
