### PR TITLE
fix: architecure mapping for ARM ARMv7-M

### DIFF
--- a/pwndbg/gdblib/arch.py
+++ b/pwndbg/gdblib/arch.py
@@ -18,6 +18,7 @@ pwnlib_archs_mapping = {
     "powerpc": "powerpc",
     "sparc": "sparc",
     "arm": "arm",
+    "armcm": "thumb",
 }
 
 arch = Arch("i386", typeinfo.ptrsize, "little")


### PR DESCRIPTION
fix: fix crash when debugging ARMv7-M and set architecture mapping for ARM Cortex to thumb
    
As per: https://developer.arm.com/documentation/ddi0403/d/Application-Level-Architecture/The-ARMv7-M-Instruction-Set/About-the-instruction-set/ARMv7-M-and-interworking-support?lang=en
   
"ARMv7-M only supports the Thumb instruction execution state"

This should also fix ARMv6-M, but I have no way of testing.