### PR TITLE
lint.sh: vermin -vvv instead of -vvvv

### DIFF
--- a/lint.sh
+++ b/lint.sh
@@ -56,7 +56,7 @@ else
 fi
 
 # Checking minimum python version
-vermin -vvvv --no-tips -q -t=3.6 --violations ./pwndbg/
+vermin -vvv --no-tips -q -t=3.6 --violations ./pwndbg/
 
 flake8 --show-source ${LINT_FILES}
 


### PR DESCRIPTION
My previous commit to this had a typo and used -vvvv instead of -vvv.

The -vvvv is imho a little bit too verbose and we should rather use -vvv only.

<!-- Please make sure to read the testing and linting instructions at https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md before creating a PR -->
