### PR TITLE
Fix auxv memory access error

### DIFF
--- a/pwndbg/auxv.py
+++ b/pwndbg/auxv.py
@@ -193,53 +193,58 @@ def walk_stack2(offset=0):
     # So we don't walk off the end of the stack
     p -= 2
 
-    # Find a ~guess at where AT_NULL is.
-    #
-    # Coming up from the end of the stack, there will be a
-    # marker at the end which is a single ULONG of zeroes, and then
-    # the ARGV and ENVP data.
-    #
-    # Assuming that the ARGV and ENVP data is formed normally,
-    # (i.e. doesn't include 8-16 consecutive zero-length args)
-    # this should land us at the *END* of AUXV, which is the
-    # AT_NULL vector.
-    while p.dereference() != 0 or (p + 1).dereference() != 0:
-        p -= 2
+    try:
+        # Find a ~guess at where AT_NULL is.
+        #
+        # Coming up from the end of the stack, there will be a
+        # marker at the end which is a single ULONG of zeroes, and then
+        # the ARGV and ENVP data.
+        #
+        # Assuming that the ARGV and ENVP data is formed normally,
+        # (i.e. doesn't include 8-16 consecutive zero-length args)
+        # this should land us at the *END* of AUXV, which is the
+        # AT_NULL vector.
+        while p.dereference() != 0 or (p + 1).dereference() != 0:
+            p -= 2
 
-    # Now we want to continue until we fine, at a minimum, AT_BASE.
-    # While there's no guarantee that this exists, I've not ever found
-    # an instance when it doesn't.
-    #
-    # This check is needed because the above loop isn't
-    # guaranteed to actually get us to AT_NULL, just to some
-    # consecutive NULLs.  QEMU is pretty generous with NULLs.
-    for i in range(1024):
-        if p.dereference() == AT_BASE:
-            break
-        p -= 2
-    else:
+        # Now we want to continue until we fine, at a minimum, AT_BASE.
+        # While there's no guarantee that this exists, I've not ever found
+        # an instance when it doesn't.
+        #
+        # This check is needed because the above loop isn't
+        # guaranteed to actually get us to AT_NULL, just to some
+        # consecutive NULLs.  QEMU is pretty generous with NULLs.
+        for i in range(1024):
+            if p.dereference() == AT_BASE:
+                break
+            p -= 2
+        else:
+            return AUXV()
+
+        # If we continue to p back, we should bump into the
+        # very end of ENVP (and perhaps ARGV if ENVP is empty).
+        #
+        # The highest value for the vector is AT_SYSINFO_EHDR, 33.
+        while (p - 2).dereference() < 37:
+            p -= 2
+
+        # Scan them into our structure
+        auxv = AUXV()
+        while True:
+            const = int((p + 0).dereference()) & pwndbg.gdblib.arch.ptrmask
+            value = int((p + 1).dereference()) & pwndbg.gdblib.arch.ptrmask
+
+            if const == AT_NULL:
+                break
+
+            auxv.set(const, value)
+            p += 2
+
+        return auxv
+    except gdb.MemoryError:
+        # If SP is inaccessible or we went past through stack and haven't found AUXV
+        # then return an empty AUXV...
         return AUXV()
-
-    # If we continue to p back, we should bump into the
-    # very end of ENVP (and perhaps ARGV if ENVP is empty).
-    #
-    # The highest value for the vector is AT_SYSINFO_EHDR, 33.
-    while (p - 2).dereference() < 37:
-        p -= 2
-
-    # Scan them into our structure
-    auxv = AUXV()
-    while True:
-        const = int((p + 0).dereference()) & pwndbg.gdblib.arch.ptrmask
-        value = int((p + 1).dereference()) & pwndbg.gdblib.arch.ptrmask
-
-        if const == AT_NULL:
-            break
-
-        auxv.set(const, value)
-        p += 2
-
-    return auxv
 
 
 def _get_execfn():


### PR DESCRIPTION
This issue can be reproduced with the following command:
```
sudo docker run --privileged --rm -it --net host ubuntu bash -c 'apt update && apt install gdbserver && umount /proc && gdbserver 127.0.0.1:1234 /bin/ls'
```

And then attaching to the gdbserver via:
```
gdb --quiet --ex 'target remote :1234'
```

This results in the following errors:
```
pwndbg> set exception-verbose on
Set whether to print a full stacktrace for exceptions raised in Pwndbg commands to True
Traceback (most recent call last):
  File "/root/pwndbg/pwndbg/gdblib/events.py", line 164, in caller
    func()
  File "/root/pwndbg/pwndbg/lib/memoize.py", line 51, in __call__
    value = self.func(*args, **kwargs)
  File "/root/pwndbg/pwndbg/stack.py", line 78, in update
    start, stop - start, 6 if not is_executable() else 7, 0, "[stack]"
  File "/root/pwndbg/pwndbg/lib/memoize.py", line 51, in __call__
    value = self.func(*args, **kwargs)
  File "/root/pwndbg/pwndbg/stack.py", line 127, in is_executable
    ehdr = pwndbg.elf.exe()
  File "/root/pwndbg/pwndbg/proc.py", line 78, in wrapper
    return func(*a, **kw)
  File "/root/pwndbg/pwndbg/lib/memoize.py", line 51, in __call__
    value = self.func(*args, **kwargs)
  File "/root/pwndbg/pwndbg/elf.py", line 181, in exe
    e = entry()
  File "/root/pwndbg/pwndbg/proc.py", line 78, in wrapper
    return func(*a, **kw)
  File "/root/pwndbg/pwndbg/lib/memoize.py", line 51, in __call__
    value = self.func(*args, **kwargs)
  File "/root/pwndbg/pwndbg/elf.py", line 192, in entry
    entry = pwndbg.auxv.get().AT_ENTRY
  File "/root/pwndbg/pwndbg/lib/memoize.py", line 51, in __call__
    value = self.func(*args, **kwargs)
  File "/root/pwndbg/pwndbg/auxv.py", line 103, in get
    return use_info_auxv() or walk_stack() or AUXV()
  File "/root/pwndbg/pwndbg/auxv.py", line 154, in walk_stack
    auxv = walk_stack2(0)
  File "/root/pwndbg/pwndbg/auxv.py", line 206, in walk_stack2
    while p.dereference() != 0 or (p + 1).dereference() != 0:
gdb.MemoryError: Cannot access memory at address 0xffffdff8
```

<!-- Please make sure to read the testing and linting instructions at https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md before creating a PR -->
