### PR TITLE
Fix the bug when using gdbserver

### DIFF
--- a/pwndbg/gdblib/remote.py
+++ b/pwndbg/gdblib/remote.py
@@ -32,10 +32,10 @@ def is_debug_probe():
             and "Black Magic Probe" not in help_output
             and "SEGGER J-Link GDB Server" not in help_output
         ):
-            # We can't directly use the `monitor` command if we are using normal GDBserver, because the `monitor` command will cause GDBserver stuck.
-            # So we check if we are using GDBserver by checking the output of `monitor help`.
-            # TODO: Does this problem only occur with normal GDBserver?
-            # If not, we should find a better way to check what remote server we are using.
+            # We can't use the `monitor` command directly when using normal GDBserver because it can cause GDBserver somehow show an additional newline in the end and fail to show the context because `pwndbg.gdblib.proc.thread_is_stopped` is False when running `gdb.prompt_hook`.
+            # To avoid this issue, we can check the output of `monitor help` to determine if we're using GDBserver.
+            # TODO/FIXME: Investigate the cause of this problem and fix it properly.
+            # TODO/FIXME: Determine if this issue only occurs with normal GDBserver and find a better way to check the remote server if necessary.
             return False
     except gdb.error:
         # Now we check if we are using Black Magic Probe or the SEGGER J-Link GDB Server

--- a/pwndbg/gdblib/remote.py
+++ b/pwndbg/gdblib/remote.py
@@ -25,24 +25,35 @@ def is_debug_probe():
     Returns True if the target is a debug probe for an embedded device.
     Currently detects the Black Magic Probe and the SEGGER J-Link GDB Server.
     """
+    # See https://github.com/pwndbg/pwndbg/pull/1439#issuecomment-1348477915 for the reason why we check the ouput like this.
     try:
         help_output = gdb.execute("monitor help", to_string=True)
-        if (
-            "GDBserver" in help_output
-            and "Black Magic Probe" not in help_output
-            and "SEGGER J-Link GDB Server" not in help_output
-        ):
+        if "Quit GDBserver\n" in help_output:
             # We can't use the `monitor` command directly when using normal GDBserver because it can cause GDBserver somehow show an additional newline in the end and fail to show the context because `pwndbg.gdblib.proc.thread_is_stopped` is False when running `gdb.prompt_hook`.
             # To avoid this issue, we can check the output of `monitor help` to determine if we're using GDBserver.
+            # The output on normal GDBserver looks like this:
+            # pwndbg> monitor help
+            # The following monitor commands are supported:
+            #   set debug <0|1>
+            #     Enable general debugging messages
+            #   set debug-hw-points <0|1>
+            #     Enable h/w breakpoint/watchpoint debugging messages
+            #   set remote-debug <0|1>
+            #     Enable remote protocol debugging messages
+            #   set event-loop-debug <0|1>
+            #     Enable event loop debugging messages
+            #   set debug-format option1[,option2,...]
+            #     Add additional information to debugging messages
+            #     Options: all, none, timestamp
+            #   exit
+            #     Quit GDBserver
             # TODO/FIXME: Investigate the cause of this problem and fix it properly.
             # TODO/FIXME: Determine if this issue only occurs with normal GDBserver and find a better way to check the remote server if necessary.
             return False
-    except gdb.error:
-        # Now we check if we are using Black Magic Probe or the SEGGER J-Link GDB Server
-        pass
-    try:
+        elif "SEGGER J-Link GDB Server" in help_output:
+            return True
         monitor_output = gdb.execute("monitor", to_string=True)
+        return "Black Magic Probe" in monitor_output or "SEGGER J-Link GDB Server" in monitor_output
     except gdb.error:
-        # the monitor command might fail, but we don't care since it doesn't fail on the devices we check for.
+        # SEGGER J-Link GDB Server and the Black Magic Probe should support the `monitor help` and `monitor` commands.
         return False
-    return "Black Magic Probe" in monitor_output or "SEGGER J-Link GDB Server" in monitor_output

--- a/pwndbg/gdblib/remote.py
+++ b/pwndbg/gdblib/remote.py
@@ -26,6 +26,21 @@ def is_debug_probe():
     Currently detects the Black Magic Probe and the SEGGER J-Link GDB Server.
     """
     try:
+        help_output = gdb.execute("monitor help", to_string=True)
+        if (
+            "GDBserver" in help_output
+            and "Black Magic Probe" not in help_output
+            and "SEGGER J-Link GDB Server" not in help_output
+        ):
+            # We can't directly use the `monitor` command if we are using normal GDBserver, because the `monitor` command will cause GDBserver stuck.
+            # So we check if we are using GDBserver by checking the output of `monitor help`.
+            # TODO: Does this problem only occur with normal GDBserver?
+            # If not, we should find a better way to check what remote server we are using.
+            return False
+    except gdb.error:
+        # Now we check if we are using Black Magic Probe or the SEGGER J-Link GDB Server
+        pass
+    try:
         monitor_output = gdb.execute("monitor", to_string=True)
     except gdb.error:
         # the monitor command might fail, but we don't care since it doesn't fail on the devices we check for.


### PR DESCRIPTION
If we execute the `monitor` command in `is_debug_probe()`, the GDB with normal GDBserver will ~~stuck~~ after first `continue`.(Edit: it didn't freeze, instead, it showed an additional newline and won't show context because `pwndbg.gdblib.proc.thread_is_stopped` is False when running `gdb.prompt_hook`)
> To reproduce this bug, you can use pwntools' `gdb.debug()`

To avoid this, we check if `monitor help` showed that we are using normal GDBserver.
