### PR TITLE
Implement __contains__ for reg module

### DIFF
--- a/pwndbg/gdblib/regs.py
+++ b/pwndbg/gdblib/regs.py
@@ -94,6 +94,10 @@ class module(ModuleType):
 
         return item
 
+    def __contains__(self, reg):
+        regs = set(reg_sets[pwndbg.gdblib.arch.current]) | {"pc", "sp"}
+        return reg in regs
+
     def __iter__(self):
         regs = set(reg_sets[pwndbg.gdblib.arch.current]) | {"pc", "sp"}
         for item in regs:


### PR DESCRIPTION
I noticed that we're doing `reg in pwndbg.gdblib.regs` in a few places, but the module doesn't have a `__contains__` method. In this case Python falls back to the `__iter__` method, so explicitly implementing `__contains__` should be slightly more efficient.