### PR TITLE
Fix #1572: fsbase/gsbase commands on x86 32-bit archs

### DIFF
--- a/pwndbg/commands/segments.py
+++ b/pwndbg/commands/segments.py
@@ -17,6 +17,7 @@ class segment(gdb.Function):
         return result + arg
 
 
+# TODO/FIXME: This should be defined only for x86 and x86_64
 segment("fsbase")
 segment("gsbase")
 
@@ -25,6 +26,7 @@ segment("gsbase")
     "Prints out the FS base address. See also $fsbase.", category=CommandCategory.REGISTER
 )
 @pwndbg.commands.OnlyWhenRunning
+@pwndbg.commands.OnlyWithArch(["i386", "x86-64"])
 def fsbase() -> None:
     """
     Prints out the FS base address. See also $fsbase.
@@ -36,6 +38,7 @@ def fsbase() -> None:
     "Prints out the GS base address. See also $gsbase.", category=CommandCategory.REGISTER
 )
 @pwndbg.commands.OnlyWhenRunning
+@pwndbg.commands.OnlyWithArch(["i386", "x86-64"])
 def gsbase() -> None:
     """
     Prints out the GS base address. See also $gsbase.

--- a/pwndbg/gdblib/regs.py
+++ b/pwndbg/gdblib/regs.py
@@ -194,7 +194,7 @@ class module(ModuleType):
 
         # For GDB >= 8.x we can use get_register directly
         # Elsewhere we have to get the register via ptrace
-        if get_register == gdb79_get_register:
+        if pwndbg.gdblib.arch.current == "x86-64" and get_register == gdb79_get_register:
             return get_register(regname)
 
         # We can't really do anything if the process is remote.


### PR DESCRIPTION
Before this fix, when we compiled a 32-bit prgoram a 'Bad register' bug would show up on `fsbase` and `gsbase` commands.

Also, those commands weren't protected to not be executed on another archs, which this commit fixes.

Additionally, this commit introduces 4 tests:
```
test_commands_segments[gsbase-gosample.x64]                            PASSED
test_commands_segments[gsbase-gosample.x86]                            PASSED
test_commands_segments[fsbase-gosample.x64]                            PASSED
test_commands_segments[fsbase-gosample.x86]                            PASSED
```

Two of those tests, the ones with x86 binaries, applied without other changes would fail.

<!-- Please make sure to read the testing and linting instructions at https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md before creating a PR -->
