### PR TITLE
symbol.py: remove _add_main_symbol_to_exe

### DIFF
--- a/pwndbg/gdblib/symbol.py
+++ b/pwndbg/gdblib/symbol.py
@@ -179,39 +179,6 @@ def static_linkage_symbol_address(symbol: str) -> int:
         return None
 
 
-@pwndbg.gdblib.events.stop
-@pwndbg.lib.memoize.reset_on_start
-def _add_main_exe_to_symbols() -> None:
-    if not pwndbg.gdblib.remote.is_remote():
-        return
-
-    if pwndbg.gdblib.android.is_android():
-        return
-
-    exe = pwndbg.gdblib.elf.exe()
-
-    if not exe:
-        return
-
-    addr = exe.address
-
-    if not addr:
-        return
-
-    addr = int(addr)
-
-    mmap = pwndbg.gdblib.vmmap.find(addr)
-    if not mmap:
-        return
-
-    path = mmap.objfile
-    if path and (pwndbg.gdblib.arch.endian == pwndbg.gdblib.arch.native_endian):
-        try:
-            gdb.execute("add-symbol-file %s" % (path,), from_tty=False, to_string=True)
-        except gdb.error:
-            pass
-
-
 @pwndbg.lib.memoize.reset_on_stop
 @pwndbg.lib.memoize.reset_on_start
 def selected_frame_source_absolute_filename():


### PR DESCRIPTION
It seems this function is redundant. If you do:

```
gdbserver 0.0.0.0:1234 ./a.out
```

on a local machine and then do `gdb ./a.out --ex 'target remote :1234'` the `_add_main_symbol_to_exe` will kick off and run its `add-symbol-file` command to add the symbols from the binary. However, the GDB already loaded the binary symbols and so we will do it for the second time. As a result, we get something like this:

```
pwndbg> info symbol main
main in section .text of /pwndbg/bug/vaccine
main in section .text of /pwndbg/bug/vaccine
```

This function has been in Pwndbg since always and I am not sure why we needed it. Perhaps an old GDB did not download the binary from the remote target, but since now GDB does this automagically, this function seems redundant.

Just for the sake of documenting it, here is how a symbol appears if you connect to a remote target on a different machine without Pwndbg (the GDB downloads the binary itself and loads its symbols):

```
(gdb) p main
$1 = {<text variable, no debug info>} 0x55555555466a <main>
(gdb) info symbol main
main in section .text of target:/home/dc/a.out
```

<!-- Please make sure to read the testing and linting instructions at https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md before creating a PR -->
