### PR TITLE
gdbinit.py: fix message when locales are wrong

### DIFF
--- a/gdbinit.py
+++ b/gdbinit.py
@@ -92,7 +92,9 @@ if encoding != "UTF-8":
     )
     print("You might try launching GDB with:")
     print("    LC_CTYPE=C.UTF-8 gdb")
-    print("If that does not work, make sure that en_US.UTF-8 is uncommented in /etc/locale.gen and that you called `locale-gen` command")
+    print(
+        "If that does not work, make sure that en_US.UTF-8 is uncommented in /etc/locale.gen and that you called `locale-gen` command"
+    )
     print("******")
 
 environ["PWNLIB_NOTERM"] = "1"

--- a/gdbinit.py
+++ b/gdbinit.py
@@ -90,9 +90,9 @@ if encoding != "UTF-8":
             encoding
         )
     )
-    print("You might try launching gdb with:")
-    print("    LC_ALL=en_US.UTF-8 PYTHONIOENCODING=UTF-8 gdb")
-    print("Make sure that en_US.UTF-8 is activated in /etc/locale.gen and you called locale-gen")
+    print("You might try launching GDB with:")
+    print("    LC_CTYPE=C.UTF-8 gdb")
+    print("If that does not work, make sure that en_US.UTF-8 is uncommented in /etc/locale.gen and that you called `locale-gen` command")
     print("******")
 
 environ["PWNLIB_NOTERM"] = "1"


### PR DESCRIPTION
Apparently the suggested solution is not great:

```
nix@33843c903468:~$ locale -a
C
C.UTF-8
POSIX
en_US.utf8
nix@33843c903468:~$ LC_ALL=en_US.UTF-8 PYTHONIOENCODING=UTF-8 pwndbg
/nix/store/qqa28hmysc23yy081d178jfd9a1yk8aw-bash-5.2-p15/bin/bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
******
Your encoding (ANSI_X3.4-1968) is different than UTF-8. pwndbg might not work properly.
You might try launching gdb with:
    LC_ALL=en_US.UTF-8 PYTHONIOENCODING=UTF-8 gdb
Make sure that en_US.UTF-8 is activated in /etc/locale.gen and you called locale-gen
******
pwndbg: loaded 164 pwndbg commands and 42 shell commands. Type pwndbg [--shell | --all] [filter] for a list.
pwndbg: created $rebase, $ida gdb functions (can be used with print/break)
Traceback (most recent call last):
  File "/nix/store/x2yncb885vd33dgigwfwc6qamjxs4d7h-pwndbg-2022.12.19/share/pwndbg/gdbinit.py", line 84, in <module>
    import pwndbg  # noqa: F401
  File "/nix/store/x2yncb885vd33dgigwfwc6qamjxs4d7h-pwndbg-2022.12.19/share/pwndbg/pwndbg/__init__.py", line 113, in <module>
    config_mod.init_params()
  File "/nix/store/x2yncb885vd33dgigwfwc6qamjxs4d7h-pwndbg-2022.12.19/share/pwndbg/pwndbg/gdblib/config.py", line 114, in init_params
    Parameter(p)
  File "/nix/store/x2yncb885vd33dgigwfwc6qamjxs4d7h-pwndbg-2022.12.19/share/pwndbg/pwndbg/gdblib/config.py", line 46, in __init__
    self.value = param.value
UnicodeEncodeError: 'ascii' codec can't encode characters in position 0-1: ordinal not in range(128)
------- tip of the day (disable with set show-tips off) -------
Use the procinfo command for better process introspection (than the GDB's info proc command)
pwndbg>

quit
nix@33843c903468:~$ LC_ALL=C.UTF-8 PYTHONIOENCODING=UTF-8 pwndbg
pwndbg: loaded 164 pwndbg commands and 42 shell commands. Type pwndbg [--shell | --all] [filter] for a list.
pwndbg: created $rebase, $ida gdb functions (can be used with print/break)
------- tip of the day (disable with set show-tips off) -------
Want to display each context panel in a separate tmux window? See https://github.com/pwndbg/pwndbg/blob/dev/FEATURES.md#splitting--layouting-context
pwndbg>

quit
nix@33843c903468:~$ LC_ALL=C.UTF-8 pwndbg
pwndbg: loaded 164 pwndbg commands and 42 shell commands. Type pwndbg [--shell | --all] [filter] for a list.
pwndbg: created $rebase, $ida gdb functions (can be used with print/break)
------- tip of the day (disable with set show-tips off) -------
Use the telescope command to dereference a given address/pointer multiple times (if the dereferenced value is a valid ptr; see config telescope to configure its behavior)
pwndbg>

quit
```

Here is the same on a screenshot:
<img width="1211" alt="image" src="https://user-images.githubusercontent.com/10009354/217663808-87892888-a79a-40dc-b149-184aab66f161.png">

