### PR TITLE
Add i686 heap alignment heuristic

### DIFF
--- a/pwndbg/heap/ptmalloc.py
+++ b/pwndbg/heap/ptmalloc.py
@@ -393,6 +393,9 @@ class Heap:
                 self._gdbValue = None
 
         self.start = self._memory_region.start
+        # i686 alignment heuristic
+        if Chunk(self.start).size == 0:
+            self.start += pwndbg.gdblib.arch.ptrsize * 2
         self.end = self._memory_region.end
         self.first_chunk = Chunk(self.start)
 


### PR DESCRIPTION
A check for the scenario where the first chunk on a heap is not at the beginning of the heap region was accidentally removed in #1346
Should resolve #1592 