### PR TITLE
Fix vmmap coredump test

### DIFF
--- a/pwndbg/gdblib/elf.py
+++ b/pwndbg/gdblib/elf.py
@@ -249,7 +249,7 @@ def get_ehdr(pointer):
         return None, None
 
     # We first check if the beginning of the page contains the ELF magic
-    if pwndbg.gdblib.memory.read(vmmap.start, 4) == b"\x7fELF":
+    if pwndbg.gdblib.memory.read(vmmap.start, 4, partial=True) == b"\x7fELF":
         base = vmmap.start
 
     # The page did not have ELF magic; it may be that .text and binary start are split
@@ -260,7 +260,7 @@ def get_ehdr(pointer):
                 vmmap = v
                 break
 
-        if pwndbg.gdblib.memory.read(vmmap.start, 4) == b"\x7fELF":
+        if pwndbg.gdblib.memory.read(vmmap.start, 4, partial=True) == b"\x7fELF":
             base = vmmap.start
 
     if base is None:

--- a/setup-dev.sh
+++ b/setup-dev.sh
@@ -92,7 +92,7 @@ install_apt() {
         build-essential \
         gdb \
         parallel \
-	netcat-openbsd
+        netcat-openbsd
 
     if [[ "$1" == "22.04" ]]; then
         sudo apt install shfmt
@@ -107,7 +107,7 @@ install_pacman() {
     set_zigpath "$(pwd)/.zig"
 
     # add debug repo for glibc-debug
-    cat <<EOF | sudo tee -a /etc/pacman.conf
+    cat << EOF | sudo tee -a /etc/pacman.conf
 [core-debug]
 Include = /etc/pacman.d/mirrorlist
 


### PR DESCRIPTION
This commits/PR fixes two issues and test them.

1. It changes the reads in `get_ehdr` to partial reads so that inability
   to read the `vmmap.start` address there will not crash Pwndbg with
`gdb.error` but instead we will simply return `None` as expected from
this function. This crash could happen on Debian 10 (GDB 8.2.1) and
Ubuntu 18.04 (not sure which GDB) when you did:
- gdb ./binary-that-crashes
- `run`
- `generate-core-file /tmp/core`
- `file` - to unload the binary
- `core-file /tmp/core` - to load the generated core

At this point I think we may have preserved the old vmmap info and use
it in `get_ehdr` maybe, which then crashed? I am not sure, but this fix
here works.

To test this behavior properly I also added the `unload_file`
parametrization to the
`test_command_vmmap_on_coredump_on_crash_simple_binary` test.

2. We fix the vmmap coredump test case when the `info proc mappings` returns nothing on core
   dumps on old GDBs. In such case we are missing the vmmap info about
the binary mapping, so now we properly remove it in the test.
