### PR TITLE
Fix ValueError of cyclic command

### DIFF
--- a/pwndbg/commands/cyclic.py
+++ b/pwndbg/commands/cyclic.py
@@ -82,5 +82,5 @@ def cyclic_cmd(alphabet, length, lookup, count=100):
         else:
             print(message.success(offset))
     else:
-        sequence = cyclic(count, alphabet, length)
+        sequence = cyclic(int(count), alphabet, length)
         print(sequence.decode())


### PR DESCRIPTION
<img width="877" alt="Screenshot 2022-12-20 at 02 14 14" src="https://user-images.githubusercontent.com/60180255/208482597-f4f559de-57e4-4f54-96e7-85a28bf70f21.png">

Fixed above ValueError of cyclic command for python 3.6.9 on ubuntu 18.04 (docker)
