### PR TITLE
Remove Arch.signed and Arch.unsigned

### DIFF
--- a/pwndbg/lib/arch.py
+++ b/pwndbg/lib/arch.py
@@ -33,9 +33,3 @@ class Arch:
 
     def unpack(self, data: bytes) -> int:
         return struct.unpack(self.fmt, data)[0]
-
-    def signed(self, integer: int) -> int:
-        return self.unpack(self.pack(integer), signed=True)  # type: ignore
-
-    def unsigned(self, integer: int) -> int:
-        return self.unpack(self.pack(integer))


### PR DESCRIPTION
<!-- Please make sure to read the testing and linting instructions at https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md before creating a PR -->

These aren't used anywhere, and `signed` is wrong (`self.unpack` doesn't take any keyword argument called `signed`).