### PR TITLE
Fix find_fake_fast command test

### DIFF
--- a/tests/gdb-tests/tests/heap/test_find_fake_fast.py
+++ b/tests/gdb-tests/tests/heap/test_find_fake_fast.py
@@ -47,12 +47,12 @@ def test_find_fake_fast_command(start_binary):
 
     # Ensure memory at fake_chunk's heap_info struct isn't mapped.
     unmapped_heap_info = pwndbg.heap.ptmalloc.heap_for_ptr(
-        pwndbg.gdblib.symbol.address("fake_chunk")
+        int(gdb.lookup_global_symbol("fake_chunk").value())
     )
     assert pwndbg.gdblib.memory.peek(unmapped_heap_info) is None
 
     # A gdb.MemoryError raised here indicates a regression from PR #1145
-    gdb.execute("find_fake_fast (void*)&fake_chunk+0x70")
+    gdb.execute("find_fake_fast fake_chunk+0x80")
 
     target_address = pwndbg.gdblib.symbol.address("target_address")
     assert target_address is not None


### PR DESCRIPTION
Introduce a more reliable method for mapping one of the fake chunks used in this suite of tests.

Part of the test setup requires the `fake_chunk` size field to be aligned in virtual memory such that its `heap_info` struct resides in unmapped memory. Previously this was left up to ASLR and the test would intermittently fail when the fake chunk's `heap_info` struct was actually mapped. The updated test attempts to `mmap()` 2 pages aligned to `HEAP_MAX_SIZE`, when successful it places `fake_chunk` in the 2nd page then `munmap()`s the 1st page, ensuring the fake chunk's `heap_info` struct is unmapped.