### PR TITLE
Correct smallbins alignment on i386

### DIFF
--- a/pwndbg/heap/ptmalloc.py
+++ b/pwndbg/heap/ptmalloc.py
@@ -808,7 +808,7 @@ class GlibcMemoryAllocator(pwndbg.heap.heap.MemoryAllocator):
 
     def _spaces_table(self):
         spaces_table = (
-            [pwndbg.gdblib.arch.ptrsize * 2] * 64
+            [self.malloc_alignment] * 64
             + [pow(2, 6)] * 32
             + [pow(2, 9)] * 16
             + [pow(2, 12)] * 8


### PR DESCRIPTION
Resolves #1616 by using `malloc_alignment` in place of `arch.ptrsize * 2` in the `_spaces_table()` method.

`malloc_alignment` takes care of potential alignment issues on i386:
https://github.com/pwndbg/pwndbg/blob/be306da2553596443d2bdaa378bf11cf59e3eab5/pwndbg/heap/ptmalloc.py#L759-L767

In the "before" screenshot below, note how the free chunks are in the wrong smallbins for their size, and how the `heap` command doesn't detect them as free.
#### Before:
![smallbins bad](https://user-images.githubusercontent.com/16000770/224394140-b2fbd42e-f9ea-4c88-8dad-735cc95b8cce.png)
#### After:
![smallbins good](https://user-images.githubusercontent.com/16000770/224394187-8ae9156d-5661-45a6-8c2d-69781e521410.png)