### PR TITLE
Disable IDA RPC by default

### DIFF
--- a/pwndbg/ida.py
+++ b/pwndbg/ida.py
@@ -28,7 +28,7 @@ ida_rpc_host = pwndbg.gdblib.config.add_param(
 )
 ida_rpc_port = pwndbg.gdblib.config.add_param("ida-rpc-port", 31337, "ida xmlrpc server port")
 ida_enabled = pwndbg.gdblib.config.add_param(
-    "ida-enabled", True, "whether to enable ida integration"
+    "ida-enabled", False, "whether to enable ida integration"
 )
 ida_timeout = pwndbg.gdblib.config.add_param(
     "ida-timeout", 2, "time to wait for ida xmlrpc in seconds"


### PR DESCRIPTION
If there is some other application using port 31337, you get an XML RPC error:
```
[!] Ida Pro xmlrpc error
Traceback (most recent call last):
  File "/home/gsgx/tools/pwndbg/pwndbg/ida.py", line 69, in init_ida_rpc_client
    _ida.here()
  File "/usr/lib/python3.10/xmlrpc/client.py", line 1122, in __call__
    return self.__send(self.__name, args)
  File "/usr/lib/python3.10/xmlrpc/client.py", line 1464, in __request
    response = self.__transport.request(
  File "/usr/lib/python3.10/xmlrpc/client.py", line 1166, in request
    return self.single_request(host, handler, request_body, verbose)
  File "/usr/lib/python3.10/xmlrpc/client.py", line 1196, in single_request
    raise ProtocolError(
xmlrpc.client.ProtocolError: <ProtocolError for 127.0.0.1:31337/RPC2: 404 Not Found>
```

We should disable IDA by default, and any users that want it can just enable it in their config.

<!-- Please make sure to read the testing and linting instructions at https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md before creating a PR -->
