### PR TITLE
lint.sh vermin: use -vvv --no-tips

### DIFF
--- a/lint.sh
+++ b/lint.sh
@@ -56,7 +56,7 @@ else
 fi
 
 # Checking minimum python version
-vermin -q -t=3.6 --violations ./pwndbg/
+vermin -vvvv --no-tips -q -t=3.6 --violations ./pwndbg/
 
 flake8 --show-source ${LINT_FILES}
 


### PR DESCRIPTION
Adds `-vvvv --no-tips` to vermin invocation, so on CI instaed of seeing:

```
+ vermin -q -t=3.6 --violations ./pwndbg/
!2, 3.10     /home/runner/work/pwndbg/pwndbg/pwndbg/disasm/__init__.py
  union types as `X | Y` require !2, 3.10
```

We will now see:

```
+ vermin -vvv --no-tips -q -t=3.6 --violations ./pwndbg/
!2, 3.10     ./pwndbg/
Detecting python files..
Analyzing using 16 processes..
!2, 3.10     /home/runner/work/pwndbg/pwndbg/pwndbg/disasm/__init__.py
  L227: union types as `X | Y` require !2, 3.10

Minimum required versions: 3.10
Incompatible versions:     2
Target versions not met:   3.6
```

Making it easier to understand the violation since it will now point to the code line (`L227` above).
