### PR TITLE
Improved configuration and automatic use of heap heuristics

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -77,6 +77,15 @@ Feel free to update the list below!
 
 * We have our own `pwndbg.config.Parameter` (which extends `gdb.Parameter`) - all of our parameters can be seen using `config` or `theme` commands. If we want to do something when user changes config/theme - we can do it defining a function and decorating it with `pwndbg.config.Trigger`.
 
+* You can create a new config with `pwndbg.gdblib.config.add_param`.
+
+* When using `pwndbg.gdblib.config.add_param` to add a new config, there are a few things to keep in mind:
+  * For the `set_show_doc` parameter, it is best to use a noun phrase like "the value of something" to ensure that the output is grammatically correct.
+  * For the `help_docstring` parameter, you can use the output of `help set follow-fork-mode` as a guide for formatting the documentation string if the config is an enum type.
+  * For the `param_class` parameter
+    * See the [documentation](https://sourceware.org/gdb/onlinedocs/gdb/Parameters-In-Python.html) for more information.
+    * If you use `gdb.PARAM_ENUM` as `param_class`, you must pass a list of strings to the `enum_sequence` parameter.
+
 * The dashboard/display/context we are displaying is done by `pwndbg/commands/context.py` which is invoked through GDB's prompt hook (which we defined in `pwndbg/prompt.py` as `prompt_hook_on_stop`).
 
 * All commands should be defined in `pwndbg/commands` - most of them lie in separate files but some files contains many of them (e.g. commands corresponding to windbg debugger - in `windbg.py` or some misc commands in `misc.py`). We would also want to make all of them to use `ArgparsedCommand` (instead of `Command`).
@@ -98,3 +107,4 @@ Feel free to update the list below!
 * Some of pwndbg's functionality - e.g. memory fetching - require us to have an instance of proper `gdb.Type` - the problem with that is that there is no way to define our own types - we have to ask gdb if it detected particular type in this particular binary (that sucks). We do it in `pwndbg/typeinfo.py` and it works most of the time. The known bug with that is that it might not work properly for Golang binaries compiled with debugging symbols.
 
 * We would like to add proper tests for pwndbg - see tests framework PR if you want to help on that.
+

--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -10,6 +10,8 @@ import pwndbg.color.message as message
 import pwndbg.exception
 import pwndbg.gdblib.regs
 import pwndbg.heap
+from pwndbg.heap.ptmalloc import DebugSymsHeap
+from pwndbg.heap.ptmalloc import HeuristicHeap
 from pwndbg.heap.ptmalloc import SymbolUnresolvableError
 
 commands = []  # type: List[Command]
@@ -263,83 +265,102 @@ def _is_statically_linked():
     return "No shared libraries loaded at this time." in out
 
 
+def _try2run_heap_command(function, a, kw):
+    e = lambda s: print(message.error(s))
+    w = lambda s: print(message.warn(s))
+    # Note: We will still raise the error for developers when exception-* is set to "on"
+    try:
+        return function(*a, **kw)
+    except SymbolUnresolvableError as err:
+        e(f"{function.__name__}: Fail to resolve the symbol: `{err.symbol}`")
+        w(
+            f"You can try to determine the libc symbols addresses manually and set them appropriately. For this, see the `heap_config` command output and set the config about `{err.symbol}`."
+        )
+        if pwndbg.gdblib.config.exception_verbose or pwndbg.gdblib.config.exception_debugger:
+            raise err
+        else:
+            pwndbg.exception.inform_verbose_and_debug()
+    except Exception as err:
+        e(f"{function.__name__}: An unknown error occurred when running this command.")
+        if isinstance(pwndbg.heap.current, HeuristicHeap):
+            w(
+                "Maybe you can try to determine the libc symbols addresses manually, set them appropriately and re-run this command. For this, see the `heap_config` command output and set the `main_arena`, `mp_`, `global_max_fast`, `tcache` and `thread_arena` addresses."
+            )
+        else:
+            w("You can try `set resolve-heap-via-heuristic force` and re-run this command.\n")
+        if pwndbg.gdblib.config.exception_verbose or pwndbg.gdblib.config.exception_debugger:
+            raise err
+        else:
+            pwndbg.exception.inform_verbose_and_debug()
+
+
 def OnlyWithResolvedHeapSyms(function):
     @functools.wraps(function)
     def _OnlyWithResolvedHeapSyms(*a, **kw):
         e = lambda s: print(message.error(s))
         w = lambda s: print(message.warn(s))
+        if (
+            isinstance(pwndbg.heap.current, HeuristicHeap)
+            and pwndbg.gdblib.config.resolve_heap_via_heuristic == "auto"
+            and DebugSymsHeap().can_be_resolved()
+        ):
+            # In auto mode, we will try to use the debug symbols if possible
+            pwndbg.heap.current = DebugSymsHeap()
         if pwndbg.heap.current.can_be_resolved():
-            # Note: We will still raise the error for developers when exception-* is set to "on"
-            try:
-                return function(*a, **kw)
-            except SymbolUnresolvableError as err:
-                e(f"{function.__name__}: Fail to resolve the symbol: `{err.symbol}`")
-                w(
-                    f"You can try to determine the libc symbols addresses manually and set them appropriately. For this, see the `heap_config` command output and set the config about `{err.symbol}`."
-                )
-                if (
-                    pwndbg.gdblib.config.exception_verbose
-                    or pwndbg.gdblib.config.exception_debugger
-                ):
-                    raise err
-                else:
-                    pwndbg.exception.inform_verbose_and_debug()
-            except Exception as err:
-                e(f"{function.__name__}: An unknown error occurred when running this command.")
-                if pwndbg.gdblib.config.resolve_heap_via_heuristic:
-                    w(
-                        "Maybe you can try to determine the libc symbols addresses manually, set them appropriately and re-run this command. For this, see the `heap_config` command output and set the `main_arena`, `mp_`, `global_max_fast`, `tcache` and `thread_arena` addresses."
-                    )
-                else:
-                    w("You can try `set resolve-heap-via-heuristic on` and re-run this command.\n")
-                if (
-                    pwndbg.gdblib.config.exception_verbose
-                    or pwndbg.gdblib.config.exception_debugger
-                ):
-                    raise err
-                else:
-                    pwndbg.exception.inform_verbose_and_debug()
+            return _try2run_heap_command(function, a, kw)
         else:
-            print(message.error(f"{function.__name__}: "), end="")
-            if not pwndbg.gdblib.config.resolve_heap_via_heuristic:
-                if _is_statically_linked():
+            if (
+                isinstance(pwndbg.heap.current, DebugSymsHeap)
+                and pwndbg.gdblib.config.resolve_heap_via_heuristic == "auto"
+            ):
+                # In auto mode, if the debug symbols are not enough, we will try to use the heuristic if possible
+                heuristic_heap = HeuristicHeap()
+                if heuristic_heap.can_be_resolved():
+                    pwndbg.heap.current = heuristic_heap
+                    w(
+                        "pwndbg will try to resolve the heap symbols via heuristic now since we cannot resolve the heap via the debug symbols.\n"
+                        "This might not work in all cases. Use `help set resolve-heap-via-heuristic` for more details.\n"
+                    )
+                    return _try2run_heap_command(function, a, kw)
+                elif _is_statically_linked():
                     e(
-                        "Can't find libc symbols addresses required for this command to work since this is a statically linked binary"
+                        "Can't find GLIBC version required for this command to work since this is a statically linked binary"
                     )
                     w(
-                        """Invoking the `set resolve-heap-via-heuristic on` command to resolve libc symbols via heuristics.
-Please set the GLIBC version you think the target binary was compiled (using `set glibc <version>` command; e.g. 2.32) and re-run this command.
-If this does not work, the only thing left is to determine the libc symbols addresses manually and set them appropriately. For this, see the `heap_config` command output and set the `main_arena`, `mp_`, `global_max_fast`, `tcache` and `thread_arena` addresses."""
+                        "Please set the GLIBC version you think the target binary was compiled (using `set glibc <version>` command; e.g. 2.32) and re-run this command."
                     )
-                    gdb.execute("set resolve-heap-via-heuristic on", to_string=True)
-                    return
-
                 else:
-
-                    w(
-                        """This command only works with libc debug symbols which are missing.
-
-They can probably be installed via the package manager of your choice.
-See also: https://sourceware.org/gdb/onlinedocs/gdb/Separate-Debug-Files.html
-
-E.g. on Ubuntu/Debian you might need to do the following steps (for 64-bit and 32-bit binaries):
-sudo apt-get install libc6-dbg
-sudo dpkg --add-architecture i386
-sudo apt-get install libc-dbg:i386
-
-If you used setup.sh on Arch based distro you'll need to do a power cycle or set environment variable manually like this: export DEBUGINFOD_URLS=https://debuginfod.archlinux.org
-"""
+                    e(
+                        "Can't find GLIBC version required for this command to work, maybe is because GLIBC is not loaded yet."
                     )
                     w(
-                        "pwndbg can still try to use this command without debug symbols after you `set resolve-heap-via-heuristic on`, but the results of those commands may be incorrect in some cases.\n"
-                        "If the output of the heap command is still wrong or gives you erros, the only thing left is to determine the libc symbols addresses manually and set them appropriately. For this, see the `heap_config` command output and set the `main_arena`, `mp_`, `global_max_fast`, `tcache` and `thread_arena` addresses."
+                        "If you believe the GLIBC is loaded or this is a statically linked binary. "
+                        "Please set the GLIBC version you think the target binary was compiled (using `set glibc <version>` command; e.g. 2.32) and re-run this command"
                     )
-            elif pwndbg.glibc.get_version() is None:
-                e("Can't resolve the heap since the GLIBC version is not set.")
-                w(
-                    "Please set the GLIBC version you think the target binary was compiled (using `set glibc <version>` command; e.g. 2.32) and re-run this command."
+            elif (
+                isinstance(pwndbg.heap.current, DebugSymsHeap)
+                and pwndbg.gdblib.config.resolve_heap_via_heuristic == "force"
+            ):
+                e(
+                    "You are forcing to resolve the heap symbols via heuristic, but we cannot resolve the heap via the debug symbols."
                 )
+                w("Use `set resolve-heap-via-heuristic auto` and re-run this command.")
+            elif pwndbg.glibc.get_version() is None:
+                if _is_statically_linked():
+                    e("Can't resolve the heap since the GLIBC version is not set.")
+                    w(
+                        "Please set the GLIBC version you think the target binary was compiled (using `set glibc <version>` command; e.g. 2.32) and re-run this command."
+                    )
+                else:
+                    e(
+                        "Can't find GLIBC version required for this command to work, maybe is because GLIBC is not loaded yet."
+                    )
+                    w(
+                        "If you believe the GLIBC is loaded or this is a statically linked binary. "
+                        "Please set the GLIBC version you think the target binary was compiled (using `set glibc <version>` command; e.g. 2.32) and re-run this command"
+                    )
             else:
+                # Note: Should not see this error, but just in case
                 e("An unknown error occurred when resolved the heap.")
                 pwndbg.exception.inform_report_issue(
                     "An unknown error occurred when resolved the heap"

--- a/pwndbg/commands/config.py
+++ b/pwndbg/commands/config.py
@@ -57,7 +57,7 @@ parser.add_argument(
 )
 
 
-def display_config(filter_pattern: str, scope: str):
+def display_config(filter_pattern: str, scope: str, has_file_command: bool = True):
     values = get_config_parameters(scope, filter_pattern)
 
     if not values:
@@ -87,12 +87,13 @@ def display_config(filter_pattern: str, scope: str):
         print_row(v.name, value, default, v.set_show_doc, longest_optname, longest_value)
 
     print(hint(f"You can set config variable with `set <{scope}-var> <value>`"))
-    print(
-        hint(
-            f"You can generate configuration file using `{scope}file` "
-            "- then put it in your .gdbinit after initializing pwndbg"
+    if has_file_command:
+        print(
+            hint(
+                f"You can generate configuration file using `{scope}file` "
+                "- then put it in your .gdbinit after initializing pwndbg"
+            )
         )
-    )
 
 
 @pwndbg.commands.ArgparsedCommand(parser)

--- a/pwndbg/commands/cymbol.py
+++ b/pwndbg/commands/cymbol.py
@@ -34,11 +34,15 @@ from pwndbg.color import message
 gcc_compiler_path = pwndbg.gdblib.config.add_param(
     "gcc-compiler-path",
     "",
-    "Path to the gcc/g++ toolchain for generating imported symbols",
+    "path to the gcc/g++ toolchain for generating imported symbols",
+    param_class=gdb.PARAM_OPTIONAL_FILENAME,
 )
 
 cymbol_editor = pwndbg.gdblib.config.add_param(
-    "cymbol-editor", "", "Path to the editor for editing custom structures"
+    "cymbol-editor",
+    "",
+    "path to the editor for editing custom structures",
+    param_class=gdb.PARAM_OPTIONAL_FILENAME,
 )
 
 # Remeber loaded symbols. This would be useful for 'remove-symbol-file'.

--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -596,7 +596,7 @@ pwndbg.gdblib.config.add_param(
 pwndbg.gdblib.config.add_param(
     "default-visualize-chunk-number",
     10,
-    "the number of chunks to visualize (default is 10)",
+    "default number of chunks to visualize (default is 10)",
 )
 
 parser = argparse.ArgumentParser()

--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -1179,7 +1179,7 @@ parser.add_argument(
 
 @pwndbg.commands.ArgparsedCommand(parser)
 def heap_config(filter_pattern):
-    display_config(filter_pattern, "heap")
+    display_config(filter_pattern, "heap", has_file_command=False)
 
     print(
         message.hint(

--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -17,6 +17,7 @@ from pwndbg.heap.ptmalloc import Arena
 from pwndbg.heap.ptmalloc import Bins
 from pwndbg.heap.ptmalloc import BinType
 from pwndbg.heap.ptmalloc import Chunk
+from pwndbg.heap.ptmalloc import DebugSymsHeap
 from pwndbg.heap.ptmalloc import Heap
 
 
@@ -29,7 +30,7 @@ def read_chunk(addr):
         "mchunk_size": "size",
         "mchunk_prev_size": "prev_size",
     }
-    if not pwndbg.gdblib.config.resolve_heap_via_heuristic:
+    if isinstance(pwndbg.heap.current, DebugSymsHeap):
         val = pwndbg.gdblib.typeinfo.read_gdbvalue("struct malloc_chunk", addr)
     else:
         val = pwndbg.heap.current.malloc_chunk(addr)

--- a/pwndbg/commands/hexdump.py
+++ b/pwndbg/commands/hexdump.py
@@ -8,6 +8,7 @@ import pwndbg.gdblib.config
 import pwndbg.gdblib.memory
 import pwndbg.gdblib.regs
 import pwndbg.hexdump
+from pwndbg.color import message
 
 pwndbg.gdblib.config.add_param("hexdump-width", 16, "line width of hexdump command")
 pwndbg.gdblib.config.add_param("hexdump-bytes", 64, "number of bytes printed by hexdump command")
@@ -19,7 +20,8 @@ pwndbg.gdblib.config.add_param(
 pwndbg.gdblib.config.add_param(
     "hexdump-group-use-big-endian",
     False,
-    "Use big-endian within each group of bytes. Only applies to raw bytes, not the ASCII part. "
+    "whether to use big-endian within each group of bytes in hexdump command",
+    help_docstring="When `on`, use big-endian within each group of bytes. Only applies to raw bytes, not the ASCII part. "
     "See also hexdump-highlight-group-lsb.",
 )
 

--- a/pwndbg/gdblib/config.py
+++ b/pwndbg/gdblib/config.py
@@ -80,9 +80,11 @@ class Parameter(gdb.Parameter):
 
     def get_show_string(self, svalue):
         """Handles the GDB `show <param>` command"""
-        return "%s is %r." % (
+        more_information_hint = " See `help set %s` for more information." % self.param.name
+        return "%s is %r.%s" % (
             self.param.set_show_doc.capitalize(),
             svalue,
+            more_information_hint if self.__doc__ else "",
         )
 
     @staticmethod

--- a/pwndbg/gdblib/config.py
+++ b/pwndbg/gdblib/config.py
@@ -29,9 +29,9 @@ class Parameter(gdb.Parameter):
         # `set_doc`, `show_doc`, and `__doc__` must be set before `gdb.Parameter.__init__`.
         # They will be used for `help set <param>` and `help show <param>`,
         # respectively
-        self.set_doc = "Set " + param.set_show_doc
-        self.show_doc = "Show " + param.set_show_doc
-        self.__doc__ = param.help_docstring
+        self.set_doc = "Set " + param.set_show_doc + "."
+        self.show_doc = "Show " + param.set_show_doc + "."
+        self.__doc__ = param.help_docstring or None
 
         if param.param_class == gdb.PARAM_ENUM:
             super().__init__(
@@ -76,13 +76,13 @@ class Parameter(gdb.Parameter):
         if not pwndbg.decorators.first_prompt:
             return ""
 
-        return "Set %s to %r" % (self.param.set_show_doc, self.native_value)
+        return "Set %s to %r." % (self.param.set_show_doc, self.native_value)
 
     def get_show_string(self, svalue):
         """Handles the GDB `show <param>` command"""
-        return "The current value of %r is %r" % (
-            self.param.name,
-            Parameter._value_to_gdb_native(svalue, self.param.param_class),
+        return "%s is %r." % (
+            self.param.set_show_doc.capitalize(),
+            svalue,
         )
 
     @staticmethod

--- a/pwndbg/heap/__init__.py
+++ b/pwndbg/heap/__init__.py
@@ -40,14 +40,11 @@ resolve_heap_via_heuristic = add_heap_param(
     "resolve-heap-via-heuristic",
     "auto",
     "the strategy to resolve heap via heuristic",
-    help_docstring="""If pwndbg fails to use the debug symbols to resolve the heap, it can try to resolve the heap via heuristics.
-This configuration sets the strategy for resolving the heap.
-
-There are three strategies:
-auto    == pwndbg will try to use heuristics if debug symbols are missing
-force   == pwndbg will always try to use heuristics, even if debug symbols are available
-never   == pwndbg will never use heuristics to resolve the heap
-
+    help_docstring="""\
+resolve-heap-via-heuristic can be:
+auto    - pwndbg will try to use heuristics if debug symbols are missing
+force   - pwndbg will always try to use heuristics, even if debug symbols are available
+never   - pwndbg will never use heuristics to resolve the heap
 
 If the output of the heap related command produces errors with heuristics, you can try manually setting the libc symbol addresses.
 For this, see the `heap_config` command output and set the `main_arena`, `mp_`, `global_max_fast`, `tcache` and `thread_arena` addresses.

--- a/pwndbg/heap/ptmalloc.py
+++ b/pwndbg/heap/ptmalloc.py
@@ -2185,7 +2185,6 @@ class HeuristicHeap(GlibcMemoryAllocator):
     def is_initialized(self):
         # TODO/FIXME: If main_arena['top'] is been modified to 0, this will not work.
         # try to use vmmap or main_arena.top to find the heap
-        return (
-            any("[heap]" == x.objfile for x in pwndbg.gdblib.vmmap.get())
-            or self.main_arena["top"] != 0
+        return any("[heap]" == x.objfile for x in pwndbg.gdblib.vmmap.get()) or (
+            self.can_be_resolved() and self.main_arena.top != 0
         )

--- a/pwndbg/lib/config.py
+++ b/pwndbg/lib/config.py
@@ -26,13 +26,18 @@ class Parameter:
         default,
         set_show_doc,
         *,
-        help_docstring=None,
+        help_docstring="",
         param_class=None,
         enum_sequence=None,
         scope="config",
     ):
+        # Note: `set_show_doc` should be a noun phrase, e.g. "the value of the foo"
+        # The `set_doc` will be "Set the value of the foo."
+        # The `show_doc` will be "Show the value of the foo."
+        # `get_set_string()` will return "Set the value of the foo to VALUE."
+        # `get_show_string()` will return "Show the value of the foo."
         self.set_show_doc = set_show_doc.strip()
-        self.help_docstring = help_docstring.strip() if help_docstring else None
+        self.help_docstring = help_docstring.strip()
         self.name = name
         self.default = default
         self.value = default
@@ -129,7 +134,7 @@ class Config:
         default,
         set_show_doc,
         *,
-        help_docstring=None,
+        help_docstring="",
         param_class=None,
         enum_sequence=None,
         scope="config",

--- a/tests/gdb-tests/tests/heap/test_heap.py
+++ b/tests/gdb-tests/tests/heap/test_heap.py
@@ -123,7 +123,7 @@ def test_malloc_chunk_command(start_binary):
 
 def test_malloc_chunk_command_heuristic(start_binary):
     start_binary(HEAP_MALLOC_CHUNK)
-    gdb.execute("set resolve-heap-via-heuristic on")
+    gdb.execute("set resolve-heap-via-heuristic force")
     gdb.execute("break break_here")
     gdb.execute("continue")
 
@@ -225,7 +225,7 @@ class mock_for_heuristic:
 
 def test_main_arena_heuristic(start_binary):
     start_binary(HEAP_MALLOC_CHUNK)
-    gdb.execute("set resolve-heap-via-heuristic on")
+    gdb.execute("set resolve-heap-via-heuristic force")
     gdb.execute("break break_here")
     gdb.execute("continue")
 
@@ -267,7 +267,7 @@ def test_main_arena_heuristic(start_binary):
 
 def test_mp_heuristic(start_binary):
     start_binary(HEAP_MALLOC_CHUNK)
-    gdb.execute("set resolve-heap-via-heuristic on")
+    gdb.execute("set resolve-heap-via-heuristic force")
     gdb.execute("break break_here")
     gdb.execute("continue")
 
@@ -303,7 +303,7 @@ def test_mp_heuristic(start_binary):
 def test_global_max_fast_heuristic(start_binary):
     # TODO: Support other architectures or different libc versions
     start_binary(HEAP_MALLOC_CHUNK)
-    gdb.execute("set resolve-heap-via-heuristic on")
+    gdb.execute("set resolve-heap-via-heuristic force")
     gdb.execute("break break_here")
     gdb.execute("continue")
 
@@ -331,7 +331,7 @@ def test_global_max_fast_heuristic(start_binary):
 def test_thread_cache_heuristic(start_binary):
     # TODO: Support other architectures or different libc versions
     start_binary(HEAP_MALLOC_CHUNK)
-    gdb.execute("set resolve-heap-via-heuristic on")
+    gdb.execute("set resolve-heap-via-heuristic force")
     gdb.execute("break break_here")
     gdb.execute("continue")
 
@@ -366,7 +366,7 @@ def test_thread_cache_heuristic(start_binary):
 def test_thread_arena_heuristic(start_binary):
     # TODO: Support other architectures or different libc versions
     start_binary(HEAP_MALLOC_CHUNK)
-    gdb.execute("set resolve-heap-via-heuristic on")
+    gdb.execute("set resolve-heap-via-heuristic force")
     gdb.execute("break break_here")
     gdb.execute("continue")
 
@@ -395,7 +395,7 @@ def test_thread_arena_heuristic(start_binary):
 def test_heuristic_fail_gracefully(start_binary):
     # TODO: Support other architectures or different libc versions
     start_binary(HEAP_MALLOC_CHUNK)
-    gdb.execute("set resolve-heap-via-heuristic on")
+    gdb.execute("set resolve-heap-via-heuristic force")
     gdb.execute("break break_here")
     gdb.execute("continue")
 

--- a/tests/gdb-tests/tests/test_gdblib_parameter.py
+++ b/tests/gdb-tests/tests/test_gdblib_parameter.py
@@ -35,10 +35,12 @@ def test_gdb_parameter_default_value_works(start_binary, params):
     param_name = f"test-param-{name_suffix}"
     help_docstring = f"Help docstring for {param_name}"
 
+    set_show_doc = "the value of the foo"
+
     param = pwndbg.gdblib.config.add_param(
         param_name,
         default_value,
-        "some show string",
+        set_show_doc,
         help_docstring=help_docstring,
         **optional_kwargs,
     )
@@ -47,7 +49,7 @@ def test_gdb_parameter_default_value_works(start_binary, params):
     pwndbg.gdblib.config_mod.Parameter(param)
 
     out = gdb.execute(f"show {param_name}", to_string=True)
-    assert out == f"The current value of {param_name!r} is {displayed_value!r}\n"
+    assert out == f"{set_show_doc.capitalize()} is {displayed_value!r}.\n"
     if (
         optional_kwargs.get("param_class") in (gdb.PARAM_UINTEGER, gdb.PARAM_INTEGER)
         and default_value == 0
@@ -62,10 +64,10 @@ def test_gdb_parameter_default_value_works(start_binary, params):
     assert param.value == default_value
 
     out = gdb.execute(f"help show {param_name}", to_string=True)
-    assert out == f"Show some show string\n{help_docstring}\n"
+    assert out == f"Show {set_show_doc}.\n{help_docstring}\n"
     assert (
         gdb.execute(f"help set {param_name}", to_string=True)
-        == f"Set some show string\n{help_docstring}\n"
+        == f"Set {set_show_doc}.\n{help_docstring}\n"
     )
 
     # TODO/FIXME: Is there a way to unregister a GDB parameter defined in Python?

--- a/tests/gdb-tests/tests/test_gdblib_parameter.py
+++ b/tests/gdb-tests/tests/test_gdblib_parameter.py
@@ -49,7 +49,10 @@ def test_gdb_parameter_default_value_works(start_binary, params):
     pwndbg.gdblib.config_mod.Parameter(param)
 
     out = gdb.execute(f"show {param_name}", to_string=True)
-    assert out == f"{set_show_doc.capitalize()} is {displayed_value!r}.\n"
+    assert (
+        out
+        == f"{set_show_doc.capitalize()} is {displayed_value!r}. See `help set {param_name}` for more information.\n"
+    )
     if (
         optional_kwargs.get("param_class") in (gdb.PARAM_UINTEGER, gdb.PARAM_INTEGER)
         and default_value == 0

--- a/tests/gdb-tests/tests/test_triggers.py
+++ b/tests/gdb-tests/tests/test_triggers.py
@@ -30,11 +30,15 @@ def test_triggers():
             set_show(param_name, 0)
             set_show(param_name, 1)
             set_show(param_name, -1)
-        elif isinstance(p.value, str):
+        elif isinstance(p.value, str) and p.param_class != gdb.PARAM_ENUM:
             set_show(param_name, "")
             set_show(param_name, "some invalid text")
             set_show(param_name, "red")
             set_show(param_name, "bold,yellow")
+        elif isinstance(p.value, str) and p.param_class == gdb.PARAM_ENUM:
+            # Only valid values are allowed, invalid values will cause an error
+            for enum in p.enum_sequence:
+                set_show(param_name, enum)
         else:
             print(p.value, type(p.value))
             assert False


### PR DESCRIPTION
Previously, we used `set resolve-heap-via-heuristic on` to apply the heuristic, but it was inconvenient at times. We had some discussions about this before (https://github.com/pwndbg/pwndbg/pull/1029#issuecomment-1273534456).
Now, the heuristics will automatically be used when the debug symbols are not sufficient to resolve the heap.
`resolve-heap-via-heuristic` is set to `auto` by default. To use or not use the heap heuristics, we can use `set resolve-heap-via-heuristic force` or `set resolve-heap-via-heuristic never`, respectively.

Here are some examples in auto mode:
(Note: the yellow hint that show we are going to use heap heuristic will only show once after heap instance changed from `DebugSymsHeap()` to `HeuristicHeap()`)
- When the debug symbols are missing:
<img width="1404" alt="截圖 2022-12-11 上午11 25 44" src="https://user-images.githubusercontent.com/61896187/206884931-9a4765d4-4157-4c41-9a56-57a593146821.png">

- When debugging statically linked binary:
<img width="1385" alt="截圖 2022-12-11 上午11 27 06" src="https://user-images.githubusercontent.com/61896187/206884944-464d26f4-1b85-403e-9845-29c719d0ffbb.png">



Additionally, this PR also attempts to fix some issues mentioned in #1416. 
(I'm not sure if all the issues related to configuration have been fixed, I just fixed the obvious errors :p)

For example:

- kernel-vmmap:
<img width="1400" alt="截圖 2022-12-11 下午12 09 34" src="https://user-images.githubusercontent.com/61896187/206885950-16f3cb9d-70dd-4495-a41e-04d346ecf1c0.png">

- hexdump-group-use-big-endian
<img width="1396" alt="截圖 2022-12-11 下午12 14 50" src="https://user-images.githubusercontent.com/61896187/206886087-1f4adca8-2fb0-459b-a6e4-8a448950ba3a.png">
