### PR TITLE
Rewrite some unreliable methods for the heap heuristics

### DIFF
--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -367,15 +367,11 @@ def _try2run_heap_command(function, a, kw):
             w(
                 "You are probably debugging a multi-threaded target without debug symbols, so we failed to determine which arena is used by the current thread.\n"
                 "To resolve this issue, you can use the `arenas` command to list all arenas, and use `set thread-arena <addr>` to set the current thread's arena address you think is correct.\n"
-                "If you want to know which exact arena is used by the current thread, you can use the `tls` command to get the thread-local storage address, and then use `search -p <arena_addr>` to find which arena's address is in your thread-local storage.\n"
-                "(If none of the arenas' address is in your thread-local storage, that's probably because the current thread doesn't allocate the arena)\n"
-                "Using `arena <addr>` to check the `attached_threads` field of the arena is also a way that can help you to determine which arena is used by the current thread."
             )
             if pwndbg.heap.current.has_tcache():
                 w(
                     "Please also notice, pwndbg will assume the tcache is at the first chunk of the arena if the `tcache` symbol does not present, so when the arena is been shared by multiple threads, the result might be wrong.\n"
                     "To resolve this, you can use `set tcache <addr>` to set the tcache structure's address manually if this problem occurs.\n"
-                    "The address of tcache should also inside your thread-local storage, so you can use the `search -p <address>` to find which chunk's address is in your thread-local storage."
                 )
         else:
             w(

--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -366,6 +366,10 @@ def _try2run_heap_command(function, a, kw):
         w(
             f"You can try to determine the libc symbols addresses manually and set them appropriately. For this, see the `heap_config` command output and set the config about `{err.symbol}`."
         )
+        if "thread_arena" == err.symbol:
+            w(
+                "You can use `arenas` command to see all the arenas, and use `set thread_arena <addr>` to set it manually."
+            )
         if pwndbg.gdblib.config.exception_verbose or pwndbg.gdblib.config.exception_debugger:
             raise err
         else:

--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -363,12 +363,23 @@ def _try2run_heap_command(function, a, kw):
         return function(*a, **kw)
     except SymbolUnresolvableError as err:
         e(f"{function.__name__}: Fail to resolve the symbol: `{err.symbol}`")
-        w(
-            f"You can try to determine the libc symbols addresses manually and set them appropriately. For this, see the `heap_config` command output and set the config about `{err.symbol}`."
-        )
         if "thread_arena" == err.symbol:
             w(
-                "You can use `arenas` command to see all the arenas, and use `set thread_arena <addr>` to set it manually."
+                "You are probably debugging a multi-threaded target without debug symbols, so we failed to determine which arena is used by the current thread.\n"
+                "To resolve this issue, you can use the `arenas` command to list all arenas, and use `set thread-arena <addr>` to set the current thread's arena address you think is correct.\n"
+                "If you want to know which exact arena is used by the current thread, you can use the `tls` command to get the thread-local storage address, and then use `search -p <arena_addr>` to find which arena's address is in your thread-local storage.\n"
+                "(If none of the arenas' address is in your thread-local storage, that's probably because the current thread doesn't allocate the arena)\n"
+                "Using `arena <addr>` to check the `attached_threads` field of the arena is also a way that can help you to determine which arena is used by the current thread."
+            )
+            if pwndbg.heap.current.has_tcache():
+                w(
+                    "Please also notice, pwndbg will assume the tcache is at the first chunk of the arena if the `tcache` symbol does not present, so when the arena is been shared by multiple threads, the result might be wrong.\n"
+                    "To resolve this, you can use `set tcache <addr>` to set the tcache structure's address manually if this problem occurs.\n"
+                    "The address of tcache should also inside your thread-local storage, so you can use the `search -p <address>` to find which chunk's address is in your thread-local storage."
+                )
+        else:
+            w(
+                f"You can try to determine the libc symbols addresses manually and set them appropriately. For this, see the `heap_config` command output and set the config about `{err.symbol}`."
             )
         if pwndbg.gdblib.config.exception_verbose or pwndbg.gdblib.config.exception_debugger:
             raise err

--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -370,7 +370,7 @@ def _try2run_heap_command(function, a, kw):
             )
         else:
             w(
-                f"You can try to determine the libc symbols addresses manually and set them appropriately. For this, see the `heap_config` command output and set the config about `{err.symbol}`."
+                f"You can try to determine the libc symbols addresses manually and set them appropriately. For this, see the `heap_config` command output and set the config for `{err.symbol}`."
             )
         if pwndbg.gdblib.config.exception_verbose or pwndbg.gdblib.config.exception_debugger:
             raise err

--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -368,11 +368,6 @@ def _try2run_heap_command(function, a, kw):
                 "You are probably debugging a multi-threaded target without debug symbols, so we failed to determine which arena is used by the current thread.\n"
                 "To resolve this issue, you can use the `arenas` command to list all arenas, and use `set thread-arena <addr>` to set the current thread's arena address you think is correct.\n"
             )
-            if pwndbg.heap.current.has_tcache():
-                w(
-                    "Please also notice, pwndbg will assume the tcache is at the first chunk of the arena if the `tcache` symbol does not present, so when the arena is been shared by multiple threads, the result might be wrong.\n"
-                    "To resolve this, you can use `set tcache <addr>` to set the tcache structure's address manually if this problem occurs.\n"
-                )
         else:
             w(
                 f"You can try to determine the libc symbols addresses manually and set them appropriately. For this, see the `heap_config` command output and set the config about `{err.symbol}`."

--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -168,6 +168,11 @@ def arena(addr=None) -> None:
         arena = Arena(addr)
     else:
         arena = allocator.thread_arena
+        # arena might be None if the current thread doesn't allocate the arena
+        if arena is None:
+            print(message.notice("No arena found for current thread."))
+            return
+        print(message.notice("current thread's arena at: ") + message.hint(hex(arena.address)))
 
     tid = pwndbg.gdblib.proc.thread_id
     print(message.hint(f"Arena for thread {tid}:"))
@@ -226,6 +231,7 @@ parser = argparse.ArgumentParser(description="Print the mp_ struct's contents.")
 def mp() -> None:
     """Print the mp_ struct's contents."""
     allocator = pwndbg.heap.current
+    print(message.notice("mp_ struct at: ") + message.hint(hex(allocator.mp.address)))
     print(allocator.mp)
 
 

--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -193,7 +193,7 @@ def arenas() -> None:
     print("main_arena:")
     print(arenas[0])
     if arenas[1:]:
-        print("thread arenas:")
+        print("non-main arena:")
         for arena in arenas[1:]:
             print(arena)
 

--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -143,7 +143,11 @@ def heap(addr=None, verbose=False, simple=False) -> None:
         arena = allocator.thread_arena
         # arena might be None if the current thread doesn't allocate the arena
         if arena is None:
-            print(message.notice("No arena found for current thread (the thread hasn't performed any allocations)."))
+            print(
+                message.notice(
+                    "No arena found for current thread (the thread hasn't performed any allocations)."
+                )
+            )
             return
         h = arena.active_heap
 
@@ -175,7 +179,11 @@ def arena(addr=None) -> None:
         tid = pwndbg.gdblib.proc.thread_id
         # arena might be None if the current thread doesn't allocate the arena
         if arena is None:
-            print(message.notice(f"No arena found for thread {message.hint(tid)} (the thread hasn't performed any allocations)."))
+            print(
+                message.notice(
+                    f"No arena found for thread {message.hint(tid)} (the thread hasn't performed any allocations)."
+                )
+            )
             return
         print(
             message.notice(
@@ -273,7 +281,11 @@ def top_chunk(addr=None) -> None:
         arena = allocator.thread_arena
         # arena might be None if the current thread doesn't allocate the arena
         if arena is None:
-            print(message.notice("No arena found for current thread (the thread hasn't performed any allocations)"))
+            print(
+                message.notice(
+                    "No arena found for current thread (the thread hasn't performed any allocations)"
+                )
+            )
             return
 
     malloc_chunk(arena.top)
@@ -701,7 +713,11 @@ def vis_heap_chunks(addr=None, count=None, naive=None, display_all=None) -> None
         arena = allocator.thread_arena
         # arena might be None if the current thread doesn't allocate the arena
         if arena is None:
-            print(message.notice("No arena found for current thread (the thread hasn't performed any allocations)"))
+            print(
+                message.notice(
+                    "No arena found for current thread (the thread hasn't performed any allocations)"
+                )
+            )
             return
         heap_region = arena.active_heap
         cursor = heap_region.start
@@ -885,7 +901,11 @@ def try_free(addr) -> None:
     arena = allocator.thread_arena
     # arena might be None if the current thread doesn't allocate the arena
     if arena is None:
-        print(message.notice("No arena found for current thread (the thread hasn't performed any allocations)"))
+        print(
+            message.notice(
+                "No arena found for current thread (the thread hasn't performed any allocations)"
+            )
+        )
         return
 
     aligned_lsb = allocator.malloc_align_mask.bit_length()

--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -141,6 +141,10 @@ def heap(addr=None, verbose=False, simple=False) -> None:
             chunk = chunk.next_chunk()
     else:
         arena = allocator.thread_arena
+        # arena might be None if the current thread doesn't allocate the arena
+        if arena is None:
+            print(message.notice("No arena found for current thread."))
+            return
         h = arena.active_heap
 
         for chunk in h:
@@ -264,6 +268,10 @@ def top_chunk(addr=None) -> None:
         arena = Arena(addr)
     else:
         arena = allocator.thread_arena
+        # arena might be None if the current thread doesn't allocate the arena
+        if arena is None:
+            print(message.notice("No arena found for current thread."))
+            return
 
     malloc_chunk(arena.top)
 
@@ -688,6 +696,10 @@ def vis_heap_chunks(addr=None, count=None, naive=None, display_all=None) -> None
         arena = heap_region.arena
     else:
         arena = allocator.thread_arena
+        # arena might be None if the current thread doesn't allocate the arena
+        if arena is None:
+            print(message.notice("No arena found for current thread."))
+            return
         heap_region = arena.active_heap
         cursor = heap_region.start
 
@@ -868,6 +880,10 @@ def try_free(addr) -> None:
     # constants
     allocator = pwndbg.heap.current
     arena = allocator.thread_arena
+    # arena might be None if the current thread doesn't allocate the arena
+    if arena is None:
+        print(message.notice("No arena found for current thread."))
+        return
 
     aligned_lsb = allocator.malloc_align_mask.bit_length()
     size_sz = allocator.size_sz

--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -885,7 +885,7 @@ def try_free(addr) -> None:
     arena = allocator.thread_arena
     # arena might be None if the current thread doesn't allocate the arena
     if arena is None:
-        print(message.notice("No arena found for current thread."))
+        print(message.notice("No arena found for current thread (the thread hasn't performed any allocations)"))
         return
 
     aligned_lsb = allocator.malloc_align_mask.bit_length()

--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -218,7 +218,13 @@ def tcache(addr=None) -> None:
     """
     allocator = pwndbg.heap.current
     tcache = allocator.get_tcache(addr)
-    print(tcache)
+    # if the current thread doesn't allocate the arena, tcache will be NULL
+    print(
+        message.notice("tcache is pointing to: ")
+        + message.hint(hex(tcache.address) if tcache else "NULL")
+    )
+    if tcache:
+        print(tcache)
 
 
 parser = argparse.ArgumentParser(description="Print the mp_ struct's contents.")
@@ -306,7 +312,6 @@ def malloc_chunk(addr, fake=False, verbose=False, simple=False) -> None:
                 headers_to_print.append(message.off("Top chunk"))
 
         if not chunk.is_top_chunk and arena:
-
             bins_list = [
                 allocator.fastbins(arena.address),
                 allocator.smallbins(arena.address),

--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -143,7 +143,7 @@ def heap(addr=None, verbose=False, simple=False) -> None:
         arena = allocator.thread_arena
         # arena might be None if the current thread doesn't allocate the arena
         if arena is None:
-            print(message.notice("No arena found for current thread."))
+            print(message.notice("No arena found for current thread (the thread hasn't performed any allocations)."))
             return
         h = arena.active_heap
 

--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -175,7 +175,7 @@ def arena(addr=None) -> None:
         tid = pwndbg.gdblib.proc.thread_id
         # arena might be None if the current thread doesn't allocate the arena
         if arena is None:
-            print(message.notice(f"No arena found for thread {message.hint(tid)}."))
+            print(message.notice(f"No arena found for thread {message.hint(tid)} (the thread hasn't performed any allocations)."))
             return
         print(
             message.notice(

--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -1220,6 +1220,6 @@ def heap_config(filter_pattern) -> None:
 
     print(
         message.hint(
-            "Some config(e.g. main_arena) will only working when resolve-heap-via-heuristic is `True`"
+            "Some config(e.g. main_arena) will only working when resolve-heap-via-heuristic is `auto` or `force`"
         )
     )

--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -184,8 +184,13 @@ parser = argparse.ArgumentParser(description="List this process's arenas.")
 def arenas() -> None:
     """Lists this process's arenas."""
     allocator = pwndbg.heap.current
-    for ar in allocator.arenas:
-        print(ar)
+    arenas = allocator.arenas
+    print("main_arena:")
+    print(arenas[0])
+    if arenas[1:]:
+        print("thread arenas:")
+        for arena in arenas[1:]:
+            print(arena)
 
 
 parser = argparse.ArgumentParser(

--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -701,7 +701,7 @@ def vis_heap_chunks(addr=None, count=None, naive=None, display_all=None) -> None
         arena = allocator.thread_arena
         # arena might be None if the current thread doesn't allocate the arena
         if arena is None:
-            print(message.notice("No arena found for current thread."))
+            print(message.notice("No arena found for current thread (the thread hasn't performed any allocations)"))
             return
         heap_region = arena.active_heap
         cursor = heap_region.start

--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -273,7 +273,7 @@ def top_chunk(addr=None) -> None:
         arena = allocator.thread_arena
         # arena might be None if the current thread doesn't allocate the arena
         if arena is None:
-            print(message.notice("No arena found for current thread."))
+            print(message.notice("No arena found for current thread (the thread hasn't performed any allocations)"))
             return
 
     malloc_chunk(arena.top)

--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -1250,6 +1250,6 @@ def heap_config(filter_pattern) -> None:
 
     print(
         message.hint(
-            "Some config(e.g. main_arena) will only working when resolve-heap-via-heuristic is `auto` or `force`"
+            "Some config values (e.g. main_arena) will be used only when resolve-heap-via-heuristic is `auto` or `force`"
         )
     )

--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -172,14 +172,17 @@ def arena(addr=None) -> None:
         arena = Arena(addr)
     else:
         arena = allocator.thread_arena
+        tid = pwndbg.gdblib.proc.thread_id
         # arena might be None if the current thread doesn't allocate the arena
         if arena is None:
-            print(message.notice("No arena found for current thread."))
+            print(message.notice(f"No arena found for thread {message.hint(tid)}."))
             return
-        print(message.notice("current thread's arena at: ") + message.hint(hex(arena.address)))
+        print(
+            message.notice(
+                f"Arena for thread {message.hint(tid)} is located at: {message.hint(hex(arena.address))}"
+            )
+        )
 
-    tid = pwndbg.gdblib.proc.thread_id
-    print(message.hint(f"Arena for thread {tid}:"))
     print(arena._gdbValue)  # Breaks encapsulation, find a better way.
 
 

--- a/pwndbg/commands/tls.py
+++ b/pwndbg/commands/tls.py
@@ -1,21 +1,45 @@
 """
 Command to print the information of the current Thread Local Storage (TLS).
 """
+import argparse
 
 import pwndbg.commands
 import pwndbg.gdblib.tls
 from pwndbg.color import message
 from pwndbg.commands import CommandCategory
 
-
-@pwndbg.commands.ArgparsedCommand(
-    "Print out base address of the current Thread Local Storage (TLS).",
-    category=CommandCategory.LINUX,
+parser = argparse.ArgumentParser(
+    formatter_class=argparse.RawTextHelpFormatter,
+    description="Print out base address of the current Thread Local Storage (TLS).",
 )
+
+parser.add_argument(
+    "-p",
+    "--pthread-self",
+    action="store_true",
+    default=False,
+    help="Try to get the address of TLS by calling pthread_self().",
+)
+
+
+@pwndbg.commands.ArgparsedCommand(parser, category=CommandCategory.LINUX)
 @pwndbg.commands.OnlyWhenRunning
-def tls() -> None:
-    tls_base = pwndbg.gdblib.tls.address
-    if tls_base:
+def tls(pthread_self=False) -> None:
+    tls_base = (
+        pwndbg.gdblib.tls.find_address_with_register()
+        if not pthread_self
+        else pwndbg.gdblib.tls.find_address_with_pthread_self()
+    )
+    if pwndbg.gdblib.memory.is_readable_address(tls_base):
         print(message.success("Thread Local Storage (TLS) base: %#x" % tls_base))
-    else:
-        print(message.error("Couldn't find Thread Local Storage (TLS) base."))
+        print(message.success("TLS is located at:"))
+        print(message.notice(pwndbg.gdblib.vmmap.find(tls_base)))
+        return
+    print(message.error("Couldn't find Thread Local Storage (TLS) base."))
+    if not pthread_self:
+        print(
+            message.notice(
+                "You can try to use -p/--pthread option to get the address of TLS by calling pthread_self().\n"
+                "(This might cause problems if the pthread_self() is not in libc or not initialized yet.)"
+            )
+        )

--- a/pwndbg/gdblib/elf.py
+++ b/pwndbg/gdblib/elf.py
@@ -11,6 +11,8 @@ import importlib
 import sys
 from collections import namedtuple
 from typing import List
+from typing import Optional
+from typing import Tuple
 
 import gdb
 from elftools.elf.constants import SH_FLAGS
@@ -169,6 +171,19 @@ def get_containing_sections(elf_filepath, elf_loadaddr, vaddr):
             continue
         sections.append(dict(sec))
     return sections
+
+
+def dump_section_by_name(filepath: str, section_name: str) -> Optional[Tuple[int, int, bytes]]:
+    """
+    Dump the content of a section from an ELF file, return the start address, size and content.
+    """
+    # TODO: We should have some cache mechanism or something at `pndbg.gdblib.file.get_file()` in the future to avoid downloading the same file multiple times when we are debugging a remote process
+    local_path = pwndbg.gdblib.file.get_file(filepath)
+
+    with open(local_path, "rb") as f:
+        elffile = ELFFile(f)
+        section = elffile.get_section_by_name(section_name)
+        return (section["sh_addr"], section["sh_size"], section.data()) if section else None
 
 
 @pwndbg.gdblib.proc.OnlyWhenRunning

--- a/pwndbg/gdblib/file.py
+++ b/pwndbg/gdblib/file.py
@@ -46,7 +46,9 @@ def get_file(path: str) -> str:
     Returns:
         The local path to the file
     """
-    assert path.startswith("/") or path.startswith("target:"), "get_file called with incorrect path"
+    assert path.startswith(("/", "./")) or path.startswith(
+        "target:"
+    ), "get_file called with incorrect path"
 
     if path.startswith("target:"):
         path = path[7:]  # len('target:') == 7

--- a/pwndbg/gdblib/proc.py
+++ b/pwndbg/gdblib/proc.py
@@ -13,7 +13,6 @@ from typing import Optional
 from typing import Tuple
 
 import gdb
-from elftools.elf.elffile import ELFFile
 
 import pwndbg.gdblib.qemu
 import pwndbg.lib.memoize
@@ -111,13 +110,7 @@ class module(ModuleType):
         """
         Dump .data section of current process's ELF file
         """
-        local_path = pwndbg.gdblib.file.get_file(pwndbg.gdblib.proc.exe)
-        with open(local_path, "rb") as f:
-            elffile = ELFFile(f)
-            section = elffile.get_section_by_name(".data")
-            if section:
-                return section["sh_addr"], section["sh_size"], section.data()
-        return None
+        return pwndbg.gdblib.elf.dump_section_by_name(self.exe, ".data")
 
     @pwndbg.lib.memoize.reset_on_start
     @pwndbg.lib.memoize.reset_on_objfile

--- a/pwndbg/gdblib/proc.py
+++ b/pwndbg/gdblib/proc.py
@@ -131,6 +131,18 @@ class module(ModuleType):
                 return int(line.split()[0], 16)
         return 0
 
+    @pwndbg.lib.memoize.reset_on_start
+    @pwndbg.lib.memoize.reset_on_objfile
+    def get_got_section_address(self) -> int:
+        """
+        Find .got section address of current process.
+        """
+        out = pwndbg.gdblib.info.files()
+        for line in out.splitlines():
+            if line.endswith(" is .got"):
+                return int(line.split()[0], 16)
+        return 0
+
     def OnlyWhenRunning(self, func):
         @functools.wraps(func)
         def wrapper(*a, **kw):

--- a/pwndbg/glibc.py
+++ b/pwndbg/glibc.py
@@ -9,8 +9,10 @@ from typing import Optional
 from typing import Tuple
 
 import gdb
+from elftools.elf.elffile import ELFFile
 
 import pwndbg.gdblib.config
+import pwndbg.gdblib.file
 import pwndbg.gdblib.info
 import pwndbg.gdblib.memory
 import pwndbg.gdblib.proc
@@ -29,6 +31,8 @@ safe_lnk = pwndbg.gdblib.config.add_param(
 glibc_version = pwndbg.gdblib.config.add_param(
     "glibc", "", "GLIBC version for heuristics", scope="heap"
 )
+
+libc_path = None
 
 
 @pwndbg.gdblib.proc.OnlyWhenRunning
@@ -71,6 +75,27 @@ def get_libc_filename_from_info_sharedlibrary() -> Optional[str]:
         # Is it possible that the libc is not called `libc.so.6`?
         if os.path.basename(filename) == "libc.so.6":
             return filename
+    return None
+
+
+@pwndbg.gdblib.proc.OnlyWhenRunning
+def dump_elf_data_section() -> Optional[Tuple[int, int, bytes]]:
+    """
+    Dump .data section of libc ELF file
+    """
+    global libc_path
+    if not libc_path:
+        libc_filename = get_libc_filename_from_info_sharedlibrary()
+        if not libc_filename:
+            # libc not loaded yet, or it's static linked
+            return None
+        libc_path = pwndbg.gdblib.file.get_file(libc_filename)
+    with open(libc_path, "rb") as f:
+        elffile = ELFFile(f)
+        section = elffile.get_section_by_name(".data")
+        if section:
+            return section["sh_addr"], section["sh_size"], section.data()
+    return None
 
 
 @pwndbg.gdblib.proc.OnlyWhenRunning
@@ -111,3 +136,9 @@ def check_safe_linking():
     - https://research.checkpoint.com/2020/safe-linking-eliminating-a-20-year-old-malloc-exploit-primitive/
     """
     return (get_version() >= (2, 32) or safe_lnk) and safe_lnk is not False
+
+
+@pwndbg.gdblib.events.start
+def reset():
+    global libc_path
+    libc_path = None

--- a/pwndbg/glibc.py
+++ b/pwndbg/glibc.py
@@ -117,6 +117,25 @@ def get_data_section_address() -> int:
     return 0
 
 
+@pwndbg.gdblib.proc.OnlyWhenRunning
+@pwndbg.lib.memoize.reset_on_start
+@pwndbg.lib.memoize.reset_on_objfile
+def get_got_section_address() -> int:
+    """
+    Find .got section address of libc
+    """
+    libc_filename = get_libc_filename_from_info_sharedlibrary()
+    if not libc_filename:
+        # libc not loaded yet, or it's static linked
+        return 0
+    # TODO: If we are debugging a remote process, this might not work if GDB cannot load the so file
+    out = pwndbg.gdblib.info.files()
+    for line in out.splitlines():
+        if line.endswith(" is .got in " + libc_filename):
+            return int(line.split()[0], 16)
+    return 0
+
+
 def OnlyWhenGlibcLoaded(function):
     @functools.wraps(function)
     def _OnlyWhenGlibcLoaded(*a, **kw):

--- a/pwndbg/heap/__init__.py
+++ b/pwndbg/heap/__init__.py
@@ -22,15 +22,15 @@ def add_heap_param(
     )
 
 
-main_arena = add_heap_param("main-arena", "0", "&main_arena for heuristics")
+main_arena = add_heap_param("main-arena", "0", "the address of main_arena")
 
-thread_arena = add_heap_param("thread-arena", "0", "*thread_arena for heuristics")
+thread_arena = add_heap_param("thread-arena", "0", "the address pointed by thread_arena")
 
-mp_ = add_heap_param("mp", "0", "&mp_ for heuristics")
+mp_ = add_heap_param("mp", "0", "the address of mp_")
 
-tcache = add_heap_param("tcache", "0", "*tcache for heuristics")
+tcache = add_heap_param("tcache", "0", "the address pointed by tcache")
 
-global_max_fast = add_heap_param("global-max-fast", "0", "&global_max_fast for heuristics")
+global_max_fast = add_heap_param("global-max-fast", "0", "the address of global_max_fast")
 
 symbol_list = [main_arena, thread_arena, mp_, tcache, global_max_fast]
 

--- a/pwndbg/heap/ptmalloc.py
+++ b/pwndbg/heap/ptmalloc.py
@@ -1495,7 +1495,7 @@ class HeuristicHeap(GlibcMemoryAllocator):
             else:
                 raise ValueError("mp_.sbrk_base is unmapped or points to unmapped memory.")
         else:
-            raise SymbolUnresolvableError("Unable to resolve mp_ struct via heuristics.")
+            raise SymbolUnresolvableError("mp_")
 
     def is_initialized(self):
         # TODO/FIXME: If main_arena['top'] is been modified to 0, this will not work.

--- a/pwndbg/heap/ptmalloc.py
+++ b/pwndbg/heap/ptmalloc.py
@@ -1144,8 +1144,10 @@ class DebugSymsHeap(GlibcMemoryAllocator):
                     pwndbg.gdblib.symbol.static_linkage_symbol_address("tcache")
                     or pwndbg.gdblib.symbol.address("tcache")
                 )
-                if tcache_addr != 0:
-                    tcache = tcache_addr
+                if tcache_addr == 0:
+                    # This thread doesn't have a tcache yet
+                    return None
+                tcache = tcache_addr
 
             try:
                 self._thread_cache = pwndbg.gdblib.memory.poi(self.tcache_perthread_struct, tcache)

--- a/pwndbg/heap/ptmalloc.py
+++ b/pwndbg/heap/ptmalloc.py
@@ -1280,10 +1280,13 @@ class HeuristicHeap(GlibcMemoryAllocator):
         if main_arena_via_config or main_arena_via_symbol:
             self._main_arena_addr = main_arena_via_config or main_arena_via_symbol
 
-        if not self._main_arena_addr and not self.is_statically_linked():
-            # TODO: Support statically linked GLIBC
-            section = pwndbg.glibc.dump_elf_data_section()
-            section_address = pwndbg.glibc.get_data_section_address()
+        if not self._main_arena_addr:
+            if self.is_statically_linked():
+                section = pwndbg.gdblib.proc.dump_elf_data_section()
+                section_address = pwndbg.gdblib.proc.get_data_section_address()
+            else:
+                section = pwndbg.glibc.dump_elf_data_section()
+                section_address = pwndbg.glibc.get_data_section_address()
             if section and section_address:
                 data_section_offset, size, data = section
 
@@ -1380,10 +1383,13 @@ class HeuristicHeap(GlibcMemoryAllocator):
         if mp_via_config or mp_via_symbol:
             self._mp_addr = mp_via_symbol
 
-        if not self._mp_addr and not self.is_statically_linked():
-            # TODO: Support statically linked GLIBC
-            section = pwndbg.glibc.dump_elf_data_section()
-            section_address = pwndbg.glibc.get_data_section_address()
+        if not self._mp_addr:
+            if self.is_statically_linked():
+                section = pwndbg.gdblib.proc.dump_elf_data_section()
+                section_address = pwndbg.gdblib.proc.get_data_section_address()
+            else:
+                section = pwndbg.glibc.dump_elf_data_section()
+                section_address = pwndbg.glibc.get_data_section_address()
             if section and section_address:
                 _, _, data = section
 

--- a/pwndbg/heap/ptmalloc.py
+++ b/pwndbg/heap/ptmalloc.py
@@ -1416,7 +1416,21 @@ class HeuristicHeap(GlibcMemoryAllocator):
             self._global_max_fast = pwndbg.gdblib.memory.u(self._global_max_fast_addr)
             return self._global_max_fast
 
-        raise SymbolUnresolvableError("global_max_fast")
+        # https://elixir.bootlin.com/glibc/glibc-2.37/source/malloc/malloc.c#L836
+        # https://elixir.bootlin.com/glibc/glibc-2.37/source/malloc/malloc.c#L1773
+        # https://elixir.bootlin.com/glibc/glibc-2.37/source/malloc/malloc.c#L1953
+        default = (64 * self.size_sz // 4 + self.size_sz) & ~self.malloc_align_mask
+        print(
+            message.warn(
+                "global_max_fast symbol not found, using the default value: 0x%x" % default
+            )
+        )
+        print(
+            message.warn(
+                "Use `set global-max-fast <address>` to set the address of global_max_fast manually if needed."
+            )
+        )
+        return default
 
     @property
     @pwndbg.lib.memoize.reset_on_objfile

--- a/pwndbg/heap/ptmalloc.py
+++ b/pwndbg/heap/ptmalloc.py
@@ -1278,9 +1278,9 @@ class HeuristicHeap(GlibcMemoryAllocator):
     @property
     def possible_page_of_symbols(self):
         if self._possible_page_of_symbols is None:
-            if pwndbg.glibc.get_data_address() > 0:
+            if pwndbg.glibc.get_data_section_address() > 0:
                 self._possible_page_of_symbols = pwndbg.gdblib.vmmap.find(
-                    pwndbg.glibc.get_data_address()
+                    pwndbg.glibc.get_data_section_address()
                 )
             elif pwndbg.gdblib.symbol.address("_IO_list_all"):
                 self._possible_page_of_symbols = pwndbg.gdblib.vmmap.find(

--- a/pwndbg/heap/ptmalloc.py
+++ b/pwndbg/heap/ptmalloc.py
@@ -629,8 +629,7 @@ class Arena:
     def __str__(self) -> str:
         prefix = "[%%%ds]    " % (pwndbg.gdblib.arch.ptrsize * 2)
         prefix_len = len(prefix % (""))
-        arena_name = "main" if self.is_main_arena else hex(self.address)
-        res = [message.hint(prefix % (arena_name)) + str(self.heaps[0])]
+        res = [message.hint(prefix % hex(self.address)) + str(self.heaps[0])]
         for h in self.heaps[1:]:
             res.append(" " * prefix_len + str(h))
 

--- a/pwndbg/heap/ptmalloc.py
+++ b/pwndbg/heap/ptmalloc.py
@@ -1125,10 +1125,12 @@ class DebugSymsHeap(GlibcMemoryAllocator):
             thread_arena_addr = pwndbg.gdblib.symbol.static_linkage_symbol_address(
                 "thread_arena"
             ) or pwndbg.gdblib.symbol.address("thread_arena")
-            if thread_arena_addr is not None and thread_arena_addr != 0:
-                return Arena(pwndbg.gdblib.memory.pvoid(thread_arena_addr))
-            else:
-                return None
+            if thread_arena_addr:
+                thread_arena_value = pwndbg.gdblib.memory.pvoid(thread_arena_addr)
+                # thread_arena might be NULL if the thread doesn't allocate arena yet
+                if thread_arena_value:
+                    return Arena(pwndbg.gdblib.memory.pvoid(thread_arena_addr))
+            return None
         else:
             return self.main_arena
 

--- a/tests/gdb-tests/tests/binaries/makefile
+++ b/tests/gdb-tests/tests/binaries/makefile
@@ -93,6 +93,20 @@ heap_malloc_chunk.out: heap_malloc_chunk.c
 	@echo "[+] Building heap_malloc_chunk.out"
 	${CC} -g -O0 -Wno-nonnull -Wno-unused-result -o heap_malloc_chunk.out heap_malloc_chunk.c -pthread -lpthread
 
+tls.x86-64.out: tls.x86-64.c
+	@echo "[+] Building tls.x86-64.c"
+	${ZIGCC} \
+	${CFLAGS} \
+	-target x86_64-linux-gnu \
+	-o tls.x86-64.out tls.x86-64.c
+
+tls.i386.out: tls.i386.c
+	@echo "[+] Building tls.i386.c"
+	${ZIGCC} \
+	${CFLAGS} \
+	-target i386-linux-gnu \
+	-o tls.i386.out tls.i386.c
+
 clean :
 	@echo "[+] Cleaning stuff"
 	@rm -f $(COMPILED) $(LINKED) $(COMPILED_ASM) $(LINKED_ASM) $(COMPILED_GO)

--- a/tests/gdb-tests/tests/binaries/tls.i386.c
+++ b/tests/gdb-tests/tests/binaries/tls.i386.c
@@ -1,0 +1,10 @@
+void *tls_address;
+
+void break_here(void) {}
+
+int main(){
+    // TODO: This only works for i386, we should support arm/aarch64 in the future
+    asm("movl %%gs:0, %0" : "=r" (tls_address));
+    break_here();
+    return 0;
+}

--- a/tests/gdb-tests/tests/binaries/tls.x86-64.c
+++ b/tests/gdb-tests/tests/binaries/tls.x86-64.c
@@ -1,0 +1,10 @@
+void *tls_address;
+
+void break_here(void) {}
+
+int main(){
+    // TODO: This only works for x86-64, we should support arm/aarch64 in the future
+    asm("movq %%fs:0, %0" : "=r" (tls_address));
+    break_here();
+    return 0;
+}

--- a/tests/gdb-tests/tests/heap/test_heap.py
+++ b/tests/gdb-tests/tests/heap/test_heap.py
@@ -340,10 +340,11 @@ def test_thread_arena_heuristic(start_binary, is_multi_threaded):
         # Check the value of `thread_arena` is correct
         assert pwndbg.heap.current.thread_arena.address == thread_arena_via_debug_symbol
 
+    # TODO: Support the test that using brute-force to find the `thread_arena`
 
-@pytest.mark.parametrize(
-    "is_multi_threaded", [False, True], ids=["single-threaded", "multi-threaded"]
-)
+
+# TODO: Support the test for multi-threaded, since it might take user's input for finding the `thread_arena`
+@pytest.mark.parametrize("is_multi_threaded", [False], ids=["single-threaded"])
 def test_heuristic_fail_gracefully(start_binary, is_multi_threaded):
     # TODO: Support other architectures or different libc versions
     start_binary(HEAP_MALLOC_CHUNK)

--- a/tests/gdb-tests/tests/test_command_tls.py
+++ b/tests/gdb-tests/tests/test_command_tls.py
@@ -1,0 +1,40 @@
+import gdb
+import pytest
+
+import pwndbg.gdblib.tls
+import pwndbg.gdblib.vmmap
+import tests
+
+TLS_X86_64_BINARY = tests.binaries.get("tls.x86-64.out")
+TLS_I386_BINARY = tests.binaries.get("tls.i386.out")
+
+
+# TODO: Support other architectures
+@pytest.mark.parametrize("binary", [TLS_X86_64_BINARY, TLS_I386_BINARY], ids=["x86-64", "i386"])
+def test_tls_address_and_command(start_binary, binary):
+    try:
+        start_binary(binary)
+    except gdb.error:
+        pytest.skip("This device does not support this test")
+    gdb.execute("break break_here")
+    gdb.execute("continue")
+
+    expected_tls_address = int(gdb.parse_and_eval("(void *)tls_address"))
+
+    assert pwndbg.gdblib.tls.find_address_with_register() == expected_tls_address
+
+    assert pwndbg.gdblib.tls.find_address_with_pthread_self() == expected_tls_address
+
+    assert (
+        gdb.execute("tls", to_string=True)
+        == f"""Thread Local Storage (TLS) base: {expected_tls_address:#x}
+TLS is located at:
+{pwndbg.gdblib.vmmap.find(expected_tls_address)}\n"""
+    )
+
+    assert (
+        gdb.execute("tls --pthread-self", to_string=True)
+        == f"""Thread Local Storage (TLS) base: {expected_tls_address:#x}
+TLS is located at:
+{pwndbg.gdblib.vmmap.find(expected_tls_address)}\n"""
+    )


### PR DESCRIPTION
This PR aims to rewrite some unreliable and hard-to-maintain methods:

- We directly search the default value of `main_arena` and `mp_` in the .data section of the ELF now. We do not rely on any of the symbols and the result of disassembly anymore.
- The original heuristic of `tcache` is unreliable. Since it highly depends on the result of disassembly and our features for TLS, I think that method might not be worth to keep maintaining. We now assume it is in the first chunk of the current heap. But the `tcache` might not be at the beginning of the heap of the current thread if the arena is been shared by multiple threads, so we'll show a prompt to ask the user if they want to try the brute force to find `tcache`, and let them decide if it is worth doing it.
- The original heuristic of `thread_arena` is similar to `tcache`, so the old method is been dropped. But since the `thread_arena` might still be found by brute force, we also provide an option to the user.
- Since the heuristic of `global_max_fast` is not reliable, now we return the default value of `global_max_fast` instead of trying to find it and then failing. (It still can be manually set by the user tho.)
- Now we won't implicitly call `pthread_self()` when executing `tls` command, calling `pthread_self()` is optional. Users can use them by `tls --pthread-self` to try it only if they think it's safe.
- Some minor changes for the output of `tls`, `arenas`, `arena`, `tcache`, and `mp` commands, to show more information.
- Handle the case that `thread_arena` and `tcache` is pointing to `NULL`.

