### PR TITLE
Support showing opcodes in the disassembly

### DIFF
--- a/pwndbg/gdblib/config.py
+++ b/pwndbg/gdblib/config.py
@@ -22,9 +22,11 @@ import pwndbg.lib.config
 config = pwndbg.lib.config.Config()
 
 # GDB < 9 does not support PARAM_ZUINTEGER*, so we implement it by ourselves for consistency
+IS_GDB_GTE_9 = True
 if not hasattr(gdb, "PARAM_ZUINTEGER"):
     gdb.PARAM_ZUINTEGER = "PARAM_ZUINTEGER"
     gdb.PARAM_ZUINTEGER_UNLIMITED = "PARAM_ZUINTEGER_UNLIMITED"
+    IS_GDB_GTE_9 = False
 
 
 # See this for details about the API of `gdb.Parameter`:
@@ -37,8 +39,13 @@ class Parameter(gdb.Parameter):
         self.set_doc = "Set " + param.set_show_doc + "."
         self.show_doc = "Show " + param.set_show_doc + "."
         self.__doc__ = param.help_docstring or None
-        self._custom_param_class = None
 
+        self.init_super(param)
+        self.param = param
+        self.value = param.value
+
+    def __init_super_gdb_gte_9(self, param: pwndbg.lib.config.Parameter) -> None:
+        """Initializes the super class for GDB >= 9"""
         if param.param_class == gdb.PARAM_ENUM:
             super().__init__(
                 param.name,
@@ -46,17 +53,19 @@ class Parameter(gdb.Parameter):
                 param.param_class,
                 param.enum_sequence,
             )
-        elif (
-            param.param_class == "PARAM_ZUINTEGER"
-            or param.param_class == "PARAM_ZUINTEGER_UNLIMITED"
-        ):
-            # GDB < 9 does not support PARAM_ZUINTEGER*, so we implement it by ourselves for consistency
-            self._custom_param_class = param.param_class
+            return
+        super().__init__(param.name, gdb.COMMAND_SUPPORT, param.param_class)
+
+    def __init_super_gdb_lt_9(self, param: pwndbg.lib.config.Parameter) -> None:
+        """Initializes the super class for GDB < 9"""
+        # GDB < 9 does not support PARAM_ZUINTEGER*, so we implement it by ourselves for consistency
+        if param.param_class in (gdb.PARAM_ZUINTEGER, gdb.PARAM_ZUINTEGER_UNLIMITED):
             super().__init__(param.name, gdb.COMMAND_SUPPORT, pwndbg.lib.config.PARAM_CLASSES[int])
-        else:
-            super().__init__(param.name, gdb.COMMAND_SUPPORT, param.param_class)
-        self.param = param
-        self.value = param.value
+            return
+        # the logic after this line is the same as GDB >= 9
+        self.__init_super_gdb_gte_9(param)
+
+    init_super = __init_super_gdb_gte_9 if IS_GDB_GTE_9 else __init_super_gdb_lt_9
 
     @property
     def native_value(self):
@@ -68,9 +77,8 @@ class Parameter(gdb.Parameter):
             self.param.default, param_class=self.param.param_class
         )
 
-    def get_set_string(self) -> str:
-        """Handles the GDB `set <param>` command"""
-
+    def __get_set_string_gdb_gte_9(self) -> str:
+        """Handles the GDB `set <param>` command for GDB >= 9"""
         # GDB will set `self.value` to the user's input
         if self.value is None and self.param.param_class in (gdb.PARAM_UINTEGER, gdb.PARAM_INTEGER):
             # Note: This is really weird, according to GDB docs, 0 should mean "unlimited" for gdb.PARAM_UINTEGER and gdb.PARAM_INTEGER, but somehow GDB sets the value to `None` actually :/
@@ -79,15 +87,6 @@ class Parameter(gdb.Parameter):
             # Anyway, to avoid some unexpected behaviors, we'll still set `self.param.value` to 0 here.
             self.param.value = 0
         else:
-            if self._custom_param_class:
-                if (self._custom_param_class == "PARAM_ZUINTEGER" and self.value < 0) or (  # type: ignore
-                    self._custom_param_class == "PARAM_ZUINTEGER_UNLIMITED" and self.value < -1  # type: ignore
-                ):
-                    err = "integer %d out of range" % self.value  # type: ignore
-                    # Restore the old value
-                    self.value = self.param.value
-                    # GDB < 9 is too buggy, it won't handle `gdb.GdbError`..., so we return a string here
-                    return err
             self.param.value = self.value
 
         for trigger in config.triggers[self.param.name]:
@@ -100,16 +99,38 @@ class Parameter(gdb.Parameter):
 
         return "Set %s to %r." % (self.param.set_show_doc, self.native_value)
 
-    def get_show_string(self, svalue) -> str:
-        """Handles the GDB `show <param>` command"""
+    def __get_set_string_gdb_le_9(self) -> str:
+        """Handles the GDB `set <param>` command for GDB < 9"""
+        if (self.param.param_class == gdb.PARAM_ZUINTEGER and self.value < 0) or (  # type: ignore
+            self.param.param_class == gdb.PARAM_ZUINTEGER_UNLIMITED and self.value < -1  # type: ignore
+        ):
+            err = "integer %d out of range" % self.value  # type: ignore
+            # Restore the old value
+            self.value = self.param.value
+            # GDB < 9 is too buggy, it won't handle `gdb.GdbError`..., so we return a string here
+            return err
+        # the logic after this line is the same as GDB >= 9
+        return self.__get_set_string_gdb_gte_9()
+
+    get_set_string = __get_set_string_gdb_gte_9 if IS_GDB_GTE_9 else __get_set_string_gdb_le_9
+
+    def __get_show_string_gdb_gte_9(self, svalue) -> str:
+        """Handles the GDB `show <param>` command for GDB >= 9"""
         more_information_hint = " See `help set %s` for more information." % self.param.name
-        if self._custom_param_class == "PARAM_ZUINTEGER_UNLIMITED" and self.value == -1:
-            svalue = "unlimited"
         return "%s is %r.%s" % (
             self.param.set_show_doc.capitalize(),
             svalue,
             more_information_hint if self.__doc__ else "",
         )
+
+    def __get_show_string_gdb_le_9(self, svalue) -> str:
+        """Handles the GDB `show <param>` command for GDB < 9"""
+        if self.param.param_class == gdb.PARAM_ZUINTEGER_UNLIMITED and self.value == -1:
+            svalue = "unlimited"
+        # the logic after this line is the same as GDB >= 9
+        return self.__get_show_string_gdb_gte_9(svalue)
+
+    get_show_string = __get_show_string_gdb_gte_9 if IS_GDB_GTE_9 else __get_show_string_gdb_le_9
 
     @staticmethod
     def _value_to_gdb_native(value, param_class=None):

--- a/pwndbg/gdblib/nearpc.py
+++ b/pwndbg/gdblib/nearpc.py
@@ -165,6 +165,7 @@ def nearpc(pc=None, lines=None, emulate=False, repeat=False) -> List[str]:
             symbol = C.highlight(symbol)
             first_pc = False
 
+        opcodes = ""
         if show_opcodes_size > 0:
             opcodes = instr.bytes.hex()
             opcodes = opcodes[: show_opcodes_size * 2]
@@ -175,9 +176,7 @@ def nearpc(pc=None, lines=None, emulate=False, repeat=False) -> List[str]:
             opcodes = opcodes.ljust(align, " ")
             if pwndbg.gdblib.config.highlight_pc and instr.address == pwndbg.gdblib.regs.pc:
                 opcodes = C.highlight(opcodes)
-            line = " ".join((prefix, address_str, opcodes, symbol, asm))
-        else:
-            line = " ".join((prefix, address_str, symbol, asm))
+        line = " ".join((prefix, address_str, opcodes, symbol, asm))
 
         # If there was a branch before this instruction which was not
         # contiguous, put in some ellipses.

--- a/pwndbg/gdblib/nearpc.py
+++ b/pwndbg/gdblib/nearpc.py
@@ -187,7 +187,7 @@ def nearpc(pc=None, lines=None, emulate=False, repeat=False) -> List[str]:
             if should_highlight_opcodes:
                 opcodes = C.highlight(opcodes)
                 should_highlight_opcodes = False
-        line = " ".join((prefix, address_str, opcodes, symbol, asm))
+        line = " ".join(filter(None, (prefix, address_str, opcodes, symbol, asm)))
 
         # If there was a branch before this instruction which was not
         # contiguous, put in some ellipses.

--- a/pwndbg/gdblib/nearpc.py
+++ b/pwndbg/gdblib/nearpc.py
@@ -138,6 +138,7 @@ def nearpc(pc=None, lines=None, emulate=False, repeat=False) -> List[str]:
     prev = None
 
     first_pc = True
+    should_highlight_opcodes = False
 
     # Print out each instruction
     for address_str, symbol, instr in zip(addresses, symbols, instructions):
@@ -164,6 +165,7 @@ def nearpc(pc=None, lines=None, emulate=False, repeat=False) -> List[str]:
             address_str = C.highlight(address_str)
             symbol = C.highlight(symbol)
             first_pc = False
+            should_highlight_opcodes = True
 
         opcodes = ""
         if show_opcode_bytes > 0:
@@ -175,8 +177,9 @@ def nearpc(pc=None, lines=None, emulate=False, repeat=False) -> List[str]:
                 # the length of gray("...") is 12, so we need to add extra 9 (12-3) alignment length for the invisible characters
                 align += 9  # len(pwndbg.color.gray(""))
             opcodes = opcodes.ljust(align, " ")
-            if pwndbg.gdblib.config.highlight_pc and instr.address == pwndbg.gdblib.regs.pc:
+            if should_highlight_opcodes:
                 opcodes = C.highlight(opcodes)
+                should_highlight_opcodes = False
         line = " ".join((prefix, address_str, opcodes, symbol, asm))
 
         # If there was a branch before this instruction which was not

--- a/pwndbg/gdblib/nearpc.py
+++ b/pwndbg/gdblib/nearpc.py
@@ -172,6 +172,7 @@ def nearpc(pc=None, lines=None, emulate=False, repeat=False) -> List[str]:
             align = show_opcodes_size * 2 + 10
             if len(instr.bytes) > show_opcodes_size:
                 opcodes += pwndbg.color.gray("...")
+                # the length of gray("...") is 12, so we need to add extra 9 (12-3) alignment length for the invisible characters
                 align += 9  # len(pwndbg.color.gray(""))
             opcodes = opcodes.ljust(align, " ")
             if pwndbg.gdblib.config.highlight_pc and instr.address == pwndbg.gdblib.regs.pc:

--- a/pwndbg/gdblib/nearpc.py
+++ b/pwndbg/gdblib/nearpc.py
@@ -56,8 +56,8 @@ nearpc_lines = pwndbg.gdblib.config.add_param(
 show_args = pwndbg.gdblib.config.add_param(
     "nearpc-show-args", True, "whether to show call arguments below instruction"
 )
-show_opcodes_size = pwndbg.gdblib.config.add_param(
-    "nearpc-opcodes-size", 0, "number of bytes of opcodes to print for each instruction"
+show_opcode_bytes = pwndbg.gdblib.config.add_param(
+    "nearpc-opcode-bytes", 0, "number of opcode bytes to print for each instruction"
 )
 
 
@@ -166,11 +166,11 @@ def nearpc(pc=None, lines=None, emulate=False, repeat=False) -> List[str]:
             first_pc = False
 
         opcodes = ""
-        if show_opcodes_size > 0:
+        if show_opcode_bytes > 0:
             opcodes = instr.bytes.hex()
-            opcodes = opcodes[: show_opcodes_size * 2]
-            align = show_opcodes_size * 2 + 10
-            if len(instr.bytes) > show_opcodes_size:
+            opcodes = opcodes[: show_opcode_bytes * 2]
+            align = show_opcode_bytes * 2 + 10
+            if len(instr.bytes) > show_opcode_bytes:
                 opcodes += pwndbg.color.gray("...")
                 # the length of gray("...") is 12, so we need to add extra 9 (12-3) alignment length for the invisible characters
                 align += 9  # len(pwndbg.color.gray(""))

--- a/pwndbg/gdblib/nearpc.py
+++ b/pwndbg/gdblib/nearpc.py
@@ -57,7 +57,7 @@ show_args = pwndbg.gdblib.config.add_param(
     "nearpc-show-args", True, "whether to show call arguments below instruction"
 )
 show_opcode_bytes = pwndbg.gdblib.config.add_param(
-    "nearpc-opcode-bytes",
+    "nearpc-num-opcode-bytes",
     0,
     "number of opcode bytes to print for each instruction",
     param_class=gdb.PARAM_ZUINTEGER,

--- a/pwndbg/gdblib/nearpc.py
+++ b/pwndbg/gdblib/nearpc.py
@@ -57,10 +57,16 @@ show_args = pwndbg.gdblib.config.add_param(
     "nearpc-show-args", True, "whether to show call arguments below instruction"
 )
 show_opcode_bytes = pwndbg.gdblib.config.add_param(
-    "nearpc-opcode-bytes", 0, "number of opcode bytes to print for each instruction"
+    "nearpc-opcode-bytes",
+    0,
+    "number of opcode bytes to print for each instruction",
+    param_class=gdb.PARAM_ZUINTEGER,
 )
 opcode_separator_bytes = pwndbg.gdblib.config.add_param(
-    "nearpc-opcode-separator-bytes", 1, "number of spaces between opcode bytes"
+    "nearpc-opcode-separator-bytes",
+    1,
+    "number of spaces between opcode bytes",
+    param_class=gdb.PARAM_ZUINTEGER,
 )
 
 

--- a/tests/gdb-tests/tests/test_gdblib_parameter.py
+++ b/tests/gdb-tests/tests/test_gdblib_parameter.py
@@ -14,15 +14,32 @@ import pwndbg.gdblib.config
         ("auto-bool", None, "auto", {"param_class": gdb.PARAM_AUTO_BOOLEAN}),
         ("unlimited-uint", 0, "unlimited", {"param_class": gdb.PARAM_UINTEGER}),
         ("unlimited-int", 0, "unlimited", {"param_class": gdb.PARAM_INTEGER}),
-        # GDB < 9.x does not support PARAM_ZUINTEGER_UNLIMITED
-        ("unlimited-zuint", -1, "unlimited", {"param_class": gdb.PARAM_ZUINTEGER_UNLIMITED})
-        if hasattr(gdb, "PARAM_ZUINTEGER_UNLIMITED")
-        else (),
         (
             "enum",
             "enum1",
             "enum1",
             {"param_class": gdb.PARAM_ENUM, "enum_sequence": ["enum1", "enum2", "enum3"]},
+        ),
+        # Note: GDB < 9 does not support PARAM_ZUINTEGER*, so we implement it by ourselves for consistency
+        (
+            "zuint",
+            0,
+            "0",
+            {
+                "param_class": gdb.PARAM_ZUINTEGER
+                if hasattr(gdb, "PARAM_ZUINTEGER")
+                else "PARAM_ZUINTEGER"
+            },
+        ),
+        (
+            "unlimited-zuint",
+            -1,
+            "unlimited",
+            {
+                "param_class": gdb.PARAM_ZUINTEGER_UNLIMITED
+                if hasattr(gdb, "PARAM_ZUINTEGER_UNLIMITED")
+                else "PARAM_ZUINTEGER_UNLIMITED"
+            },
         ),
     ),
 )

--- a/tests/gdb-tests/tests/test_nearpc.py
+++ b/tests/gdb-tests/tests/test_nearpc.py
@@ -1,0 +1,181 @@
+import gdb
+import pytest
+
+import tests
+
+SYSCALLS_BINARY = tests.binaries.get("syscalls-x64.out")
+
+OPCODE_BYTES_TESTS_EXPECTED_OUTPUT = {
+    1: [
+        "b8\x1b[90m...\x1b[0m       ",
+        "bf\x1b[90m...\x1b[0m       ",
+        "be\x1b[90m...\x1b[0m       ",
+        "b9\x1b[90m...\x1b[0m       ",
+        "0f\x1b[90m...\x1b[0m       ",
+        "b8\x1b[90m...\x1b[0m       ",
+        "cd\x1b[90m...\x1b[0m       ",
+        "00\x1b[90m...\x1b[0m       ",
+        "00\x1b[90m...\x1b[0m       ",
+        "00\x1b[90m...\x1b[0m       ",
+        "00\x1b[90m...\x1b[0m       ",
+    ],
+    2: [
+        "b8 00\x1b[90m...\x1b[0m       ",
+        "bf 37\x1b[90m...\x1b[0m       ",
+        "be ef\x1b[90m...\x1b[0m       ",
+        "b9 10\x1b[90m...\x1b[0m       ",
+        "0f 05          ",
+        "b8 0a\x1b[90m...\x1b[0m       ",
+        "cd 80          ",
+        "00 00          ",
+        "00 00          ",
+        "00 00          ",
+        "00 00          ",
+    ],
+    3: [
+        "b8 00 00\x1b[90m...\x1b[0m       ",
+        "bf 37 13\x1b[90m...\x1b[0m       ",
+        "be ef be\x1b[90m...\x1b[0m       ",
+        "b9 10 00\x1b[90m...\x1b[0m       ",
+        "0f 05             ",
+        "b8 0a 00\x1b[90m...\x1b[0m       ",
+        "cd 80             ",
+        "00 00             ",
+        "00 00             ",
+        "00 00             ",
+        "00 00             ",
+    ],
+    4: [
+        "b8 00 00 00\x1b[90m...\x1b[0m       ",
+        "bf 37 13 00\x1b[90m...\x1b[0m       ",
+        "be ef be ad\x1b[90m...\x1b[0m       ",
+        "b9 10 00 00\x1b[90m...\x1b[0m       ",
+        "0f 05                ",
+        "b8 0a 00 00\x1b[90m...\x1b[0m       ",
+        "cd 80                ",
+        "00 00                ",
+        "00 00                ",
+        "00 00                ",
+        "00 00                ",
+    ],
+    5: [
+        "b8 00 00 00 00          ",
+        "bf 37 13 00 00          ",
+        "be ef be ad de          ",
+        "b9 10 00 00 00          ",
+        "0f 05                   ",
+        "b8 0a 00 00 00          ",
+        "cd 80                   ",
+        "00 00                   ",
+        "00 00                   ",
+        "00 00                   ",
+        "00 00                   ",
+    ],
+}
+
+OPCODE_SEPERATOR_TESTS_EXPECTED_OUTPUT = {
+    0: [
+        "b800000000          ",
+        "bf37130000          ",
+        "beefbeadde          ",
+        "b910000000          ",
+        "0f05                ",
+        "b80a000000          ",
+        "cd80                ",
+        "0000                ",
+        "0000                ",
+        "0000                ",
+        "0000                ",
+    ],
+    1: [
+        "b8 00 00 00 00          ",
+        "bf 37 13 00 00          ",
+        "be ef be ad de          ",
+        "b9 10 00 00 00          ",
+        "0f 05                   ",
+        "b8 0a 00 00 00          ",
+        "cd 80                   ",
+        "00 00                   ",
+        "00 00                   ",
+        "00 00                   ",
+        "00 00                   ",
+    ],
+    2: [
+        "b8  00  00  00  00          ",
+        "bf  37  13  00  00          ",
+        "be  ef  be  ad  de          ",
+        "b9  10  00  00  00          ",
+        "0f  05                      ",
+        "b8  0a  00  00  00          ",
+        "cd  80                      ",
+        "00  00                      ",
+        "00  00                      ",
+        "00  00                      ",
+        "00  00                      ",
+    ],
+}
+
+
+@pytest.mark.parametrize("opcode_bytes", (1, 2, 3, 4, 5))
+def test_nearpc_opcode_bytes(start_binary, opcode_bytes):
+    start_binary(SYSCALLS_BINARY)
+    gdb.execute("nextsyscall")
+    gdb.execute(f"set nearpc-opcode-bytes {opcode_bytes}")
+    dis = gdb.execute("nearpc", to_string=True)
+    expected = (
+        "   0x400080 {0} <_start>       mov    eax, 0\n"
+        "   0x400085 {1} <_start+5>     mov    edi, 0x1337\n"
+        "   0x40008a {2} <_start+10>    mov    esi, 0xdeadbeef\n"
+        "   0x40008f {3} <_start+15>    mov    ecx, 0x10\n"
+        " ► 0x400094 {4} <_start+20>    syscall  <SYS_read>\n"
+        "        fd:        0x1337\n"
+        "        buf:       0xdeadbeef\n"
+        "        nbytes:    0x0\n"
+        "   0x400096 {5} <_start+22>    mov    eax, 0xa\n"
+        "   0x40009b {6} <_start+27>    int    0x80\n"
+        "   0x40009d {7}                add    byte ptr [rax], al\n"
+        "   0x40009f {8}                add    byte ptr [rax], al\n"
+        "   0x4000a1 {9}                add    byte ptr [rax], al\n"
+        "   0x4000a3 {10}                add    byte ptr [rax], al\n"
+    ).format(*OPCODE_BYTES_TESTS_EXPECTED_OUTPUT[opcode_bytes])
+    assert dis == expected
+
+
+@pytest.mark.parametrize("separator_bytes", (0, 1, 2))
+def test_nearpc_opcode_seperator(start_binary, separator_bytes):
+    start_binary(SYSCALLS_BINARY)
+    gdb.execute("nextsyscall")
+    gdb.execute("set nearpc-opcode-bytes 5")
+    gdb.execute(f"set nearpc-opcode-separator-bytes {separator_bytes}")
+    dis = gdb.execute("nearpc", to_string=True)
+    excepted = (
+        "   0x400080 {0} <_start>       mov    eax, 0\n"
+        "   0x400085 {1} <_start+5>     mov    edi, 0x1337\n"
+        "   0x40008a {2} <_start+10>    mov    esi, 0xdeadbeef\n"
+        "   0x40008f {3} <_start+15>    mov    ecx, 0x10\n"
+        " ► 0x400094 {4} <_start+20>    syscall  <SYS_read>\n"
+        "        fd:        0x1337\n"
+        "        buf:       0xdeadbeef\n"
+        "        nbytes:    0x0\n"
+        "   0x400096 {5} <_start+22>    mov    eax, 0xa\n"
+        "   0x40009b {6} <_start+27>    int    0x80\n"
+        "   0x40009d {7}                add    byte ptr [rax], al\n"
+        "   0x40009f {8}                add    byte ptr [rax], al\n"
+        "   0x4000a1 {9}                add    byte ptr [rax], al\n"
+        "   0x4000a3 {10}                add    byte ptr [rax], al\n"
+    ).format(*OPCODE_SEPERATOR_TESTS_EXPECTED_OUTPUT[separator_bytes])
+    assert dis == excepted
+
+
+def test_nearpc_opcode_invalid_config():
+    try:
+        gdb.execute("set nearpc-opcode-bytes -1")
+        assert False, "nearpc-opcode-bytes should not accept negative values"
+    except gdb.error as e:
+        pass
+
+    try:
+        gdb.execute("set nearpc-opcode-separator-bytes -1")
+        assert False, "nearpc-opcode-separator-bytes should not accept negative values"
+    except gdb.error as e:
+        pass

--- a/tests/gdb-tests/tests/test_nearpc.py
+++ b/tests/gdb-tests/tests/test_nearpc.py
@@ -168,14 +168,16 @@ def test_nearpc_opcode_seperator(start_binary, separator_bytes):
 
 
 def test_nearpc_opcode_invalid_config():
+    expected = "integer -1 out of range"
     try:
-        gdb.execute("set nearpc-opcode-bytes -1")
-        assert False, "nearpc-opcode-bytes should not accept negative values"
+        # We try to catch the output since GDB < 9 won't raise the exception
+        assert gdb.execute("set nearpc-opcode-bytes -1", to_string=True).rstrip() == expected
     except gdb.error as e:
-        pass
+        assert expected == str(e)
 
     try:
-        gdb.execute("set nearpc-opcode-separator-bytes -1")
-        assert False, "nearpc-opcode-separator-bytes should not accept negative values"
+        assert (
+            gdb.execute("set nearpc-opcode-separator-bytes -1", to_string=True).rstrip() == expected
+        )
     except gdb.error as e:
-        pass
+        assert expected == str(e)

--- a/tests/gdb-tests/tests/test_nearpc.py
+++ b/tests/gdb-tests/tests/test_nearpc.py
@@ -120,7 +120,7 @@ OPCODE_SEPERATOR_TESTS_EXPECTED_OUTPUT = {
 def test_nearpc_opcode_bytes(start_binary, opcode_bytes):
     start_binary(SYSCALLS_BINARY)
     gdb.execute("nextsyscall")
-    gdb.execute(f"set nearpc-opcode-bytes {opcode_bytes}")
+    gdb.execute(f"set nearpc-num-opcode-bytes {opcode_bytes}")
     dis = gdb.execute("nearpc", to_string=True)
     expected = (
         "   0x400080 {0} <_start>       mov    eax, 0\n"
@@ -145,7 +145,7 @@ def test_nearpc_opcode_bytes(start_binary, opcode_bytes):
 def test_nearpc_opcode_seperator(start_binary, separator_bytes):
     start_binary(SYSCALLS_BINARY)
     gdb.execute("nextsyscall")
-    gdb.execute("set nearpc-opcode-bytes 5")
+    gdb.execute("set nearpc-num-opcode-bytes 5")
     gdb.execute(f"set nearpc-opcode-separator-bytes {separator_bytes}")
     dis = gdb.execute("nearpc", to_string=True)
     excepted = (
@@ -171,7 +171,7 @@ def test_nearpc_opcode_invalid_config():
     expected = "integer -1 out of range"
     try:
         # We try to catch the output since GDB < 9 won't raise the exception
-        assert gdb.execute("set nearpc-opcode-bytes -1", to_string=True).rstrip() == expected
+        assert gdb.execute("set nearpc-num-opcode-bytes -1", to_string=True).rstrip() == expected
     except gdb.error as e:
         assert expected == str(e)
 


### PR DESCRIPTION
This PR is trying to implement the feature that #1422 mentioned.
By setting `nearpc-num-opcode-bytes`(default is 0) and `nearpc-opcode-seperator-bytes` (default is 1):
- `set nearpc-num-opcode-bytes 9`
<img width="1217" alt="截圖 2023-01-24 下午8 25 49" src="https://user-images.githubusercontent.com/61896187/214291494-023e86cb-d718-4aeb-ab15-8533acff4d19.png">

- `set nearpc-num-opcode-bytes 4`

<img width="1036" alt="截圖 2023-01-24 下午8 26 34" src="https://user-images.githubusercontent.com/61896187/214291517-2ffc415f-8f88-4be9-8c04-cc2f70cddad0.png">

- `set nearpc-num-opcode-bytes 9` + `set nearpc-opcode-seperator-bytes 0`
 <img width="1119" alt="截圖 2023-01-24 下午8 36 51" src="https://user-images.githubusercontent.com/61896187/214293493-3e27d77a-7b58-4067-82e1-5aad8c209654.png">
