### PR TITLE
Fix #1534: disable emulation if mmap(1G,RWX) fails

### DIFF
--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -616,12 +616,18 @@ def context_disasm(target=sys.stdout, with_banner=True, width=None):
     if cs is not None and cs.syntax != syntax:
         pwndbg.lib.memoize.reset()
 
-    arch = pwndbg.gdblib.arch.current
-    emulate = bool(pwndbg.gdblib.config.emulate)
+    result = pwndbg.gdblib.nearpc.nearpc(
+        lines=code_lines // 2, emulate=bool(pwndbg.gdblib.config.emulate)
+    )
 
-    info = " / %s / set emulate %s" % (arch, "on" if emulate else "off")
+    # Note: we must fetch emulate value again and after disasm since
+    # we check if we can actually use emulation in `can_run_first_emulate`
+    # and this call may disable it
+    info = " / %s / set emulate %s" % (
+        pwndbg.gdblib.arch.current,
+        "on" if bool(pwndbg.gdblib.config.emulate) else "off",
+    )
     banner = [pwndbg.ui.banner("disasm", target=target, width=width, extra=info)]
-    result = pwndbg.gdblib.nearpc.nearpc(lines=code_lines // 2, emulate=emulate)
 
     # If we didn't disassemble backward, try to make sure
     # that the amount of screen space taken is roughly constant.

--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -620,7 +620,7 @@ def context_disasm(target=sys.stdout, with_banner=True, width=None):
         lines=code_lines // 2, emulate=bool(pwndbg.gdblib.config.emulate)
     )
 
-    # Note: we must fetch emulate value again and after disasm since
+    # Note: we must fetch emulate value again after disasm since
     # we check if we can actually use emulation in `can_run_first_emulate`
     # and this call may disable it
     info = " / %s / set emulate %s" % (

--- a/pwndbg/disasm/__init__.py
+++ b/pwndbg/disasm/__init__.py
@@ -221,14 +221,12 @@ def can_run_first_emulate():
     first_time_emulate = False
 
     try:
-        from mmap import MAP_ANON
-        from mmap import MAP_PRIVATE
-        from mmap import PROT_EXEC
-        from mmap import PROT_READ
-        from mmap import PROT_WRITE
-        from mmap import mmap
+        from mmap import mmap, MAP_ANON, MAP_PRIVATE, PROT_EXEC, PROT_READ, PROT_WRITE  # isort:skip
 
-        mmap(-1, 1024 * 1024 * 1024, MAP_PRIVATE | MAP_ANON, PROT_WRITE | PROT_READ | PROT_EXEC)
+        mm = mmap(
+            -1, 1024 * 1024 * 1024, MAP_PRIVATE | MAP_ANON, PROT_WRITE | PROT_READ | PROT_EXEC
+        )
+        mm.close()
     except OSError:
         print(
             message.error(

--- a/pwndbg/disasm/__init__.py
+++ b/pwndbg/disasm/__init__.py
@@ -223,7 +223,7 @@ def can_run_first_emulate():
     try:
         from mmap import mmap, MAP_ANON, MAP_PRIVATE, PROT_EXEC, PROT_READ, PROT_WRITE  # isort:skip
 
-        mm = mmap(
+        mm = mmap(  # novm
             -1, 1024 * 1024 * 1024, MAP_PRIVATE | MAP_ANON, PROT_WRITE | PROT_READ | PROT_EXEC
         )
         mm.close()


### PR DESCRIPTION
TL:DR: Unicorn Engine aborts if mmap(1G, RWX) fails, so we are doing a best effort check if we can do such allocation before using it for the first time and if we can't, we disable it.

<!-- Please make sure to read the testing and linting instructions at https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md before creating a PR -->
