### PR TITLE
Add `default-visualize-chunk-number` config and refactor some code related to config

### DIFF
--- a/pwndbg/color/theme.py
+++ b/pwndbg/color/theme.py
@@ -6,9 +6,9 @@ class ColorParameter(pwndbg.lib.config.Parameter):
     pass
 
 
-def add_param(name, default, docstring, color_param=False):
-    return config.add_param(name, default, docstring, scope="theme")
+def add_param(name, default, set_show_doc, color_param=False):
+    return config.add_param(name, default, set_show_doc, scope="theme")
 
 
-def add_color_param(name, default, docstring):
-    return config.add_param_obj(ColorParameter(name, default, docstring, scope="theme"))
+def add_color_param(name, default, set_show_doc):
+    return config.add_param_obj(ColorParameter(name, default, set_show_doc, scope="theme"))

--- a/pwndbg/commands/config.py
+++ b/pwndbg/commands/config.py
@@ -12,11 +12,11 @@ from pwndbg.color import strip
 from pwndbg.color.message import hint
 
 
-def print_row(name, value, default, docstring, ljust_optname, ljust_value, empty_space=6):
+def print_row(name, value, default, set_show_doc, ljust_optname, ljust_value, empty_space=6):
     name = ljust_colored(name, ljust_optname + empty_space)
     defval = extend_value_with_default(value, default)
     defval = ljust_colored(defval, ljust_value + empty_space)
-    result = " ".join((name, defval, docstring))
+    result = " ".join((name, defval, set_show_doc))
     print(result)
     return result
 
@@ -39,7 +39,7 @@ def get_config_parameters(scope, filter_pattern):
         values = [
             v
             for v in values
-            if filter_pattern in v.name.lower() or filter_pattern in v.docstring.lower()
+            if filter_pattern in v.name.lower() or filter_pattern in v.set_show_doc.lower()
         ]
 
     return values
@@ -84,7 +84,7 @@ def display_config(filter_pattern: str, scope: str):
             value = repr(v.value)
             default = repr(v.default)
 
-        print_row(v.name, value, default, v.docstring, longest_optname, longest_value)
+        print_row(v.name, value, default, v.set_show_doc, longest_optname, longest_value)
 
     print(hint(f"You can set config variable with `set <{scope}-var> <value>`"))
     print(
@@ -152,7 +152,7 @@ def configfile_print_scope(scope, show_all=False):
         if not show_all:
             print(hint("Showing only changed values:"))
         for p in params:
-            print("# %s: %s" % (p.name, p.docstring))
+            print("# %s: %s" % (p.name, p.set_show_doc))
             print("# default: %s" % p.native_default)
             print("set %s %s" % (p.name, p.native_value))
             print()

--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -592,13 +592,19 @@ pwndbg.gdblib.config.add_param(
     "max display size for heap chunks visualization (0 for display all)",
 )
 
+pwndbg.gdblib.config.add_param(
+    "default-visualize-chunk-number",
+    10,
+    "the number of chunks to visualize (default is 10)",
+)
+
 parser = argparse.ArgumentParser()
 parser.description = "Visualize chunks on a heap, default to the current arena's active heap."
 parser.add_argument(
     "count",
     nargs="?",
     type=lambda n: max(int(n, 0), 1),
-    default=10,
+    default=pwndbg.gdblib.config.default_visualize_chunk_number,
     help="Number of chunks to visualize.",
 )
 parser.add_argument("addr", nargs="?", default=None, help="Address of the first chunk.")

--- a/pwndbg/gdblib/config.py
+++ b/pwndbg/gdblib/config.py
@@ -29,8 +29,8 @@ class Parameter(gdb.Parameter):
         # `set_doc`, `show_doc`, and `__doc__` must be set before `gdb.Parameter.__init__`.
         # They will be used for `help set <param>` and `help show <param>`,
         # respectively
-        self.set_doc = "Set " + param.docstring
-        self.show_doc = "Show " + param.docstring
+        self.set_doc = "Set " + param.set_show_doc
+        self.show_doc = "Show " + param.set_show_doc
         self.__doc__ = param.help_docstring
 
         if param.param_class == gdb.PARAM_ENUM:
@@ -76,7 +76,7 @@ class Parameter(gdb.Parameter):
         if not pwndbg.decorators.first_prompt:
             return ""
 
-        return "Set %s to %r" % (self.param.docstring, self.native_value)
+        return "Set %s to %r" % (self.param.set_show_doc, self.native_value)
 
     def get_show_string(self, svalue):
         """Handles the GDB `show <param>` command"""

--- a/pwndbg/heap/__init__.py
+++ b/pwndbg/heap/__init__.py
@@ -7,12 +7,12 @@ current = None
 
 
 def add_heap_param(
-    name, default, docstring, *, help_docstring=None, param_class=None, enum_sequence=None
+    name, default, set_show_doc, *, help_docstring=None, param_class=None, enum_sequence=None
 ):
     return pwndbg.gdblib.config.add_param(
         name,
         default,
-        docstring,
+        set_show_doc,
         help_docstring=help_docstring,
         param_class=param_class,
         enum_sequence=enum_sequence,

--- a/pwndbg/lib/config.py
+++ b/pwndbg/lib/config.py
@@ -24,13 +24,14 @@ class Parameter:
         self,
         name,
         default,
-        docstring,
+        set_show_doc,
+        *,
         help_docstring=None,
         param_class=None,
         enum_sequence=None,
         scope="config",
     ):
-        self.docstring = docstring.strip()
+        self.set_show_doc = set_show_doc.strip()
         self.help_docstring = help_docstring.strip() if help_docstring else None
         self.name = name
         self.default = default
@@ -126,7 +127,7 @@ class Config:
         self,
         name,
         default,
-        docstring,
+        set_show_doc,
         *,
         help_docstring=None,
         param_class=None,
@@ -139,11 +140,11 @@ class Config:
         p = Parameter(
             name,
             default,
-            docstring,
-            help_docstring,
-            param_class,
-            enum_sequence,
-            scope,
+            set_show_doc,
+            help_docstring=help_docstring,
+            param_class=param_class,
+            enum_sequence=enum_sequence,
+            scope=scope,
         )
         return self.add_param_obj(p)
 

--- a/tests/gdb-tests/tests/heap/test_vis_heap_chunks.py
+++ b/tests/gdb-tests/tests/heap/test_vis_heap_chunks.py
@@ -69,6 +69,16 @@ def test_vis_heap_chunk_command(start_binary):
     expected.append("%#x\t0x0000000000000000" % heap_iter())
     assert result == expected
 
+    ## This time using `default-visualize-chunk-number` to set `count`, to make sure that the config can work
+    gdb.execute("set default-visualize-chunk-number 1")
+    assert pwndbg.gdblib.config.default_visualize_chunk_number == 1
+    result = gdb.execute("vis_heap_chunk", to_string=True).splitlines()
+    assert result == expected
+    gdb.execute(
+        "set default-visualize-chunk-number %d"
+        % pwndbg.gdblib.config.default_visualize_chunk_number.default
+    )
+
     del result
 
     ## Test vis_heap_chunk with count=2


### PR DESCRIPTION
According to the feedback in the Discord server,  this PR create a new config called `default-visualize-chunk-number` to set the default number of chunks to visualize with `vis_heap_chunks`

And this PR also did some refactoring which was mentioned in #1315's discussion.