### PR TITLE
Fail tests if an error occurs

### DIFF
--- a/tests/gdb-tests/tests.sh
+++ b/tests/gdb-tests/tests.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+set -o errexit
+set -o pipefail
+
 ROOT_DIR="$(readlink -f ../../)"
 GDB_INIT_PATH="$ROOT_DIR/gdbinit.py"
 COVERAGERC_PATH="$ROOT_DIR/pyproject.toml"


### PR DESCRIPTION
Errors in the tests.sh script itself are currently being ignored, resulting in the tests passing even if some error prevents them from running.