### PR TITLE
Fix memoize debug path

### DIFF
--- a/pwndbg/lib/memoize.py
+++ b/pwndbg/lib/memoize.py
@@ -70,8 +70,8 @@ class forever(memoize):
     """
     Memoizes forever - for a pwndbg session or until `_reset` is called explicitly.
     """
-
     caches = []  # type: List[forever]
+    kind = "forever"
 
     @staticmethod
     def _reset() -> None:


### PR DESCRIPTION
This fixes memoize when debug=True is set in pwndbg/lib/memoize.py

Before this commit, one gets the following error:
```
dc@jhtc:~$ gdb
Executed: <stop-memoized function pwndbg.ida.available>(())
.... False
Traceback (most recent call last):
  File "/home/dc/pwndbg/gdbinit.py", line 100, in <module>
    import pwndbg  # noqa: F401
  File "/home/dc/pwndbg/pwndbg/__init__.py", line 11, in <module>
    load_commands()
  File "/home/dc/pwndbg/pwndbg/commands/__init__.py", line 601, in load_commands
    import pwndbg.commands.cymbol
  File "/home/dc/pwndbg/pwndbg/commands/cymbol.py", line 53, in <module>
    pwndbg_cachedir = pwndbg.lib.tempfile.cachedir("custom-symbols")
  File "/home/dc/pwndbg/pwndbg/lib/memoize.py", line 52, in __call__
    print("%s: %s(%r)" % (how, self, args))
  File "/home/dc/pwndbg/pwndbg/lib/memoize.py", line 58, in __repr__
    return "<%s-memoized function %s>" % (self.kind, funcname)
AttributeError: 'forever' object has no attribute 'kind'
/home/dc/.gdbinit:12: Error in sourced command file:
No symbol table is loaded.  Use the "file" command.
```

<!-- Please make sure to read the testing and linting instructions at https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md before creating a PR -->
