### PR TITLE
Fix optimize color memoization

### DIFF
--- a/pwndbg/color/__init__.py
+++ b/pwndbg/color/__init__.py
@@ -30,8 +30,16 @@ BOLD = "\x1b[1m"
 UNDERLINE = "\x1b[4m"
 
 
-def none(x):
-    return str(x)
+# We assign `none` instead of creating a function since it is faster this way
+# While this is a microptimization, the `none` may be called thousands of times with
+# a single context or a `hexdump $rsp 5000` call
+# A simple benchmark below:
+#   In [1]: def f(x): return str(x)
+#   In [2]: %timeit f('')
+#   117 ns ± 0.642 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)
+#   In [3]: %timeit str('')
+#   72 ns ± 0.222 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)
+none = str
 
 
 def normal(x):
@@ -153,20 +161,20 @@ class ColorConfig:
         raise AttributeError(f"ColorConfig object for {self._namespace} has no attribute '{attr}'")
 
 
-def generateColorFunction(config: str):
-    # the `x` here may be a config Parameter object
+def generateColorFunction(config: str, _globals=globals()):
+    # the `config` here may be a config Parameter object
     # and if we run with disable_colors or if the config value
     # is empty, we need to ensure we cast it to string
     # so it can be properly formatted e.g. with:
     # "{config_param:5}".format(config_param=some_config_parameter)
-    function = lambda x: str(x)
+    function = str
 
     if disable_colors:
         return function
 
     for color in config.split(","):
         func_name = color.lower().replace("-", "_")
-        function = generateColorFunctionInner(function, globals()[func_name])
+        function = generateColorFunctionInner(function, _globals[func_name])
     return function
 
 

--- a/pwndbg/lib/memoize.py
+++ b/pwndbg/lib/memoize.py
@@ -70,6 +70,7 @@ class forever(memoize):
     """
     Memoizes forever - for a pwndbg session or until `_reset` is called explicitly.
     """
+
     caches = []  # type: List[forever]
     kind = "forever"
 


### PR DESCRIPTION
This commit adds three small optimizations to the coloring layer:
1. It fixes a bug where we always triggered a cache miss on first call
to `generateColorFunctionInner` in `generateColorFunction` because we
recreated a lambda object on each call. This is described in more
details below.
2. The `none` function is now just assigned to `str` so that we don't
perform an unnecessary call
3. We now don't call `globals()` on each iteration of the loop in
`generateColorFunction` and instead cache the reference to the globals
dictionary in a fast lookup variable (default keyword argument). Note
that this means a `LOAD_FAST` is used for fetching it, instead of e.g.
`LOAD_GLOBAL` which would be the case if it were a global variable.

More details to 1.:

This commit fixes an embarassing and silly cache miss that we always hit
during calls like `pwndbg.color.memory.c.code` which really boils down to
calling the `ColorConfig.__getattr__` function.

The `ColorConfig.__getattr__` calls `generateColorFunction` which may call
`generateColorFunctionInner` multiple times, depending on thedesired
coloring.

The problem was that the `generateColorFunction` would always call the
`generateColorFunctionInner` with a "convert to string" function, which
was created as a local variable with the following code:

```
function = lambda x: str(x)
```

Since we always passed a new lambda to the `generateColorFunctionInner`
function, the memoization/caching layer always had a cache miss because
the hashing of a *new* lambda object always lead to a new hash, even if
the lambda seems to be the same thing.

Here are some benchmarks for just this 1) matter:

Before:
```
In [7]: %timeit pwndbg.color.memory.c.code('')
5.61 µs ± 135 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

In [8]: %timeit pwndbg.color.memory.c.code('')
5.65 µs ± 291 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

In [9]: %timeit pwndbg.color.memory.c.code('')
5.63 µs ± 28.2 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

In [10]: %timeit pwndbg.color.memory.c.code('')
5.77 µs ± 704 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
```

After:
```
In [1]: %timeit pwndbg.color.memory.c.code('')
3.68 µs ± 22.8 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

In [2]: %timeit pwndbg.color.memory.c.code('')
3.66 µs ± 31.3 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

In [3]: %timeit pwndbg.color.memory.c.code('')
3.7 µs ± 23.8 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

In [4]: %timeit pwndbg.color.memory.c.code('')
3.68 µs ± 24.5 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

In [5]: %timeit pwndbg.color.memory.c.code('')
3.63 µs ± 15 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
```
