### PR TITLE
Fix: support malloc_ptr of glibc<=2.23

### DIFF
--- a/pwndbg/heap/structs.py
+++ b/pwndbg/heap/structs.py
@@ -515,12 +515,65 @@ class TcacheEntry(CStruct2GDB):
         _c_struct = c_tcache_entry_2_28
     sizeof = ctypes.sizeof(_c_struct)
 
-
-class c_malloc_par_2_25(ctypes.LittleEndianStructure):
+class c_malloc_par_2_23(ctypes.LittleEndianStructure):
     """
-    This class represents the malloc_par struct for GLIBC < 2.26 as a ctypes struct.
+    This class represents the malloc_par struct for GLIBC < 2.24 as a ctypes struct.
+
+    https://github.com/bminor/glibc/blob/glibc-2.23/malloc/malloc.c#L1726
+
+    struct malloc_par
+    {
+    /* Tunable parameters */
+    unsigned long trim_threshold;
+    INTERNAL_SIZE_T top_pad;
+    INTERNAL_SIZE_T mmap_threshold;
+    INTERNAL_SIZE_T arena_test;
+    INTERNAL_SIZE_T arena_max;
+
+    /* Memory map support */
+    int n_mmaps;
+    int n_mmaps_max;
+    int max_n_mmaps;
+    /* the mmap_threshold is dynamic, until the user sets
+        it manually, at which point we need to disable any
+        dynamic behavior. */
+    int no_dyn_threshold;
+
+    /* Statistics */
+    INTERNAL_SIZE_T mmapped_mem;
+    /*INTERNAL_SIZE_T  sbrked_mem;*/
+    /*INTERNAL_SIZE_T  max_sbrked_mem;*/
+    INTERNAL_SIZE_T max_mmapped_mem;
+    INTERNAL_SIZE_T max_total_mem;  /* only kept for NO_THREADS */
+
+    /* First address handed out by MORECORE/sbrk.  */
+    char *sbrk_base;
+    };
+    """
+
+    _fields_ = [
+        ("trim_threshold", c_size_t),
+        ("top_pad", c_size_t),
+        ("mmap_threshold", c_size_t),
+        ("arena_test", c_size_t),
+        ("arena_max", c_size_t),
+        ("n_mmaps", ctypes.c_int32),
+        ("n_mmaps_max", ctypes.c_int32),
+        ("max_n_mmaps", ctypes.c_int32),
+        ("no_dyn_threshold", ctypes.c_int32),
+        ("mmapped_mem", c_size_t),
+        ("max_mmapped_mem", c_size_t),
+        ("max_total_mem", c_size_t),
+        ("sbrk_base", c_pvoid),
+    ]
+
+
+class c_malloc_par_2_24(ctypes.LittleEndianStructure):
+    """
+    This class represents the malloc_par struct for GLIBC >= 2.24 as a ctypes struct.
 
     https://github.com/bminor/glibc/blob/glibc-2.25/malloc/malloc.c#L1690
+    https://github.com/bminor/glibc/blob/glibc-2.24/malloc/malloc.c#L1719
 
     struct malloc_par
     {
@@ -714,6 +767,8 @@ class MallocPar(CStruct2GDB):
         _c_struct = c_malloc_par_2_35
     elif pwndbg.glibc.get_version() >= (2, 26):
         _c_struct = c_malloc_par_2_26
+    elif pwndbg.glibc.get_version() >= (2, 24):
+        _c_struct = c_malloc_par_2_24
     else:
-        _c_struct = c_malloc_par_2_25
+        _c_struct = c_malloc_par_2_23
     sizeof = ctypes.sizeof(_c_struct)

--- a/pwndbg/heap/structs.py
+++ b/pwndbg/heap/structs.py
@@ -515,6 +515,7 @@ class TcacheEntry(CStruct2GDB):
         _c_struct = c_tcache_entry_2_28
     sizeof = ctypes.sizeof(_c_struct)
 
+
 class c_malloc_par_2_23(ctypes.LittleEndianStructure):
     """
     This class represents the malloc_par struct for GLIBC < 2.24 as a ctypes struct.


### PR DESCRIPTION
<!-- Please make sure to read the testing and linting instructions at https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md before creating a PR -->

struct `malloc_par` of glibc<=2.23 is different from glibc 2.24 and 2.25, the former has an extra member `max_total_mem`， which will lead to failure while using `heap` command with `set resolve-heap-via-heuristic on`.
```
Traceback (most recent call last):
  File "/home/user/pwndbg/pwndbg/commands/__init__.py", line 144, in __call__
    return self.function(*args, **kwargs)
  File "/home/user/pwndbg/pwndbg/commands/__init__.py", line 215, in _OnlyWhenRunning
    return function(*a, **kw)
  File "/home/user/pwndbg/pwndbg/commands/__init__.py", line 299, in _OnlyWithResolvedHeapSyms
    raise err
  File "/home/user/pwndbg/pwndbg/commands/__init__.py", line 274, in _OnlyWithResolvedHeapSyms
    return function(*a, **kw)
  File "/home/user/pwndbg/pwndbg/commands/__init__.py", line 240, in _OnlyWhenHeapIsInitialized
    return function(*a, **kw)
  File "/home/user/pwndbg/pwndbg/commands/heap.py", line 140, in heap
    h = arena.active_heap
  File "/home/user/pwndbg/pwndbg/heap/ptmalloc.py", line 586, in active_heap
    self._active_heap = Heap(self.top, arena=self)
  File "/home/user/pwndbg/pwndbg/heap/ptmalloc.py", line 349, in __init__
    sbrk_region = allocator.get_sbrk_heap_region()
  File "/home/user/pwndbg/pwndbg/heap/ptmalloc.py", line 2181, in get_sbrk_heap_region
    raise ValueError("mp_.sbrk_base is unmapped or points to unmapped memory.")
ValueError: mp_.sbrk_base is unmapped or points to unmapped memory.
```

diff  malloc.c

``` c
// https://github.com/bminor/glibc/blob/glibc-2.24/malloc/malloc.c#L1719
struct malloc_par
{
  /* Tunable parameters */
  unsigned long trim_threshold;
  INTERNAL_SIZE_T top_pad;
  INTERNAL_SIZE_T mmap_threshold;
  INTERNAL_SIZE_T arena_test;
  INTERNAL_SIZE_T arena_max;

  /* Memory map support */
  int n_mmaps;
  int n_mmaps_max;
  int max_n_mmaps;
  /* the mmap_threshold is dynamic, until the user sets
     it manually, at which point we need to disable any
     dynamic behavior. */
  int no_dyn_threshold;

  /* Statistics */
  INTERNAL_SIZE_T mmapped_mem;
  INTERNAL_SIZE_T max_mmapped_mem;

  /* First address handed out by MORECORE/sbrk.  */
  char *sbrk_base;
};

// https://github.com/bminor/glibc/blob/glibc-2.23/malloc/malloc.c#L1726
struct malloc_par
{
  /* Tunable parameters */
  unsigned long trim_threshold;
  INTERNAL_SIZE_T top_pad;
  INTERNAL_SIZE_T mmap_threshold;
  INTERNAL_SIZE_T arena_test;
  INTERNAL_SIZE_T arena_max;

  /* Memory map support */
  int n_mmaps;
  int n_mmaps_max;
  int max_n_mmaps;
  /* the mmap_threshold is dynamic, until the user sets
     it manually, at which point we need to disable any
     dynamic behavior. */
  int no_dyn_threshold;

  /* Statistics */
  INTERNAL_SIZE_T mmapped_mem;
  /*INTERNAL_SIZE_T  sbrked_mem;*/
  /*INTERNAL_SIZE_T  max_sbrked_mem;*/
  INTERNAL_SIZE_T max_mmapped_mem;
  INTERNAL_SIZE_T max_total_mem;  /* only kept for NO_THREADS */

  /* First address handed out by MORECORE/sbrk.  */
  char *sbrk_base;
};
```
