### PR TITLE
Add safe type hints

### DIFF
--- a/pwndbg/auxv.py
+++ b/pwndbg/auxv.py
@@ -77,7 +77,7 @@ sys.modules[__name__].__dict__.update({v: k for k, v in AT_CONSTANTS.items()})
 
 
 class AUXV(dict):
-    def set(self, const, value):
+    def set(self, const, value) -> None:
         name = AT_CONSTANTS.get(const, "AT_UNKNOWN%i" % const)
 
         if name in ["AT_EXECFN", "AT_PLATFORM"]:
@@ -93,7 +93,7 @@ class AUXV(dict):
     def __getattr__(self, attr):
         return self.get(attr)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return str({k: v for k, v in self.items() if v is not None})
 
 

--- a/pwndbg/color/__init__.py
+++ b/pwndbg/color/__init__.py
@@ -137,7 +137,7 @@ ColorParamSpec = namedtuple("ColorParamSpec", ["name", "default", "doc"])
 
 
 class ColorConfig:
-    def __init__(self, namespace: str, params: List[ColorParamSpec]):
+    def __init__(self, namespace: str, params: List[ColorParamSpec]) -> None:
         self._namespace = namespace
         self._params = {}
         for param in params:

--- a/pwndbg/color/syntax_highlight.py
+++ b/pwndbg/color/syntax_highlight.py
@@ -26,7 +26,7 @@ lexer_cache: Dict[str, Any] = {}
 
 
 @pwndbg.gdblib.config.trigger(style)
-def check_style():
+def check_style() -> None:
     global formatter
     try:
         formatter = pygments.formatters.Terminal256Formatter(style=str(style))

--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -54,7 +54,7 @@ class Command(gdb.Command):
 
     def __init__(
         self, function, prefix=False, command_name=None, shell=False, is_alias=False, aliases=[]
-    ):
+    ) -> None:
         self.is_alias = is_alias
         self.aliases = aliases
         self.shell = shell
@@ -109,7 +109,7 @@ class Command(gdb.Command):
         finally:
             self.repeat = False
 
-    def check_repeated(self, argument, from_tty):
+    def check_repeated(self, argument, from_tty) -> bool:
         """Keep a record of all commands which come from the TTY.
 
         Returns:
@@ -311,7 +311,7 @@ def OnlyWhenHeapIsInitialized(function):
 
 
 # TODO/FIXME: Move this elsewhere? Have better logic for that? Maybe caching?
-def _is_statically_linked():
+def _is_statically_linked() -> bool:
     out = gdb.execute("info dll", to_string=True)
     return "No shared libraries loaded at this time." in out
 
@@ -421,7 +421,9 @@ def OnlyWithResolvedHeapSyms(function):
 
 
 class _ArgparsedCommand(Command):
-    def __init__(self, parser, function, command_name=None, is_alias=False, aliases=[], *a, **kw):
+    def __init__(
+        self, parser, function, command_name=None, is_alias=False, aliases=[], *a, **kw
+    ) -> None:
         self.parser = parser
         if command_name is None:
             self.parser.prog = function.__name__
@@ -447,7 +449,7 @@ class _ArgparsedCommand(Command):
 class ArgparsedCommand:
     """Adds documentation and offloads parsing for a Command via argparse"""
 
-    def __init__(self, parser_or_desc, aliases=[], command_name=None):
+    def __init__(self, parser_or_desc, aliases=[], command_name=None) -> None:
         """
         :param parser_or_desc: `argparse.ArgumentParser` instance or `str`
         """
@@ -529,7 +531,7 @@ def HexOrAddressExpr(s):
         return AddressExpr(s)
 
 
-def load_commands():
+def load_commands() -> None:
     import pwndbg.commands.argv
     import pwndbg.commands.aslr
     import pwndbg.commands.attachp

--- a/pwndbg/commands/argv.py
+++ b/pwndbg/commands/argv.py
@@ -10,7 +10,7 @@ import pwndbg.gdblib.typeinfo
 
 @pwndbg.commands.ArgparsedCommand("Prints out the number of arguments.")
 @pwndbg.commands.OnlyWhenRunning
-def argc():
+def argc() -> None:
     print(pwndbg.gdblib.argv.argc)
 
 
@@ -22,7 +22,7 @@ parser.add_argument(
 
 @pwndbg.commands.ArgparsedCommand(parser, aliases=["args"])
 @pwndbg.commands.OnlyWhenRunning
-def argv(i=None):
+def argv(i=None) -> None:
     start = pwndbg.gdblib.argv.argv
     n = pwndbg.gdblib.argv.argc + 1
 
@@ -59,7 +59,7 @@ class argv_function(gdb.Function):
     Evaluate argv on the supplied value.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         super(argv_function, self).__init__("argv")
 
     def invoke(self, number=0):
@@ -82,7 +82,7 @@ class envp_function(gdb.Function):
     Evaluate envp on the supplied value.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         super(envp_function, self).__init__("envp")
 
     def invoke(self, number=0):
@@ -105,7 +105,7 @@ class argc_function(gdb.Function):
     Evaluates to argc.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         super(argc_function, self).__init__("argc")
 
     def invoke(self, number=0):
@@ -120,7 +120,7 @@ class environ_function(gdb.Function):
     Evaluate getenv() on the supplied value.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         super(environ_function, self).__init__("environ")
 
     def invoke(self, name):

--- a/pwndbg/commands/aslr.py
+++ b/pwndbg/commands/aslr.py
@@ -27,7 +27,7 @@ parser.add_argument(
 
 
 @pwndbg.commands.ArgparsedCommand(parser)
-def aslr(state=None):
+def aslr(state=None) -> None:
     if state:
         gdb.execute("set disable-randomization %s" % options[state], from_tty=False, to_string=True)
 

--- a/pwndbg/commands/attachp.py
+++ b/pwndbg/commands/attachp.py
@@ -35,7 +35,7 @@ parser.add_argument("target", type=str, help="pid, process name or device file t
 
 
 @pwndbg.commands.ArgparsedCommand(parser)
-def attachp(target):
+def attachp(target) -> None:
     try:
         resolved_target = int(target)
     except ValueError:
@@ -80,7 +80,7 @@ def attachp(target):
         print(message.error("Error: %s" % e))
 
 
-def _is_device(path):
+def _is_device(path) -> bool:
     try:
         mode = os.stat(path).st_mode
     except FileNotFoundError:

--- a/pwndbg/commands/auxv.py
+++ b/pwndbg/commands/auxv.py
@@ -5,7 +5,7 @@ import pwndbg.commands
 
 @pwndbg.commands.ArgparsedCommand("Print information from the Auxiliary ELF Vector.")
 @pwndbg.commands.OnlyWhenRunning
-def auxv():
+def auxv() -> None:
     for k, v in pwndbg.auxv.get().items():
         if v is not None:
             print(k.ljust(24), v if not isinstance(v, int) else pwndbg.chain.format(v))

--- a/pwndbg/commands/canary.py
+++ b/pwndbg/commands/canary.py
@@ -23,7 +23,7 @@ def canary_value():
 
 @pwndbg.commands.ArgparsedCommand("Print out the current stack canary.")
 @pwndbg.commands.OnlyWhenRunning
-def canary():
+def canary() -> None:
     global_canary, at_random = canary_value()
 
     if global_canary is None or at_random is None:

--- a/pwndbg/commands/checksec.py
+++ b/pwndbg/commands/checksec.py
@@ -5,5 +5,5 @@ import pwndbg.wrappers.checksec
 
 @pwndbg.commands.ArgparsedCommand("Prints out the binary security settings using `checksec`.")
 @pwndbg.commands.OnlyWithFile
-def checksec():
+def checksec() -> None:
     print(pwndbg.wrappers.checksec.get_raw_out())

--- a/pwndbg/commands/comments.py
+++ b/pwndbg/commands/comments.py
@@ -15,7 +15,7 @@ file_lists = {}  # type:Dict[str,str] #This saves all comments.
 
 @pwndbg.commands.ArgparsedCommand(parser)
 @pwndbg.commands.OnlyWhenRunning
-def comm(addr=None, comment=None):
+def comm(addr=None, comment=None) -> None:
     if addr is None:
         addr = hex(pwndbg.gdblib.regs.pc)
     try:
@@ -35,7 +35,7 @@ def comm(addr=None, comment=None):
         print(message.error("Permission denied to create file"))
 
 
-def init():
+def init() -> None:
     try:
         with open(".gdb_comments", "r") as f:
             text = f.read()

--- a/pwndbg/commands/config.py
+++ b/pwndbg/commands/config.py
@@ -55,7 +55,7 @@ parser.add_argument(
 )
 
 
-def display_config(filter_pattern: str, scope: str, has_file_command: bool = True):
+def display_config(filter_pattern: str, scope: str, has_file_command: bool = True) -> None:
     values = get_config_parameters(scope, filter_pattern)
 
     if not values:
@@ -95,7 +95,7 @@ def display_config(filter_pattern: str, scope: str, has_file_command: bool = Tru
 
 
 @pwndbg.commands.ArgparsedCommand(parser)
-def config(filter_pattern):
+def config(filter_pattern) -> None:
     display_config(filter_pattern, "config")
 
 
@@ -117,12 +117,12 @@ parser.add_argument(
 
 
 @pwndbg.commands.ArgparsedCommand(parser)
-def theme(filter_pattern):
+def theme(filter_pattern) -> None:
     display_config(filter_pattern, "theme")
 
 
 @pwndbg.commands.ArgparsedCommand(configfile_parser)
-def configfile(show_all=False):
+def configfile(show_all=False) -> None:
     configfile_print_scope("config", show_all)
 
 
@@ -135,11 +135,11 @@ themefile_parser.add_argument(
 
 
 @pwndbg.commands.ArgparsedCommand(themefile_parser)
-def themefile(show_all=False):
+def themefile(show_all=False) -> None:
     configfile_print_scope("theme", show_all)
 
 
-def configfile_print_scope(scope, show_all=False):
+def configfile_print_scope(scope, show_all=False) -> None:
     params = pwndbg.gdblib.config.get_params(scope)
 
     if not show_all:

--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -45,7 +45,7 @@ c = ColorConfig(
 )
 
 
-def clear_screen(out=sys.stdout):
+def clear_screen(out=sys.stdout) -> None:
     """
     Clear the screen by moving the cursor to top-left corner and
     clearing the content. Different terminals may act differently
@@ -86,7 +86,7 @@ output_settings = {}
 
 
 @pwndbg.gdblib.config.trigger(config_context_sections)
-def validate_context_sections():
+def validate_context_sections() -> None:
     valid_values = [
         context.__name__.replace("context_", "") for context in context_sections.values()
     ]
@@ -126,20 +126,20 @@ class StdOutput:
     def __enter__(self):
         return sys.stdout
 
-    def __exit__(self, *args, **kwargs):
+    def __exit__(self, *args, **kwargs) -> None:
         pass
 
     def __hash__(self):
         return hash(sys.stdout)
 
-    def __eq__(self, other):
+    def __eq__(self, other) -> bool:
         return type(other) is StdOutput
 
 
 class FileOutput:
     """A context manager wrapper to reopen files on enter"""
 
-    def __init__(self, *args):
+    def __init__(self, *args) -> None:
         self.args = args
         self.handle = None
 
@@ -147,7 +147,7 @@ class FileOutput:
         self.handle = open(*self.args)
         return self.handle
 
-    def __exit__(self, *args, **kwargs):
+    def __exit__(self, *args, **kwargs) -> None:
         self.handle.close()
 
     def __hash__(self):
@@ -160,13 +160,13 @@ class FileOutput:
 class CallOutput:
     """A context manager which calls a function on write"""
 
-    def __init__(self, func):
+    def __init__(self, func) -> None:
         self.func = func
 
     def __enter__(self):
         return self
 
-    def __exit__(self, *args, **kwargs):
+    def __exit__(self, *args, **kwargs) -> None:
         pass
 
     def __hash__(self):
@@ -175,7 +175,7 @@ class CallOutput:
     def __eq__(self, other):
         return self.func == other.func
 
-    def write(self, data):
+    def write(self, data) -> None:
         self.func(data)
 
     def flush(self):
@@ -275,7 +275,7 @@ parser.add_argument(
 
 
 @pwndbg.commands.ArgparsedCommand(parser, aliases=["ctx-watch", "cwatch"])
-def contextwatch(expression, cmd=None):
+def contextwatch(expression, cmd=None) -> None:
     expressions.append((expression, expression_commands.get(cmd, gdb.parse_and_eval)))
 
 
@@ -286,7 +286,7 @@ parser.add_argument("num", type=int, help="The expression number to be removed f
 
 
 @pwndbg.commands.ArgparsedCommand(parser, aliases=["ctx-unwatch", "cunwatch"])
-def contextunwatch(num):
+def contextunwatch(num) -> None:
     if num < 1 or num > len(expressions):
         print(message.error("Invalid input"))
         return
@@ -371,7 +371,7 @@ parser.add_argument(
 
 @pwndbg.commands.ArgparsedCommand(parser, aliases=["ctx"])
 @pwndbg.commands.OnlyWhenRunning
-def context(subcontext=None):
+def context(subcontext=None) -> None:
     """
     Print out the current register, instruction, and stack context.
 
@@ -523,7 +523,7 @@ parser.add_argument("regs", nargs="*", type=str, default=None, help="Registers t
 
 @pwndbg.commands.ArgparsedCommand(parser)
 @pwndbg.commands.OnlyWhenRunning
-def regs(regs=None):
+def regs(regs=None) -> None:
     """Print out all registers and enhance the information."""
     print("\n".join(get_regs(*regs)))
 
@@ -830,7 +830,7 @@ def context_args(with_banner=True, target=sys.stdout, width=None):
 last_signal = []
 
 
-def save_signal(signal):
+def save_signal(signal) -> None:
     global last_signal
     last_signal = result = []
 
@@ -884,7 +884,7 @@ context_sections = {
 
 
 @pwndbg.lib.memoize.forever
-def _is_rr_present():
+def _is_rr_present() -> bool:
     """
     Checks whether rr project is present (so someone launched e.g. `rr replay <some-recording>`)
     """

--- a/pwndbg/commands/cpsr.py
+++ b/pwndbg/commands/cpsr.py
@@ -9,7 +9,7 @@ from pwndbg.color import context
 )
 @pwndbg.commands.OnlyWithArch(["arm", "armcm", "aarch64"])
 @pwndbg.commands.OnlyWhenRunning
-def cpsr():
+def cpsr() -> None:
     reg = "xpsr" if pwndbg.gdblib.arch.name == "armcm" else "cpsr"
     reg_val = getattr(pwndbg.gdblib.regs, reg)
     reg_flags = pwndbg.gdblib.regs.flags[reg]

--- a/pwndbg/commands/cyclic.py
+++ b/pwndbg/commands/cyclic.py
@@ -50,7 +50,7 @@ group.add_argument(
 
 
 @pwndbg.commands.ArgparsedCommand(parser, command_name="cyclic")
-def cyclic_cmd(alphabet, length, lookup, count=100):
+def cyclic_cmd(alphabet, length, lookup, count=100) -> None:
     if length:
         # Convert from gdb.Value
         length = int(length)

--- a/pwndbg/commands/cymbol.py
+++ b/pwndbg/commands/cymbol.py
@@ -52,7 +52,7 @@ loaded_symbols = {}
 pwndbg_cachedir = pwndbg.lib.tempfile.cachedir("custom-symbols")
 
 
-def unload_loaded_symbol(custom_structure_name):
+def unload_loaded_symbol(custom_structure_name) -> None:
     custom_structure_symbols_file = loaded_symbols.get(custom_structure_name)
     if custom_structure_symbols_file is not None:
         gdb.execute(f"remove-symbol-file {custom_structure_symbols_file}")
@@ -110,7 +110,7 @@ def generate_debug_symbols(custom_structure_path, pwndbg_debug_symbols_output_fi
     return pwndbg_debug_symbols_output_file
 
 
-def add_custom_structure(custom_structure_name):
+def add_custom_structure(custom_structure_name) -> None:
     pwndbg_custom_structure_path = os.path.join(pwndbg_cachedir, custom_structure_name) + ".c"
 
     if os.path.exists(pwndbg_custom_structure_path):
@@ -139,7 +139,7 @@ def add_custom_structure(custom_structure_name):
 
 
 @OnlyWhenStructFileExists
-def edit_custom_structure(custom_structure_name, custom_structure_path):
+def edit_custom_structure(custom_structure_name, custom_structure_path) -> None:
 
     # Lookup an editor to use for editing the custom structure.
     editor_preference = os.getenv("EDITOR")
@@ -173,14 +173,14 @@ def edit_custom_structure(custom_structure_name, custom_structure_path):
 
 
 @OnlyWhenStructFileExists
-def remove_custom_structure(custom_structure_name, custom_structure_path):
+def remove_custom_structure(custom_structure_name, custom_structure_path) -> None:
     unload_loaded_symbol(custom_structure_name)
     os.remove(custom_structure_path)
     print(message.success("Symbols are removed!"))
 
 
 @OnlyWhenStructFileExists
-def load_custom_structure(custom_structure_name, custom_structure_path):
+def load_custom_structure(custom_structure_name, custom_structure_path) -> None:
     unload_loaded_symbol(custom_structure_name)
     pwndbg_debug_symbols_output_file = generate_debug_symbols(custom_structure_path)
     if not pwndbg_debug_symbols_output_file:
@@ -194,7 +194,7 @@ def load_custom_structure(custom_structure_name, custom_structure_path):
 
 
 @OnlyWhenStructFileExists
-def show_custom_structure(custom_structure_name, custom_structure_path):
+def show_custom_structure(custom_structure_name, custom_structure_path) -> None:
     # Call wrapper .func() to avoid memoization.
     highlighted_source = pwndbg.pwndbg.commands.context.get_highlight_source.func(
         custom_structure_path
@@ -250,7 +250,7 @@ parser.add_argument(
 @pwndbg.commands.ArgparsedCommand(parser)
 @pwndbg.commands.OnlyWithArch(["x86_64"])
 @pwndbg.commands.OnlyWhenRunning
-def cymbol(add, remove, edit, load, show):
+def cymbol(add, remove, edit, load, show) -> None:
     if add:
         add_custom_structure(add)
     elif remove:

--- a/pwndbg/commands/dt.py
+++ b/pwndbg/commands/dt.py
@@ -20,7 +20,7 @@ parser.add_argument(
 
 
 @pwndbg.commands.ArgparsedCommand(parser)
-def dt(typename, address=None):
+def dt(typename, address=None) -> None:
     """
     Dump out information on a type (e.g. ucontext_t).
 

--- a/pwndbg/commands/dumpargs.py
+++ b/pwndbg/commands/dumpargs.py
@@ -12,7 +12,7 @@ parser.add_argument("-f", "--force", action="store_true", help="Force displaying
 
 @pwndbg.commands.ArgparsedCommand(parser)
 @pwndbg.commands.OnlyWhenRunning
-def dumpargs(force=False):
+def dumpargs(force=False) -> None:
     args = (not force and call_args()) or all_args()
 
     if args:

--- a/pwndbg/commands/elf.py
+++ b/pwndbg/commands/elf.py
@@ -6,7 +6,7 @@ from pwndbg.color import message
 
 @pwndbg.commands.ArgparsedCommand("Prints the section mappings contained in the ELF header.")
 @pwndbg.commands.OnlyWithFile
-def elfheader():
+def elfheader() -> None:
     local_path = pwndbg.gdblib.file.get_file(pwndbg.gdblib.proc.exe)
 
     with open(local_path, "rb") as f:
@@ -30,13 +30,13 @@ def elfheader():
 
 @pwndbg.commands.ArgparsedCommand("Prints any symbols found in the .got.plt section if it exists.")
 @pwndbg.commands.OnlyWithFile
-def gotplt():
+def gotplt() -> None:
     print_symbols_in_section(".got.plt", "@got.plt")
 
 
 @pwndbg.commands.ArgparsedCommand("Prints any symbols found in the .plt section if it exists.")
 @pwndbg.commands.OnlyWithFile
-def plt():
+def plt() -> None:
     print_symbols_in_section(".plt", "@plt")
 
 
@@ -56,7 +56,7 @@ def get_section_bounds(section_name):
         return (start, start + size)
 
 
-def print_symbols_in_section(section_name, filter_text=""):
+def print_symbols_in_section(section_name, filter_text="") -> None:
     start, end = get_section_bounds(section_name)
 
     if start is None:

--- a/pwndbg/commands/flags.py
+++ b/pwndbg/commands/flags.py
@@ -34,7 +34,7 @@ parser.add_argument(
     parser,
     aliases=["flag"],
 )
-def setflag(flag, value):
+def setflag(flag, value) -> None:
     if value not in [0, 1]:
         print("can only set flag bit to 0 or 1")
         return

--- a/pwndbg/commands/gdbinit.py
+++ b/pwndbg/commands/gdbinit.py
@@ -11,7 +11,7 @@ import pwndbg.commands
 
 @pwndbg.commands.ArgparsedCommand("GDBINIT compatibility alias for 'start' command.")
 @pwndbg.commands.OnlyWhenRunning
-def init():
+def init() -> None:
     """GDBINIT compatibility alias for 'start' command."""
     pwndbg.commands.start.start()
 
@@ -20,7 +20,7 @@ def init():
     "GDBINIT compatibility alias for 'tbreak __libc_start_main; run' command."
 )
 @pwndbg.commands.OnlyWhenRunning
-def sstart():
+def sstart() -> None:
     """GDBINIT compatibility alias for 'tbreak __libc_start_main; run' command."""
     gdb.execute("tbreak __libc_start_main")
     gdb.execute("run")
@@ -28,14 +28,14 @@ def sstart():
 
 @pwndbg.commands.ArgparsedCommand("GDBINIT compatibility alias for 'main' command.")
 @pwndbg.commands.OnlyWhenRunning
-def main():
+def main() -> None:
     """GDBINIT compatibility alias for 'main' command."""
     pwndbg.commands.start.start()
 
 
 @pwndbg.commands.ArgparsedCommand("GDBINIT compatibility alias for 'libs' command.")
 @pwndbg.commands.OnlyWhenRunning
-def libs():
+def libs() -> None:
     """GDBINIT compatibility alias for 'libs' command."""
     pwndbg.commands.vmmap.vmmap()
 
@@ -44,7 +44,7 @@ def libs():
     "GDBINIT compatibility alias to print the entry point. See also the 'entry' command."
 )
 @pwndbg.commands.OnlyWhenRunning
-def entry_point():
+def entry_point() -> None:
     """GDBINIT compatibility alias to print the entry point.
     See also the 'entry' command."""
     print(hex(int(pwndbg.gdblib.elf.entry())))

--- a/pwndbg/commands/ghidra.py
+++ b/pwndbg/commands/ghidra.py
@@ -16,7 +16,7 @@ parser.add_argument(
 
 @pwndbg.commands.OnlyWithFile
 @pwndbg.commands.ArgparsedCommand(parser)
-def ghidra(func):
+def ghidra(func) -> None:
     try:
         print(pwndbg.ghidra.decompile(func))
     except Exception as e:

--- a/pwndbg/commands/got.py
+++ b/pwndbg/commands/got.py
@@ -17,7 +17,7 @@ parser.add_argument(
 
 @pwndbg.commands.ArgparsedCommand(parser)
 @pwndbg.commands.OnlyWhenRunning
-def got(name_filter=""):
+def got(name_filter="") -> None:
 
     relro_status = pwndbg.wrappers.checksec.relro_status()
     pie_status = pwndbg.wrappers.checksec.pie_status()

--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -127,7 +127,7 @@ parser.add_argument(
 @pwndbg.commands.OnlyWhenRunning
 @pwndbg.commands.OnlyWithResolvedHeapSyms
 @pwndbg.commands.OnlyWhenHeapIsInitialized
-def heap(addr=None, verbose=False, simple=False):
+def heap(addr=None, verbose=False, simple=False) -> None:
     """Iteratively print chunks on a heap, default to the current thread's
     active heap.
     """
@@ -159,7 +159,7 @@ parser.add_argument("addr", nargs="?", type=int, default=None, help="Address of 
 @pwndbg.commands.OnlyWhenRunning
 @pwndbg.commands.OnlyWithResolvedHeapSyms
 @pwndbg.commands.OnlyWhenHeapIsInitialized
-def arena(addr=None):
+def arena(addr=None) -> None:
     """Print the contents of an arena, default to the current thread's arena."""
     allocator = pwndbg.heap.current
 
@@ -178,7 +178,7 @@ parser = argparse.ArgumentParser(description="List this process's arenas.")
 @pwndbg.commands.OnlyWhenRunning
 @pwndbg.commands.OnlyWithResolvedHeapSyms
 @pwndbg.commands.OnlyWhenHeapIsInitialized
-def arenas():
+def arenas() -> None:
     """Lists this process's arenas."""
     allocator = pwndbg.heap.current
     for ar in allocator.arenas:
@@ -199,7 +199,7 @@ parser.add_argument("addr", nargs="?", type=int, default=None, help="Address of 
 @pwndbg.commands.OnlyWithResolvedHeapSyms
 @pwndbg.commands.OnlyWhenHeapIsInitialized
 @pwndbg.commands.OnlyWithTcache
-def tcache(addr=None):
+def tcache(addr=None) -> None:
     """Print a thread's tcache contents, default to the current thread's
     tcache.
     """
@@ -215,7 +215,7 @@ parser = argparse.ArgumentParser(description="Print the mp_ struct's contents.")
 @pwndbg.commands.OnlyWhenRunning
 @pwndbg.commands.OnlyWithResolvedHeapSyms
 @pwndbg.commands.OnlyWhenHeapIsInitialized
-def mp():
+def mp() -> None:
     """Print the mp_ struct's contents."""
     allocator = pwndbg.heap.current
     print(allocator.mp)
@@ -234,7 +234,7 @@ parser.add_argument("addr", nargs="?", type=int, default=None, help="Address of 
 @pwndbg.commands.OnlyWhenRunning
 @pwndbg.commands.OnlyWithResolvedHeapSyms
 @pwndbg.commands.OnlyWhenHeapIsInitialized
-def top_chunk(addr=None):
+def top_chunk(addr=None) -> None:
     """Print relevant information about an arena's top chunk, default to the
     current thread's arena.
     """
@@ -265,7 +265,7 @@ parser.add_argument(
 @pwndbg.commands.OnlyWhenRunning
 @pwndbg.commands.OnlyWithResolvedHeapSyms
 @pwndbg.commands.OnlyWhenHeapIsInitialized
-def malloc_chunk(addr, fake=False, verbose=False, simple=False):
+def malloc_chunk(addr, fake=False, verbose=False, simple=False) -> None:
     """Print a malloc_chunk struct's contents."""
     allocator = pwndbg.heap.current
 
@@ -348,7 +348,7 @@ parser.add_argument("tcache_addr", nargs="?", type=int, default=None, help="Addr
 @pwndbg.commands.OnlyWhenRunning
 @pwndbg.commands.OnlyWithResolvedHeapSyms
 @pwndbg.commands.OnlyWhenHeapIsInitialized
-def bins(addr=None, tcache_addr=None):
+def bins(addr=None, tcache_addr=None) -> None:
     """Print the contents of all an arena's bins and a thread's tcache,
     default to the current thread's arena and tcache.
     """
@@ -374,7 +374,7 @@ parser.add_argument("verbose", nargs="?", type=bool, default=True, help="Show ex
 @pwndbg.commands.OnlyWhenRunning
 @pwndbg.commands.OnlyWithResolvedHeapSyms
 @pwndbg.commands.OnlyWhenHeapIsInitialized
-def fastbins(addr=None, verbose=True):
+def fastbins(addr=None, verbose=True) -> None:
     """Print the contents of an arena's fastbins, default to the current
     thread's arena.
     """
@@ -405,7 +405,7 @@ parser.add_argument("verbose", nargs="?", type=bool, default=True, help="Show ex
 @pwndbg.commands.OnlyWhenRunning
 @pwndbg.commands.OnlyWithResolvedHeapSyms
 @pwndbg.commands.OnlyWhenHeapIsInitialized
-def unsortedbin(addr=None, verbose=True):
+def unsortedbin(addr=None, verbose=True) -> None:
     """Print the contents of an arena's unsortedbin, default to the current
     thread's arena.
     """
@@ -436,7 +436,7 @@ parser.add_argument("verbose", nargs="?", type=bool, default=False, help="Show e
 @pwndbg.commands.OnlyWhenRunning
 @pwndbg.commands.OnlyWithResolvedHeapSyms
 @pwndbg.commands.OnlyWhenHeapIsInitialized
-def smallbins(addr=None, verbose=False):
+def smallbins(addr=None, verbose=False) -> None:
     """Print the contents of an arena's smallbins, default to the current
     thread's arena.
     """
@@ -467,7 +467,7 @@ parser.add_argument("verbose", nargs="?", type=bool, default=False, help="Show e
 @pwndbg.commands.OnlyWhenRunning
 @pwndbg.commands.OnlyWithResolvedHeapSyms
 @pwndbg.commands.OnlyWhenHeapIsInitialized
-def largebins(addr=None, verbose=False):
+def largebins(addr=None, verbose=False) -> None:
     """Print the contents of an arena's largebins, default to the current
     thread's arena.
     """
@@ -503,7 +503,7 @@ parser.add_argument(
 @pwndbg.commands.OnlyWithResolvedHeapSyms
 @pwndbg.commands.OnlyWhenHeapIsInitialized
 @pwndbg.commands.OnlyWithTcache
-def tcachebins(addr=None, verbose=False):
+def tcachebins(addr=None, verbose=False) -> None:
     """Print the contents of a tcache, default to the current thread's tcache."""
     allocator = pwndbg.heap.current
     tcachebins = allocator.tcachebins(addr)
@@ -539,7 +539,7 @@ parser.add_argument(
 @pwndbg.commands.OnlyWhenRunning
 @pwndbg.commands.OnlyWithResolvedHeapSyms
 @pwndbg.commands.OnlyWhenHeapIsInitialized
-def find_fake_fast(addr, size=None, align=False):
+def find_fake_fast(addr, size=None, align=False) -> None:
     """Find candidate fake fast chunks overlapping the specified address."""
     psize = pwndbg.gdblib.arch.ptrsize
     allocator = pwndbg.heap.current
@@ -657,7 +657,7 @@ parser.add_argument(
 @pwndbg.commands.OnlyWhenRunning
 @pwndbg.commands.OnlyWithResolvedHeapSyms
 @pwndbg.commands.OnlyWhenHeapIsInitialized
-def vis_heap_chunks(addr=None, count=None, naive=None, display_all=None):
+def vis_heap_chunks(addr=None, count=None, naive=None, display_all=None) -> None:
     """Visualize chunks on a heap, default to the current arena's active heap."""
     allocator = pwndbg.heap.current
 
@@ -832,7 +832,7 @@ try_free_parser.add_argument("addr", nargs="?", help="Address passed to free")
 @pwndbg.commands.ArgparsedCommand(try_free_parser)
 @pwndbg.commands.OnlyWhenRunning
 @pwndbg.commands.OnlyWhenHeapIsInitialized
-def try_free(addr):
+def try_free(addr) -> None:
     addr = int(addr)
 
     # check hook
@@ -870,7 +870,7 @@ def try_free(addr):
         # maybe move this to ptmalloc.py
         return chunk_size & (~7)
 
-    def finalize(errors_found, returned_before_error):
+    def finalize(errors_found, returned_before_error) -> None:
         print("-" * 10)
         if returned_before_error:
             print(message.success("Free should succeed!"))
@@ -1192,7 +1192,7 @@ def try_free(addr):
     finalize(errors_found, returned_before_error)
 
 
-def try_unlink(addr):
+def try_unlink(addr) -> None:
     pass
 
 
@@ -1207,7 +1207,7 @@ parser.add_argument(
 
 
 @pwndbg.commands.ArgparsedCommand(parser)
-def heap_config(filter_pattern):
+def heap_config(filter_pattern) -> None:
     display_config(filter_pattern, "heap", has_file_command=False)
 
     print(

--- a/pwndbg/commands/hexdump.py
+++ b/pwndbg/commands/hexdump.py
@@ -59,7 +59,7 @@ parser.add_argument(
 
 @pwndbg.commands.ArgparsedCommand(parser)
 @pwndbg.commands.OnlyWhenRunning
-def hexdump(address, count=pwndbg.gdblib.config.hexdump_bytes):
+def hexdump(address, count=pwndbg.gdblib.config.hexdump_bytes) -> None:
     if hexdump.repeat:
         address = hexdump.last_address
         hexdump.offset += 1

--- a/pwndbg/commands/ida.py
+++ b/pwndbg/commands/ida.py
@@ -16,7 +16,7 @@ from pwndbg.gdblib.functions import GdbFunction
 @pwndbg.commands.OnlyWhenRunning
 @pwndbg.gdblib.events.stop
 @pwndbg.ida.withIDA
-def j(*args):
+def j(*args) -> None:
     """
     Synchronize IDA's cursor with GDB
     """
@@ -35,7 +35,7 @@ parser.add_argument(
 
 @pwndbg.commands.ArgparsedCommand(parser)
 @pwndbg.commands.OnlyWhenRunning
-def up(n=1):
+def up(n=1) -> None:
     """
     Select and print stack frame that called this one.
     """
@@ -63,7 +63,7 @@ parser.add_argument(
 
 @pwndbg.commands.ArgparsedCommand(parser)
 @pwndbg.commands.OnlyWhenRunning
-def down(n=1):
+def down(n=1) -> None:
     """
     Select and print stack frame called by this one.
     """
@@ -85,7 +85,7 @@ def down(n=1):
 
 @pwndbg.commands.ArgparsedCommand("Save the ida database.")
 @pwndbg.ida.withIDA
-def save_ida():
+def save_ida() -> None:
     """Save the IDA database"""
     if not pwndbg.ida.available():
         return

--- a/pwndbg/commands/ignore.py
+++ b/pwndbg/commands/ignore.py
@@ -24,7 +24,7 @@ parser.add_argument("count", metavar="COUNT", type=int, help="The number to set 
 
 
 @pwndbg.commands.ArgparsedCommand(parser)
-def ignore(bpnum, count):
+def ignore(bpnum, count) -> None:
     bps = gdb.breakpoints()
 
     if not bps:

--- a/pwndbg/commands/ipython_interactive.py
+++ b/pwndbg/commands/ipython_interactive.py
@@ -26,7 +26,7 @@ def switch_to_ipython_env():
 
 
 @pwndbg.commands.ArgparsedCommand("Start an interactive IPython prompt.")
-def ipi():
+def ipi() -> None:
     with switch_to_ipython_env():
         # Use `gdb.execute` to embed IPython into GDB's variable scope
         try:

--- a/pwndbg/commands/kbase.py
+++ b/pwndbg/commands/kbase.py
@@ -12,7 +12,7 @@ parser = argparse.ArgumentParser(description="Finds the kernel virtual base addr
 @pwndbg.commands.ArgparsedCommand(parser)
 @pwndbg.commands.OnlyWhenQemuKernel
 @pwndbg.commands.OnlyWhenPagingEnabled
-def kbase():
+def kbase() -> None:
     if config.kernel_vmmap == "none":
         print(M.error("kbase does not work when kernel-vmmap is set to none"))
         return

--- a/pwndbg/commands/kchecksec.py
+++ b/pwndbg/commands/kchecksec.py
@@ -104,7 +104,7 @@ parser = argparse.ArgumentParser(description="Checks for kernel hardening config
 @pwndbg.commands.OnlyWhenQemuKernel
 @pwndbg.commands.OnlyWithKernelDebugSyms
 @pwndbg.commands.OnlyWhenPagingEnabled
-def kchecksec():
+def kchecksec() -> None:
     kconfig = pwndbg.gdblib.kernel.kconfig()
 
     if len(kconfig) == 0:

--- a/pwndbg/commands/kcmdline.py
+++ b/pwndbg/commands/kcmdline.py
@@ -10,5 +10,5 @@ parser = argparse.ArgumentParser(description="Return the kernel commandline (/pr
 @pwndbg.commands.OnlyWhenQemuKernel
 @pwndbg.commands.OnlyWithKernelDebugSyms
 @pwndbg.commands.OnlyWhenPagingEnabled
-def kcmdline():
+def kcmdline() -> None:
     print(pwndbg.gdblib.kernel.kcmdline())

--- a/pwndbg/commands/kconfig.py
+++ b/pwndbg/commands/kconfig.py
@@ -15,7 +15,7 @@ parser.add_argument("config_name", nargs="?", type=str, help="A config name to s
 @pwndbg.commands.OnlyWhenQemuKernel
 @pwndbg.commands.OnlyWithKernelDebugSyms
 @pwndbg.commands.OnlyWhenPagingEnabled
-def kconfig(config_name=None):
+def kconfig(config_name=None) -> None:
     kconfig_ = pwndbg.gdblib.kernel.kconfig()
 
     if len(kconfig_) == 0:

--- a/pwndbg/commands/kversion.py
+++ b/pwndbg/commands/kversion.py
@@ -10,5 +10,5 @@ parser = argparse.ArgumentParser(description="Outputs the kernel version (/proc/
 @pwndbg.commands.OnlyWhenQemuKernel
 @pwndbg.commands.OnlyWithKernelDebugSyms
 @pwndbg.commands.OnlyWhenPagingEnabled
-def kversion():
+def kversion() -> None:
     print(pwndbg.gdblib.kernel.kversion())

--- a/pwndbg/commands/leakfind.py
+++ b/pwndbg/commands/leakfind.py
@@ -45,7 +45,7 @@ def get_rec_addr_string(addr, visited_map):
 
 
 # Useful for debugging. Prints a map of child -> (parent, parent_start)
-def dbg_print_map(maps):
+def dbg_print_map(maps) -> None:
     for child, parent_info in maps.items():
         print("0x%x + (0x%x, 0x%x)" % (child, parent_info[0], parent_info[1]))
 

--- a/pwndbg/commands/memoize.py
+++ b/pwndbg/commands/memoize.py
@@ -14,7 +14,7 @@ Useful for diagnosing caching-related bugs. Decreases performance.
 
 
 @pwndbg.commands.ArgparsedCommand(parser)
-def memoize():
+def memoize() -> None:
     pwndbg.lib.memoize.memoize.caching = not pwndbg.lib.memoize.memoize.caching
 
     status = message.off("OFF (pwndbg will work slower, use only for debugging pwndbg)")

--- a/pwndbg/commands/misc.py
+++ b/pwndbg/commands/misc.py
@@ -25,7 +25,7 @@ parser.add_argument(
 
 @pwndbg.commands.ArgparsedCommand(parser, command_name="errno")
 @pwndbg.commands.OnlyWhenRunning
-def errno_(err):
+def errno_(err) -> None:
     if err is None:
         # Try to get the `errno` variable value
         # if it does not exist, get the errno variable from its location
@@ -74,7 +74,7 @@ parser.add_argument(
 
 
 @pwndbg.commands.ArgparsedCommand(parser, command_name="pwndbg")
-def pwndbg_(filter_pattern, shell, all_):
+def pwndbg_(filter_pattern, shell, all_) -> None:
     if all_:
         shell_cmds = True
         pwndbg_cmds = True
@@ -109,7 +109,7 @@ parser.add_argument("b", type=int, help="The second address.")
 
 
 @pwndbg.commands.ArgparsedCommand(parser)
-def distance(a, b):
+def distance(a, b) -> None:
     """Print the distance between the two arguments"""
     a = int(a) & pwndbg.gdblib.arch.ptrmask
     b = int(b) & pwndbg.gdblib.arch.ptrmask

--- a/pwndbg/commands/mprotect.py
+++ b/pwndbg/commands/mprotect.py
@@ -60,7 +60,7 @@ def prot_str_to_val(protstr):
 
 @pwndbg.commands.ArgparsedCommand(parser)
 @pwndbg.commands.OnlyWhenRunning
-def mprotect(addr, length, prot):
+def mprotect(addr, length, prot) -> None:
 
     prot_int = prot_str_to_val(prot)
 

--- a/pwndbg/commands/next.py
+++ b/pwndbg/commands/next.py
@@ -12,7 +12,7 @@ import pwndbg.gdblib.next
 
 @pwndbg.commands.ArgparsedCommand("Breaks at the next jump instruction.", aliases=["nextjump"])
 @pwndbg.commands.OnlyWhenRunning
-def nextjmp():
+def nextjmp() -> None:
     """Breaks at the next jump instruction"""
     if pwndbg.gdblib.next.break_next_branch():
         pwndbg.commands.context.context()
@@ -30,7 +30,7 @@ parser.add_argument(
 
 @pwndbg.commands.ArgparsedCommand(parser)
 @pwndbg.commands.OnlyWhenRunning
-def nextcall(symbol_regex=None):
+def nextcall(symbol_regex=None) -> None:
     """Breaks at the next call instruction"""
     if pwndbg.gdblib.next.break_next_call(symbol_regex):
         pwndbg.commands.context.context()
@@ -38,7 +38,7 @@ def nextcall(symbol_regex=None):
 
 @pwndbg.commands.ArgparsedCommand("Breaks at next return-like instruction.")
 @pwndbg.commands.OnlyWhenRunning
-def nextret():
+def nextret() -> None:
     """Breaks at next return-like instruction"""
     if pwndbg.gdblib.next.break_next_ret():
         pwndbg.commands.context.context()
@@ -46,7 +46,7 @@ def nextret():
 
 @pwndbg.commands.ArgparsedCommand("Breaks at next return-like instruction by 'stepping' to it.")
 @pwndbg.commands.OnlyWhenRunning
-def stepret():
+def stepret() -> None:
     """Breaks at next return-like instruction by 'stepping' to it"""
     while (
         pwndbg.gdblib.proc.alive
@@ -66,7 +66,7 @@ def stepret():
     "Breaks at the next instruction that belongs to the running program."
 )
 @pwndbg.commands.OnlyWhenRunning
-def nextproginstr():
+def nextproginstr() -> None:
     pwndbg.gdblib.next.break_on_program_code()
 
 
@@ -76,7 +76,7 @@ parser.add_argument("addr", type=int, default=None, nargs="?", help="The address
 
 @pwndbg.commands.ArgparsedCommand(parser, aliases=["so"])
 @pwndbg.commands.OnlyWhenRunning
-def stepover(addr=None):
+def stepover(addr=None) -> None:
     """Sets a breakpoint on the instruction after this one"""
     pwndbg.gdblib.next.break_on_next(addr)
 
@@ -85,7 +85,7 @@ def stepover(addr=None):
     "Breaks at the next syscall not taking branches.", aliases=["nextsc"]
 )
 @pwndbg.commands.OnlyWhenRunning
-def nextsyscall():
+def nextsyscall() -> None:
     """
     Breaks at the next syscall not taking branches.
     """
@@ -104,7 +104,7 @@ def nextsyscall():
     "Breaks at the next syscall by taking branches.", aliases=["stepsc"]
 )
 @pwndbg.commands.OnlyWhenRunning
-def stepsyscall():
+def stepsyscall() -> None:
     """
     Breaks at the next syscall by taking branches.
     """

--- a/pwndbg/commands/p2p.py
+++ b/pwndbg/commands/p2p.py
@@ -11,11 +11,11 @@ ts = pwndbg.commands.telescope.telescope
 
 
 class AddrRange:
-    def __init__(self, begin, end):
+    def __init__(self, begin, end) -> None:
         self.begin = begin
         self.end = end
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return (self.begin, self.end).__repr__()
 
 
@@ -113,7 +113,7 @@ def p2p_walk(addr, ranges, current_level):
 
 @pwndbg.commands.ArgparsedCommand(parser)
 @pwndbg.commands.OnlyWhenRunning
-def p2p(mapping_names: Optional[List] = None):
+def p2p(mapping_names: Optional[List] = None) -> None:
 
     if not mapping_names:
         return

--- a/pwndbg/commands/patch.py
+++ b/pwndbg/commands/patch.py
@@ -21,7 +21,7 @@ parser.add_argument("ins", type=str, help="instruction[s]")
 
 @pwndbg.commands.ArgparsedCommand(parser)
 @pwndbg.commands.OnlyWhenRunning
-def patch(address, ins):
+def patch(address, ins) -> None:
     new_mem = asm(ins)
 
     old_mem = pwndbg.gdblib.memory.read(address, len(new_mem))
@@ -39,7 +39,7 @@ parser2.add_argument("address", type=int, help="Address to revert patch on")
 
 @pwndbg.commands.ArgparsedCommand(parser2)
 @pwndbg.commands.OnlyWhenRunning
-def patch_revert(address):
+def patch_revert(address) -> None:
     if not patches:
         print(message.notice("No patches to revert"))
         return
@@ -61,7 +61,7 @@ parser3 = argparse.ArgumentParser(description="List all patches.")
 
 @pwndbg.commands.ArgparsedCommand(parser3)
 @pwndbg.commands.OnlyWhenRunning
-def patch_list():
+def patch_list() -> None:
     if not patches:
         print(message.hint("No patches to list"))
         return

--- a/pwndbg/commands/peda.py
+++ b/pwndbg/commands/peda.py
@@ -12,13 +12,13 @@ import pwndbg.gdblib.proc
 
 @pwndbg.commands.ArgparsedCommand("Gets the current file.")
 @pwndbg.commands.OnlyWhenRunning
-def getfile():
+def getfile() -> None:
     print(repr(pwndbg.auxv.get().AT_EXECFN))
 
 
 @pwndbg.commands.ArgparsedCommand("Get the pid.")
 @pwndbg.commands.OnlyWhenRunning
-def getpid():
+def getpid() -> None:
     print(pwndbg.gdblib.proc.pid)
 
 
@@ -27,7 +27,7 @@ parser.add_argument("target", type=str, help="Address or function to stop execut
 
 
 @pwndbg.commands.ArgparsedCommand(parser)
-def xuntil(target):
+def xuntil(target) -> None:
     try:
         addr = int(target, 0)
 

--- a/pwndbg/commands/pie.py
+++ b/pwndbg/commands/pie.py
@@ -80,7 +80,7 @@ parser.add_argument(
 
 @pwndbg.commands.ArgparsedCommand(parser)
 @pwndbg.commands.OnlyWhenRunning
-def piebase(offset=None, module=None):
+def piebase(offset=None, module=None) -> None:
     offset = int(offset)
     if not module:
         # Note: we do not use `pwndbg.gdblib.file.get_file(module)` here as it is not needed.
@@ -109,7 +109,7 @@ parser.add_argument(
 
 @pwndbg.commands.ArgparsedCommand(parser, aliases=["brva"])
 @pwndbg.commands.OnlyWhenRunning
-def breakrva(offset=0, module=None):
+def breakrva(offset=0, module=None) -> None:
     offset = int(offset)
     if not module:
         # Note: we do not use `pwndbg.gdblib.file.get_file(module)` here as it is not needed.

--- a/pwndbg/commands/probeleak.py
+++ b/pwndbg/commands/probeleak.py
@@ -80,7 +80,9 @@ parser.add_argument(
 
 @pwndbg.commands.ArgparsedCommand(parser)
 @pwndbg.commands.OnlyWhenRunning
-def probeleak(address=None, count=0x40, max_distance=0x0, point_to=None, max_ptrs=0, flags=None):
+def probeleak(
+    address=None, count=0x40, max_distance=0x0, point_to=None, max_ptrs=0, flags=None
+) -> None:
 
     address = int(address)
     address &= pwndbg.gdblib.arch.ptrmask

--- a/pwndbg/commands/procinfo.py
+++ b/pwndbg/commands/procinfo.py
@@ -62,7 +62,7 @@ capabilities = {
 
 
 class Process:
-    def __init__(self, pid=None, tid=None):
+    def __init__(self, pid=None, tid=None) -> None:
         if pid is None:
             pid = pwndbg.gdblib.proc.pid
         if tid is None:
@@ -180,13 +180,13 @@ class Process:
 
 @pwndbg.commands.ArgparsedCommand("Gets the pid.")
 @pwndbg.commands.OnlyWhenRunning
-def pid():
+def pid() -> None:
     print(pwndbg.gdblib.proc.pid)
 
 
 @pwndbg.commands.ArgparsedCommand("Display information about the running process.")
 @pwndbg.commands.OnlyWhenRunning
-def procinfo():
+def procinfo() -> None:
     """
     Display information about the running process.
     """

--- a/pwndbg/commands/radare2.py
+++ b/pwndbg/commands/radare2.py
@@ -17,7 +17,7 @@ parser.add_argument("arguments", nargs="*", type=str, help="Arguments to pass to
 
 @pwndbg.commands.ArgparsedCommand(parser, aliases=["radare2"])
 @pwndbg.commands.OnlyWithFile
-def r2(arguments, no_seek=False, no_rebase=False):
+def r2(arguments, no_seek=False, no_rebase=False) -> None:
     filename = pwndbg.gdblib.file.get_file(pwndbg.gdblib.proc.exe)
 
     # Build up the command line to run
@@ -51,7 +51,7 @@ parser.add_argument("arguments", nargs="+", type=str, help="Arguments to pass to
 
 @pwndbg.commands.ArgparsedCommand(parser)
 @pwndbg.commands.OnlyWithFile
-def r2pipe(arguments):
+def r2pipe(arguments) -> None:
     try:
         r2 = pwndbg.radare2.r2pipe()
         print(r2.cmd(" ".join(arguments)))

--- a/pwndbg/commands/reload.py
+++ b/pwndbg/commands/reload.py
@@ -7,7 +7,7 @@ import pwndbg.gdblib.events
 import pwndbg.lib.memoize
 
 
-def rreload(module, mdict=None):
+def rreload(module, mdict=None) -> None:
     """Recursively reload modules."""
     name = module.__name__
 
@@ -27,14 +27,14 @@ def rreload(module, mdict=None):
 
 
 @pwndbg.commands.ArgparsedCommand("Reload pwndbg.")
-def reload(*a):
+def reload(*a) -> None:
     pwndbg.gdblib.events.on_reload()
     rreload(pwndbg)
     pwndbg.gdblib.events.after_reload()
 
 
 @pwndbg.commands.ArgparsedCommand("Makes pwndbg reinitialize all state.")
-def reinit_pwndbg():
+def reinit_pwndbg() -> None:
     """
     Makes pwndbg reinitialize all state.
     """

--- a/pwndbg/commands/rop.py
+++ b/pwndbg/commands/rop.py
@@ -18,7 +18,7 @@ parser.add_argument("argument", nargs="*", type=str, help="Arguments to pass to 
 
 @pwndbg.commands.ArgparsedCommand(parser, aliases=["ropgadget"])
 @pwndbg.commands.OnlyWithFile
-def rop(grep, argument):
+def rop(grep, argument) -> None:
     with tempfile.NamedTemporaryFile() as corefile:
 
         # If the process is running, dump a corefile so we get actual addresses.

--- a/pwndbg/commands/ropper.py
+++ b/pwndbg/commands/ropper.py
@@ -16,7 +16,7 @@ parser.add_argument("argument", nargs="*", type=str, help="Arguments to pass to 
 
 @pwndbg.commands.ArgparsedCommand(parser)
 @pwndbg.commands.OnlyWithFile
-def ropper(argument):
+def ropper(argument) -> None:
     with tempfile.NamedTemporaryFile() as corefile:
 
         # If the process is running, dump a corefile so we get actual addresses.

--- a/pwndbg/commands/search.py
+++ b/pwndbg/commands/search.py
@@ -17,7 +17,7 @@ from pwndbg.color import message
 saved = set()  # type:Set[int]
 
 
-def print_search_hit(address):
+def print_search_hit(address) -> None:
     """Prints out a single search hit.
 
     Arguments:
@@ -130,7 +130,7 @@ parser.add_argument(
 
 @pwndbg.commands.ArgparsedCommand(parser)
 @pwndbg.commands.OnlyWhenRunning
-def search(type, hex, executable, writable, value, mapping_name, save, next, trunc_out):
+def search(type, hex, executable, writable, value, mapping_name, save, next, trunc_out) -> None:
     global saved
     if next and not saved:
         print(

--- a/pwndbg/commands/segments.py
+++ b/pwndbg/commands/segments.py
@@ -7,7 +7,7 @@ import pwndbg.gdblib.regs
 class segment(gdb.Function):
     """Get the flat address of memory based off of the named segment register."""
 
-    def __init__(self, name):
+    def __init__(self, name) -> None:
         super(segment, self).__init__(name)
         self.name = name
 
@@ -22,7 +22,7 @@ segment("gsbase")
 
 @pwndbg.commands.ArgparsedCommand("Prints out the FS base address. See also $fsbase.")
 @pwndbg.commands.OnlyWhenRunning
-def fsbase():
+def fsbase() -> None:
     """
     Prints out the FS base address. See also $fsbase.
     """
@@ -31,7 +31,7 @@ def fsbase():
 
 @pwndbg.commands.ArgparsedCommand("Prints out the GS base address. See also $gsbase.")
 @pwndbg.commands.OnlyWhenRunning
-def gsbase():
+def gsbase() -> None:
     """
     Prints out the GS base address. See also $gsbase.
     """

--- a/pwndbg/commands/shell.py
+++ b/pwndbg/commands/shell.py
@@ -64,8 +64,8 @@ pwncmds = list(filter(pwndbg.lib.which.which, pwncmd_names))
 shellcmds = list(filter(pwndbg.lib.which.which, shellcmd_names))
 
 
-def register_shell_function(cmd, deprecated=False):
-    def handler(*a):
+def register_shell_function(cmd, deprecated=False) -> None:
+    def handler(*a) -> None:
         if os.fork() == 0:
             os.execvp(cmd, (cmd,) + a)
         os.wait()

--- a/pwndbg/commands/slab.py
+++ b/pwndbg/commands/slab.py
@@ -21,7 +21,7 @@ parser.add_argument(
 @pwndbg.commands.OnlyWhenQemuKernel
 @pwndbg.commands.OnlyWithKernelDebugSyms
 @pwndbg.commands.OnlyWhenPagingEnabled
-def slab(filter_=None):
+def slab(filter_=None) -> None:
     results = []
     for cache in pwndbg.gdblib.kernel.slab.caches():
         name = pwndbg.gdblib.memory.string(cache["name"]).decode("ascii")

--- a/pwndbg/commands/stack.py
+++ b/pwndbg/commands/stack.py
@@ -9,7 +9,7 @@ import pwndbg.gdblib.vmmap
 
 @pwndbg.commands.ArgparsedCommand("Print out the stack addresses that contain return addresses.")
 @pwndbg.commands.OnlyWhenRunning
-def retaddr():
+def retaddr() -> None:
     sp = pwndbg.gdblib.regs.sp
     stack = pwndbg.gdblib.vmmap.find(sp)
 

--- a/pwndbg/commands/start.py
+++ b/pwndbg/commands/start.py
@@ -17,7 +17,7 @@ break_on_first_instruction = False
 
 
 @pwndbg.gdblib.events.start
-def on_start():
+def on_start() -> None:
     global break_on_first_instruction
     if break_on_first_instruction:
         spec = "*%#x" % (int(pwndbg.gdblib.elf.entry()))
@@ -53,7 +53,7 @@ parser.add_argument(
 
 
 @pwndbg.commands.ArgparsedCommand(parser)
-def start(args=None):
+def start(args=None) -> None:
     if args is None:
         args = []
     run = "run " + " ".join(args)
@@ -104,7 +104,7 @@ parser.add_argument(
 
 @pwndbg.commands.ArgparsedCommand(parser)
 @pwndbg.commands.OnlyWithFile
-def entry(args=None):
+def entry(args=None) -> None:
     if args is None:
         arg = []
     global break_on_first_instruction

--- a/pwndbg/commands/telescope.py
+++ b/pwndbg/commands/telescope.py
@@ -139,7 +139,7 @@ def telescope(address=None, count=telescope_lines, to_string=False, reverse=Fals
     )
 
     # Collapse repeating values exceeding minimum delta.
-    def collapse_repeating_values():
+    def collapse_repeating_values() -> None:
         # The first line was already printed, hence increment by 1
         if collapse_buffer and len(collapse_buffer) + 1 >= skip_repeating_values_minimum:
             result.append(
@@ -210,7 +210,7 @@ parser.add_argument(
 
 @pwndbg.commands.ArgparsedCommand(parser)
 @pwndbg.commands.OnlyWhenRunning
-def stack(count, offset):
+def stack(count, offset) -> None:
     ptrsize = pwndbg.gdblib.typeinfo.ptrsize
     telescope.repeat = stack.repeat
     telescope(address=pwndbg.gdblib.regs.sp + offset * ptrsize, count=count)

--- a/pwndbg/commands/tls.py
+++ b/pwndbg/commands/tls.py
@@ -11,7 +11,7 @@ from pwndbg.color import message
     "Print out base address of the current Thread Local Storage (TLS)."
 )
 @pwndbg.commands.OnlyWhenRunning
-def tls():
+def tls() -> None:
     tls_base = pwndbg.gdblib.tls.address
     if tls_base:
         print(message.success("Thread Local Storage (TLS) base: %#x" % tls_base))

--- a/pwndbg/commands/version.py
+++ b/pwndbg/commands/version.py
@@ -70,7 +70,7 @@ def all_versions():
 
 
 @pwndbg.commands.ArgparsedCommand("Displays GDB, Python, and pwndbg versions.")
-def version():
+def version() -> None:
     """
     Displays GDB, Python, and pwndbg versions.
     """

--- a/pwndbg/commands/vmmap.py
+++ b/pwndbg/commands/vmmap.py
@@ -30,7 +30,7 @@ def pages_filter(gdbval_or_str):
         raise argparse.ArgumentTypeError("Unknown vmmap argument type.")
 
 
-def print_vmmap_table_header():
+def print_vmmap_table_header() -> None:
     """
     Prints the table header for the vmmap command.
     """
@@ -79,7 +79,7 @@ parser.add_argument("-x", "--executable", action="store_true", help="Display exe
 
 @pwndbg.commands.ArgparsedCommand(parser, aliases=["lm", "address", "vprot"])
 @pwndbg.commands.OnlyWhenRunning
-def vmmap(gdbval_or_str=None, writable=False, executable=False):
+def vmmap(gdbval_or_str=None, writable=False, executable=False) -> None:
     pages = pwndbg.gdblib.vmmap.get()
 
     if gdbval_or_str:
@@ -120,7 +120,7 @@ parser.add_argument(
 
 @pwndbg.commands.ArgparsedCommand(parser)
 @pwndbg.commands.OnlyWhenRunning
-def vmmap_add(start, size, flags, offset):
+def vmmap_add(start, size, flags, offset) -> None:
     page_flags = {
         "r": pwndbg.gdblib.elf.PF_R,
         "w": pwndbg.gdblib.elf.PF_W,
@@ -142,7 +142,7 @@ def vmmap_add(start, size, flags, offset):
 
 @pwndbg.commands.ArgparsedCommand("Clear the vmmap cache.")  # TODO is this accurate?
 @pwndbg.commands.OnlyWhenRunning
-def vmmap_clear():
+def vmmap_clear() -> None:
     pwndbg.gdblib.vmmap.clear_custom_page()
 
 
@@ -154,7 +154,7 @@ parser.add_argument(
 
 @pwndbg.commands.ArgparsedCommand(parser)
 @pwndbg.commands.OnlyWhenRunning
-def vmmap_load(filename):
+def vmmap_load(filename) -> None:
     if filename is None:
         filename = pwndbg.gdblib.file.get_file(pwndbg.gdblib.proc.exe)
 

--- a/pwndbg/commands/windbg.py
+++ b/pwndbg/commands/windbg.py
@@ -252,7 +252,7 @@ def eza(address, data):
     return ez(address, data)
 
 
-def eX(size, address, data, hex=True):
+def eX(size, address, data, hex=True) -> None:
     """
     This relies on windbg's default hex encoding being enforced
     """
@@ -319,7 +319,7 @@ da_parser.add_argument("max", type=int, nargs="?", default=256, help="Maximum st
 
 @pwndbg.commands.ArgparsedCommand(da_parser)
 @pwndbg.commands.OnlyWhenRunning
-def da(address, max):
+def da(address, max) -> None:
     print("%x" % address, repr(pwndbg.gdblib.strings.get(address, max)))
 
 
@@ -330,7 +330,7 @@ ds_parser.add_argument("max", type=int, nargs="?", default=256, help="Maximum st
 
 @pwndbg.commands.ArgparsedCommand(ds_parser)
 @pwndbg.commands.OnlyWhenRunning
-def ds(address, max):
+def ds(address, max) -> None:
     # We do change the max length to the default if its too low
     # because the truncated display is not that ideal/not the same as GDB's yet
     # (ours: "truncated ...", GDBs: "truncated "...)
@@ -349,7 +349,7 @@ def ds(address, max):
 
 
 @pwndbg.commands.ArgparsedCommand("List breakpoints.")
-def bl():
+def bl() -> None:
     """
     List breakpoints
     """
@@ -363,7 +363,7 @@ parser.add_argument(
 
 
 @pwndbg.commands.ArgparsedCommand(parser)
-def bd(which="*"):
+def bd(which="*") -> None:
     """
     Disable the breakpoint with the specified index.
     """
@@ -380,7 +380,7 @@ parser.add_argument(
 
 
 @pwndbg.commands.ArgparsedCommand(parser)
-def be(which="*"):
+def be(which="*") -> None:
     """
     Enable the breakpoint with the specified index.
     """
@@ -397,7 +397,7 @@ parser.add_argument(
 
 
 @pwndbg.commands.ArgparsedCommand(parser)
-def bc(which="*"):
+def bc(which="*") -> None:
     """
     Clear the breakpoint with the specified index.
     """
@@ -412,7 +412,7 @@ parser.add_argument("where", type=int, help="The address to break at.")
 
 
 @pwndbg.commands.ArgparsedCommand(parser)
-def bp(where):
+def bp(where) -> None:
     """
     Set a breakpoint at the specified address.
     """
@@ -446,7 +446,7 @@ def u(where=None, n=5, to_string=False):
 
 @pwndbg.commands.ArgparsedCommand("Print a backtrace (alias 'bt').")
 @pwndbg.commands.OnlyWhenRunning
-def k():
+def k() -> None:
     """
     Print a backtrace (alias 'bt')
     """
@@ -461,7 +461,7 @@ parser.add_argument(
 
 @pwndbg.commands.ArgparsedCommand(parser)
 @pwndbg.commands.OnlyWhenRunning
-def ln(value=None):
+def ln(value=None) -> None:
     """
     List the symbols nearest to the provided value.
     """
@@ -482,13 +482,13 @@ def ln(value=None):
 
 @pwndbg.commands.ArgparsedCommand("Not be windows.")
 @pwndbg.commands.OnlyWhenRunning
-def peb():
+def peb() -> None:
     print("This isn't Windows!")
 
 
 @pwndbg.commands.ArgparsedCommand("Windbg compatibility alias for 'continue' command.")
 @pwndbg.commands.OnlyWhenRunning
-def go():
+def go() -> None:
     """
     Windbg compatibility alias for 'continue' command.
     """

--- a/pwndbg/commands/xinfo.py
+++ b/pwndbg/commands/xinfo.py
@@ -16,7 +16,7 @@ parser = argparse.ArgumentParser(
 parser.add_argument("address", nargs="?", default="$pc", help="Address to inspect")
 
 
-def print_line(name, addr, first, second, op, width=20):
+def print_line(name, addr, first, second, op, width=20) -> None:
 
     print(
         "{} {} = {} {} {:#x}".format(
@@ -29,7 +29,7 @@ def print_line(name, addr, first, second, op, width=20):
     )
 
 
-def xinfo_stack(page, addr):
+def xinfo_stack(page, addr) -> None:
     # If it's a stack address, print offsets to top and bottom of stack, as
     # well as offsets to current stack and base pointer (if used by debuggee)
 
@@ -58,7 +58,7 @@ def xinfo_stack(page, addr):
             print_line("Next Stack Canary", addr, nxt, nxt - addr, "-")
 
 
-def xinfo_mmap_file(page, addr):
+def xinfo_mmap_file(page, addr) -> None:
     # If it's an address pointing into a memory mapped file, print offsets
     # to beginning of file in memory and on disk
 
@@ -98,14 +98,14 @@ def xinfo_mmap_file(page, addr):
             print_line(sec["x_name"], addr, sec["sh_addr"], addr - sec["sh_addr"], "+")
 
 
-def xinfo_default(page, addr):
+def xinfo_default(page, addr) -> None:
     # Just print the distance to the beginning of the mapping
     print_line("Mapped Area", addr, page.vaddr, addr - page.vaddr, "+")
 
 
 @pwndbg.commands.ArgparsedCommand(parser)
 @pwndbg.commands.OnlyWhenRunning
-def xinfo(address=None):
+def xinfo(address=None) -> None:
     address = address.cast(
         pwndbg.gdblib.typeinfo.pvoid
     )  # Fixes issues with function ptrs (xinfo malloc)

--- a/pwndbg/commands/xor.py
+++ b/pwndbg/commands/xor.py
@@ -29,7 +29,7 @@ parser.add_argument("count", type=int, help="The number of bytes to xor.")
 
 @pwndbg.commands.ArgparsedCommand(parser)
 @pwndbg.commands.OnlyWhenRunning
-def xor(address, key, count):
+def xor(address, key, count) -> None:
     try:
         xorred_memory = xor_memory(address, key, count)
         pwndbg.gdblib.memory.write(address, xorred_memory)

--- a/pwndbg/disasm/__init__.py
+++ b/pwndbg/disasm/__init__.py
@@ -124,7 +124,7 @@ def get_disassembler(pc):
 
 
 class SimpleInstruction:
-    def __init__(self, address):
+    def __init__(self, address) -> None:
         self.address = address
         ins = gdb.newest_frame().architecture().disassemble(address)[0]
         asm = ins["asm"].split(None, 1)

--- a/pwndbg/disasm/arch.py
+++ b/pwndbg/disasm/arch.py
@@ -20,7 +20,7 @@ class DisassemblyAssistant:
     # Registry of all instances, {architecture: instance}
     assistants = {}
 
-    def __init__(self, architecture):
+    def __init__(self, architecture) -> None:
         if architecture is not None:
             self.assistants[architecture] = self
 
@@ -37,7 +37,7 @@ class DisassemblyAssistant:
         }
 
     @staticmethod
-    def enhance(instruction):
+    def enhance(instruction) -> None:
         enhancer = DisassemblyAssistant.assistants.get(
             pwndbg.gdblib.arch.current, generic_assistant
         )
@@ -49,7 +49,7 @@ class DisassemblyAssistant:
         if debug:
             print(enhancer.dump(instruction))
 
-    def enhance_conditional(self, instruction):
+    def enhance_conditional(self, instruction) -> None:
         """
         Adds a ``condition`` field to the instruction.
 
@@ -71,10 +71,10 @@ class DisassemblyAssistant:
 
         instruction.condition = c
 
-    def condition(self, instruction):
+    def condition(self, instruction) -> bool:
         return False
 
-    def enhance_next(self, instruction):
+    def enhance_next(self, instruction) -> None:
         """
         Adds a ``next`` field to the instruction.
 
@@ -152,7 +152,7 @@ class DisassemblyAssistant:
 
         return int(addr)
 
-    def enhance_symbol(self, instruction):
+    def enhance_symbol(self, instruction) -> None:
         """
         Adds a ``symbol`` and ``symbol_addr`` fields to the instruction.
 
@@ -173,7 +173,7 @@ class DisassemblyAssistant:
         instruction.symbol = o.symbol
         instruction.symbol_addr = o.int
 
-    def enhance_operands(self, instruction):
+    def enhance_operands(self, instruction) -> None:
         """
         Enhances all of the operands in the instruction, by adding the following
         fields:
@@ -203,7 +203,7 @@ class DisassemblyAssistant:
     def immediate(self, instruction, operand):
         return operand.value.imm
 
-    def immediate_sz(self, instruction, operand):
+    def immediate_sz(self, instruction, operand) -> str:
         value = operand.int
 
         if abs(value) < 0x10:

--- a/pwndbg/disasm/arm.py
+++ b/pwndbg/disasm/arm.py
@@ -8,7 +8,7 @@ import pwndbg.gdblib.regs
 
 
 class DisassemblyAssistant(pwndbg.disasm.arch.DisassemblyAssistant):
-    def memory_sz(self, instruction, op):
+    def memory_sz(self, instruction, op) -> str:
         segment = ""
         parts = []
 

--- a/pwndbg/emu/emulator.py
+++ b/pwndbg/emu/emulator.py
@@ -62,7 +62,7 @@ arch_to_CS = {
 DEBUG = False
 
 
-def debug(fmt, args=()):
+def debug(fmt, args=()) -> None:
     if DEBUG:
         print(fmt % args)
 
@@ -99,7 +99,7 @@ e.until_jump()
 
 
 class Emulator:
-    def __init__(self):
+    def __init__(self) -> None:
         self.arch = pwndbg.gdblib.arch.current
 
         if self.arch not in arch_to_UC:
@@ -177,7 +177,7 @@ class Emulator:
 
         raise AttributeError("AttributeError: %r object has no attribute %r" % (self, name))
 
-    def update_pc(self, pc=None):
+    def update_pc(self, pc=None) -> None:
         if pc is None:
             pc = pwndbg.gdblib.regs.pc
         self.uc.reg_write(self.get_reg_enum(self.regs.pc), pc)
@@ -212,7 +212,7 @@ class Emulator:
 
         return mode
 
-    def map_page(self, page):
+    def map_page(self, page) -> bool:
         page = pwndbg.lib.memory.page_align(page)
         size = pwndbg.lib.memory.PAGE_SIZE
 
@@ -238,7 +238,7 @@ class Emulator:
 
         return True
 
-    def hook_mem_invalid(self, uc, access, address, size, value, user_data):
+    def hook_mem_invalid(self, uc, access, address, size, value, user_data) -> bool:
         debug("# Invalid access at %#x", address)
 
         # Page-align the start address
@@ -257,7 +257,7 @@ class Emulator:
 
         return True
 
-    def hook_intr(self, uc, intno, user_data):
+    def hook_intr(self, uc, intno, user_data) -> None:
         """
         We never want to emulate through an interrupt.  Just stop.
         """
@@ -318,7 +318,7 @@ class Emulator:
         debug("uc.emu_stop(*%r, **%r)", (a, kw))
         return self.uc.emu_stop(*a, **kw)
 
-    def emulate_with_hook(self, hook, count=512):
+    def emulate_with_hook(self, hook, count=512) -> None:
         ident = self.hook_add(U.UC_HOOK_CODE, hook)
         try:
             self.emu_start(self.pc, 0, count=count)
@@ -368,7 +368,7 @@ class Emulator:
         # We're done emulating
         return self._prev, self._curr
 
-    def until_jump_hook_code(self, _uc, address, instruction_size, _user_data):
+    def until_jump_hook_code(self, _uc, address, instruction_size, _user_data) -> None:
         # We have not emulated any instructions yet.
         if self._prev is None:
             pass
@@ -406,7 +406,7 @@ class Emulator:
         self.emulate_with_hook(self.until_syscall_hook_code)
         return (self.until_syscall_address, None)
 
-    def until_syscall_hook_code(self, uc, address, size, user_data):
+    def until_syscall_hook_code(self, uc, address, size, user_data) -> None:
         data = binascii.hexlify(self.mem_read(address, size))
         debug("# Executing instruction at %(address)#x with bytes %(data)s", locals())
         self.until_syscall_address = address
@@ -447,7 +447,7 @@ class Emulator:
             yield a
             a = self.single_step(pc)
 
-    def single_step_hook_code(self, _uc, address, instruction_size, _user_data):
+    def single_step_hook_code(self, _uc, address, instruction_size, _user_data) -> None:
         # For whatever reason, the hook will hit twice on
         # unicorn >= 1.0.2rc4, but not on unicorn-1.0.2rc1~unicorn-1.0.2rc3,
         # So we use a counter to ensure the code run only once
@@ -456,7 +456,7 @@ class Emulator:
             self._single_step = (address, instruction_size)
             self.single_step_hook_hit_count += 1
 
-    def dumpregs(self):
+    def dumpregs(self) -> None:
         for reg in (
             list(self.regs.retaddr)
             + list(self.regs.misc)
@@ -473,6 +473,6 @@ class Emulator:
             value = self.uc.reg_read(enum)
             debug("uc.reg_read(%(name)s) ==> %(value)x", locals())
 
-    def trace_hook(self, _uc, address, instruction_size, _user_data):
+    def trace_hook(self, _uc, address, instruction_size, _user_data) -> None:
         data = binascii.hexlify(self.mem_read(address, instruction_size))
         debug("# trace_hook: %#-8x %r", (address, data))

--- a/pwndbg/enhance.py
+++ b/pwndbg/enhance.py
@@ -24,7 +24,7 @@ from pwndbg.color.syntax_highlight import syntax_highlight
 bad_instrs = [".byte", ".long", "rex.R", "rex.XB", ".inst", "(bad)"]
 
 
-def good_instr(i):
+def good_instr(i) -> bool:
     return not any(bad in i for bad in bad_instrs)
 
 

--- a/pwndbg/exception.py
+++ b/pwndbg/exception.py
@@ -26,7 +26,7 @@ debug = config.add_param(
 
 
 @pwndbg.lib.memoize.forever
-def inform_report_issue(exception_msg):
+def inform_report_issue(exception_msg) -> None:
     """
     Informs user that he can report an issue.
     The use of `memoize` makes it reporting only once for a given exception message.
@@ -42,7 +42,7 @@ def inform_report_issue(exception_msg):
     )
 
 
-def inform_verbose_and_debug():
+def inform_verbose_and_debug() -> None:
     print(
         message.notice("For more info invoke `")
         + message.hint("set exception-verbose on")
@@ -88,7 +88,7 @@ def handle(name="Error"):
 
 
 @functools.wraps(pdb.set_trace)
-def set_trace():
+def set_trace() -> None:
     """Enable sane debugging in Pwndbg by switching to the "real" stdio."""
     debugger = pdb.Pdb(
         stdin=sys.__stdin__, stdout=sys.__stdout__, skip=["pwndbg.lib.stdio", "pwndbg.exception"]
@@ -100,7 +100,7 @@ pdb.set_trace = set_trace
 
 
 @config.trigger(verbose, debug)
-def update():
+def update() -> None:
     if verbose or debug:
         command = "set python print-stack full"
     else:

--- a/pwndbg/gdblib/__init__.py
+++ b/pwndbg/gdblib/__init__.py
@@ -9,7 +9,7 @@ __all__ = ["ctypes", "memory", "typeinfo"]
 
 
 # TODO: should the imports above be moved here?
-def load_gdblib():
+def load_gdblib() -> None:
     """
     Import all gdblib modules that need to run code on import
     """

--- a/pwndbg/gdblib/abi.py
+++ b/pwndbg/gdblib/abi.py
@@ -8,7 +8,7 @@ abi = None
 linux = False
 
 
-def update():
+def update() -> None:
     global abi
     global linux
 

--- a/pwndbg/gdblib/android.py
+++ b/pwndbg/gdblib/android.py
@@ -9,7 +9,7 @@ import pwndbg.lib.memoize
 
 @pwndbg.lib.memoize.reset_on_start
 @pwndbg.lib.memoize.reset_on_exit
-def is_android():
+def is_android() -> bool:
     if pwndbg.gdblib.qemu.is_qemu():
         return False
 
@@ -23,7 +23,7 @@ def is_android():
 
 
 @pwndbg.gdblib.events.start
-def sysroot():
+def sysroot() -> None:
     cmd = "set sysroot remote:/"
     if is_android():
         if gdb.parameter("sysroot") == "target:":

--- a/pwndbg/gdblib/arch.py
+++ b/pwndbg/gdblib/arch.py
@@ -52,7 +52,7 @@ def _get_arch(ptrsize):
     return arch, ptrsize, endian
 
 
-def update():
+def update() -> None:
     # We can't just assign to `arch` with a new `Arch` object. Modules that have
     # already imported it will still have a reference to the old `arch`
     # object. Instead, we call `__init__` again with the new args

--- a/pwndbg/gdblib/argv.py
+++ b/pwndbg/gdblib/argv.py
@@ -21,7 +21,7 @@ envc = None
 
 @pwndbg.gdblib.events.start
 @pwndbg.gdblib.abi.LinuxOnly()
-def update():
+def update() -> None:
     global argc
     global argv
     global envp

--- a/pwndbg/gdblib/config.py
+++ b/pwndbg/gdblib/config.py
@@ -25,7 +25,7 @@ config = pwndbg.lib.config.Config()
 # See this for details about the API of `gdb.Parameter`:
 # https://sourceware.org/gdb/onlinedocs/gdb/Parameters-In-Python.html
 class Parameter(gdb.Parameter):
-    def __init__(self, param: pwndbg.lib.config.Parameter):
+    def __init__(self, param: pwndbg.lib.config.Parameter) -> None:
         # `set_doc`, `show_doc`, and `__doc__` must be set before `gdb.Parameter.__init__`.
         # They will be used for `help set <param>` and `help show <param>`,
         # respectively
@@ -55,7 +55,7 @@ class Parameter(gdb.Parameter):
             self.param.default, param_class=self.param.param_class
         )
 
-    def get_set_string(self):
+    def get_set_string(self) -> str:
         """Handles the GDB `set <param>` command"""
 
         # GDB will set `self.value` to the user's input
@@ -78,7 +78,7 @@ class Parameter(gdb.Parameter):
 
         return "Set %s to %r." % (self.param.set_show_doc, self.native_value)
 
-    def get_show_string(self, svalue):
+    def get_show_string(self, svalue) -> str:
         """Handles the GDB `show <param>` command"""
         more_information_hint = " See `help set %s` for more information." % self.param.name
         return "%s is %r.%s" % (
@@ -107,7 +107,7 @@ class Parameter(gdb.Parameter):
         return value
 
 
-def init_params():
+def init_params() -> None:
     # Create a gdb.Parameter for each parameter
     for p in pwndbg.gdblib.config.params.values():
         # We don't need to store this anywhere, GDB will handle this

--- a/pwndbg/gdblib/ctypes.py
+++ b/pwndbg/gdblib/ctypes.py
@@ -20,7 +20,7 @@ Structure = ctypes.LittleEndianStructure  # default Structure type
 
 @pwndbg.gdblib.events.start
 @pwndbg.gdblib.events.new_objfile
-def update():
+def update() -> None:
     global module
 
     if pwndbg.gdblib.arch.endian == "little":

--- a/pwndbg/gdblib/elf.py
+++ b/pwndbg/gdblib/elf.py
@@ -49,7 +49,7 @@ class ELFInfo(namedtuple("ELFInfo", "header sections segments")):
 
 @pwndbg.gdblib.events.start
 @pwndbg.gdblib.events.new_objfile
-def update():
+def update() -> None:
     importlib.reload(pwndbg.lib.elftypes)
 
     if pwndbg.gdblib.arch.ptrsize == 4:
@@ -224,7 +224,7 @@ ehdr_type_loaded = 0
 
 
 @pwndbg.lib.memoize.reset_on_start
-def reset_ehdr_type_loaded():
+def reset_ehdr_type_loaded() -> None:
     global ehdr_type_loaded
     ehdr_type_loaded = 0
 

--- a/pwndbg/gdblib/events.py
+++ b/pwndbg/gdblib/events.py
@@ -34,19 +34,19 @@ debug = config.add_param("debug-events", False, "display internal event debuggin
 # very first event which is fired is a 'stop' event.  We need to
 # capture this so that we can fire off all of the 'start' events first.
 class StartEvent:
-    def __init__(self):
+    def __init__(self) -> None:
         self.registered = list()
         self.running = False
 
-    def connect(self, function):
+    def connect(self, function) -> None:
         if function not in self.registered:
             self.registered.append(function)
 
-    def disconnect(self, function):
+    def disconnect(self, function) -> None:
         if function in self.registered:
             self.registered.remove(function)
 
-    def on_new_objfile(self):
+    def on_new_objfile(self) -> None:
         if self.running or not gdb.selected_thread():
             return
 
@@ -57,10 +57,10 @@ class StartEvent:
                 sys.stdout.write("%r %s.%s\n" % ("start", function.__module__, function.__name__))
             function()
 
-    def on_exited(self):
+    def on_exited(self) -> None:
         self.running = False
 
-    def on_stop(self):
+    def on_stop(self) -> None:
         self.on_new_objfile()
 
 
@@ -73,17 +73,17 @@ class EventWrapper:
     fire them manually (to invoke them you have to call `invoke_callbacks`).
     """
 
-    def __init__(self, name):
+    def __init__(self, name) -> None:
         self.name = name
 
         self._event = getattr(gdb.events, self.name, None)
         self._is_real_event = self._event is not None
 
-    def connect(self, func):
+    def connect(self, func) -> None:
         if self._event is not None:
             self._event.connect(func)
 
-    def disconnect(self, func):
+    def disconnect(self, func) -> None:
         if self._event is not None:
             self._event.disconnect(func)
 
@@ -91,7 +91,7 @@ class EventWrapper:
     def is_real_event(self):
         return self._is_real_event
 
-    def invoke_callbacks(self):
+    def invoke_callbacks(self) -> None:
         """
         As an optimization please don't call this if your GDB has this event (check `.is_real_event`).
         """
@@ -206,7 +206,7 @@ def mem_changed(func):
         return func
 
 
-def log_objfiles(ofile=None):
+def log_objfiles(ofile=None) -> None:
     if not (debug and ofile):
         return
 
@@ -219,7 +219,7 @@ def log_objfiles(ofile=None):
 gdb.events.new_objfile.connect(log_objfiles)
 
 
-def after_reload(start=True):
+def after_reload(start=True) -> None:
     if gdb.selected_inferior().pid:
         for f in registered[gdb.events.stop]:
             f()
@@ -232,7 +232,7 @@ def after_reload(start=True):
             f()
 
 
-def on_reload():
+def on_reload() -> None:
     for event, functions in registered.items():
         for function in functions:
             event.disconnect(function)
@@ -240,21 +240,21 @@ def on_reload():
 
 
 @new_objfile
-def _start_newobjfile():
+def _start_newobjfile() -> None:
     gdb.events.start.on_new_objfile()
 
 
 @exit
-def _start_exit():
+def _start_exit() -> None:
     gdb.events.start.on_exited()
 
 
 @stop
-def _start_stop():
+def _start_stop() -> None:
     gdb.events.start.on_stop()
 
 
 @exit
-def _reset_objfiles():
+def _reset_objfiles() -> None:
     global objfile_cache
     objfile_cache = dict()

--- a/pwndbg/gdblib/file.py
+++ b/pwndbg/gdblib/file.py
@@ -18,7 +18,7 @@ import pwndbg.gdblib.remote
 _remote_files_dir = None
 
 
-def reset_remote_files():
+def reset_remote_files() -> None:
     global _remote_files_dir
 
     if _remote_files_dir is not None:

--- a/pwndbg/gdblib/functions.py
+++ b/pwndbg/gdblib/functions.py
@@ -18,7 +18,7 @@ def GdbFunction(only_when_running=False):
 
 
 class _GdbFunction(gdb.Function):
-    def __init__(self, func, only_when_running):
+    def __init__(self, func, only_when_running) -> None:
         self.name = func.__name__
         self.func = func
         self.only_when_running = only_when_running

--- a/pwndbg/gdblib/hooks.py
+++ b/pwndbg/gdblib/hooks.py
@@ -21,80 +21,80 @@ from pwndbg.lib.memoize import while_running
 @pwndbg.gdblib.events.new_objfile
 @pwndbg.gdblib.events.start
 @pwndbg.gdblib.events.stop
-def update_typeinfo():
+def update_typeinfo() -> None:
     pwndbg.gdblib.typeinfo.update()
 
 
 @pwndbg.gdblib.events.start
 @pwndbg.gdblib.events.stop
 @pwndbg.gdblib.events.new_objfile
-def update_arch():
+def update_arch() -> None:
     arch_mod.update()
 
 
 @pwndbg.gdblib.events.new_objfile
-def reset_config():
+def reset_config() -> None:
     pwndbg.gdblib.kernel._kconfig = None
 
 
 @pwndbg.gdblib.events.start
-def on_start():
+def on_start() -> None:
     pwndbg.gdblib.abi.update()
     pwndbg.gdblib.memory.update_min_addr()
 
 
 @pwndbg.gdblib.events.exit
-def on_exit():
+def on_exit() -> None:
     pwndbg.gdblib.tls.reset()
     pwndbg.gdblib.file.reset_remote_files()
     pwndbg.gdblib.next.clear_temp_breaks()
 
 
 @pwndbg.gdblib.events.stop
-def on_stop():
+def on_stop() -> None:
     pwndbg.gdblib.strings.update_length()
 
 
 @pwndbg.gdblib.events.stop
 @pwndbg.gdblib.events.mem_changed
 @pwndbg.gdblib.events.reg_changed
-def memoize_on_stop():
+def memoize_on_stop() -> None:
     reset_on_stop._reset()
 
 
 @pwndbg.gdblib.events.before_prompt
-def memoize_before_prompt():
+def memoize_before_prompt() -> None:
     reset_on_prompt._reset()
 
 
 @pwndbg.gdblib.events.cont
-def memoize_on_cont():
+def memoize_on_cont() -> None:
     reset_on_cont._reset()
 
 
 @pwndbg.gdblib.events.new_objfile
-def memoize_on_new_objfile():
+def memoize_on_new_objfile() -> None:
     reset_on_objfile._reset()
 
 
 @pwndbg.gdblib.events.start
-def memoize_on_start():
+def memoize_on_start() -> None:
     while_running._start_caching()
     reset_on_start._reset()
 
 
 @pwndbg.gdblib.events.exit
-def memoize_on_exit():
+def memoize_on_exit() -> None:
     while_running._reset()
     reset_on_exit._reset()
 
 
 @pwndbg.gdblib.events.thread
-def memoize_on_new_thread():
+def memoize_on_new_thread() -> None:
     reset_on_thread._reset()
 
 
-def init():
+def init() -> None:
     """Calls all GDB hook functions that need to be called when GDB/pwndbg
     itself is loaded, as opposed to when an actual hook event occurs
     """

--- a/pwndbg/gdblib/kernel/__init__.py
+++ b/pwndbg/gdblib/kernel/__init__.py
@@ -115,7 +115,7 @@ class ArchOps:
 
 
 class x86_64Ops(ArchOps):
-    def __init__(self):
+    def __init__(self) -> None:
         if "X86_5LEVEL" in kconfig() and "no5lvl" not in kcmdline():
             raise NotImplementedError("Level 5 page table support is not implemented")
 
@@ -165,7 +165,7 @@ class x86_64Ops(ArchOps):
 
 
 class Aarch64Ops(ArchOps):
-    def __init__(self):
+    def __init__(self) -> None:
         self.STRUCT_PAGE_SIZE = gdb.lookup_type("struct page").sizeof
         self.STRUCT_PAGE_SHIFT = int(math.log2(self.STRUCT_PAGE_SIZE))
 

--- a/pwndbg/gdblib/memory.py
+++ b/pwndbg/gdblib/memory.py
@@ -79,7 +79,7 @@ def readtype(gdb_type, addr):
     return int(gdb.Value(addr).cast(gdb_type.pointer()).dereference())
 
 
-def write(addr, data):
+def write(addr, data) -> None:
     """write(addr, data)
 
     Writes data into the memory of the process being debugged.
@@ -114,7 +114,7 @@ def peek(address):
     return None
 
 
-def poke(address):
+def poke(address) -> bool:
     """poke(address)
 
     Checks whether an address is writable.
@@ -330,7 +330,7 @@ def find_lower_boundary(addr, max_pages=1024):
     return addr
 
 
-def update_min_addr():
+def update_min_addr() -> None:
     global MMAP_MIN_ADDR
     if pwndbg.gdblib.qemu.is_qemu_kernel():
         MMAP_MIN_ADDR = 0

--- a/pwndbg/gdblib/next.py
+++ b/pwndbg/gdblib/next.py
@@ -19,7 +19,7 @@ jumps = set((capstone.CS_GRP_CALL, capstone.CS_GRP_JUMP, capstone.CS_GRP_RET, ca
 interrupts = set((capstone.CS_GRP_INT,))
 
 
-def clear_temp_breaks():
+def clear_temp_breaks() -> None:
     if not pwndbg.gdblib.proc.alive:
         for bp in gdb.breakpoints():
             # visible is used instead of internal because older gdb's don't support internal
@@ -128,7 +128,7 @@ def break_next_ret(address=None):
             return ins
 
 
-def break_on_program_code():
+def break_on_program_code() -> bool:
     """
     Breaks on next instruction that belongs to process' objfile code
 
@@ -162,7 +162,7 @@ def break_on_program_code():
     return False
 
 
-def break_on_next(address=None):
+def break_on_next(address=None) -> None:
     address = address or pwndbg.gdblib.regs.pc
     ins = pwndbg.disasm.one(address)
 

--- a/pwndbg/gdblib/proc.py
+++ b/pwndbg/gdblib/proc.py
@@ -41,7 +41,7 @@ class module(ModuleType):
         return self.pid
 
     @property
-    def alive(self):
+    def alive(self) -> bool:
         """
         Informs whether the process has a thread. However, note that it will
         still return True for a segfaulted thread. To detect that, consider

--- a/pwndbg/gdblib/prompt.py
+++ b/pwndbg/gdblib/prompt.py
@@ -35,7 +35,7 @@ show_tip = pwndbg.gdblib.config.add_param(
 cur = None
 
 
-def initial_hook(*a):
+def initial_hook(*a) -> None:
     if show_tip and not pwndbg.decorators.first_prompt:
         colored_tip = re.sub(
             "`(.*?)`", lambda s: message.warn(s.group()[1:-1]), get_tip_of_the_day()
@@ -59,7 +59,7 @@ def initial_hook(*a):
 context_shown = False
 
 
-def prompt_hook(*a):
+def prompt_hook(*a) -> None:
     global cur, context_shown
 
     new = (gdb.selected_inferior(), gdb.selected_thread())
@@ -74,13 +74,13 @@ def prompt_hook(*a):
 
 
 @pwndbg.gdblib.events.cont
-def reset_context_shown(*a):
+def reset_context_shown(*a) -> None:
     global context_shown
     context_shown = False
 
 
 @pwndbg.gdblib.config.trigger(message.config_prompt_color, disable_colors)
-def set_prompt():
+def set_prompt() -> None:
     prompt = "pwndbg> "
 
     if not disable_colors:

--- a/pwndbg/gdblib/qemu.py
+++ b/pwndbg/gdblib/qemu.py
@@ -14,7 +14,7 @@ from pwndbg.gdblib.events import start
 
 
 @pwndbg.lib.memoize.reset_on_stop
-def is_qemu():
+def is_qemu() -> bool:
     if not pwndbg.gdblib.remote.is_remote():
         return False
 
@@ -28,7 +28,7 @@ def is_qemu():
 
 
 @pwndbg.lib.memoize.reset_on_stop
-def is_usermode():
+def is_usermode() -> bool:
     if not pwndbg.gdblib.remote.is_remote():
         return False
 

--- a/pwndbg/gdblib/regs.py
+++ b/pwndbg/gdblib/regs.py
@@ -213,7 +213,7 @@ class module(ModuleType):
 
         return 0
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<module pwndbg.gdblib.regs>"
 
 
@@ -224,7 +224,7 @@ sys.modules[__name__] = module(__name__, "")
 
 @pwndbg.gdblib.events.cont
 @pwndbg.gdblib.events.stop
-def update_last():
+def update_last() -> None:
     M = sys.modules[__name__]
     M.previous = M.last
     M.last = {k: M[k] for k in M.common}

--- a/pwndbg/gdblib/remote.py
+++ b/pwndbg/gdblib/remote.py
@@ -10,7 +10,7 @@ import pwndbg.lib.memoize
 
 @pwndbg.lib.memoize.reset_on_objfile
 @pwndbg.lib.memoize.reset_on_start
-def is_remote():
+def is_remote() -> bool:
     # Example:
     # pwndbg> maintenance print target-stack
     # The current target stack is:
@@ -20,7 +20,7 @@ def is_remote():
     return "remote" in gdb.execute("maintenance print target-stack", to_string=True)
 
 
-def is_debug_probe():
+def is_debug_probe() -> bool:
     """
     Returns True if the target is a debug probe for an embedded device.
     Currently detects the Black Magic Probe and the SEGGER J-Link GDB Server.

--- a/pwndbg/gdblib/stack.py
+++ b/pwndbg/gdblib/stack.py
@@ -52,7 +52,7 @@ def find_upper_stack_boundary(stack_ptr, max_pages=1024):
 
 @pwndbg.gdblib.events.stop
 @pwndbg.lib.memoize.reset_on_stop
-def update():
+def update() -> None:
     """
     For each running thread, updates the known address range
     for its stack.
@@ -109,7 +109,7 @@ def current():
 
 
 @pwndbg.gdblib.events.exit
-def clear():
+def clear() -> None:
     """
     Clears everything we know about any stack memory ranges.
 
@@ -122,7 +122,7 @@ def clear():
 
 @pwndbg.gdblib.events.stop
 @pwndbg.lib.memoize.reset_on_exit
-def is_executable():
+def is_executable() -> bool:
     global nx
     nx = False
 

--- a/pwndbg/gdblib/strings.py
+++ b/pwndbg/gdblib/strings.py
@@ -12,7 +12,7 @@ import pwndbg.gdblib.memory
 length = 15
 
 
-def update_length():
+def update_length() -> None:
     r"""
     Unfortunately there's not a better way to get at this info.
 

--- a/pwndbg/gdblib/symbol.py
+++ b/pwndbg/gdblib/symbol.py
@@ -47,11 +47,11 @@ def _get_debug_file_directory():
     return ""
 
 
-def _set_debug_file_directory(d):
+def _set_debug_file_directory(d) -> None:
     gdb.execute("set debug-file-directory %s" % d, to_string=True, from_tty=False)
 
 
-def _add_debug_file_directory(d):
+def _add_debug_file_directory(d) -> None:
     current = _get_debug_file_directory()
     if current:
         _set_debug_file_directory("%s:%s" % (current, d))
@@ -67,13 +67,13 @@ _remote_files = {}
 
 
 @pwndbg.gdblib.events.exit
-def _reset_remote_files():
+def _reset_remote_files() -> None:
     global _remote_files
     _remote_files = {}
 
 
 @pwndbg.gdblib.events.new_objfile
-def _autofetch():
+def _autofetch() -> None:
     """
     Automatically downloads ELF files with debug symbols from the remotely debugged system.
     Does not work with QEMU and Android. It also does not work when debugging embedded devices, as they don't even have a filesystem.
@@ -270,7 +270,7 @@ def static_linkage_symbol_address(symbol: str) -> int:
 
 @pwndbg.gdblib.events.stop
 @pwndbg.lib.memoize.reset_on_start
-def _add_main_exe_to_symbols():
+def _add_main_exe_to_symbols() -> None:
     if not pwndbg.gdblib.remote.is_remote():
         return
 

--- a/pwndbg/gdblib/tls.py
+++ b/pwndbg/gdblib/tls.py
@@ -102,7 +102,7 @@ class module(ModuleType):
         )
         return tls_base if is_valid_tls_base else self.get_tls_base_via_errno_location()
 
-    def reset(self):
+    def reset(self) -> None:
         # We should reset the offset when we attach to a new process
         self._errno_offset = None
 

--- a/pwndbg/gdblib/vmmap.py
+++ b/pwndbg/gdblib/vmmap.py
@@ -60,7 +60,7 @@ Note that the page-tables method will require the QEMU kernel process to be on t
 
 @pwndbg.lib.memoize.reset_on_objfile
 @pwndbg.lib.memoize.reset_on_start
-def is_corefile():
+def is_corefile() -> bool:
     """
     For example output use:
         gdb ./tests/binaries/crash_simple.out -ex run -ex 'generate-core-file ./core' -ex 'quit'
@@ -191,18 +191,18 @@ def explore(address_maybe):
 
 # Automatically ensure that all registers are explored on each stop
 # @pwndbg.gdblib.events.stop
-def explore_registers():
+def explore_registers() -> None:
     for regname in pwndbg.gdblib.regs.common:
         find(pwndbg.gdblib.regs[regname])
 
 
 # @pwndbg.gdblib.events.exit
-def clear_explored_pages():
+def clear_explored_pages() -> None:
     while explored_pages:
         explored_pages.pop()
 
 
-def add_custom_page(page):
+def add_custom_page(page) -> None:
     bisect.insort(custom_pages, page)
 
     # Reset all the cache
@@ -211,7 +211,7 @@ def add_custom_page(page):
     pwndbg.lib.memoize.reset()
 
 
-def clear_custom_page():
+def clear_custom_page() -> None:
     while custom_pages:
         custom_pages.pop()
 
@@ -710,7 +710,7 @@ def check_aslr():
 
 
 @pwndbg.gdblib.events.cont
-def mark_pc_as_executable():
+def mark_pc_as_executable() -> None:
     mapping = find(pwndbg.gdblib.regs.pc)
     if mapping and not mapping.execute:
         mapping.flags |= os.X_OK

--- a/pwndbg/heap/__init__.py
+++ b/pwndbg/heap/__init__.py
@@ -68,12 +68,12 @@ If you used setup.sh on Arch based distro you'll need to do a power cycle or set
 
 
 @pwndbg.gdblib.events.start
-def update():
+def update() -> None:
     resolve_heap(is_first_run=True)
 
 
 @pwndbg.gdblib.events.exit
-def reset():
+def reset() -> None:
     global current
     # Re-initialize the heap
     if current:
@@ -83,7 +83,7 @@ def reset():
 
 
 @pwndbg.gdblib.config.trigger(resolve_heap_via_heuristic)
-def resolve_heap(is_first_run=False):
+def resolve_heap(is_first_run=False) -> None:
     import pwndbg.heap.ptmalloc
 
     global current

--- a/pwndbg/heap/ptmalloc.py
+++ b/pwndbg/heap/ptmalloc.py
@@ -50,13 +50,13 @@ class BinType(str, Enum):
 
 
 class Bin:
-    def __init__(self, fd_chain, bk_chain=None, count=None, is_corrupted=False):
+    def __init__(self, fd_chain, bk_chain=None, count=None, is_corrupted=False) -> None:
         self.fd_chain = fd_chain
         self.bk_chain = bk_chain
         self.count = count
         self.is_corrupted = is_corrupted
 
-    def contains_chunk(self, chunk):
+    def contains_chunk(self, chunk) -> bool:
         return chunk in self.fd_chain
 
     @staticmethod
@@ -70,7 +70,7 @@ class Bin:
 
 
 class Bins:
-    def __init__(self, bin_type):
+    def __init__(self, bin_type) -> None:
         self.bins = OrderedDict()
         self.bin_type = bin_type
 
@@ -140,7 +140,7 @@ class Chunk:
         "_is_top_chunk",
     )
 
-    def __init__(self, addr, heap=None, arena=None):
+    def __init__(self, addr, heap=None, arena=None) -> None:
         if isinstance(pwndbg.heap.current.malloc_chunk, gdb.Type):
             self._gdbValue = pwndbg.gdblib.memory.poi(pwndbg.heap.current.malloc_chunk, addr)
         else:
@@ -335,7 +335,7 @@ class Heap:
         "first_chunk",
     )
 
-    def __init__(self, addr, arena=None):
+    def __init__(self, addr, arena=None) -> None:
         """Build a Heap object given an address on that heap.
         Heap regions are treated differently depending on their arena:
         1) main_arena - uses the sbrk heap
@@ -409,7 +409,7 @@ class Heap:
     def __contains__(self, addr: int) -> bool:
         return self.start <= addr < self.end
 
-    def __str__(self):
+    def __str__(self) -> str:
         fmt = "[%%%ds]" % (pwndbg.gdblib.arch.ptrsize * 2)
         return message.hint(fmt % (hex(self.first_chunk.address))) + M.heap(
             str(pwndbg.gdblib.vmmap.find(self.start))
@@ -436,7 +436,7 @@ class Arena:
         "_system_mem",
     )
 
-    def __init__(self, addr):
+    def __init__(self, addr) -> None:
         if isinstance(pwndbg.heap.current.malloc_state, gdb.Type):
             self._gdbValue = pwndbg.gdblib.memory.poi(pwndbg.heap.current.malloc_state, addr)
         else:
@@ -623,7 +623,7 @@ class Arena:
             result.bins[size] = chain
         return result
 
-    def __str__(self):
+    def __str__(self) -> str:
         prefix = "[%%%ds]    " % (pwndbg.gdblib.arch.ptrsize * 2)
         prefix_len = len(prefix % (""))
         arena_name = "main" if self.is_main_arena else hex(self.address)
@@ -635,7 +635,7 @@ class Arena:
 
 
 class GlibcMemoryAllocator(pwndbg.heap.heap.MemoryAllocator):
-    def __init__(self):
+    def __init__(self) -> None:
         # Global ptmalloc objects
         self._global_max_fast_addr = None
         self._global_max_fast = None
@@ -1082,7 +1082,7 @@ class GlibcMemoryAllocator(pwndbg.heap.heap.MemoryAllocator):
     def is_initialized(self):
         raise NotImplementedError()
 
-    def is_statically_linked(self):
+    def is_statically_linked(self) -> bool:
         out = gdb.execute("info dll", to_string=True)
         return "No shared libraries loaded at this time." in out
 
@@ -1245,15 +1245,15 @@ class DebugSymsHeap(GlibcMemoryAllocator):
 
 
 class SymbolUnresolvableError(Exception):
-    def __init__(self, symbol):
+    def __init__(self, symbol) -> None:
         self.symbol = symbol
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "`%s` can not be resolved via heuristic" % self.symbol
 
 
 class HeuristicHeap(GlibcMemoryAllocator):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self._thread_arena_offset = None
         self._thread_cache_offset = None
@@ -1284,7 +1284,7 @@ class HeuristicHeap(GlibcMemoryAllocator):
                 )
         return self._possible_page_of_symbols
 
-    def can_be_resolved(self):
+    def can_be_resolved(self) -> bool:
         return self.struct_module is not None
 
     def is_glibc_symbol(self, addr):

--- a/pwndbg/heap/structs.py
+++ b/pwndbg/heap/structs.py
@@ -87,7 +87,7 @@ class FakeGDBField:
         artificial=False,
         is_base_class=False,
         bitsize=0,
-    ):
+    ) -> None:
         # Note: pwndbg only uses `name` currently
         self.bitpos = bitpos
         self.name = name

--- a/pwndbg/hexdump.py
+++ b/pwndbg/hexdump.py
@@ -38,7 +38,7 @@ config_byte_separator = theme.add_param(
 @pwndbg.gdblib.config.trigger(
     H.config_normal, H.config_zero, H.config_special, H.config_printable, config_colorize_ascii
 )
-def load_color_scheme():
+def load_color_scheme() -> None:
     global color_scheme, printable
     #
     # We want to colorize the hex characters and only print out

--- a/pwndbg/ida.py
+++ b/pwndbg/ida.py
@@ -49,7 +49,7 @@ _ida_last_connection_check = 0
 
 @pwndbg.decorators.only_after_first_prompt()
 @pwndbg.gdblib.config.trigger(ida_rpc_host, ida_rpc_port, ida_enabled, ida_timeout)
-def init_ida_rpc_client():
+def init_ida_rpc_client() -> None:
     global _ida, _ida_last_exception, _ida_last_connection_check
 
     if not ida_enabled:
@@ -122,7 +122,7 @@ def init_ida_rpc_client():
 
 
 class withIDA:
-    def __init__(self, fn):
+    def __init__(self, fn) -> None:
         self.fn = fn
         functools.update_wrapper(self, fn)
 
@@ -168,7 +168,7 @@ def available():
 
 
 @withIDA
-def can_connect():
+def can_connect() -> bool:
     return True
 
 
@@ -188,7 +188,7 @@ def r2l(addr):
     return result
 
 
-def remote(function):
+def remote(function) -> None:
     """Runs the provided function in IDA's interpreter.
 
     The function must be self-contained and not reference any
@@ -285,7 +285,7 @@ _breakpoints = []
 @pwndbg.gdblib.events.cont
 @pwndbg.gdblib.events.stop
 @withIDA
-def UpdateBreakpoints():
+def UpdateBreakpoints() -> None:
     # XXX: Remove breakpoints from IDA when the user removes them.
     current = set(eval(b.location.lstrip("*")) for b in _breakpoints)
     want = set(GetBreakpoints())
@@ -320,7 +320,7 @@ colored_pc = None
 
 @pwndbg.gdblib.events.stop
 @withIDA
-def Auto_Color_PC():
+def Auto_Color_PC() -> None:
     global colored_pc
     colored_pc = pwndbg.gdblib.regs.pc
     SetColor(colored_pc, 0x7F7FFF)
@@ -328,7 +328,7 @@ def Auto_Color_PC():
 
 @pwndbg.gdblib.events.cont
 @withIDA
-def Auto_UnColor_PC():
+def Auto_UnColor_PC() -> None:
     global colored_pc
     if colored_pc:
         SetColor(colored_pc, 0xFFFFFF)
@@ -381,7 +381,7 @@ def isASCII(flags):
 @withIDA
 @takes_address
 @pwndbg.lib.memoize.reset_on_objfile
-def ArgCount(address):
+def ArgCount(address) -> None:
     pass
 
 
@@ -484,7 +484,7 @@ def GetStrucNextOff(sid, offset):
 class IDC:
     query = "{k:v for k,v in globals()['idc'].__dict__.items() if type(v) in (int,long)}"
 
-    def __init__(self):
+    def __init__(self) -> None:
         if available():
             data = _ida.eval(self.query)
             self.__dict__.update(data)
@@ -493,7 +493,7 @@ class IDC:
 idc = IDC()
 
 
-def print_member(sid, offset):
+def print_member(sid, offset) -> None:
     mid = GetMemberId(sid, offset)
     mname = GetMemberName(sid, offset) or "(no name)"
     msize = GetMemberSize(sid, offset) or 0
@@ -501,7 +501,7 @@ def print_member(sid, offset):
     print("    +%#x - %s [%#x bytes]" % (offset, mname, msize))
 
 
-def print_structs():
+def print_structs() -> None:
     for i in range(GetStrucQty() or 0):
         sid = GetStrucId(i)
 

--- a/pwndbg/lib/abi.py
+++ b/pwndbg/lib/abi.py
@@ -25,7 +25,7 @@ class ABI:
     #: Indicates that this ABI returns to the next address on the slot
     returns = True
 
-    def __init__(self, regs, align, minimum):
+    def __init__(self, regs, align, minimum) -> None:
         self.register_arguments = regs
         self.arg_alignment = align
         self.stack_minimum = minimum
@@ -49,7 +49,7 @@ class SyscallABI(ABI):
     which must be loaded into the specified register.
     """
 
-    def __init__(self, register_arguments, *a, **kw):
+    def __init__(self, register_arguments, *a, **kw) -> None:
         self.syscall_register = register_arguments.pop(0)
         super(SyscallABI, self).__init__(register_arguments, *a, **kw)
 

--- a/pwndbg/lib/config.py
+++ b/pwndbg/lib/config.py
@@ -30,7 +30,7 @@ class Parameter:
         param_class=None,
         enum_sequence=None,
         scope="config",
-    ):
+    ) -> None:
         # Note: `set_show_doc` should be a noun phrase, e.g. "the value of the foo"
         # The `set_doc` will be "Set the value of the foo."
         # The `show_doc` will be "Show the value of the foo."
@@ -49,7 +49,7 @@ class Parameter:
     def is_changed(self):
         return self.value != self.default
 
-    def revert_default(self):
+    def revert_default(self) -> None:
         self.value = self.default
 
     def attr_name(self):
@@ -61,13 +61,13 @@ class Parameter:
         return getattr(self.value, name)
 
     # Casting
-    def __int__(self):
+    def __int__(self) -> int:
         return int(self.value)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return str(self.value)
 
-    def __bool__(self):
+    def __bool__(self) -> bool:
         return bool(self.value)
 
     # Compare operators
@@ -119,12 +119,12 @@ class Parameter:
     def __mod__(self, other):
         return self.value % other
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self.value)
 
 
 class Config:
-    def __init__(self):
+    def __init__(self) -> None:
         self.params = {}
         self.triggers = collections.defaultdict(lambda: [])
 

--- a/pwndbg/lib/funcparser.py
+++ b/pwndbg/lib/funcparser.py
@@ -39,7 +39,7 @@ Function = collections.namedtuple("Function", ("type", "derefcnt", "name", "args
 Argument = collections.namedtuple("Argument", ("type", "derefcnt", "name"))
 
 
-def Stringify(X):
+def Stringify(X) -> str:
     return "%s %s %s" % (X.type, X.derefcnt * "*", X.name)
 
 
@@ -72,7 +72,7 @@ def ExtractAllFuncDecls(ast, verbose=False):
     Functions = {}
 
     class FuncDefVisitor(c_ast.NodeVisitor):
-        def visit_FuncDecl(self, node, *a):
+        def visit_FuncDecl(self, node, *a) -> None:
             f = ExtractFuncDecl(node, verbose)
             Functions[f.name] = f
 

--- a/pwndbg/lib/kernel/kconfig.py
+++ b/pwndbg/lib/kernel/kconfig.py
@@ -25,7 +25,7 @@ def config_to_key(name: str) -> str:
 
 
 class Kconfig(UserDict):
-    def __init__(self, compressed_config: bytes):
+    def __init__(self, compressed_config: bytes) -> None:
         super().__init__()
         self.data = parse_compresed_config(compressed_config)
 
@@ -50,7 +50,7 @@ class Kconfig(UserDict):
 
         raise KeyError(f"Key {name} not found")
 
-    def __contains__(self, name: str):
+    def __contains__(self, name: str) -> bool:
         return self.get_key(name) is not None
 
     def __getattr__(self, name: str):

--- a/pwndbg/lib/memoize.py
+++ b/pwndbg/lib/memoize.py
@@ -53,7 +53,7 @@ class memoize:
             print(".... %r" % (value,))
         return value
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         funcname = self.func.__module__ + "." + self.func.__name__
         return "<%s-memoized function %s>" % (self.kind, funcname)
 
@@ -74,7 +74,7 @@ class forever(memoize):
     caches = []  # type: List[forever]
 
     @staticmethod
-    def _reset():
+    def _reset() -> None:
         for obj in forever.caches:
             obj.cache.clear()
 
@@ -96,7 +96,7 @@ class reset_on_prompt(memoize):
     kind = "prompt"
 
     @staticmethod
-    def __reset_on_prompt():
+    def __reset_on_prompt() -> None:
         for obj in reset_on_prompt.caches:
             obj.cache.clear()
 
@@ -181,7 +181,7 @@ class while_running(memoize):
     _reset = __reset_while_running
 
 
-def reset():
+def reset() -> None:
     forever._reset()
     reset_on_stop._reset()
     reset_on_exit._reset()

--- a/pwndbg/lib/memory.py
+++ b/pwndbg/lib/memory.py
@@ -128,7 +128,7 @@ class Page:
             ]
         )
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "{start:#{width}x} {end:#{width}x} {permstr} {size:8x} {offset:6x} {objfile}".format(
             start=self.vaddr,
             end=self.vaddr + self.memsz,
@@ -139,7 +139,7 @@ class Page:
             width=2 + 2 * pwndbg.gdblib.arch.ptrsize,
         )
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "%s(%r)" % (self.__class__.__name__, self.__str__())
 
     def __contains__(self, addr: int) -> bool:

--- a/pwndbg/lib/net.py
+++ b/pwndbg/lib/net.py
@@ -41,7 +41,7 @@ class Connection(inode):
 
     family = None
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "%s %s:%s => %s:%s (%s)" % (
             self.family,
             self.lhost,
@@ -51,17 +51,17 @@ class Connection(inode):
             self.status,
         )
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return 'Connection("%s")' % self
 
 
 class UnixSocket(inode):
     path = "(anonymous)"
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "unix %r" % self.path
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "UnixSocket(%s)" % self
 
 
@@ -191,10 +191,10 @@ class Netlink(inode):
     eth = 0
     pid = None
 
-    def __str__(self):
+    def __str__(self) -> str:
         return NETLINK_TYPES.get(self.eth, "(unknown netlink)")
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "Netlink(%s)" % self
 
 

--- a/pwndbg/lib/regs.py
+++ b/pwndbg/lib/regs.py
@@ -50,7 +50,7 @@ class RegisterSet:
         misc=tuple(),
         args=tuple(),
         retval=None,
-    ):
+    ) -> None:
         self.pc = pc
         self.stack = stack
         self.frame = frame

--- a/pwndbg/lib/stdio.py
+++ b/pwndbg/lib/stdio.py
@@ -10,14 +10,14 @@ from typing import *  # noqa note: TextIO is not abaliable in low python version
 class Stdio:
     queue = []  # type: List[Tuple[TextIO, TextIO, TextIO]]
 
-    def __enter__(self, *a, **kw):
+    def __enter__(self, *a, **kw) -> None:
         self.queue.append((sys.stdin, sys.stdout, sys.stderr))
 
         sys.stdin = sys.__stdin__
         sys.stdout = sys.__stdout__
         sys.stderr = sys.__stderr__
 
-    def __exit__(self, *a, **kw):
+    def __exit__(self, *a, **kw) -> None:
         sys.stdin, sys.stdout, sys.stderr = self.queue.pop()
 
 

--- a/pwndbg/lib/version.py
+++ b/pwndbg/lib/version.py
@@ -2,7 +2,7 @@ import os
 import subprocess
 
 
-def build_id():  # type: () -> str
+def build_id() -> str:
     """
     Returns pwndbg commit id if git is available.
     """

--- a/pwndbg/profiling.py
+++ b/pwndbg/profiling.py
@@ -5,14 +5,14 @@ from typing import Optional
 profiler = None
 
 
-def init(p: cProfile.Profile, _start_time: Optional[float]):
+def init(p: cProfile.Profile, _start_time: Optional[float]) -> None:
     global profiler
     profiler = Profiler(p)
     profiler._start_time = _start_time
 
 
 class Profiler:
-    def __init__(self, p: cProfile.Profile):
+    def __init__(self, p: cProfile.Profile) -> None:
         self._profiler = p
         self._start_time = None
 
@@ -20,11 +20,11 @@ class Profiler:
         assert self._start_time is not None
         return print("Time Elapsed:", time.time() - self._start_time)
 
-    def start(self):
+    def start(self) -> None:
         self._start_time = time.time()
         self._profiler.enable()
 
-    def stop(self, filename=None):
+    def stop(self, filename=None) -> None:
         if not filename:
             filename = f"pwndbg-{int(time.time())}.pstats"
 

--- a/pwndbg/ui.py
+++ b/pwndbg/ui.py
@@ -26,7 +26,7 @@ title_position = theme.add_param("banner-title-position", "center", "banner titl
 
 
 @config.trigger(title_position)
-def check_title_position():
+def check_title_position() -> None:
     valid_values = ["center", "left", "right"]
     if title_position not in valid_values:
         print(
@@ -59,7 +59,7 @@ def banner(title, target=sys.stdin, width=None, extra=""):
     return C.banner(banner)
 
 
-def addrsz(address):
+def addrsz(address) -> str:
     address = int(address) & pwndbg.gdblib.arch.ptrmask
     return "%#{}x".format(2 * pwndbg.gdblib.arch.ptrsize) % address
 

--- a/pwndbg/wrappers/__init__.py
+++ b/pwndbg/wrappers/__init__.py
@@ -7,7 +7,7 @@ import pwndbg.lib.which
 
 
 class OnlyWithCommand:
-    def __init__(self, *commands):
+    def __init__(self, *commands) -> None:
         self.all_cmds = list(map(lambda cmd: cmd[0] if isinstance(cmd, list) else cmd, commands))
         for command in commands:
             self.cmd = command if isinstance(command, list) else [command]


### PR DESCRIPTION
These type hints were automatically generated with https://github.com/JelleZijlstra/autotyping:
```
python -m libcst.tool codemod autotyping.AutotypeCommand --safe true pwndbg
```

There have been some recent bugs that could have been caught with type checking, so I think it's time we get serious about type checking the code.