### PR TITLE
Add gdbserver dependency to Ubuntu build

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -20,7 +20,7 @@ osx() {
 
 install_apt() {
     sudo apt-get update || true
-    sudo apt-get install -y git gdb python3-dev python3-pip python3-setuptools libglib2.0-dev libc6-dbg
+    sudo apt-get install -y git gdb gdbserver python3-dev python3-pip python3-setuptools libglib2.0-dev libc6-dbg
 
     if uname -m | grep x86_64 > /dev/null; then
         sudo dpkg --add-architecture i386 || true


### PR DESCRIPTION
gdbserver feels like an important part of the gdb toolset, this PR adds a gdbserver dependency to the Ubuntu build.