### PR TITLE
Avoid downloading files from remote server in some cases

### DIFF
--- a/pwndbg/commands/elf.py
+++ b/pwndbg/commands/elf.py
@@ -10,7 +10,7 @@ from pwndbg.commands import CommandCategory
 )
 @pwndbg.commands.OnlyWithFile
 def elfsections() -> None:
-    local_path = pwndbg.gdblib.file.get_file(pwndbg.gdblib.proc.exe)
+    local_path = pwndbg.gdblib.file.get_proc_exe_file()
 
     with open(local_path, "rb") as f:
         elffile = ELFFile(f)
@@ -49,7 +49,7 @@ def plt() -> None:
 
 
 def get_section_bounds(section_name):
-    local_path = pwndbg.gdblib.file.get_file(pwndbg.gdblib.proc.exe)
+    local_path = pwndbg.gdblib.file.get_proc_exe_file()
 
     with open(local_path, "rb") as f:
         elffile = ELFFile(f)

--- a/pwndbg/commands/radare2.py
+++ b/pwndbg/commands/radare2.py
@@ -21,7 +21,7 @@ parser.add_argument("arguments", nargs="*", type=str, help="Arguments to pass to
 )
 @pwndbg.commands.OnlyWithFile
 def r2(arguments, no_seek=False, no_rebase=False) -> None:
-    filename = pwndbg.gdblib.file.get_file(pwndbg.gdblib.proc.exe)
+    filename = pwndbg.gdblib.file.get_proc_exe_file()
 
     # Build up the command line to run
     cmd = ["radare2"]

--- a/pwndbg/commands/rizin.py
+++ b/pwndbg/commands/rizin.py
@@ -19,7 +19,7 @@ parser.add_argument("arguments", nargs="*", type=str, help="Arguments to pass to
 @pwndbg.commands.ArgparsedCommand(parser, aliases=["rizin"], category=CommandCategory.INTEGRATIONS)
 @pwndbg.commands.OnlyWithFile
 def rz(arguments, no_seek=False, no_rebase=False) -> None:
-    filename = pwndbg.gdblib.file.get_file(pwndbg.gdblib.proc.exe)
+    filename = pwndbg.gdblib.file.get_proc_exe_file()
 
     # Build up the command line to run
     cmd = ["rizin"]

--- a/pwndbg/commands/vmmap.py
+++ b/pwndbg/commands/vmmap.py
@@ -161,7 +161,7 @@ parser.add_argument(
 @pwndbg.commands.OnlyWhenRunning
 def vmmap_load(filename) -> None:
     if filename is None:
-        filename = pwndbg.gdblib.file.get_file(pwndbg.gdblib.proc.exe)
+        filename = pwndbg.gdblib.file.get_proc_exe_file()
 
     print('Load "%s" ...' % filename)
 

--- a/pwndbg/gdblib/elf.py
+++ b/pwndbg/gdblib/elf.py
@@ -173,12 +173,14 @@ def get_containing_sections(elf_filepath, elf_loadaddr, vaddr):
     return sections
 
 
-def dump_section_by_name(filepath: str, section_name: str) -> Optional[Tuple[int, int, bytes]]:
+def dump_section_by_name(
+    filepath: str, section_name: str, try_local_path: bool = False
+) -> Optional[Tuple[int, int, bytes]]:
     """
     Dump the content of a section from an ELF file, return the start address, size and content.
     """
     # TODO: We should have some cache mechanism or something at `pndbg.gdblib.file.get_file()` in the future to avoid downloading the same file multiple times when we are debugging a remote process
-    local_path = pwndbg.gdblib.file.get_file(filepath)
+    local_path = pwndbg.gdblib.file.get_file(filepath, try_local_path=try_local_path)
 
     with open(local_path, "rb") as f:
         elffile = ELFFile(f)

--- a/pwndbg/gdblib/file.py
+++ b/pwndbg/gdblib/file.py
@@ -35,13 +35,22 @@ def remote_files_dir():
     return _remote_files_dir
 
 
-def get_file(path: str) -> str:
+def get_proc_exe_file() -> str:
+    """
+    Returns the local path to the debugged file name.
+    """
+    return get_file(pwndbg.gdblib.proc.exe, try_local_path=True)
+
+
+def get_file(path: str, try_local_path: bool = False) -> str:
     """
     Downloads the specified file from the system where the current process is
     being debugged.
 
     If the `path` is prefixed with "target:" the prefix is stripped
     (to support remote target paths properly).
+
+    If the `try_local_path` is set to `True` and the `path` exists locally and "target:" prefix is not present, it will return the local path instead of downloading the file.
 
     Returns:
         The local path to the file
@@ -50,7 +59,8 @@ def get_file(path: str) -> str:
         "target:"
     ), "get_file called with incorrect path"
 
-    if path.startswith("target:"):
+    has_target_prefix = path.startswith("target:")
+    if has_target_prefix:
         path = path[7:]  # len('target:') == 7
 
     local_path = path
@@ -61,6 +71,8 @@ def get_file(path: str) -> str:
 
     elif pwndbg.gdblib.remote.is_remote():
         if not pwndbg.gdblib.qemu.is_qemu():
+            if try_local_path and not has_target_prefix and os.path.exists(local_path):
+                return local_path
             local_path = tempfile.mktemp(dir=remote_files_dir())
             error = None
             try:
@@ -73,7 +85,7 @@ def get_file(path: str) -> str:
         else:
             print(
                 message.warn(
-                    "pwndbg.gdblib.file.get(%s) returns local path as we can't download file from QEMU"
+                    "pwndbg.gdblib.file.get_file(%s) returns local path as we can't download file from QEMU"
                     % path
                 )
             )

--- a/pwndbg/gdblib/proc.py
+++ b/pwndbg/gdblib/proc.py
@@ -88,7 +88,8 @@ class module(ModuleType):
         2. gdb -ex "target remote :1234" -ex "pi pwndbg.gdblib.proc.exe"
 
         If you need to process the debugged file use:
-            `pwndbg.gdblib.file.get_file(pwndbg.gdblib.proc.exe)`
+            `pwndbg.gdblib.file.get_proc_exe_file()`
+            (This will call `pwndbg.gdblib.file.get_file(pwndbg.gdblib.proc.exe, try_local_path=True)`)
         """
         return gdb.current_progspace().filename
 
@@ -110,7 +111,7 @@ class module(ModuleType):
         """
         Dump .data section of current process's ELF file
         """
-        return pwndbg.gdblib.elf.dump_section_by_name(self.exe, ".data")
+        return pwndbg.gdblib.elf.dump_section_by_name(self.exe, ".data", try_local_path=True)
 
     @pwndbg.lib.memoize.reset_on_start
     @pwndbg.lib.memoize.reset_on_objfile

--- a/pwndbg/glibc.py
+++ b/pwndbg/glibc.py
@@ -85,7 +85,7 @@ def dump_elf_data_section() -> Optional[Tuple[int, int, bytes]]:
     if not libc_filename:
         # libc not loaded yet, or it's static linked
         return None
-    return pwndbg.gdblib.elf.dump_section_by_name(libc_filename, ".data")
+    return pwndbg.gdblib.elf.dump_section_by_name(libc_filename, ".data", try_local_path=True)
 
 
 @pwndbg.gdblib.proc.OnlyWhenRunning

--- a/pwndbg/wrappers/checksec.py
+++ b/pwndbg/wrappers/checksec.py
@@ -11,7 +11,7 @@ cmd_pwntools = ["pwn", "checksec"]
 @pwndbg.wrappers.OnlyWithCommand(cmd_name, cmd_pwntools)
 @pwndbg.lib.memoize.reset_on_objfile
 def get_raw_out():
-    local_path = pwndbg.gdblib.file.get_file(pwndbg.gdblib.proc.exe)
+    local_path = pwndbg.gdblib.file.get_proc_exe_file()
     try:
         return pwndbg.wrappers.call_cmd(get_raw_out.cmd + ["--file=" + local_path])
     except CalledProcessError:

--- a/pwndbg/wrappers/readelf.py
+++ b/pwndbg/wrappers/readelf.py
@@ -5,7 +5,7 @@ cmd_name = "readelf"
 
 @pwndbg.wrappers.OnlyWithCommand(cmd_name)
 def get_jmpslots():
-    local_path = pwndbg.gdblib.file.get_file(pwndbg.gdblib.proc.exe)
+    local_path = pwndbg.gdblib.file.get_proc_exe_file()
     cmd = get_jmpslots.cmd + ["--relocs", local_path]
     readelf_out = pwndbg.wrappers.call_cmd(cmd)
 


### PR DESCRIPTION
In some cases, we might not need to download the file if we can find the file locally, and this can be determined by the return value of the gdb command/API.

For example, the path we get from `pwndbg.gdblib.proc.exe` has different when gdb have loaded the file or not:

If we have executed `file /path/to/exe` before connecting to gdbserver:
```python
In [1]: pwndbg.gdblib.proc.exe
Out[1]: '/path/to/exe'
```
The output doesn't have "target:" prefix because gdb is able to find the file locally.

If we haven't executed `file /path/to/exe`, gdb can't find it locally, the output will be:
```python
In [1]: pwndbg.gdblib.proc.exe
Out[1]: 'target:/path/to/exe'
```

So if the "target:" prefix doesn't present when using `pwndbg.gdblib.file.get_file(pwndbg.gdblib.proc.exe)`, we don't need to download the file. (The behavior of file path also occurred in `info files` and `info sharedlibrary` commands output.)

This PR aims to prevent downloading the file when the "target:" prefix doesn't present in the above cases.

---

This PR should fix #1591
(And will probably fix the potential similar issues on every place we used `pwndbg.gdblib.file.get_file(pwndbg.gdblib.proc.exe)`. 
