### PR TITLE
Fix #808: set search-memory-packet off only on GDB<=9

### DIFF
--- a/pwndbg/__init__.py
+++ b/pwndbg/__init__.py
@@ -54,6 +54,10 @@ handle SIGSEGV stop   print nopass
     pwndbg.ui.get_window_size()[1]
 )
 
+# See https://github.com/pwndbg/pwndbg/issues/808
+if int(getattr(gdb, "VERSION", "0.0").split(".")[0]) <= 9:
+    pre_commands += "\nset remote search-memory-packet off"
+
 for line in pre_commands.strip().splitlines():
     gdb.execute(line)
 


### PR DESCRIPTION
This commit fixes #808 and #1618.

I can confirmed that the search bug to happen on GDB 9.2, but not on GDB 10.2, so I am hardcoding here to only apply the workaround for GDB major version <= 9.

```
pwndbg> version
Gdb:      9.2
Python:   3.8.10 (default, Nov 14 2022, 12:59:47)  [GCC 9.4.0]
Pwndbg:   1.1.1 build: a3f12bc
Capstone: 4.0.1024
Unicorn:  2.0.1

pwndbg> search "GNU C"
Searching for value: 'GNU C'

pwndbg> set remote search-memory-packet off

pwndbg> search "GNU C"
Searching for value: 'GNU C'
libc-2.31.so    0x7ffff7f85b80 0x694c204320554e47 ('GNU C Li')
libc-2.31.so    0x7ffff7f85c9e 'GNU CC version 9.3.0.\nlibc ABIs: UNIQUE IFUNC ABSOLUTE\nFor bug reporting instructions, please see:\n<https://bugs.launchpad.net/ubuntu/+source/glibc/+bugs>.\n'
```

<!-- Please make sure to read the testing and linting instructions at https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md before creating a PR -->
