### PR TITLE
gdb-tests/tests.sh: don't do make clean on each run

### DIFF
--- a/tests/gdb-tests/tests.sh
+++ b/tests/gdb-tests/tests.sh
@@ -93,7 +93,7 @@ if [[ -z "$ZIGPATH" ]]; then
 fi
 echo "ZIGPATH set to $ZIGPATH"
 
-(cd ./tests/binaries && make clean && make all) || exit 1
+(cd ./tests/binaries && make all) || exit 1
 
 run_gdb() {
     gdb --silent --nx --nh "$@" --eval-command quit


### PR DESCRIPTION
From my tests `make all` should rebuild the binaries when their sources change, so there's probably not much need of `make clean` except when someone runs tests on host and then on a container with different libc with mounted Pwndbg directory as a volume or something like that.