### PR TITLE
Don't assign result of fetch_lazy

### DIFF
--- a/pwndbg/heap/ptmalloc.py
+++ b/pwndbg/heap/ptmalloc.py
@@ -1146,7 +1146,7 @@ class DebugSymsHeap(GlibcMemoryAllocator):
 
             try:
                 self._thread_cache = pwndbg.gdblib.memory.poi(self.tcache_perthread_struct, tcache)
-                _ = self._thread_cache["entries"].fetch_lazy()
+                self._thread_cache["entries"].fetch_lazy()
             except Exception as e:
                 print(
                     message.error(


### PR DESCRIPTION
Fixes a type checking error from #1475 