### PR TITLE
Use RawTextHelpFormatter for more commands

### DIFF
--- a/pwndbg/commands/argv.py
+++ b/pwndbg/commands/argv.py
@@ -14,8 +14,7 @@ def argc():
     print(pwndbg.gdblib.argv.argc)
 
 
-parser = argparse.ArgumentParser()
-parser.description = "Prints out the contents of argv."
+parser = argparse.ArgumentParser(description="Prints out the contents of argv.")
 parser.add_argument(
     "i", nargs="?", type=int, default=None, help="Index of the argument to print out."
 )
@@ -34,8 +33,7 @@ def argv(i=None):
     pwndbg.commands.telescope.telescope(start, n)
 
 
-parser = argparse.ArgumentParser()
-parser.description = "Prints out the contents of the environment."
+parser = argparse.ArgumentParser(description="Prints out the contents of the environment.")
 parser.add_argument(
     "name", nargs="?", type=str, default=None, help="Name of the environment variable to see."
 )

--- a/pwndbg/commands/aslr.py
+++ b/pwndbg/commands/aslr.py
@@ -10,11 +10,12 @@ from pwndbg.color import message
 options = {"on": "off", "off": "on"}
 
 parser = argparse.ArgumentParser(
+    formatter_class=argparse.RawTextHelpFormatter,
     description="""
 Check the current ASLR status, or turn it on/off.
 
 Does not take effect until the program is restarted.
-"""
+""",
 )
 parser.add_argument(
     "state",

--- a/pwndbg/commands/attachp.py
+++ b/pwndbg/commands/attachp.py
@@ -10,6 +10,7 @@ import pwndbg.color.message as message
 import pwndbg.commands
 
 parser = argparse.ArgumentParser(
+    formatter_class=argparse.RawTextHelpFormatter,
     description="""Attaches to a given pid, process name or device file.
 
 This command wraps the original GDB `attach` command to add the ability
@@ -27,7 +28,7 @@ Original GDB attach command help:
     program running in the process, looking first in the current working
     directory, or (if not found there) using the source file search path
     (see the "directory" command).  You can also use the "file" command
-    to specify the program, and to load its symbol table."""
+    to specify the program, and to load its symbol table.""",
 )
 
 parser.add_argument("target", type=str, help="pid, process name or device file to attach to")

--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -202,8 +202,7 @@ def output(section):
         return FileOutput(target, "w")
 
 
-parser = argparse.ArgumentParser()
-parser.description = "Sets the output of a context section."
+parser = argparse.ArgumentParser(description="Sets the output of a context section.")
 parser.add_argument(
     "section",
     type=str,
@@ -251,8 +250,9 @@ expression_commands = {
     "execute": lambda exp: gdb.execute(exp, False, True),
 }
 
-parser = argparse.ArgumentParser()
-parser.description = """
+parser = argparse.ArgumentParser(
+    formatter_class=argparse.RawTextHelpFormatter,
+    description="""
 Adds an expression to be shown on context.
 
 'cmd' controls what command is used to interpret the expression.
@@ -260,7 +260,8 @@ eval: the expression is parsed and evaluated as in the debugged language.
 execute: the expression is executed as an gdb command.
 
 To remove an expression, see `cunwatch`.
-"""
+""",
+)
 parser.add_argument(
     "cmd",
     type=str,
@@ -356,8 +357,9 @@ def context_ghidra(target=sys.stdout, with_banner=True, width=None):
 
 # @pwndbg.gdblib.events.stop
 
-parser = argparse.ArgumentParser()
-parser.description = "Print out the current register, instruction, and stack context."
+parser = argparse.ArgumentParser(
+    description="Print out the current register, instruction, and stack context."
+)
 parser.add_argument(
     "subcontext",
     nargs="*",
@@ -515,8 +517,7 @@ def context_regs(target=sys.stdout, with_banner=True, width=None):
     return banner + regs if with_banner else regs
 
 
-parser = argparse.ArgumentParser()
-parser.description = """Print out all registers and enhance the information."""
+parser = argparse.ArgumentParser(description="Print out all registers and enhance the information.")
 parser.add_argument("regs", nargs="*", type=str, default=None, help="Registers to be shown")
 
 

--- a/pwndbg/commands/dt.py
+++ b/pwndbg/commands/dt.py
@@ -5,12 +5,14 @@ import pwndbg.commands
 import pwndbg.gdblib.dt
 import pwndbg.gdblib.vmmap
 
-parser = argparse.ArgumentParser()
-parser.description = """
+parser = argparse.ArgumentParser(
+    formatter_class=argparse.RawTextHelpFormatter,
+    description="""
     Dump out information on a type (e.g. ucontext_t).
 
     Optionally overlay that information at an address.
-    """
+    """,
+)
 parser.add_argument("typename", type=str, help="The name of the structure being dumped.")
 parser.add_argument(
     "address", type=int, nargs="?", default=None, help="The address of the structure."

--- a/pwndbg/commands/ghidra.py
+++ b/pwndbg/commands/ghidra.py
@@ -4,8 +4,7 @@ import pwndbg.color.message as message
 import pwndbg.commands
 import pwndbg.ghidra
 
-parser = argparse.ArgumentParser()
-parser.description = """Decompile a given function using ghidra"""
+parser = argparse.ArgumentParser(description="Decompile a given function using ghidra")
 parser.add_argument(
     "func",
     type=str,

--- a/pwndbg/commands/ida.py
+++ b/pwndbg/commands/ida.py
@@ -27,11 +27,7 @@ def j(*args):
         pass
 
 
-parser = argparse.ArgumentParser()
-parser.description = """
-    Select and print stack frame that called this one.
-    An argument says how many frames up to go.
-    """
+parser = argparse.ArgumentParser(description="Select and print stack frame that called this one.")
 parser.add_argument(
     "n", nargs="?", default=1, type=int, help="The number of stack frames to go up."
 )
@@ -42,7 +38,6 @@ parser.add_argument(
 def up(n=1):
     """
     Select and print stack frame that called this one.
-    An argument says how many frames up to go.
     """
     f = gdb.selected_frame()
 
@@ -60,11 +55,7 @@ def up(n=1):
     j()
 
 
-parser = argparse.ArgumentParser()
-parser.description = """
-    Select and print stack frame called by this one.
-    An argument says how many frames down to go.
-    """
+parser = argparse.ArgumentParser(description="Select and print stack frame called by this one.")
 parser.add_argument(
     "n", nargs="?", default=1, type=int, help="The number of stack frames to go down."
 )
@@ -75,7 +66,6 @@ parser.add_argument(
 def down(n=1):
     """
     Select and print stack frame called by this one.
-    An argument says how many frames down to go.
     """
     f = gdb.selected_frame()
 

--- a/pwndbg/commands/ignore.py
+++ b/pwndbg/commands/ignore.py
@@ -9,13 +9,14 @@ import gdb
 import pwndbg.color.message as message
 import pwndbg.commands
 
-parser = argparse.ArgumentParser()
-parser.description = """Set ignore-count of breakpoint number N to COUNT.
+parser = argparse.ArgumentParser(
+    formatter_class=argparse.RawTextHelpFormatter,
+    description="""Set ignore-count of breakpoint number N to COUNT.
 
 While the ignore count is positive, execution will not stop on the breakpoint.
 
-By default, if `N' is ommitted, the last breakpoint (i.e. greatest breakpoint number) will be used."""
-parser.formatter_class = argparse.RawDescriptionHelpFormatter
+By default, if `N' is ommitted, the last breakpoint (i.e. greatest breakpoint number) will be used.""",
+)
 parser.add_argument(
     "bpnum", metavar="N", type=int, default=None, nargs="?", help="The breakpoint number N."
 )

--- a/pwndbg/commands/leakfind.py
+++ b/pwndbg/commands/leakfind.py
@@ -50,16 +50,17 @@ def dbg_print_map(maps):
         print("0x%x + (0x%x, 0x%x)" % (child, parent_info[0], parent_info[1]))
 
 
-parser = argparse.ArgumentParser()
-parser.description = """
+parser = argparse.ArgumentParser(
+    formatter_class=argparse.RawTextHelpFormatter,
+    description="""
 Attempt to find a leak chain given a starting address.
 Scans memory near the given address, looks for pointers, and continues that process to attempt to find leaks.
 
 Example: leakfind $rsp --page_name=filename --max_offset=0x48 --max_depth=6. This would look for any chains of leaks \
 that point to a section in filename which begin near $rsp, are never 0x48 bytes further from a known pointer, \
 and are a maximum length of 6.
-"""
-parser.formatter_class = argparse.RawDescriptionHelpFormatter
+""",
+)
 parser.add_argument(
     "address", nargs="?", default="$sp", help="Starting address to find a leak chain from"
 )

--- a/pwndbg/commands/misc.py
+++ b/pwndbg/commands/misc.py
@@ -11,9 +11,7 @@ import pwndbg.gdblib.symbol
 errno.errorcode[0] = "OK"  # type: ignore # manually add error code 0 for "OK"
 
 parser = argparse.ArgumentParser(
-    description="""
-Converts errno (or argument) to its string representation.
-"""
+    description="Converts errno (or argument) to its string representation."
 )
 parser.add_argument(
     "err",
@@ -60,9 +58,7 @@ def errno_(err):
 
 
 parser = argparse.ArgumentParser(
-    description="""
-Prints out a list of all pwndbg commands. The list can be optionally filtered if filter_pattern is passed.
-"""
+    description="Prints out a list of all pwndbg commands. The list can be optionally filtered if filter_pattern is passed."
 )
 
 group = parser.add_mutually_exclusive_group()
@@ -94,7 +90,7 @@ def pwndbg_(filter_pattern, shell, all_):
         print("%-20s %s" % (name, docs))
 
 
-parser = argparse.ArgumentParser(description="""Print the distance between the two arguments.""")
+parser = argparse.ArgumentParser(description="Print the distance between the two arguments.")
 parser.add_argument("a", type=int, help="The first address.")
 parser.add_argument("b", type=int, help="The second address.")
 

--- a/pwndbg/commands/mprotect.py
+++ b/pwndbg/commands/mprotect.py
@@ -14,6 +14,7 @@ import pwndbg.wrappers.readelf
 from pwndbg.lib.regs import reg_sets
 
 parser = argparse.ArgumentParser(
+    formatter_class=argparse.RawTextHelpFormatter,
     description="""
 Calls the mprotect syscall and prints its result value
 
@@ -24,7 +25,7 @@ can be decoded with the `errno <value>` command.
 Examples:
     mprotect $rsp PROT_READ|PROT_WRITE|PROT_EXEC
     mprotect some_symbol PROT_NONE
-"""
+""",
 )
 parser.add_argument(
     "addr", help="Page-aligned address to all mprotect on.", type=pwndbg.commands.sloppy_gdb_parse

--- a/pwndbg/commands/nearpc.py
+++ b/pwndbg/commands/nearpc.py
@@ -57,7 +57,7 @@ show_args = pwndbg.gdblib.config.add_param(
     "nearpc-show-args", True, "show call arguments below instruction"
 )
 
-parser = argparse.ArgumentParser(description="""Disassemble near a specified address.""")
+parser = argparse.ArgumentParser(description="Disassemble near a specified address.")
 parser.add_argument("pc", type=int, nargs="?", default=None, help="Address to disassemble near.")
 parser.add_argument(
     "lines",
@@ -225,7 +225,7 @@ def nearpc(pc=None, lines=None, to_string=False, emulate=False):
 
 
 parser = argparse.ArgumentParser(
-    description="""Like nearpc, but will emulate instructions from the current $PC forward."""
+    description="Like nearpc, but will emulate instructions from the current $PC forward."
 )
 parser.add_argument("pc", type=int, nargs="?", default=None, help="Address to emulate near.")
 parser.add_argument(
@@ -250,7 +250,7 @@ def emulate(pc=None, lines=None, to_string=False, emulate=True):
 emulate_command = emulate
 
 
-parser = argparse.ArgumentParser(description="""Compatibility layer for PEDA's pdisass command.""")
+parser = argparse.ArgumentParser(description="Compatibility layer for PEDA's pdisass command.")
 parser.add_argument("pc", type=int, nargs="?", default=None, help="Address to disassemble near.")
 parser.add_argument(
     "lines",

--- a/pwndbg/commands/next.py
+++ b/pwndbg/commands/next.py
@@ -18,7 +18,7 @@ def nextjmp():
         pwndbg.commands.context.context()
 
 
-parser = argparse.ArgumentParser(description="""Breaks at the next call instruction""")
+parser = argparse.ArgumentParser(description="Breaks at the next call instruction")
 parser.add_argument(
     "symbol_regex",
     type=str,
@@ -70,9 +70,7 @@ def nextproginstr():
     pwndbg.gdblib.next.break_on_program_code()
 
 
-parser = argparse.ArgumentParser(
-    description="""Sets a breakpoint on the instruction after this one"""
-)
+parser = argparse.ArgumentParser(description="Sets a breakpoint on the instruction after this one")
 parser.add_argument("addr", type=int, default=None, nargs="?", help="The address to break after.")
 
 

--- a/pwndbg/commands/pie.py
+++ b/pwndbg/commands/pie.py
@@ -67,8 +67,7 @@ def translate_addr(offset, module):
     return addr
 
 
-parser = argparse.ArgumentParser()
-parser.description = "Calculate VA of RVA from PIE base."
+parser = argparse.ArgumentParser(description="Calculate VA of RVA from PIE base.")
 parser.add_argument("offset", nargs="?", default=0, help="Offset from PIE base.")
 parser.add_argument(
     "module",

--- a/pwndbg/commands/probeleak.py
+++ b/pwndbg/commands/probeleak.py
@@ -43,6 +43,7 @@ def flags_str2int(flags_s):
 
 
 parser = argparse.ArgumentParser(
+    formatter_class=argparse.RawTextHelpFormatter,
     description="""
 Pointer scan for possible offset leaks.
 Examples:
@@ -50,9 +51,8 @@ Examples:
     probeleak $rsp 0x64 --max-dist 0x10 - as above, but pointers may point 0x10 bytes outside of memory page
     probeleak $rsp 0x64 --point-to libc --max-ptrs 1 --flags rwx - leaks 0x64 bytes starting at stack pointer and \
 search for one valid pointer which points to a libc rwx page
-"""
+""",
 )
-parser.formatter_class = argparse.RawDescriptionHelpFormatter
 parser.add_argument("address", nargs="?", default="$sp", help="Leak memory address")
 parser.add_argument("count", nargs="?", default=0x40, help="Leak size in bytes")
 parser.add_argument(

--- a/pwndbg/commands/search.py
+++ b/pwndbg/commands/search.py
@@ -45,9 +45,7 @@ auto_save = pwndbg.gdblib.config.add_param(
 )
 
 parser = argparse.ArgumentParser(
-    description="""
-Search memory for byte sequences, strings, pointers, and integer values
-"""
+    description="Search memory for byte sequences, strings, pointers, and integer values"
 )
 parser.add_argument(
     "-t",

--- a/pwndbg/commands/start.py
+++ b/pwndbg/commands/start.py
@@ -28,6 +28,7 @@ def on_start():
 # Starting from 3rd paragraph, the description is
 # taken from the GDB's `starti` command description
 parser = argparse.ArgumentParser(
+    formatter_class=RawTextHelpFormatter,
     description="""
 Start the debugged program stopping at the first convenient location
 from this list: main, _main, start, _start, init or _init.
@@ -44,7 +45,6 @@ use "set args" without arguments.
 
 To start the inferior without using a shell, use "set startup-with-shell off".
 """,
-    formatter_class=RawTextHelpFormatter,
 )
 
 parser.add_argument(
@@ -77,6 +77,7 @@ def start(args=None):
 # Starting from 3rd paragraph, the description is
 # taken from the GDB's `starti` command description
 parser = argparse.ArgumentParser(
+    formatter_class=RawTextHelpFormatter,
     description="""
 Start the debugged program stopping at its entrypoint address.
 You may specify arguments to give it.
@@ -96,7 +97,6 @@ use "set args" without arguments.
 
 To start the inferior without using a shell, use "set startup-with-shell off".
 """,
-    formatter_class=RawTextHelpFormatter,
 )
 parser.add_argument(
     "args", nargs="*", type=str, default=None, help="The arguments to run the binary with."

--- a/pwndbg/commands/telescope.py
+++ b/pwndbg/commands/telescope.py
@@ -44,10 +44,7 @@ repeating_marker = theme.add_param(
 
 
 parser = argparse.ArgumentParser(
-    description="""
-    Recursively dereferences pointers starting at the specified address
-    ($sp by default)
-    """
+    description="Recursively dereferences pointers starting at the specified address ($sp by default)"
 )
 parser.add_argument(
     "-r",

--- a/pwndbg/commands/version.py
+++ b/pwndbg/commands/version.py
@@ -77,11 +77,7 @@ def version():
     print("\n".join(map(message.system, all_versions())))
 
 
-bugreport_parser = argparse.ArgumentParser(
-    description="""
-    Generate bugreport
-    """
-)
+bugreport_parser = argparse.ArgumentParser(description="Generate bugreport")
 bugreport_group = bugreport_parser.add_mutually_exclusive_group()
 bugreport_group.add_argument(
     "--run-browser", "-b", action="store_true", help="Open browser on github/issues/new"

--- a/pwndbg/commands/vmmap.py
+++ b/pwndbg/commands/vmmap.py
@@ -47,8 +47,9 @@ def print_vmmap_table_header():
     )
 
 
-parser = argparse.ArgumentParser()
-parser.description = """Print virtual memory map pages. Results can be filtered by providing address/module name.
+parser = argparse.ArgumentParser(
+    formatter_class=argparse.RawTextHelpFormatter,
+    description="""Print virtual memory map pages. Results can be filtered by providing address/module name.
 
 Unnamed mappings are named as [anon_%#x] where %#x is high part of their start address. This is useful for filtering with `vmmap` or `search` commands.
 
@@ -63,8 +64,8 @@ As a last resort, we sometimes try to explore the addresses in CPU registers and
 
 Memory pages can also be added manually with the use of vmmap_add, vmmap_clear and vmmap_load commands. This may be useful for bare metal debugging.
 
-[0] https://lore.kernel.org/all/20220221030910.3203063-1-dominik.b.czarnota@gmail.com/"""
-parser.formatter_class = argparse.RawDescriptionHelpFormatter
+[0] https://lore.kernel.org/all/20220221030910.3203063-1-dominik.b.czarnota@gmail.com/""",
+)
 parser.add_argument(
     "gdbval_or_str",
     type=pwndbg.commands.sloppy_gdb_parse,
@@ -103,8 +104,7 @@ def vmmap(gdbval_or_str=None, writable=False, executable=False):
         print("\n[QEMU target detected - vmmap result might not be accurate; see `help vmmap`]")
 
 
-parser = argparse.ArgumentParser()
-parser.description = "Add Print virtual memory map page."
+parser = argparse.ArgumentParser(description="Add virtual memory map page.")
 parser.add_argument("start", help="Starting virtual address")
 parser.add_argument("size", help="Size of the address space, in bytes")
 parser.add_argument(
@@ -144,8 +144,7 @@ def vmmap_clear():
     pwndbg.gdblib.vmmap.clear_custom_page()
 
 
-parser = argparse.ArgumentParser()
-parser.description = "Load virtual memory map pages from ELF file."
+parser = argparse.ArgumentParser(description="Load virtual memory map pages from ELF file.")
 parser.add_argument(
     "filename", nargs="?", type=str, help="ELF filename, by default uses current loaded filename."
 )

--- a/pwndbg/commands/windbg.py
+++ b/pwndbg/commands/windbg.py
@@ -312,8 +312,7 @@ def dds(addr):
     return pwndbg.commands.telescope.telescope(addr)
 
 
-da_parser = argparse.ArgumentParser()
-da_parser.description = "Dump a string at the specified address."
+da_parser = argparse.ArgumentParser(description="Dump a string at the specified address.")
 da_parser.add_argument("address", type=pwndbg.commands.HexOrAddressExpr, help="Address to dump")
 da_parser.add_argument("max", type=int, nargs="?", default=256, help="Maximum string length")
 
@@ -324,8 +323,7 @@ def da(address, max):
     print("%x" % address, repr(pwndbg.gdblib.strings.get(address, max)))
 
 
-ds_parser = argparse.ArgumentParser()
-ds_parser.description = "Dump a string at the specified address."
+ds_parser = argparse.ArgumentParser(description="Dump a string at the specified address.")
 ds_parser.add_argument("address", type=pwndbg.commands.HexOrAddressExpr, help="Address to dump")
 ds_parser.add_argument("max", type=int, nargs="?", default=256, help="Maximum string length")
 


### PR DESCRIPTION
Also removes triple quotes when they're not necessary (makes it easier to grep for real multiline strings) and sets the `description` field in the `ArgumentParser` constructor.