### PR TITLE
requirements.txt: bump pwntools to 4.0.9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 capstone==4.0.2
 psutil==5.9.4
-pwntools==4.8.0
+pwntools==4.9.0
 pycparser==2.21
 pyelftools==0.29
 Pygments==2.13.0


### PR DESCRIPTION
Updates the pwntools dependency to version 4.0.9 - https://github.com/Gallopsled/pwntools/blob/dev/CHANGELOG.md#490-stable

<!-- Please make sure to read the testing and linting instructions at https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md before creating a PR -->
