### PR TITLE
Rewrite memoization logic

### DIFF
--- a/pwndbg/gdblib/hooks.py
+++ b/pwndbg/gdblib/hooks.py
@@ -79,7 +79,7 @@ def memoize_on_new_objfile() -> None:
 
 @pwndbg.gdblib.events.start
 def memoize_on_start() -> None:
-    while_running._start_caching()
+    #while_running._start_caching()
     reset_on_start._reset()
 
 

--- a/pwndbg/lib/memoize.py
+++ b/pwndbg/lib/memoize.py
@@ -12,173 +12,83 @@ from typing import Callable
 from typing import Dict
 from typing import List  # noqa: F401
 
-debug = False
+debug = 0
+
+# function -> function wrapper
+wrappers = {}
+functions_to_reset_on = {}
+
+_kwargs_separator = object()
+_sentinel = object()
+
+def _reset_on(func, kind, reset_list):
+    if func in reset_list:
+        raise ValueError("Function's %s cache is already registered to be resetted on %s" % (func.__name__, kind))
+    reset_list.append(func)
+
+    wrapper_func = wrappers.get(func)
+    if wrapper_func is not None:
+        #print(f"[{func.__name__}] ({kind}) already registered for caching")
+        return wrapper_func
+    #print(f"[{func.__name__}] ({kind}) registered for caching")
+
+    # If we encounter this function for the first time we create the
+    # cache and wrapper function
+    cache = {}
+
+    # save cache and its clear method in function
+    func.cache = cache
+    func.clear_cache = cache.clear
+
+    @functools.wraps(func)
+    def wrapper_func(*args, **kwargs):
+        # Based on functools.lru_cache / functools.cache
+        # but they have lots of code we don't need
+        key = args
+        if kwargs:
+            key += (_kwargs_separator,)
+            # Note that we rely on the dict order here, meaning that
+            # func(x=1, y=2) and func(y=2, x=1) will be cached separately
+            key += tuple(kwargs.items())
+
+        result = cache.get(key, _sentinel)
+        if result is not _sentinel:
+            if debug: print(f"[{func.__name__}] cache hit: {key}")
+            return result
+
+        if debug: print(f"[{func.__name__}] cache miss: {key}")
+        result = func(*args, **kwargs)
+        cache[key] = result
+        #print(cache)
+
+        return result
+
+    # Save the wrapper
+    wrappers[func] = wrapper_func
+    return wrapper_func
 
 
-class memoize:
-    """
-    Base memoization class. Do not use directly. Instead use one of classes defined below.
-    """
+def create_caching_function(kind):
+    reset_list = []
+    functions_to_reset_on[kind] = reset_list
+    func = functools.partial(_reset_on, kind=kind, reset_list=reset_list)
 
-    caching = True
+    def reset_cache():
+        for f in reset_list:
+            f.clear_cache()
 
-    def __init__(self, func: Callable) -> None:
-        self.func = func
-        self.cache: Dict[Any, Any] = {}
-        self.caches.append(self)  # must be provided by base class
-        functools.update_wrapper(self, func)
+    func._reset = reset_cache
+    return func
 
-    def __call__(self, *args: Any, **kwargs: Any) -> Any:
-        how = None
-
-        if not isinstance(args, Hashable):
-            print("Cannot memoize %r!", file=sys.stderr)
-            how = "Not memoizeable!"
-            value = self.func(*args)
-
-        if self.caching and args in self.cache:
-            how = "Cached"
-            value = self.cache[args]
-
-        else:
-            how = "Executed"
-            value = self.func(*args, **kwargs)
-            self.cache[args] = value
-
-            if isinstance(value, list):
-                print("Should not cache mutable types! %r" % self.func.__name__)
-
-        if debug:
-            print("%s: %s(%r)" % (how, self, args))
-            print(".... %r" % (value,))
-        return value
-
-    def __repr__(self) -> str:
-        funcname = self.func.__module__ + "." + self.func.__name__
-        return "<%s-memoized function %s>" % (self.kind, funcname)
-
-    def __get__(self, obj, objtype: type) -> Callable:
-        return functools.partial(self.__call__, obj)
-
-    def clear(self) -> None:
-        if debug:
-            print("Clearing %s %r" % (self, self.cache))
-        self.cache.clear()
-
-
-class forever(memoize):
-    """
-    Memoizes forever - for a pwndbg session or until `_reset` is called explicitly.
-    """
-    caches = []  # type: List[forever]
-    kind = "forever"
-
-    @staticmethod
-    def _reset() -> None:
-        for obj in forever.caches:
-            obj.cache.clear()
-
-
-class reset_on_stop(memoize):
-    caches = []  # type: List[reset_on_stop]
-    kind = "stop"
-
-    @staticmethod
-    def __reset_on_stop() -> None:
-        for obj in reset_on_stop.caches:
-            obj.cache.clear()
-
-    _reset = __reset_on_stop
-
-
-class reset_on_prompt(memoize):
-    caches = []  # type: List[reset_on_prompt]
-    kind = "prompt"
-
-    @staticmethod
-    def __reset_on_prompt() -> None:
-        for obj in reset_on_prompt.caches:
-            obj.cache.clear()
-
-    _reset = __reset_on_prompt
-
-
-class reset_on_exit(memoize):
-    caches = []  # type: List[reset_on_exit]
-    kind = "exit"
-
-    @staticmethod
-    def __reset_on_exit() -> None:
-        for obj in reset_on_exit.caches:
-            obj.clear()
-
-    _reset = __reset_on_exit
-
-
-class reset_on_objfile(memoize):
-    caches = []  # type: List[reset_on_objfile]
-    kind = "objfile"
-
-    @staticmethod
-    def __reset_on_objfile() -> None:
-        for obj in reset_on_objfile.caches:
-            obj.clear()
-
-    _reset = __reset_on_objfile
-
-
-class reset_on_start(memoize):
-    caches = []  # type: List[reset_on_start]
-    kind = "start"
-
-    @staticmethod
-    def __reset_on_start() -> None:
-        for obj in reset_on_start.caches:
-            obj.clear()
-
-    _reset = __reset_on_start
-
-
-class reset_on_cont(memoize):
-    caches = []  # type: List[reset_on_cont]
-    kind = "cont"
-
-    @staticmethod
-    def __reset_on_cont() -> None:
-        for obj in reset_on_cont.caches:
-            obj.clear()
-
-    _reset = __reset_on_cont
-
-
-class reset_on_thread(memoize):
-    caches = []  # type: List[reset_on_thread]
-    kind = "thread"
-
-    @staticmethod
-    def __reset_on_thread() -> None:
-        for obj in reset_on_thread.caches:
-            obj.clear()
-
-    _reset = __reset_on_thread
-
-
-class while_running(memoize):
-    caches = []  # type: List[while_running]
-    kind = "running"
-    caching = False
-
-    @staticmethod
-    def _start_caching() -> None:
-        while_running.caching = True
-
-    @staticmethod
-    def __reset_while_running() -> None:
-        for obj in while_running.caches:
-            obj.clear()
-        while_running.caching = False
-
-    _reset = __reset_while_running
+forever = create_caching_function("forever")
+reset_on_stop = create_caching_function("stop")
+reset_on_exit = create_caching_function("exit")
+reset_on_objfile = create_caching_function("objfile")
+reset_on_start = create_caching_function("start")
+reset_on_cont = create_caching_function("cont")
+reset_on_prompt = create_caching_function("prompt")
+reset_on_thread = create_caching_function("thread")
+while_running = create_caching_function("running")
 
 
 def reset() -> None:


### PR DESCRIPTION
An attempt to make memoization implementation:
1) with fixed bugs -- current memoization does not handle kwargs 2) maybe more efficient -- current memoization logic will create cache dictionaries per event even if a function is decorated with multiple `reset_on_*` functions; this new impl fixes tha
3) more readable -- hopefully :)

I'll include some simple benchmarking in comments to this PR.

#1453 
