### PR TITLE
Add pcp command for printing Linux kernel per-cpu page cache

### DIFF
--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -702,6 +702,7 @@ def load_commands() -> None:
     import pwndbg.commands.onegadget
     import pwndbg.commands.p2p
     import pwndbg.commands.patch
+    import pwndbg.commands.pcp
     import pwndbg.commands.peda
     import pwndbg.commands.pie
     import pwndbg.commands.plist

--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -702,7 +702,7 @@ def load_commands() -> None:
     import pwndbg.commands.onegadget
     import pwndbg.commands.p2p
     import pwndbg.commands.patch
-    import pwndbg.commands.pcp
+    import pwndbg.commands.pcplist
     import pwndbg.commands.peda
     import pwndbg.commands.pie
     import pwndbg.commands.plist

--- a/pwndbg/commands/pcp.py
+++ b/pwndbg/commands/pcp.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import argparse
+
+import gdb
+
+import pwndbg.commands
+import pwndbg.gdblib.memory
+from pwndbg.commands import CommandCategory
+from pwndbg.gdblib.kernel import per_cpu
+from pwndbg.gdblib.kernel.macros import for_each_entry
+
+parser = argparse.ArgumentParser(description="Print Per-CPU page list")
+
+parser.add_argument("zone", type=int, nargs="?", help="")
+# parser.add_argument("list_num", type=int, help="")
+
+
+def print_zone(zone, list_num=None) -> None:
+    print(f"Zone {zone}")
+    pageset_addr = per_cpu(
+        gdb.lookup_global_symbol("contig_page_data").value()["node_zones"][zone]["pageset"]
+    )
+    pageset = pwndbg.gdblib.memory.get_typed_pointer_value(
+        gdb.lookup_type("struct per_cpu_pageset"), pageset_addr
+    )
+    pcp = pageset["pcp"]
+    print("count: ", pcp["count"])
+    print("high: ", pcp["high"])
+    print("")
+    for i in range(4):
+        print(f"pcp.lists[{i}]:")
+
+        count = 0
+        for e in for_each_entry(pcp["lists"][i], "struct page", "lru"):
+            count += 1
+            print(e)
+
+        if count == 0:
+            print("EMPTY")
+        else:
+            print(f"{count} entries")
+
+        print("")
+
+
+@pwndbg.commands.ArgparsedCommand(parser, category=CommandCategory.KERNEL)
+@pwndbg.commands.OnlyWhenQemuKernel
+@pwndbg.commands.OnlyWithKernelDebugSyms
+@pwndbg.commands.OnlyWhenPagingEnabled
+def pcp(zone=None, list_num=None) -> None:
+    if zone:
+        print_zone(zone, list_num)
+    else:
+        for i in range(3):
+            print_zone(i)

--- a/pwndbg/commands/pcplist.py
+++ b/pwndbg/commands/pcplist.py
@@ -48,7 +48,7 @@ def print_zone(zone, list_num=None) -> None:
 @pwndbg.commands.OnlyWhenQemuKernel
 @pwndbg.commands.OnlyWithKernelDebugSyms
 @pwndbg.commands.OnlyWhenPagingEnabled
-def pcp(zone=None, list_num=None) -> None:
+def pcplist(zone=None, list_num=None) -> None:
     if zone:
         print_zone(zone, list_num)
     else:

--- a/pwndbg/commands/pcplist.py
+++ b/pwndbg/commands/pcplist.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import logging
 
 import gdb
 
@@ -9,6 +10,8 @@ import pwndbg.gdblib.memory
 from pwndbg.commands import CommandCategory
 from pwndbg.gdblib.kernel import per_cpu
 from pwndbg.gdblib.kernel.macros import for_each_entry
+
+log = logging.getLogger(__name__)
 
 parser = argparse.ArgumentParser(description="Print Per-CPU page list")
 
@@ -49,6 +52,7 @@ def print_zone(zone, list_num=None) -> None:
 @pwndbg.commands.OnlyWithKernelDebugSyms
 @pwndbg.commands.OnlyWhenPagingEnabled
 def pcplist(zone=None, list_num=None) -> None:
+    log.warning("This command is a work in progress and may not work as expected.")
     if zone:
         print_zone(zone, list_num)
     else:


### PR DESCRIPTION
The Linux kernel uses a per-cpu cache for allocating order-0 pages. Being able to print the contents of these caches can be useful for exploiting some UAF bugs. This is a very rough command to print the caches for each zone. This isn't polished at all or in a state where it should be merged, but I found it useful and won't have time to improve it in the near future, so putting it here for now in case anyone wants to use it or improve it.

Example output:
```
pwndbg> pcp
Zone 0
count:  371
high:  378

pcp.lists[0]:
0xfffffffefff5a2c0
0xfffffffefff586c0
...
```