### PR TITLE
fix: Prevent pwndbg from trying to download ELF files from a remote embedded device.

### DIFF
--- a/pwndbg/gdblib/remote.py
+++ b/pwndbg/gdblib/remote.py
@@ -18,3 +18,16 @@ def is_remote():
     #   - exec (Local exec file)
     #   - None (None)
     return "remote" in gdb.execute("maintenance print target-stack", to_string=True)
+
+
+def is_debug_probe():
+    """
+    Returns True if the target is a debug probe for an embedded device.
+    Currently detects the Black Magic Probe and the SEGGER J-Link GDB Server.
+    """
+    try:
+        monitor_output = gdb.execute("monitor", to_string=True)
+    except gdb.error:
+        # the monitor command might fail, but we don't care since it doesn't fail on the devices we check for.
+        return False
+    return "Black Magic Probe" in monitor_output or "SEGGER J-Link GDB Server" in monitor_output

--- a/pwndbg/gdblib/symbol.py
+++ b/pwndbg/gdblib/symbol.py
@@ -74,8 +74,14 @@ def _reset_remote_files():
 
 @pwndbg.gdblib.events.new_objfile
 def _autofetch():
-    """ """
+    """
+    Automatically downloads ELF files with debug symbols from the remotely debugged system.
+    Does not work with QEMU and Android. It also does not work when debugging embedded devices, as they don't even have a filesystem.
+    """
     if not pwndbg.gdblib.remote.is_remote():
+        return
+
+    if pwndbg.gdblib.remote.is_debug_probe():
         return
 
     if pwndbg.gdblib.qemu.is_qemu_usermode():


### PR DESCRIPTION
Added a heuristic to check whether we are debugging using a Blackmagic probe or a SEGGER J-link, if yes we don't download any elf files (this caused pwndbg to error out).
