### PR TITLE
Fix #1394: Improve installation process

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -63,11 +63,24 @@ install_emerge() {
 install_pacman() {
     sudo pacman -Syy --noconfirm || true
     sudo pacman -S --noconfirm git gdb python python-pip python-capstone python-unicorn python-pycparser python-psutil python-ptrace python-pyelftools python-six python-pygments which debuginfod
-    echo "set debuginfod enabled on" >> ~/.gdbinit
+    if ! grep -q "^set debuginfod enabled on" ~/.gdbinit; then
+        echo "set debuginfod enabled on" >> ~/.gdbinit
+    fi
 }
 
 PYTHON=''
 INSTALLFLAGS=''
+
+# Check for the presence of the initializer line in the user's ~/.gdbinit file
+if grep -q '^[^#]*source.*pwndbg/gdbinit.py' ~/.gdbinit; then
+    # Ask the user if they want to proceed and override the initializer line
+    read -p "An initializer line was found in your ~/.gdbinit file. Do you want to proceed and override it? (y/n) " answer
+
+    # If the user does not want to proceed, exit the script
+    if [[ "$answer" != "y" ]]; then
+        exit 0
+    fi
+fi
 
 if osx || [ "$1" == "--user" ]; then
     INSTALLFLAGS="--user"
@@ -154,7 +167,10 @@ ${PYTHON} -m pip install ${INSTALLFLAGS} --upgrade pip
 # Install Python dependencies
 ${PYTHON} -m pip install ${INSTALLFLAGS} -Ur requirements.txt
 
-# Load Pwndbg into GDB on every launch.
-if ! grep pwndbg ~/.gdbinit &> /dev/null; then
-    echo "source $PWD/gdbinit.py" >> ~/.gdbinit
+# Comment old configs out
+if grep -q '^[^#]*source.*pwndbg/gdbinit.py' ~/.gdbinit; then
+    sed -i '/^[^#]*source.*pwndbg\/gdbinit.py/ s/^/# /' ~/.gdbinit
 fi
+
+# Load Pwndbg into GDB on every launch.
+echo "source $PWD/gdbinit.py" >> ~/.gdbinit


### PR DESCRIPTION
Now the installation process contains the following steps: 
1. Check for any line with `source <gdbinit.py>` before installation
2. If any, ask the user if they want to proceed
4. After the installation, comment out old `source <gdbinit.py>` lines if any and add a new `source <gdbinit.py>` line.
 
A check for presence of the line `set debuginfod enabled on` is also added to avoid being appended repeatedly.
