### PR TITLE
Cleanup command docstrings

### DIFF
--- a/pwndbg/commands/comments.py
+++ b/pwndbg/commands/comments.py
@@ -4,7 +4,7 @@ from typing import Dict
 import pwndbg.commands
 from pwndbg.color import message
 
-parser = argparse.ArgumentParser(description="Put comments in assembly code")
+parser = argparse.ArgumentParser(description="Put comments in assembly code.")
 parser.add_argument(
     "--addr", metavar="address", default=None, type=str, help="Address to write comments"
 )

--- a/pwndbg/commands/config.py
+++ b/pwndbg/commands/config.py
@@ -45,9 +45,7 @@ def get_config_parameters(scope, filter_pattern):
     return values
 
 
-parser = argparse.ArgumentParser(
-    description="Shows pwndbg-specific config. The list can be filtered."
-)
+parser = argparse.ArgumentParser(description="Shows pwndbg-specific configuration.")
 parser.add_argument(
     "filter_pattern",
     type=str,
@@ -102,15 +100,13 @@ def config(filter_pattern):
 
 
 configfile_parser = argparse.ArgumentParser(
-    description="Generates a configuration file for the current Pwndbg options"
+    description="Generates a configuration file for the current pwndbg options."
 )
 configfile_parser.add_argument(
-    "--show-all", action="store_true", help="Force displaying of all configs."
+    "--show-all", action="store_true", help="Display all configuration options."
 )
 
-parser = argparse.ArgumentParser(
-    description="Shows pwndbg-specific theme config. The list can be filtered."
-)
+parser = argparse.ArgumentParser(description="Shows pwndbg-specific theme configuration.")
 parser.add_argument(
     "filter_pattern",
     type=str,
@@ -131,7 +127,7 @@ def configfile(show_all=False):
 
 
 themefile_parser = argparse.ArgumentParser(
-    description="Generates a configuration file for the current Pwndbg theme options"
+    description="Generates a configuration file for the current pwndbg theme options."
 )
 themefile_parser.add_argument(
     "--show-all", action="store_true", help="Force displaying of all theme options."

--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -255,9 +255,9 @@ parser = argparse.ArgumentParser(
     description="""
 Adds an expression to be shown on context.
 
-'cmd' controls what command is used to interpret the expression.
-eval: the expression is parsed and evaluated as in the debugged language.
-execute: the expression is executed as an gdb command.
+'cmd' controls what command is used to interpret the expression:
+- eval: the expression is parsed and evaluated as in the debugged language.
+- execute: the expression is executed as a GDB command.
 
 To remove an expression, see `cunwatch`.
 """,

--- a/pwndbg/commands/cpsr.py
+++ b/pwndbg/commands/cpsr.py
@@ -4,7 +4,9 @@ import pwndbg.gdblib.regs
 from pwndbg.color import context
 
 
-@pwndbg.commands.ArgparsedCommand("Print out ARM CPSR or xPSR register", aliases=["xpsr", "pstate"])
+@pwndbg.commands.ArgparsedCommand(
+    "Print out ARM CPSR or xPSR register.", aliases=["xpsr", "pstate"]
+)
 @pwndbg.commands.OnlyWithArch(["arm", "armcm", "aarch64"])
 @pwndbg.commands.OnlyWhenRunning
 def cpsr():

--- a/pwndbg/commands/cyclic.py
+++ b/pwndbg/commands/cyclic.py
@@ -9,7 +9,7 @@ import pwndbg.commands
 import pwndbg.gdblib.arch
 from pwndbg.color import message
 
-parser = argparse.ArgumentParser(description="Cyclic pattern creator/finder")
+parser = argparse.ArgumentParser(description="Cyclic pattern creator/finder.")
 
 parser.add_argument(
     "-a",

--- a/pwndbg/commands/cymbol.py
+++ b/pwndbg/commands/cymbol.py
@@ -203,7 +203,7 @@ def show_custom_structure(custom_structure_name, custom_structure_path):
 
 
 parser = argparse.ArgumentParser(
-    description="Add, show, load, edit, or delete custom structures in plain C"
+    description="Add, show, load, edit, or delete custom structures in plain C."
 )
 parser.add_argument(
     "-a",

--- a/pwndbg/commands/flags.py
+++ b/pwndbg/commands/flags.py
@@ -3,7 +3,7 @@ from argparse import RawTextHelpFormatter
 
 import pwndbg.commands
 
-description = "Modify the flags register"
+description = "Modify the flags register."
 epilog = """Examples:
   On X86/X64:
     setflag ZF 1        -- set zero flag

--- a/pwndbg/commands/ghidra.py
+++ b/pwndbg/commands/ghidra.py
@@ -4,7 +4,7 @@ import pwndbg.color.message as message
 import pwndbg.commands
 import pwndbg.ghidra
 
-parser = argparse.ArgumentParser(description="Decompile a given function using ghidra")
+parser = argparse.ArgumentParser(description="Decompile a given function using Ghidra.")
 parser.add_argument(
     "func",
     type=str,

--- a/pwndbg/commands/got.py
+++ b/pwndbg/commands/got.py
@@ -9,7 +9,7 @@ import pwndbg.wrappers.checksec
 import pwndbg.wrappers.readelf
 from pwndbg.color import message
 
-parser = argparse.ArgumentParser(description="Show the state of the Global Offset Table")
+parser = argparse.ArgumentParser(description="Show the state of the Global Offset Table.")
 parser.add_argument(
     "name_filter", help="Filter results by passed name.", type=str, nargs="?", default=""
 )

--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -102,9 +102,11 @@ def format_bin(bins: Bins, verbose=False, offset=None):
     return result
 
 
-parser = argparse.ArgumentParser()
-parser.description = (
-    "Iteratively print chunks on a heap, default to the current thread's active heap."
+parser = argparse.ArgumentParser(
+    formatter_class=argparse.RawTextHelpFormatter,
+    description="""Iteratively print chunks on a heap.
+
+Default to the current thread's active heap.""",
 )
 parser.add_argument(
     "addr",
@@ -144,8 +146,12 @@ def heap(addr=None, verbose=False, simple=False):
             malloc_chunk(chunk.address)
 
 
-parser = argparse.ArgumentParser()
-parser.description = "Print the contents of an arena, default to the current thread's arena."
+parser = argparse.ArgumentParser(
+    formatter_class=argparse.RawTextHelpFormatter,
+    description="""Print the contents of an arena.
+
+Default to the current thread's arena.""",
+)
 parser.add_argument("addr", nargs="?", type=int, default=None, help="Address of the arena.")
 
 
@@ -165,8 +171,7 @@ def arena(addr=None):
     print(arena._gdbValue)  # Breaks encapsulation, find a better way.
 
 
-parser = argparse.ArgumentParser()
-parser.description = "List this process's arenas."
+parser = argparse.ArgumentParser(description="List this process's arenas.")
 
 
 @pwndbg.commands.ArgparsedCommand(parser)
@@ -180,8 +185,12 @@ def arenas():
         print(ar)
 
 
-parser = argparse.ArgumentParser()
-parser.description = "Print a thread's tcache contents, default to the current thread's tcache."
+parser = argparse.ArgumentParser(
+    formatter_class=argparse.RawTextHelpFormatter,
+    description="""Print a thread's tcache contents.
+
+Default to the current thread's tcache.""",
+)
 parser.add_argument("addr", nargs="?", type=int, default=None, help="Address of the tcache.")
 
 
@@ -199,8 +208,7 @@ def tcache(addr=None):
     print(tcache)
 
 
-parser = argparse.ArgumentParser()
-parser.description = "Print the mp_ struct's contents."
+parser = argparse.ArgumentParser(description="Print the mp_ struct's contents.")
 
 
 @pwndbg.commands.ArgparsedCommand(parser)
@@ -213,9 +221,11 @@ def mp():
     print(allocator.mp)
 
 
-parser = argparse.ArgumentParser()
-parser.description = (
-    "Print relevant information about an arena's top chunk, default to current thread's arena."
+parser = argparse.ArgumentParser(
+    formatter_class=argparse.RawTextHelpFormatter,
+    description="""Print relevant information about an arena's top chunk.
+
+Default to current thread's arena.""",
 )
 parser.add_argument("addr", nargs="?", type=int, default=None, help="Address of the arena.")
 
@@ -238,8 +248,7 @@ def top_chunk(addr=None):
     malloc_chunk(arena.top)
 
 
-parser = argparse.ArgumentParser()
-parser.description = "Print a chunk."
+parser = argparse.ArgumentParser(description="Print a chunk.")
 parser.add_argument(
     "addr", type=int, help="Address of the chunk (malloc_chunk struct start, prev_size field)."
 )
@@ -325,8 +334,12 @@ def malloc_chunk(addr, fake=False, verbose=False, simple=False):
     print(" | ".join(headers_to_print) + "\n" + out_fields)
 
 
-parser = argparse.ArgumentParser()
-parser.description = "Print the contents of all an arena's bins and a thread's tcache, default to the current thread's arena and tcache."
+parser = argparse.ArgumentParser(
+    formatter_class=argparse.RawTextHelpFormatter,
+    description="""Print the contents of all an arena's bins and a thread's tcache.
+
+Default to the current thread's arena and tcache.""",
+)
 parser.add_argument("addr", nargs="?", type=int, default=None, help="Address of the arena.")
 parser.add_argument("tcache_addr", nargs="?", type=int, default=None, help="Address of the tcache.")
 
@@ -347,9 +360,11 @@ def bins(addr=None, tcache_addr=None):
     largebins(addr)
 
 
-parser = argparse.ArgumentParser()
-parser.description = (
-    "Print the contents of an arena's fastbins, default to the current thread's arena."
+parser = argparse.ArgumentParser(
+    formatter_class=argparse.RawTextHelpFormatter,
+    description="""Print the contents of an arena's fastbins.
+
+Default to the current thread's arena.""",
 )
 parser.add_argument("addr", nargs="?", type=int, default=None, help="Address of the arena.")
 parser.add_argument("verbose", nargs="?", type=bool, default=True, help="Show extra detail.")
@@ -376,9 +391,11 @@ def fastbins(addr=None, verbose=True):
         print(node)
 
 
-parser = argparse.ArgumentParser()
-parser.description = (
-    "Print the contents of an arena's unsortedbin, default to the current thread's arena."
+parser = argparse.ArgumentParser(
+    formatter_class=argparse.RawTextHelpFormatter,
+    description="""Print the contents of an arena's unsortedbin.
+
+Default to the current thread's arena.""",
 )
 parser.add_argument("addr", nargs="?", type=int, default=None, help="Address of the arena.")
 parser.add_argument("verbose", nargs="?", type=bool, default=True, help="Show extra detail.")
@@ -405,9 +422,11 @@ def unsortedbin(addr=None, verbose=True):
         print(node)
 
 
-parser = argparse.ArgumentParser()
-parser.description = (
-    "Print the contents of an arena's smallbins, default to the current thread's arena."
+parser = argparse.ArgumentParser(
+    formatter_class=argparse.RawTextHelpFormatter,
+    description="""Print the contents of an arena's smallbins.
+
+Default to the current thread's arena.""",
 )
 parser.add_argument("addr", nargs="?", type=int, default=None, help="Address of the arena.")
 parser.add_argument("verbose", nargs="?", type=bool, default=False, help="Show extra detail.")
@@ -434,9 +453,11 @@ def smallbins(addr=None, verbose=False):
         print(node)
 
 
-parser = argparse.ArgumentParser()
-parser.description = (
-    "Print the contents of an arena's largebins, default to the current thread's arena."
+parser = argparse.ArgumentParser(
+    formatter_class=argparse.RawTextHelpFormatter,
+    description="""Print the contents of an arena's largebins.
+
+Default to the current thread's arena.""",
 )
 parser.add_argument("addr", nargs="?", type=int, default=None, help="Address of the arena.")
 parser.add_argument("verbose", nargs="?", type=bool, default=False, help="Show extra detail.")
@@ -463,8 +484,12 @@ def largebins(addr=None, verbose=False):
         print(node)
 
 
-parser = argparse.ArgumentParser()
-parser.description = "Print the contents of a tcache, default to the current thread's tcache."
+parser = argparse.ArgumentParser(
+    formatter_class=argparse.RawTextHelpFormatter,
+    description="""Print the contents of a tcache.
+
+Default to the current thread's tcache.""",
+)
 parser.add_argument(
     "addr", nargs="?", type=int, default=None, help="The address of the tcache bins."
 )
@@ -493,8 +518,9 @@ def tcachebins(addr=None, verbose=False):
         print(node)
 
 
-parser = argparse.ArgumentParser()
-parser.description = "Find candidate fake fast or tcache chunks overlapping the specified address."
+parser = argparse.ArgumentParser(
+    description="Find candidate fake fast or tcache chunks overlapping the specified address."
+)
 parser.add_argument("addr", type=int, help="Address of the word-sized value to overlap.")
 parser.add_argument(
     "size", nargs="?", type=int, default=None, help="Maximum size of fake chunks to find."
@@ -597,8 +623,12 @@ pwndbg.gdblib.config.add_param(
     "default number of chunks to visualize (default is 10)",
 )
 
-parser = argparse.ArgumentParser()
-parser.description = "Visualize chunks on a heap, default to the current arena's active heap."
+parser = argparse.ArgumentParser(
+    formatter_class=argparse.RawTextHelpFormatter,
+    description="""Visualize chunks on a heap.
+
+Default to the current arena's active heap.""",
+)
 parser.add_argument(
     "count",
     nargs="?",
@@ -794,7 +824,7 @@ def bin_labels(addr, collections):
 
 
 try_free_parser = argparse.ArgumentParser(
-    description="Check what would happen if free was called with given address"
+    description="Check what would happen if free was called with given address."
 )
 try_free_parser.add_argument("addr", nargs="?", help="Address passed to free")
 
@@ -1166,7 +1196,7 @@ def try_unlink(addr):
     pass
 
 
-parser = argparse.ArgumentParser(description="Shows heap related config. The list can be filtered.")
+parser = argparse.ArgumentParser(description="Shows heap related configuration.")
 parser.add_argument(
     "filter_pattern",
     type=str,

--- a/pwndbg/commands/hexdump.py
+++ b/pwndbg/commands/hexdump.py
@@ -43,7 +43,7 @@ def address_or_module_name(s):
 
 
 parser = argparse.ArgumentParser(
-    description="Hexdumps data at the specified address or module name (or at $sp)"
+    description="Hexdumps data at the specified address or module name."
 )
 parser.add_argument(
     "address",

--- a/pwndbg/commands/ida.py
+++ b/pwndbg/commands/ida.py
@@ -12,7 +12,7 @@ import pwndbg.ida
 from pwndbg.gdblib.functions import GdbFunction
 
 
-@pwndbg.commands.ArgparsedCommand("Synchronize IDA's cursor with GDB")
+@pwndbg.commands.ArgparsedCommand("Synchronize IDA's cursor with GDB.")
 @pwndbg.commands.OnlyWhenRunning
 @pwndbg.gdblib.events.stop
 @pwndbg.ida.withIDA

--- a/pwndbg/commands/kbase.py
+++ b/pwndbg/commands/kbase.py
@@ -6,7 +6,7 @@ import pwndbg.gdblib.memory
 import pwndbg.gdblib.vmmap
 from pwndbg.gdblib.config import config
 
-parser = argparse.ArgumentParser(description="Finds the kernel virtual base address")
+parser = argparse.ArgumentParser(description="Finds the kernel virtual base address.")
 
 
 @pwndbg.commands.ArgparsedCommand(parser)

--- a/pwndbg/commands/kchecksec.py
+++ b/pwndbg/commands/kchecksec.py
@@ -97,7 +97,7 @@ _arch_hardening_options["aarch64"] = [
     Option("ARM64_MTE"),
 ]
 
-parser = argparse.ArgumentParser(description="Checks for kernel hardening configuration options")
+parser = argparse.ArgumentParser(description="Checks for kernel hardening configuration options.")
 
 
 @pwndbg.commands.ArgparsedCommand(parser)

--- a/pwndbg/commands/kcmdline.py
+++ b/pwndbg/commands/kcmdline.py
@@ -3,7 +3,7 @@ import argparse
 import pwndbg.commands
 import pwndbg.gdblib.kernel
 
-parser = argparse.ArgumentParser(description="Return the kernel commandline (/proc/cmdline)")
+parser = argparse.ArgumentParser(description="Return the kernel commandline (/proc/cmdline).")
 
 
 @pwndbg.commands.ArgparsedCommand(parser)

--- a/pwndbg/commands/kconfig.py
+++ b/pwndbg/commands/kconfig.py
@@ -4,7 +4,9 @@ import pwndbg.color.message as M
 import pwndbg.commands
 import pwndbg.gdblib.kernel
 
-parser = argparse.ArgumentParser(description="Outputs the kernel config (requires CONFIG_IKCONFIG)")
+parser = argparse.ArgumentParser(
+    description="Outputs the kernel config (requires CONFIG_IKCONFIG)."
+)
 
 parser.add_argument("config_name", nargs="?", type=str, help="A config name to search for")
 

--- a/pwndbg/commands/kversion.py
+++ b/pwndbg/commands/kversion.py
@@ -3,7 +3,7 @@ import argparse
 import pwndbg.commands
 import pwndbg.gdblib.kernel
 
-parser = argparse.ArgumentParser(description="Outputs the kernel version (/proc/version)")
+parser = argparse.ArgumentParser(description="Outputs the kernel version (/proc/version).")
 
 
 @pwndbg.commands.ArgparsedCommand(parser)

--- a/pwndbg/commands/memoize.py
+++ b/pwndbg/commands/memoize.py
@@ -4,10 +4,12 @@ import pwndbg.commands
 from pwndbg.color import message
 
 parser = argparse.ArgumentParser(
+    formatter_class=argparse.RawTextHelpFormatter,
     description="""
-Toggles memoization (caching). Pwndbg will work slower when it's off, however
-it's useful for diagnosing caching-related bugs.
-"""
+Toggles memoization (caching).
+
+Useful for diagnosing caching-related bugs. Decreases performance.
+""",
 )
 
 

--- a/pwndbg/commands/misc.py
+++ b/pwndbg/commands/misc.py
@@ -57,9 +57,7 @@ def errno_(err):
     print("Errno %s: %s" % (err, msg))
 
 
-parser = argparse.ArgumentParser(
-    description="Prints out a list of all pwndbg commands. The list can be optionally filtered if filter_pattern is passed."
-)
+parser = argparse.ArgumentParser(description="Prints out a list of all pwndbg commands.")
 
 group = parser.add_mutually_exclusive_group()
 group.add_argument("--shell", action="store_true", help="Only display shell commands")

--- a/pwndbg/commands/mprotect.py
+++ b/pwndbg/commands/mprotect.py
@@ -16,7 +16,7 @@ from pwndbg.lib.regs import reg_sets
 parser = argparse.ArgumentParser(
     formatter_class=argparse.RawTextHelpFormatter,
     description="""
-Calls the mprotect syscall and prints its result value
+Calls the mprotect syscall and prints its result value.
 
 Note that the mprotect syscall may fail for various reasons
 (see `man mprotect`) and a non-zero error return value

--- a/pwndbg/commands/next.py
+++ b/pwndbg/commands/next.py
@@ -18,7 +18,7 @@ def nextjmp():
         pwndbg.commands.context.context()
 
 
-parser = argparse.ArgumentParser(description="Breaks at the next call instruction")
+parser = argparse.ArgumentParser(description="Breaks at the next call instruction.")
 parser.add_argument(
     "symbol_regex",
     type=str,
@@ -36,7 +36,7 @@ def nextcall(symbol_regex=None):
         pwndbg.commands.context.context()
 
 
-@pwndbg.commands.ArgparsedCommand("""Breaks at next return-like instruction""")
+@pwndbg.commands.ArgparsedCommand("Breaks at next return-like instruction.")
 @pwndbg.commands.OnlyWhenRunning
 def nextret():
     """Breaks at next return-like instruction"""
@@ -44,7 +44,7 @@ def nextret():
         pwndbg.commands.context.context()
 
 
-@pwndbg.commands.ArgparsedCommand("""Breaks at next return-like instruction by 'stepping' to it""")
+@pwndbg.commands.ArgparsedCommand("Breaks at next return-like instruction by 'stepping' to it.")
 @pwndbg.commands.OnlyWhenRunning
 def stepret():
     """Breaks at next return-like instruction by 'stepping' to it"""
@@ -63,14 +63,14 @@ def stepret():
 
 
 @pwndbg.commands.ArgparsedCommand(
-    """Breaks at the next instruction that belongs to the running program"""
+    "Breaks at the next instruction that belongs to the running program."
 )
 @pwndbg.commands.OnlyWhenRunning
 def nextproginstr():
     pwndbg.gdblib.next.break_on_program_code()
 
 
-parser = argparse.ArgumentParser(description="Sets a breakpoint on the instruction after this one")
+parser = argparse.ArgumentParser(description="Sets a breakpoint on the instruction after this one.")
 parser.add_argument("addr", type=int, default=None, nargs="?", help="The address to break after.")
 
 

--- a/pwndbg/commands/p2p.py
+++ b/pwndbg/commands/p2p.py
@@ -72,9 +72,10 @@ def address_range(section):
 
 
 parser = argparse.ArgumentParser(
-    description="Pointer to pointer chain search - "
-    "Searches given mapping for all pointers that point to specified mapping (any chain length > 0 is valid)."
-    "If only one mapping is given it just looks for any pointers in that mapping."
+    formatter_class=argparse.RawTextHelpFormatter,
+    description="""Pointer to pointer chain search. Searches given mapping for all pointers that point to specified mapping.
+
+Any chain length greater than 0 is valid. If only one mapping is given it just looks for any pointers in that mapping.""",
 )
 
 parser.add_argument("mapping_names", type=address_range, nargs="+", help="Mapping name ")

--- a/pwndbg/commands/patch.py
+++ b/pwndbg/commands/patch.py
@@ -14,7 +14,7 @@ import pwndbg.lib.memoize
 patches = {}
 
 
-parser = argparse.ArgumentParser(description="Patches given instruction with given code or bytes")
+parser = argparse.ArgumentParser(description="Patches given instruction with given code or bytes.")
 parser.add_argument("address", type=int, help="The address to patch")
 parser.add_argument("ins", type=str, help="instruction[s]")
 
@@ -33,7 +33,7 @@ def patch(address, ins):
     pwndbg.lib.memoize.reset()
 
 
-parser2 = argparse.ArgumentParser(description="Revert patch at given address")
+parser2 = argparse.ArgumentParser(description="Revert patch at given address.")
 parser2.add_argument("address", type=int, help="Address to revert patch on")
 
 
@@ -56,7 +56,7 @@ def patch_revert(address):
     pwndbg.lib.memoize.reset()
 
 
-parser3 = argparse.ArgumentParser(description="List all patches")
+parser3 = argparse.ArgumentParser(description="List all patches.")
 
 
 @pwndbg.commands.ArgparsedCommand(parser3)

--- a/pwndbg/commands/radare2.py
+++ b/pwndbg/commands/radare2.py
@@ -5,7 +5,7 @@ import pwndbg.color.message as message
 import pwndbg.commands
 import pwndbg.radare2
 
-parser = argparse.ArgumentParser(description="Launches radare2", epilog="Example: r2 -- -S -AA")
+parser = argparse.ArgumentParser(description="Launches radare2.", epilog="Example: r2 -- -S -AA")
 parser.add_argument("--no-seek", action="store_true", help="Do not seek to current pc")
 parser.add_argument(
     "--no-rebase",
@@ -43,7 +43,7 @@ def r2(arguments, no_seek=False, no_rebase=False):
 
 
 parser = argparse.ArgumentParser(
-    description="Execute stateful radare2 commands through r2pipe",
+    description="Execute stateful radare2 commands through r2pipe.",
     epilog="Example: r2pipe pdf sym.main",
 )
 parser.add_argument("arguments", nargs="+", type=str, help="Arguments to pass to r2pipe")

--- a/pwndbg/commands/search.py
+++ b/pwndbg/commands/search.py
@@ -45,7 +45,7 @@ auto_save = pwndbg.gdblib.config.add_param(
 )
 
 parser = argparse.ArgumentParser(
-    description="Search memory for byte sequences, strings, pointers, and integer values"
+    description="Search memory for byte sequences, strings, pointers, and integer values."
 )
 parser.add_argument(
     "-t",

--- a/pwndbg/commands/segments.py
+++ b/pwndbg/commands/segments.py
@@ -20,19 +20,19 @@ segment("fsbase")
 segment("gsbase")
 
 
-@pwndbg.commands.ArgparsedCommand("Prints out the FS base address.  See also $fsbase.")
+@pwndbg.commands.ArgparsedCommand("Prints out the FS base address. See also $fsbase.")
 @pwndbg.commands.OnlyWhenRunning
 def fsbase():
     """
-    Prints out the FS base address.  See also $fsbase.
+    Prints out the FS base address. See also $fsbase.
     """
     print(hex(int(pwndbg.gdblib.regs.fsbase)))
 
 
-@pwndbg.commands.ArgparsedCommand("Prints out the GS base address.  See also $gsbase.")
+@pwndbg.commands.ArgparsedCommand("Prints out the GS base address. See also $gsbase.")
 @pwndbg.commands.OnlyWhenRunning
 def gsbase():
     """
-    Prints out the GS base address.  See also $gsbase.
+    Prints out the GS base address. See also $gsbase.
     """
     print(hex(int(pwndbg.gdblib.regs.gsbase)))

--- a/pwndbg/commands/slab.py
+++ b/pwndbg/commands/slab.py
@@ -7,7 +7,7 @@ import pwndbg.gdblib.kernel.slab
 from pwndbg.gdblib.kernel.slab import oo_objects
 from pwndbg.gdblib.kernel.slab import oo_order
 
-parser = argparse.ArgumentParser(description="Prints information about the SLUB allocator")
+parser = argparse.ArgumentParser(description="Prints information about the SLUB allocator.")
 parser.add_argument(
     "filter_",
     metavar="filter",

--- a/pwndbg/commands/start.py
+++ b/pwndbg/commands/start.py
@@ -80,7 +80,6 @@ parser = argparse.ArgumentParser(
     formatter_class=RawTextHelpFormatter,
     description="""
 Start the debugged program stopping at its entrypoint address.
-You may specify arguments to give it.
 
 Note that the entrypoint may not be the first instruction executed
 by the program. If you want to stop on the first executed instruction,

--- a/pwndbg/commands/telescope.py
+++ b/pwndbg/commands/telescope.py
@@ -44,7 +44,7 @@ repeating_marker = theme.add_param(
 
 
 parser = argparse.ArgumentParser(
-    description="Recursively dereferences pointers starting at the specified address ($sp by default)"
+    description="Recursively dereferences pointers starting at the specified address."
 )
 parser.add_argument(
     "-r",
@@ -56,7 +56,7 @@ parser.add_argument(
 )
 
 parser.add_argument(
-    "address", nargs="?", default=None, type=int, help="The address to telescope at."
+    "address", nargs="?", default="$sp", type=int, help="The address to telescope at."
 )
 
 parser.add_argument(
@@ -196,7 +196,7 @@ def telescope(address=None, count=telescope_lines, to_string=False, reverse=Fals
 
 
 parser = argparse.ArgumentParser(
-    description="dereferences on stack data with specified count and offset."
+    description="Dereferences on stack data with specified count and offset."
 )
 parser.add_argument("count", nargs="?", default=8, type=int, help="number of element to dump")
 parser.add_argument(

--- a/pwndbg/commands/version.py
+++ b/pwndbg/commands/version.py
@@ -69,15 +69,15 @@ def all_versions():
     return all_versions
 
 
-@pwndbg.commands.ArgparsedCommand("Displays gdb, python and pwndbg versions.")
+@pwndbg.commands.ArgparsedCommand("Displays GDB, Python, and pwndbg versions.")
 def version():
     """
-    Displays gdb, python and pwndbg versions.
+    Displays GDB, Python, and pwndbg versions.
     """
     print("\n".join(map(message.system, all_versions())))
 
 
-bugreport_parser = argparse.ArgumentParser(description="Generate bugreport")
+bugreport_parser = argparse.ArgumentParser(description="Generate a bug report.")
 bugreport_group = bugreport_parser.add_mutually_exclusive_group()
 bugreport_group.add_argument(
     "--run-browser", "-b", action="store_true", help="Open browser on github/issues/new"

--- a/pwndbg/commands/vmmap.py
+++ b/pwndbg/commands/vmmap.py
@@ -49,7 +49,7 @@ def print_vmmap_table_header():
 
 parser = argparse.ArgumentParser(
     formatter_class=argparse.RawTextHelpFormatter,
-    description="""Print virtual memory map pages. Results can be filtered by providing address/module name.
+    description="""Print virtual memory map pages.
 
 Unnamed mappings are named as [anon_%#x] where %#x is high part of their start address. This is useful for filtering with `vmmap` or `search` commands.
 
@@ -71,7 +71,7 @@ parser.add_argument(
     type=pwndbg.commands.sloppy_gdb_parse,
     nargs="?",
     default=None,
-    help="Address or module name.",
+    help="Address or module name filter",
 )
 parser.add_argument("-w", "--writable", action="store_true", help="Display writable maps only")
 parser.add_argument("-x", "--executable", action="store_true", help="Display executable maps only")

--- a/pwndbg/commands/xinfo.py
+++ b/pwndbg/commands/xinfo.py
@@ -11,7 +11,7 @@ import pwndbg.gdblib.vmmap
 import pwndbg.wrappers
 
 parser = argparse.ArgumentParser(
-    description="Shows offsets of the specified address to useful other locations"
+    description="Shows offsets of the specified address from various useful locations."
 )
 parser.add_argument("address", nargs="?", default="$pc", help="Address to inspect")
 

--- a/pwndbg/commands/xor.py
+++ b/pwndbg/commands/xor.py
@@ -19,7 +19,7 @@ def xor_memory(address, key, count):
     return mem
 
 
-parser = argparse.ArgumentParser(description="XOR `count` bytes at address` with the key key`.")
+parser = argparse.ArgumentParser(description="XOR `count` bytes at `address` with the key `key`.")
 parser.add_argument(
     "address", type=pwndbg.commands.sloppy_gdb_parse, help="The address to start xoring at."
 )

--- a/pwndbg/gdblib/abi.py
+++ b/pwndbg/gdblib/abi.py
@@ -35,8 +35,8 @@ def update():
         msg = M.warn(
             "The bare metal debugging is enabled since gdb's osabi is '%s' which is not 'GNU/Linux'.\n"
             "Ex. the page resolving and memory de-referencing ONLY works on known pages.\n"
-            "This option is based on gdb client compile arguments (by default) and will be corrected if you load an ELF with a '.note.ABI-tag' section.\n"
-            "If you are debugging a program that runs on the Linux ABI, please select the correct gdb client."
+            "This option is based on GDB client compile arguments (by default) and will be corrected if you load an ELF with a '.note.ABI-tag' section.\n"
+            "If you are debugging a program that runs on the Linux ABI, please select the correct GDB client."
             % abi
         )
         print(msg)

--- a/pwndbg/gdblib/prompt.py
+++ b/pwndbg/gdblib/prompt.py
@@ -19,7 +19,7 @@ num_shell_cmds = sum(1 for _ in filter(lambda c: c.shell, pwndbg.commands.comman
 hint_lines = (
     "loaded %i pwndbg commands and %i shell commands. Type %s for a list."
     % (num_pwndbg_cmds, num_shell_cmds, message.notice("pwndbg [--shell | --all] [filter]")),
-    "created %s gdb functions (can be used with print/break)" % funcs_list_str,
+    "created %s GDB functions (can be used with print/break)" % funcs_list_str,
 )
 
 for line in hint_lines:

--- a/tests/gdb-tests/tests/test_loads.py
+++ b/tests/gdb-tests/tests/test_loads.py
@@ -7,7 +7,7 @@ from .utils import run_gdb_with_script
 
 HELLO = [
     "pwndbg: loaded ### pwndbg commands and ### shell commands. Type pwndbg [--shell | --all] [filter] for a list.",
-    "pwndbg: created $rebase, $ida gdb functions (can be used with print/break)",
+    "pwndbg: created $rebase, $ida GDB functions (can be used with print/break)",
 ]
 
 BINARY = tests.binaries.get("div_zero.out")

--- a/tests/gdb-tests/tests/test_misc.py
+++ b/tests/gdb-tests/tests/test_misc.py
@@ -6,7 +6,7 @@ STACK_COMMANDS = [
     ("context", "Print out the current register, instruction, and stack context."),
     ("down", "Select and print stack frame called by this one."),
     ("retaddr", "Print out the stack addresses that contain return addresses."),
-    ("stack", "dereferences on stack data with specified count and offset."),
+    ("stack", "Dereferences on stack data with specified count and offset."),
     ("up", "Select and print stack frame that called this one."),
 ]
 


### PR DESCRIPTION
Reduce the length of the first sentence in docstrings by removing redundant information so that the output of the `pwndbg` command is easier to read. Also some minor formatting improvements.