### PR TITLE
Upgrade dependencies

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,10 +1,14 @@
-black==22.12.0
+black==22.8.0; python_version < '3.7'
+black==22.12.0; python_version >= '3.7'
 coverage==6.2; python_version < '3.7'
 coverage==7.0.1; python_version >= '3.7'
-flake8==6.0.0
-flake8-builtins==2.1.0
+flake8==5.0.4; python_version < '3.9'
+flake8==6.0.0; python_version >= '3.9'
+flake8-builtins==2.0.0; python_version < '3.7'
+flake8-builtins==2.1.0; python_version >= '3.7'
 testresources==2.0.1
-isort==5.11.4
+isort==5.10.1; python_version < '3.7'
+isort==5.11.4; python_version >= '3.7'
 pytest==7.0.1; python_version < '3.7'
 pytest==7.2.0; python_version >= '3.7'
 types-gdb==12.1.4.1

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,11 +1,11 @@
-black==22.8.0
+black==22.12.0
 coverage==6.2; python_version < '3.7'
-coverage==6.4.4; python_version >= '3.7'
-flake8==5.0.4
-flake8-builtins==2.0.0
+coverage==7.0.1; python_version >= '3.7'
+flake8==6.0.0
+flake8-builtins==2.1.0
 testresources==2.0.1
-isort==5.10.1
+isort==5.11.4
 pytest==7.0.1; python_version < '3.7'
-pytest==7.1.2; python_version >= '3.7'
-types-gdb==12.1.3
-vermin==1.4.2
+pytest==7.2.0; python_version >= '3.7'
+types-gdb==12.1.4.1
+vermin==1.5.1

--- a/pwndbg/commands/search.py
+++ b/pwndbg/commands/search.py
@@ -14,7 +14,7 @@ import pwndbg.gdblib.vmmap
 import pwndbg.search
 from pwndbg.color import message
 
-saved = set()  # type:Set[int]
+saved: Set[int] = set()
 
 
 def print_search_hit(address) -> None:

--- a/pwndbg/heap/ptmalloc.py
+++ b/pwndbg/heap/ptmalloc.py
@@ -5,7 +5,6 @@ from enum import Enum
 from typing import Any
 from typing import Dict
 from typing import Set
-from typing import Union
 
 import gdb
 

--- a/pwndbg/lib/elftypes.py
+++ b/pwndbg/lib/elftypes.py
@@ -48,7 +48,7 @@ Elf64_Xword = ctypes.c_uint64
 Elf64_Sxword = ctypes.c_int64
 
 
-AT_CONSTANTS = {
+AT_CONSTANTS: Dict[int, str] = {
     0: "AT_NULL",  # /* End of vector */
     1: "AT_IGNORE",  # /* Entry should be ignored */
     2: "AT_EXECFD",  # /* File descriptor of program */
@@ -82,7 +82,7 @@ AT_CONSTANTS = {
     35: "AT_L1D_CACHESHAPE",
     36: "AT_L2_CACHESHAPE",
     37: "AT_L3_CACHESHAPE",
-}  # type: Dict[int,str]
+}
 
 
 class constants:

--- a/pwndbg/lib/gcc.py
+++ b/pwndbg/lib/gcc.py
@@ -13,7 +13,7 @@ from pwndbg.lib.arch import Arch
 printed_message = False
 
 
-def which(arch):  # type: (Arch) -> List[str]
+def which(arch: Arch) -> List[str]:
     gcc = _which_binutils("g++", arch)
 
     if not gcc:

--- a/pwndbg/lib/memoize.py
+++ b/pwndbg/lib/memoize.py
@@ -10,7 +10,6 @@ from collections.abc import Hashable
 from typing import Any
 from typing import Callable
 from typing import Dict
-from typing import List
 
 debug = False
 
@@ -24,7 +23,7 @@ class memoize:
 
     def __init__(self, func: Callable) -> None:
         self.func = func
-        self.cache = {}  # type: Dict[Any,Any]
+        self.cache: Dict[Any, Any] = {}
         self.caches.append(self)  # must be provided by base class
         functools.update_wrapper(self, func)
 

--- a/pwndbg/lib/tips.py
+++ b/pwndbg/lib/tips.py
@@ -1,7 +1,7 @@
 from random import choice
 from typing import List
 
-TIPS = [
+TIPS: List[str] = [
     # GDB hints
     "GDB's `apropos <topic>` command displays all registered commands that are related to the given <topic>",
     "GDB's `follow-fork-mode` parameter can be used to set whether to trace parent or child after fork() calls",
@@ -26,7 +26,7 @@ TIPS = [
     "The $heap_base GDB variable can be used to refer to the starting address of the heap after running the `heap` command",
     "Use the `errno` (or `errno <number>`) command to see the name of the last or provided (libc) error",
     "Pwndbg sets the SIGLARM, SIGBUS, SIGPIPE and SIGSEGV signals so they are not passed to the app; see `info signals` for full GDB signals configuration",
-]  # type: List[str]
+]
 
 
 def get_tip_of_the_day() -> str:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 capstone==4.0.2
-psutil==5.9.2
+psutil==5.9.4
 pwntools==4.8.0
 pycparser==2.21
 pyelftools==0.29
 Pygments==2.13.0
-ROPGadget==7.1
+ROPGadget==7.2
 tabulate==0.8.10
-unicorn==2.0.1; python_version >= '3.7'
+unicorn==2.0.1.post1; python_version >= '3.7'
 unicorn==2.0.0rc7; python_version < '3.7'


### PR DESCRIPTION
We needed to upgrade `types-gdb` to at least 12.1.4.1 to include https://github.com/python/typeshed/commit/c13a9ed985bd27e262f7e6a7394c1abc99a2a884, and I updated everything else at the same time.

A few lint errors popped up related to typing, so I fixed those as well.