### PR TITLE
Add ArchOps

### DIFF
--- a/pwndbg/gdblib/kernel/__init__.py
+++ b/pwndbg/gdblib/kernel/__init__.py
@@ -1,4 +1,7 @@
 import functools
+import math
+
+import gdb
 
 import pwndbg.gdblib.memory
 import pwndbg.gdblib.symbol
@@ -75,3 +78,174 @@ def is_kaslr_enabled() -> bool:
         return False
 
     return "nokaslr" not in kcmdline()
+
+
+class ArchOps:
+    def per_cpu(addr: gdb.Value, cpu=None):
+        raise NotImplementedError()
+
+    def virt_to_phys(self, virt: int) -> int:
+        raise NotImplementedError()
+
+    def phys_to_virt(self, phys: int) -> int:
+        raise NotImplementedError()
+
+    def phys_to_pfn(self, phys: int) -> int:
+        raise NotImplementedError()
+
+    def pfn_to_phys(self, pfn: int) -> int:
+        raise NotImplementedError()
+
+    def phys_to_page(self, phys: int) -> int:
+        raise NotImplementedError()
+
+    def page_to_phys(self, page: int) -> int:
+        raise NotImplementedError()
+
+    def virt_to_page(self, virt: int) -> int:
+        return phys_to_page(virt_to_phys(virt))
+
+    def page_to_virt(self, page: int) -> int:
+        return phys_to_virt(page_to_phys(page))
+
+
+class Aarch64Ops(ArchOps):
+    def __init__(self):
+        self.STRUCT_PAGE_SIZE = gdb.lookup_type("struct page").sizeof
+        self.STRUCT_PAGE_SHIFT = int(math.log2(self.STRUCT_PAGE_SIZE))
+
+        self.VA_BITS = int(kconfig()["ARM64_VA_BITS"])
+        self.PAGE_SHIFT = int(kconfig()["CONFIG_ARM64_PAGE_SHIFT"])
+        self.PAGE_SIZE = 1 << self.PAGE_SHIFT
+
+        self.PHYS_OFFSET = pwndbg.gdblib.memory.u(pwndbg.gdblib.symbol.address("memstart_addr"))
+        self.PAGE_OFFSET = (-1 << self.VA_BITS) + 2**64
+
+        VA_BITS_MIN = 48 if self.VA_BITS > 48 else self.VA_BITS
+        PAGE_END = (-1 << (VA_BITS_MIN - 1)) + 2**64
+        VMEMMAP_SIZE = (PAGE_END - self.PAGE_OFFSET) >> (self.PAGE_SHIFT - self.STRUCT_PAGE_SHIFT)
+
+        self.VMEMMAP_START = (-VMEMMAP_SIZE - 2 * 1024 * 1024) + 2**64
+
+    def per_cpu(self, addr: gdb.Value, cpu=None):
+        if cpu is None:
+            cpu = gdb.selected_thread().num - 1
+
+        per_cpu_offset = pwndbg.gdblib.symbol.address("__per_cpu_offset")
+        offset = pwndbg.gdblib.memory.u(per_cpu_offset + (cpu * 8))
+        per_cpu_addr = (int(addr) + offset) % 2**64
+        return gdb.Value(per_cpu_addr).cast(addr.type)
+
+    def virt_to_phys(self, virt: int) -> int:
+        return virt - self.PAGE_OFFSET
+
+    def phys_to_virt(self, phys: int) -> int:
+        return phys + self.PAGE_OFFSET
+
+    def phys_to_pfn(self, phys: int) -> int:
+        return phys >> self.PAGE_SHIFT
+
+    def pfn_to_phys(self, pfn: int) -> int:
+        return pfn << self.PAGE_SHIFT
+
+    def phys_to_page(self, phys: int) -> int:
+        return (self.STRUCT_PAGE_SIZE * phys_to_pfn(phys)) + self.VMEMMAP_START
+
+    def page_to_phys(self, page: int) -> int:
+        return pfn_to_phys((page - self.VMEMMAP_START) >> self.STRUCT_PAGE_SHIFT)
+
+
+_arch_ops = None
+
+
+@requires_debug_syms(default={})
+@pwndbg.lib.memoize.reset_on_start
+def arch_ops():
+    global _arch_ops
+    if _arch_ops is None:
+        arch_name = pwndbg.gdblib.arch.name
+        if pwndbg.gdblib.arch.name == "aarch64":
+            _arch_ops = Aarch64Ops()
+
+    return _arch_ops
+
+
+def per_cpu(addr: gdb.Value, cpu=None):
+    arch_name = pwndbg.gdblib.arch.name
+    ops = arch_ops()
+    if ops:
+        return ops.per_cpu(addr, cpu)
+    else:
+        raise NotImplementedError()
+
+
+def virt_to_phys(virt: int) -> int:
+    arch_name = pwndbg.gdblib.arch.name
+    ops = arch_ops()
+    if ops:
+        return ops.virt_to_phys(virt)
+    else:
+        raise NotImplementedError()
+
+
+def phys_to_virt(phys: int) -> int:
+    arch_name = pwndbg.gdblib.arch.name
+    ops = arch_ops()
+    if ops:
+        return ops.phys_to_virt(phys)
+    else:
+        raise NotImplementedError()
+
+
+def phys_to_pfn(phys: int) -> int:
+    arch_name = pwndbg.gdblib.arch.name
+    ops = arch_ops()
+    if ops:
+        return ops.phys_to_pfn(phys)
+    else:
+        raise NotImplementedError()
+
+
+def pfn_to_phys(pfn: int) -> int:
+    arch_name = pwndbg.gdblib.arch.name
+    ops = arch_ops()
+    if ops:
+        return ops.pfn_to_phys(pfn)
+    else:
+        raise NotImplementedError()
+
+
+def phys_to_page(phys: int) -> int:
+    arch_name = pwndbg.gdblib.arch.name
+    ops = arch_ops()
+    if ops:
+        return ops.phys_to_page(phys)
+    else:
+        raise NotImplementedError()
+
+
+def page_to_phys(page: int) -> int:
+    arch_name = pwndbg.gdblib.arch.name
+    ops = arch_ops()
+    if ops:
+        return ops.page_to_phys(page)
+    else:
+        raise NotImplementedError()
+
+
+def virt_to_page(virt: int) -> int:
+    arch_name = pwndbg.gdblib.arch.name
+    ops = arch_ops()
+    if ops:
+        return ops.virt_to_page(virt)
+    else:
+        raise NotImplementedError()
+
+
+def page_to_virt(page: int) -> int:
+    arch_name = pwndbg.gdblib.arch.name
+    ops = arch_ops()
+    if ops:
+        return ops.page_to_virt(page)
+    else:
+        raise NotImplementedError()


### PR DESCRIPTION
`ArchOps` abstracts away any architecture defined behavior of the kernel. Currently only implemented for AArch64.