### PR TITLE
tests.sh: fix --pdb (set SERIAL when --pdb is set)

### DIFF
--- a/tests/gdb-tests/tests.sh
+++ b/tests/gdb-tests/tests.sh
@@ -32,7 +32,8 @@ while [[ $# -gt 0 ]]; do
     case $1 in
         -p | --pdb)
             USE_PDB=1
-            echo "Will run tests with Python debugger"
+	    SERIAL=1
+            echo "Will run tests in serial and with Python debugger"
             shift
             ;;
         -c | --cov)


### PR DESCRIPTION
When we optimized tests runs with gnu parallel execution, we broke the --pdb flag. This commit fixes it and sets the SERIAL flag so that tests are run one by one when --pdb is passed.

<!-- Please make sure to read the testing and linting instructions at https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md before creating a PR -->
