### PR TITLE
Add simple qemu-aarch64 test

### DIFF
--- a/tests/qemu-tests/binaries/Makefile
+++ b/tests/qemu-tests/binaries/Makefile
@@ -1,0 +1,3 @@
+reference-binary.aarch64.out : reference-binary.aarch64.c
+	@echo "[+] Building '$@'"
+	@aarch64-linux-gnu-gcc $(CFLAGS) $(EXTRA_FLAGS) -w -o $@ $? $(LDFLAGS)

--- a/tests/qemu-tests/binaries/reference-binary.aarch64.c
+++ b/tests/qemu-tests/binaries/reference-binary.aarch64.c
@@ -1,0 +1,36 @@
+#include <arpa/inet.h>
+#include <stdio.h>
+
+#define PORT 80
+
+void break_here() {};
+
+int main(int argc, char const* argv[]) {
+    puts("Hello World");
+
+    int sock = 0, client_fd;
+    struct sockaddr_in serv_addr;
+
+    if ((sock = socket(AF_INET, SOCK_STREAM, 0)) < 0) {
+        perror("socket");
+        return -1;
+    }
+
+    serv_addr.sin_family = AF_INET;
+    serv_addr.sin_port = htons(PORT);
+
+    if (inet_pton(AF_INET, "1.1.1.1", &serv_addr.sin_addr) <= 0) {
+        perror("inet_pton");
+        return -1;
+    }
+
+    if ((client_fd = connect(sock, (struct sockaddr*)&serv_addr, sizeof(serv_addr))) < 0) {
+        perror("connect");
+        return -1;
+    }
+
+    break_here();
+
+    close(client_fd);
+    return 0;
+}

--- a/tests/qemu-tests/test_qemu.sh
+++ b/tests/qemu-tests/test_qemu.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+qemu-aarch64 \
+    -g 1234 \
+    -L /usr/aarch64-linux-gnu/ \
+    ./binaries/reference-binary.aarch64.out &
+
+gdb-multiarch \
+    -ex "file ./binaries/reference-binary.aarch64.out" \
+    -ex "target remote :1234" \
+    -ex "source ./tests/test_qemu_user_aarch64.py" \
+    -ex "quit"

--- a/tests/qemu-tests/tests/test_qemu_user_aarch64.py
+++ b/tests/qemu-tests/tests/test_qemu_user_aarch64.py
@@ -1,0 +1,20 @@
+import gdb
+
+import pwndbg
+
+gdb.execute("break break_here")
+print(pwndbg.gdblib.symbol.address("main"))
+gdb.execute("continue")
+
+gdb.execute("argv")
+gdb.execute("argc")
+gdb.execute("auxv")
+gdb.execute("cpsr")
+gdb.execute("context")
+gdb.execute("hexdump")
+gdb.execute("retaddr")
+gdb.execute("piebase")
+gdb.execute("telescope")
+gdb.execute("procinfo")
+gdb.execute("vmmap")
+gdb.execute("nextret")


### PR DESCRIPTION
Ideally we want to integrate these QEMU tests into the gdb-tests, but it will be easier to start with them separately.

#1417 