### PR TITLE
Fix is_memory_mapped_file

### DIFF
--- a/pwndbg/lib/memory.py
+++ b/pwndbg/lib/memory.py
@@ -94,7 +94,7 @@ class Page:
 
     @property
     def is_memory_mapped_file(self) -> bool:
-        return self.objfile and self.objfile[0] != "[" and self.objfile != "<pt>"
+        return len(self.objfile) != 0 and self.objfile[0] != "[" and self.objfile != "<pt>"
 
     @property
     def read(self) -> bool:


### PR DESCRIPTION
If `self.objfile` is an empty string, `self.objfile and self.objfile[0] != "[" and self.objfile != "<pt>"` will actually return an empty string instead of `False`. `self.objfile` can only be used as a boolean in an if statement or while loop condition. In this case, it's easier to just check the length instead of adding an if statement. This was caught with `mypy`.