### PR TITLE
Run QEMU tests on CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
         echo 'Installed packages:'
         python -m pip freeze
 
-    # We to set `kernel.yama.ptrace_scope=0` for `attachp` command tests
+    # We set `kernel.yama.ptrace_scope=0` for `attachp` command tests
     - name: Run tests
       run: |
         mkdir .cov
@@ -49,3 +49,29 @@ jobs:
       if: matrix.os == 'ubuntu-22.04'
       uses: codecov/codecov-action@v3
 
+  qemu-tests:
+    runs-on: [ubuntu-22.04]
+    timeout-minutes: 20
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Cache for pip
+      uses: actions/cache@v3
+      with:
+        path: ~/.cache/pip
+        key: ${{ matrix.os }}-cache-pip
+
+    - name: Install dependencies
+      run: |
+        ./setup.sh --user
+        ./setup-dev.sh --user
+
+    - name: Download images
+      run: |
+        ./tests/qemu-tests/download_images.sh
+
+    # We set `kernel.yama.ptrace_scope=0` for `gdb-pt-dump`
+    - name: Run tests
+      run: |
+        sudo sysctl -w kernel.yama.ptrace_scope=0
+        ./tests/qemu-tests/tests.sh

--- a/setup-dev.sh
+++ b/setup-dev.sh
@@ -91,8 +91,11 @@ install_apt() {
         curl \
         build-essential \
         gdb \
+        gdb-multiarch \
         parallel \
-        netcat-openbsd
+        netcat-openbsd \
+        qemu-system-x86 \
+        qemu-system-arm
 
     if [[ "$1" == "22.04" ]]; then
         sudo apt install shfmt

--- a/tests/qemu-tests/gdb.sh
+++ b/tests/qemu-tests/gdb.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 
 ARCH="$1"
-KERNEL_TYPE="$2"
+shift
+
+KERNEL_TYPE="$1"
+shift
 
 CWD=$(dirname -- "$0")
 IMAGE_DIR="${CWD}/images"
@@ -23,10 +26,10 @@ alternatively run the following command:
 EOF
 fi
 
-if [[ $ARCH == "arm64" ]]; then
-    GDB=gdb-multiarch
-else
+if [[ "$ARCH" == x86_64 ]]; then
     GDB=gdb
+else
+    GDB=gdb-multiarch
 fi
 
 VMLINUX="${IMAGE_DIR}/vmlinux-${KERNEL_TYPE}-${ARCH}"

--- a/tests/qemu-tests/tests.sh
+++ b/tests/qemu-tests/tests.sh
@@ -6,15 +6,14 @@ set -x
 
 for kernel_type in linux ack; do
     for arch in x86_64 arm64; do
-        tmux splitw -h "${CWD}/run_qemu_system.sh" $arch $kernel_type
-        pane_id=$(tmux display-message -p "#{pane_id}")
+        "${CWD}/run_qemu_system.sh" $arch $kernel_type > /dev/null &
 
         "${CWD}/gdb.sh" $arch $kernel_type
         exit_code=$?
 
-        tmux send-keys -t $pane_id ^A x
         if [ $exit_code -ne 0 ]; then
             exit $exit_code
         fi
+        pkill qemu
     done
 done


### PR DESCRIPTION
This PR adds a CI job to run the qemu tests. There are some minor tweaks to the scripts, most notably the removal of tmux as it doesn't work well with CI.

#1417 