### PR TITLE
Remove dependency to `python-future` (#1250)

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -18,5 +18,4 @@ pycparser
 psutil>=3.1.0
 python-ptrace>=0.8
 six
-future
 unicorn>=1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,4 @@
 capstone==4.0.2
-# This can be removed after ida_script.py upgrades to Python 3
-future==0.18.2
 psutil==5.9.2
 pwntools==4.8.0
 pycparser==2.21

--- a/setup.sh
+++ b/setup.sh
@@ -62,7 +62,7 @@ install_emerge() {
 
 install_pacman() {
     sudo pacman -Syy --noconfirm || true
-    sudo pacman -S --noconfirm git gdb python python-pip python-capstone python-unicorn python-pycparser python-psutil python-ptrace python-pyelftools python-six python-future python-pygments which debuginfod
+    sudo pacman -S --noconfirm git gdb python python-pip python-capstone python-unicorn python-pycparser python-psutil python-ptrace python-pyelftools python-six python-pygments which debuginfod
     echo "set debuginfod enabled on" >> ~/.gdbinit
 }
 


### PR DESCRIPTION
`python-future` isn't used in the entire code and abandoned upstream. The module `__future__` is a Python builtin instead.

Closes #1250