### PR TITLE
Enhance the checks before accessing the memory for the heap heuristics

### DIFF
--- a/pwndbg/gdblib/memory.py
+++ b/pwndbg/gdblib/memory.py
@@ -114,6 +114,22 @@ def peek(address):
     return None
 
 
+@pwndbg.lib.memoize.reset_on_stop
+def is_readable_address(address):
+    """is_readable_address(address) -> bool
+
+    Check if the address can be read by GDB.
+
+    Arguments:
+        address(int): Address to read
+
+    Returns:
+        :class:`bool`: Whether the address is readable.
+    """
+    # We use vmmap to check before `peek()` because accessing memory for embedded targets might be slow and expensive.
+    return pwndbg.gdblib.vmmap.find(address) is not None and peek(address) is not None
+
+
 def poke(address) -> bool:
     """poke(address)
 

--- a/pwndbg/heap/ptmalloc.py
+++ b/pwndbg/heap/ptmalloc.py
@@ -1401,7 +1401,7 @@ class HeuristicHeap(GlibcMemoryAllocator):
                         tmp_arena = self.malloc_state(addr)
                         try:
                             tmp_next = int(tmp_arena["next"])
-                        except Exception:
+                        except gdb.MemoryError:
                             # the memory after tmp_arena is not valid, stop searching
                             break
                         # check if the `next` pointer of tmp_arena will point to the same address we guess
@@ -1423,7 +1423,7 @@ class HeuristicHeap(GlibcMemoryAllocator):
                                 break
                             try:
                                 tmp_next = int(tmp_arena["next"])
-                            except Exception:
+                            except gdb.MemoryError:
                                 break
                         if found:
                             break

--- a/pwndbg/heap/ptmalloc.py
+++ b/pwndbg/heap/ptmalloc.py
@@ -1410,7 +1410,8 @@ class HeuristicHeap(GlibcMemoryAllocator):
                         # check if the `next` pointer of tmp_arena will point to the same address we guess
                         # e.g. when our process is single-threaded, &tmp_arena->next == &main_arena
                         # when our process is multi-threaded, &tmp_arena->next->...->next == &main_arena
-                        while tmp_next > 0:
+                        while tmp_next > 0 and tmp_next % pwndbg.gdblib.arch.ptrsize == 0:
+                            # tmp_next should align with ptrsize
                             if tmp_next == addr:
                                 self._main_arena_addr = addr
                                 found = True

--- a/tests/gdb-tests/tests/heap/test_heap.py
+++ b/tests/gdb-tests/tests/heap/test_heap.py
@@ -261,13 +261,15 @@ def test_main_arena_heuristic(start_binary):
     pwndbg.heap.current = type(pwndbg.heap.current)()  # Reset the heap object of pwndbg
 
     # Level 3: We check we can get the address of `main_arena` by parsing the memory
-    for _ in range(2):
-        with mock_for_heuristic(mock_all=True):
-            # Check the address of `main_arena` is correct
-            assert pwndbg.heap.current.main_arena.address == main_arena_addr_via_debug_symbol
+    with mock_for_heuristic(mock_all=True):
+        # Check the address of `main_arena` is correct
+        assert pwndbg.heap.current.main_arena.address == main_arena_addr_via_debug_symbol
+        pwndbg.heap.current = type(pwndbg.heap.current)()  # Reset the heap object of pwndbg
+
         # Check if it works when there's more than one arena
         gdb.execute("continue")
         assert gdb.selected_thread().num == 2
+        assert pwndbg.heap.current.main_arena.address == main_arena_addr_via_debug_symbol
 
 
 def test_mp_heuristic(start_binary):

--- a/tests/gdb-tests/tests/heap/test_heap.py
+++ b/tests/gdb-tests/tests/heap/test_heap.py
@@ -6,10 +6,12 @@ import pwndbg.gdblib.arch
 import pwndbg.gdblib.memory
 import pwndbg.gdblib.symbol
 import pwndbg.gdblib.typeinfo
+import pwndbg.gdblib.vmmap
 import pwndbg.glibc
 import pwndbg.heap
 import tests
 from pwndbg.heap.ptmalloc import SymbolUnresolvableError
+from pwndbg.lib.memory import Page
 
 HEAP_MALLOC_CHUNK = tests.binaries.get("heap_malloc_chunk.out")
 
@@ -175,7 +177,9 @@ def test_malloc_chunk_command_heuristic(start_binary):
 
 
 class mock_for_heuristic:
-    def __init__(self, mock_symbols=[], mock_all=False, mess_up_memory=False):
+    def __init__(
+        self, mock_symbols=[], mock_all=False, mess_up_memory=False, test_memory_parsing=False
+    ):
         self.mock_symbols = (
             mock_symbols  # every symbol's address in the list will be mocked to `None`
         )
@@ -187,10 +191,23 @@ class mock_for_heuristic:
         )
         # We mess up the memory in the page of the symbols, to make sure that the heuristic will not succeed by parsing the memory
         self.mess_up_memory = mess_up_memory
+
+        # Some addresses can be found by `pwndbg.gdblib.vmmap.find()`, but it is not a valid memory address to access (e.g. the address in [vsyscall])
+        # This option is to make sure that the heuristic will not affect by this
+        self.test_memory_parsing = test_memory_parsing
+
         if mess_up_memory:
             # Save all the memory before we mess it up
             self.page = pwndbg.heap.current.possible_page_of_symbols
             self.saved_memory = pwndbg.gdblib.memory.read(self.page.vaddr, self.page.memsz)
+        if test_memory_parsing:
+
+            def fake_vmmap_find(addr):
+                # The heuristics should work without vmmap working
+                return Page(0, 0xFFFFFFFFFFFFFFFF, 4, 0, "[deadbeaf]")
+
+            fake_vmmap_find.original = pwndbg.gdblib.vmmap.find
+            pwndbg.gdblib.vmmap.find = fake_vmmap_find
 
     def __enter__(self):
         def mock(original):
@@ -212,6 +229,8 @@ class mock_for_heuristic:
         if self.mess_up_memory:
             # Fill the page with `0xff`
             pwndbg.gdblib.memory.write(self.page.vaddr, b"\xff" * self.page.memsz)
+        if self.test_memory_parsing:
+            pwndbg.gdblib.vmmap.find = pwndbg.gdblib.vmmap.find.original
 
     def __exit__(self, exc_type, exc_value, traceback):
         # Restore `pwndbg.gdblib.symbol.address` and `pwndbg.gdblib.symbol.static_linkage_symbol_address`
@@ -261,7 +280,7 @@ def test_main_arena_heuristic(start_binary):
     pwndbg.heap.current = type(pwndbg.heap.current)()  # Reset the heap object of pwndbg
 
     # Level 3: We check we can get the address of `main_arena` by parsing the memory
-    with mock_for_heuristic(mock_all=True):
+    with mock_for_heuristic(mock_all=True, test_memory_parsing=True):
         # Check the address of `main_arena` is correct
         assert pwndbg.heap.current.main_arena.address == main_arena_addr_via_debug_symbol
         pwndbg.heap.current = type(pwndbg.heap.current)()  # Reset the heap object of pwndbg
@@ -302,7 +321,7 @@ def test_mp_heuristic(start_binary):
     pwndbg.heap.current = type(pwndbg.heap.current)()  # Reset the heap object of pwndbg
 
     # Level 3: We check we can get the address of `mp_` by parsing the memory
-    with mock_for_heuristic(mock_all=True):
+    with mock_for_heuristic(mock_all=True, test_memory_parsing=True):
         # Check the address of `mp_` is correct
         assert pwndbg.heap.current.mp.address == mp_addr_via_debug_symbol
 


### PR DESCRIPTION
We used `pwndbg.gdblib.vmmap.find()` to verify whether some addresses are valid or not in the heap heuristics.
But in some edge cases, it's still possible that an address can be found by vmmap, but still cause an error when we tried to access it.

This can be reproduced by something like this:
```text
pwndbg> ipi

In [1]: pwndbg.gdblib.vmmap.find(0xffffffffff600000)
Out[1]: Page('0xffffffffff600000 0xffffffffff601000 r-xp     1000      0 [vsyscall]')

In [2]: pwndbg.gdblib.memory.byte(0xffffffffff600000)
---------------------------------------------------------------------------
MemoryError                               Traceback (most recent call last)
<ipython-input-2-410a4ed1fe80> in <module>
----> 1 pwndbg.gdblib.memory.byte(0xffffffffff600000)

/ctf/work/pwndbg/pwndbg/gdblib/memory.py in byte(addr)
    162     Read one byte at the specified address
    163     """
--> 164     return readtype(pwndbg.gdblib.typeinfo.uchar, addr)
    165
    166

/ctf/work/pwndbg/pwndbg/gdblib/memory.py in readtype(gdb_type, addr)
     77         :class:`int`
     78     """
---> 79     return int(gdb.Value(addr).cast(gdb_type.pointer()).dereference())
     80
     81

MemoryError: Cannot access memory at address 0xffffffffff600000
```

This PR aims to prevent it and fixes #1542.