### PR TITLE
Add commands to memory category

### DIFF
--- a/pwndbg/commands/leakfind.py
+++ b/pwndbg/commands/leakfind.py
@@ -15,6 +15,7 @@ import pwndbg.commands
 import pwndbg.gdblib.config
 import pwndbg.gdblib.vmmap
 from pwndbg.chain import c as C
+from pwndbg.commands import CommandCategory
 
 
 # Used to recursively print the pointer chain.
@@ -99,7 +100,7 @@ parser.add_argument(
 )
 
 
-@pwndbg.commands.ArgparsedCommand(parser)
+@pwndbg.commands.ArgparsedCommand(parser, category=CommandCategory.MEMORY)
 @pwndbg.commands.OnlyWhenRunning
 def leakfind(
     address=None, page_name=None, max_offset=0x40, max_depth=0x4, step=0x1, negative_offset=0x0

--- a/pwndbg/commands/p2p.py
+++ b/pwndbg/commands/p2p.py
@@ -7,6 +7,7 @@ import pwndbg.commands
 import pwndbg.commands.telescope
 import pwndbg.gdblib.arch
 import pwndbg.gdblib.memory
+from pwndbg.commands import CommandCategory
 
 ts = pwndbg.commands.telescope.telescope
 
@@ -112,7 +113,7 @@ def p2p_walk(addr, ranges, current_level):
     return p2p_walk(maybe_addr, ranges, current_level + 1)
 
 
-@pwndbg.commands.ArgparsedCommand(parser)
+@pwndbg.commands.ArgparsedCommand(parser, category=CommandCategory.MEMORY)
 @pwndbg.commands.OnlyWhenRunning
 def p2p(mapping_names: Optional[List] = None) -> None:
 

--- a/pwndbg/commands/probeleak.py
+++ b/pwndbg/commands/probeleak.py
@@ -10,6 +10,7 @@ import pwndbg.commands
 import pwndbg.gdblib.arch
 import pwndbg.gdblib.elf
 import pwndbg.gdblib.vmmap
+from pwndbg.commands import CommandCategory
 
 
 def find_module(addr, max_distance):
@@ -78,7 +79,7 @@ parser.add_argument(
 )
 
 
-@pwndbg.commands.ArgparsedCommand(parser)
+@pwndbg.commands.ArgparsedCommand(parser, category=CommandCategory.MEMORY)
 @pwndbg.commands.OnlyWhenRunning
 def probeleak(
     address=None, count=0x40, max_distance=0x0, point_to=None, max_ptrs=0, flags=None

--- a/pwndbg/commands/search.py
+++ b/pwndbg/commands/search.py
@@ -13,6 +13,7 @@ import pwndbg.gdblib.config
 import pwndbg.gdblib.vmmap
 import pwndbg.search
 from pwndbg.color import message
+from pwndbg.commands import CommandCategory
 
 saved: Set[int] = set()
 
@@ -128,7 +129,7 @@ parser.add_argument(
 )
 
 
-@pwndbg.commands.ArgparsedCommand(parser)
+@pwndbg.commands.ArgparsedCommand(parser, category=CommandCategory.MEMORY)
 @pwndbg.commands.OnlyWhenRunning
 def search(type, hex, executable, writable, value, mapping_name, save, next, trunc_out) -> None:
     global saved

--- a/pwndbg/commands/telescope.py
+++ b/pwndbg/commands/telescope.py
@@ -66,7 +66,7 @@ parser.add_argument(
 )
 
 
-@pwndbg.commands.ArgparsedCommand(parser)
+@pwndbg.commands.ArgparsedCommand(parser, category=CommandCategory.MEMORY)
 @pwndbg.commands.OnlyWhenRunning
 def telescope(address=None, count=telescope_lines, to_string=False, reverse=False):
     """

--- a/pwndbg/commands/xinfo.py
+++ b/pwndbg/commands/xinfo.py
@@ -9,6 +9,7 @@ import pwndbg.gdblib.regs
 import pwndbg.gdblib.stack
 import pwndbg.gdblib.vmmap
 import pwndbg.wrappers
+from pwndbg.commands import CommandCategory
 
 parser = argparse.ArgumentParser(
     description="Shows offsets of the specified address from various useful locations."
@@ -103,7 +104,7 @@ def xinfo_default(page, addr) -> None:
     print_line("Mapped Area", addr, page.vaddr, addr - page.vaddr, "+")
 
 
-@pwndbg.commands.ArgparsedCommand(parser)
+@pwndbg.commands.ArgparsedCommand(parser, category=CommandCategory.MEMORY)
 @pwndbg.commands.OnlyWhenRunning
 def xinfo(address=None) -> None:
     address = address.cast(

--- a/pwndbg/commands/xor.py
+++ b/pwndbg/commands/xor.py
@@ -4,6 +4,7 @@ import gdb
 
 import pwndbg.commands
 import pwndbg.gdblib.memory
+from pwndbg.commands import CommandCategory
 
 
 def xor_memory(address, key, count):
@@ -27,7 +28,7 @@ parser.add_argument("key", type=str, help="The key to use.")
 parser.add_argument("count", type=int, help="The number of bytes to xor.")
 
 
-@pwndbg.commands.ArgparsedCommand(parser)
+@pwndbg.commands.ArgparsedCommand(parser, category=CommandCategory.MEMORY)
 @pwndbg.commands.OnlyWhenRunning
 def xor(address, key, count) -> None:
     try:
@@ -42,7 +43,7 @@ parser.add_argument("address", type=int, help="The address to start xoring at.")
 parser.add_argument("count", type=int, help="The number of bytes to xor.")
 
 
-@pwndbg.commands.ArgparsedCommand(parser)
+@pwndbg.commands.ArgparsedCommand(parser, category=CommandCategory.MEMORY)
 @pwndbg.commands.OnlyWhenRunning
 def memfrob(address, count):
     return xor(address, "*", count)


### PR DESCRIPTION
I can't decide whether it's best to have on memory category, or split it up because the commands do different things with memory (read, write, show mappings, etc.). For now they're all in the same category.

Fixes #1289 (adding commands to multiple categories will be handled separately).