### PR TITLE
Fix procinfo command (#1544) on QEMU targets and with abstract UDS

### DIFF
--- a/pwndbg/commands/procinfo.py
+++ b/pwndbg/commands/procinfo.py
@@ -6,6 +6,7 @@ import pwndbg.gdblib.file
 import pwndbg.gdblib.net
 import pwndbg.gdblib.proc
 import pwndbg.lib.memoize
+from pwndbg.color import message
 from pwndbg.commands import CommandCategory
 
 """
@@ -191,7 +192,15 @@ def procinfo() -> None:
     """
     Display information about the running process.
     """
-    exe = str(pwndbg.auxv.get()["AT_EXECFN"])
+    if pwndbg.gdblib.qemu.is_qemu():
+        print(
+            message.error(
+                "QEMU target detected: showing result for the qemu process"
+                " - so it will be a bit inaccurate (excessive for the parts"
+                " used directly by the qemu process)"
+            )
+        )
+    exe = pwndbg.auxv.get()["AT_EXECFN"]
     print("%-10s %r" % ("exe", exe))
 
     proc = Process()

--- a/pwndbg/gdblib/file.py
+++ b/pwndbg/gdblib/file.py
@@ -107,6 +107,8 @@ def readlink(path):
 
     if is_qemu:
         if not os.path.exists(path):
+            # The or "" is needed since .root() may return None
+            # Then we just use the path (it can also be absolute too)
             path = os.path.join(pwndbg.gdblib.qemu.root() or "", path)
 
     if is_qemu or not pwndbg.gdblib.remote.is_remote():

--- a/pwndbg/gdblib/file.py
+++ b/pwndbg/gdblib/file.py
@@ -107,7 +107,7 @@ def readlink(path):
 
     if is_qemu:
         if not os.path.exists(path):
-            path = os.path.join(pwndbg.gdblib.qemu.root(), path)
+            path = os.path.join(pwndbg.gdblib.qemu.root() or "", path)
 
     if is_qemu or not pwndbg.gdblib.remote.is_remote():
         try:

--- a/pwndbg/gdblib/net.py
+++ b/pwndbg/gdblib/net.py
@@ -15,7 +15,10 @@ def tcp():
 
 
 def unix():
-    data = pwndbg.gdblib.file.get("/proc/net/unix").decode()
+    # We use errors=ignore because of https://github.com/pwndbg/pwndbg/issues/1544
+    # TODO/FIXME: this may not be the best solution because we may end up with
+    # invalid UDS data. Can this be a problem?
+    data = pwndbg.gdblib.file.get("/proc/net/unix").decode(errors="ignore")
     return pwndbg.lib.net.unix(data)
 
 

--- a/pwndbg/lib/net.py
+++ b/pwndbg/lib/net.py
@@ -146,7 +146,12 @@ def unix(data: str):
         return []
 
     result = []
-    for line in data.splitlines()[1:]:
+    # Note: it is super important to split by "\n" instead of .splitlines() here
+    # because there may be a line like this:
+    # "0000000000000000: 00000002 00000000 00000000 0002 01 23302 @@@@\x9e\x05@@\x01=\r@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@\n"
+    # and splitlines will also split by \r which we do not want here
+    # We also finish at -1 index since with .split() the empty last line is kept in the result
+    for line in data.split("\n")[1:-1]:
         """
         Num       RefCount Protocol Flags    Type St Inode Path
         0000000000000000: 00000002 00000000 00010000 0005 01  1536 /dev/socket/msm_irqbalance


### PR DESCRIPTION
Actually, this also fixes some QEMU procinfo issues. Hope this is good enough.

This is how it looks now on qemu targets:

<img width="838" alt="image" src="https://user-images.githubusercontent.com/10009354/215291384-451e28a5-d818-4b23-98c6-47a1105236bd.png">
