### PR TITLE
Run lint CI job and Ubuntu 22.04 and 18.04

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,7 +3,12 @@ on: [push, pull_request]
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Only care about the oldest and newest versions
+        os: [ubuntu-22.04, ubuntu-18.04]
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     steps:
     - uses: actions/checkout@v3
@@ -12,11 +17,6 @@ jobs:
       with:
         path: ~/.cache/pip
         key: ${{ matrix.os }}-cache-pip
-
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v4
-      with:
-        python-version: 3.8
 
     - name: Install dependencies
       run: |

--- a/pwndbg/heap/ptmalloc.py
+++ b/pwndbg/heap/ptmalloc.py
@@ -5,7 +5,7 @@ from enum import Enum
 from typing import Any
 from typing import Dict
 from typing import Set
-from typing import Union
+from typing import Union  # noqa: F401
 
 import gdb
 

--- a/pwndbg/lib/memoize.py
+++ b/pwndbg/lib/memoize.py
@@ -10,7 +10,7 @@ from collections.abc import Hashable
 from typing import Any
 from typing import Callable
 from typing import Dict
-from typing import List
+from typing import List  # noqa: F401
 
 debug = False
 


### PR DESCRIPTION
The current linter is using Python 3.8, instead let's use the oldest and newest platforms we support. We're currently missing linter issues because things that are passing on CI on 3.8 are not passing on 3.10, so we need to check both.