### PR TITLE
Don't fail CI if codecov upload fails

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,8 +46,6 @@ jobs:
         coverage xml
 
     - name: "Upload coverage to Codecov"
-      if: matrix.os == 'ubuntu-22.04' && success() || failure()
+      if: matrix.os == 'ubuntu-22.04'
       uses: codecov/codecov-action@v3
-      with:
-        fail_ci_if_error: true
 


### PR DESCRIPTION
I think this probably should have been the actual fix for https://github.com/pwndbg/pwndbg/issues/1427