### PR TITLE
Display bin size range in `largebins` command output

### DIFF
--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -82,10 +82,12 @@ def format_bin(bins: Bins, verbose=False, offset=None):
 
         if isinstance(size, int):
             if bins_type == BinType.LARGE:
-                infinity_symbol = "\u221e"  # Unicode "infinity"
                 start_size, end_size = allocator.largebin_size_range_from_index(size)
                 size = hex(start_size) + "-"
-                size += infinity_symbol if end_size == pwndbg.gdblib.arch.ptrmask else hex(end_size)
+                if end_size != pwndbg.gdblib.arch.ptrmask:
+                    size += hex(end_size)
+                else:
+                    size += "\u221e"  # Unicode "infinity"
             else:
                 size = hex(size)
 

--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -81,7 +81,13 @@ def format_bin(bins: Bins, verbose=False, offset=None):
             formatted_chain = pwndbg.chain.format(chain_fd[0], offset=offset, safe_linking=safe_lnk)
 
         if isinstance(size, int):
-            size = hex(size)
+            if bins_type == BinType.LARGE:
+                infinity_symbol = "\u221e"  # Unicode "infinity"
+                start_size, end_size = allocator.largebin_size_range_from_index(size)
+                size = hex(start_size) + "-"
+                size += infinity_symbol if end_size == pwndbg.gdblib.arch.ptrmask else hex(end_size)
+            else:
+                size = hex(size)
 
         if is_chain_corrupted:
             line = message.hint(size) + message.error(" [corrupted]") + "\n"

--- a/pwndbg/heap/ptmalloc.py
+++ b/pwndbg/heap/ptmalloc.py
@@ -667,9 +667,9 @@ class GlibcMemoryAllocator(pwndbg.heap.heap.MemoryAllocator):
         for i in range(NSMALLBINS, index + 1):
             start_size += spaces_table[i]
 
-        end_size = start_size + spaces_table[index + 1] - self.malloc_alignment
-
-        if index == largest_largebin:
+        if index != largest_largebin:
+            end_size = start_size + spaces_table[index + 1] - self.malloc_alignment
+        else:
             end_size = pwndbg.gdblib.arch.ptrmask
 
         return (start_size, end_size)

--- a/pwndbg/heap/ptmalloc.py
+++ b/pwndbg/heap/ptmalloc.py
@@ -658,6 +658,22 @@ class GlibcMemoryAllocator(pwndbg.heap.heap.MemoryAllocator):
         # ptmalloc cache for current thread
         self._thread_cache: gdb.Value = None
 
+    def largebin_size_range_from_index(self, index):
+        index += NSMALLBINS
+        spaces_table = self._spaces_table()
+        largest_largebin = self.largebin_index(pwndbg.gdblib.arch.ptrmask)
+        start_size = (NSMALLBINS * self.malloc_alignment) - self.malloc_alignment
+
+        for i in range(NSMALLBINS, index + 1):
+            start_size += spaces_table[i]
+
+        end_size = start_size + spaces_table[index + 1] - self.malloc_alignment
+
+        if index == largest_largebin:
+            end_size = pwndbg.gdblib.arch.ptrmask
+
+        return (start_size, end_size)
+
     def can_be_resolved(self):
         raise NotImplementedError()
 


### PR DESCRIPTION
Show the chunk size range for bins printed by the `largebins` command.
I think this is more useful than showing only the bin index (current behavior) or just the minimum size (old behavior).
It also follows the same format as the other `*bins` commands, which print size information rather than index.

#### Before:
![largebins old behavior](https://user-images.githubusercontent.com/16000770/223621668-5ea82ba3-e848-4cbf-a2b6-f7d5339d941a.png)
#### After:
![largebins with size range](https://user-images.githubusercontent.com/16000770/223621704-75222035-37e9-4318-8863-ce5051c8c180.png)