### PR TITLE
Support using the `rich` module to print the full stacktrace

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -17,3 +17,5 @@ types-psutil==5.9.5
 types-Pygments==2.12.1
 types-tabulate==0.9.0.0
 vermin==1.5.1
+rich==12.6.0; python_version < '3.7'
+rich==13.3.1; python_version >= '3.7'

--- a/pwndbg/exception.py
+++ b/pwndbg/exception.py
@@ -14,6 +14,12 @@ with pwndbg.lib.stdio.stdio:
         import ipdb as pdb
     except ImportError:
         import pdb  # type: ignore
+    try:
+        from rich.console import Console
+
+        _rich_console = Console()
+    except ImportError:
+        _rich_console = None
 
 verbose = config.add_param(
     "exception-verbose",
@@ -71,7 +77,10 @@ def handle(name="Error"):
     # Display the error
     if debug or verbose:
         exception_msg = traceback.format_exc()
-        print(exception_msg)
+        if _rich_console:
+            _rich_console.print_exception()
+        else:
+            print(exception_msg)
         inform_report_issue(exception_msg)
 
     else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ module = [
 disable_error_code = ["name-defined"]
 
 [[tool.mypy.overrides]]
-module = ["capstone.*", "unicorn.*", "pwnlib.*", "elftools.*", "ipdb.*", "r2pipe", "rzpipe", "pt"]
+module = ["capstone.*", "unicorn.*", "pwnlib.*", "elftools.*", "ipdb.*", "r2pipe", "rzpipe", "rich.*", "pt"]
 ignore_missing_imports = true
 
 [tool.isort]


### PR DESCRIPTION
~Create a new option, `exception-use-rich`, to~ use the `rich` module to print the full stacktrace
(Use `rich.console.Console().print_exception()`)

With ~`set exception-use-rich` +~ `set exception-verbose`:

<img width="1310" alt="screenshot" src="https://user-images.githubusercontent.com/61896187/218421372-497f3e5c-62c9-4653-b817-707b7e64b0b3.png">

Edit: Will always use `rich` if it's available, and `rich` is been added to `dev-requirements.txt` now.