### PR TITLE
WIP: Add sigreturn command

### DIFF
--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -634,6 +634,7 @@ def load_commands() -> None:
     import pwndbg.commands.search
     import pwndbg.commands.segments
     import pwndbg.commands.shell
+    import pwndbg.commands.sigreturn
     import pwndbg.commands.slab
     import pwndbg.commands.stack
     import pwndbg.commands.start

--- a/pwndbg/commands/sigreturn.py
+++ b/pwndbg/commands/sigreturn.py
@@ -1,0 +1,37 @@
+import argparse
+
+import pwndbg.commands
+import pwndbg.gdblib.arch
+import pwndbg.gdblib.memory
+import pwndbg.gdblib.regs
+
+parser = argparse.ArgumentParser(description="")
+
+
+@pwndbg.commands.ArgparsedCommand(parser)
+def sigreturn():
+    mem = pwndbg.gdblib.memory.read(pwndbg.gdblib.regs.rsp, 0x400)
+    for i, reg in enumerate(
+        [
+            "r8",
+            "r9",
+            "r10",
+            "r11",
+            "r12",
+            "r13",
+            "r14",
+            "r15",
+            "rdi",
+            "rsi",
+            "rbp",
+            "rbx",
+            "rdx",
+            "rax",
+            "rcx",
+            "rsp",
+            "rip",
+            "eflags",
+        ]
+    ):
+        offset = 0x28 + i * 8
+        print(reg, hex(pwndbg.gdblib.arch.unpack((mem[offset : offset + 8]))))


### PR DESCRIPTION
A command to dump the `ucontext_t` at the top of the stack, useful for debugging SROP exploits. Still a WIP, but what I'm most confused about is what to call this command. `sigreturn`, `srop`, `ucontext`, or something else?