### PR TITLE
Resolve some `find_fake_fast` command issues

### DIFF
--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -716,11 +716,11 @@ def find_fake_fast(
         search_start = pwndbg.lib.memory.page_size_align(search_start)
         if (
             search_start > (search_end - size_field_width)
-            or pwndbg.gdblib.memory.peek(search_start) == None
+            or pwndbg.gdblib.memory.peek(search_start) is None
         ):
             print(
                 message.warn(
-                    f"No fake fast chunk candidates found; memory preceding target address is not readable"
+                    "No fake fast chunk candidates found; memory preceding target address is not readable"
                 )
             )
             return None
@@ -732,7 +732,7 @@ def find_fake_fast(
         if search_start > (search_end - size_field_width):
             print(
                 message.warn(
-                    f"No fake fast chunk candidates found; alignment didn't leave enough space for a size field"
+                    "No fake fast chunk candidates found; alignment didn't leave enough space for a size field"
                 )
             )
             return None

--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -671,12 +671,12 @@ def find_fake_fast(
     target_address, max_candidate_size=None, align=False, glibc_fastbin_bug=False
 ) -> None:
     """Find candidate fake fast chunks overlapping the specified address."""
-    ptrsize = pwndbg.gdblib.arch.ptrsize
     allocator = pwndbg.heap.current
 
+    size_sz = allocator.size_sz
     min_chunk_size = allocator.min_chunk_size
     global_max_fast = allocator.global_max_fast
-    size_field_width = gdb.lookup_type("unsigned int").sizeof if glibc_fastbin_bug else ptrsize
+    size_field_width = gdb.lookup_type("unsigned int").sizeof if glibc_fastbin_bug else size_sz
 
     if max_candidate_size is None:
         max_candidate_size = global_max_fast
@@ -709,7 +709,7 @@ def find_fake_fast(
 
     max_candidate_size &= ~(allocator.malloc_align_mask)
 
-    search_start = target_address - max_candidate_size + ptrsize
+    search_start = target_address - max_candidate_size + size_sz
     search_end = target_address
 
     if pwndbg.gdblib.memory.peek(search_start) is None:
@@ -726,8 +726,8 @@ def find_fake_fast(
             return None
 
     if align:
-        search_start = pwndbg.lib.memory.align_up(search_start, ptrsize)
-        search_start |= ptrsize
+        search_start = pwndbg.lib.memory.align_up(search_start, size_sz)
+        search_start |= size_sz
 
         if search_start > (search_end - size_field_width):
             print(
@@ -758,8 +758,8 @@ def find_fake_fast(
                 continue
 
             candidate_address = search_start + i
-            if (candidate_address + size_field) >= (target_address + ptrsize):
-                malloc_chunk(candidate_address - ptrsize, fake=True)
+            if (candidate_address + size_field) >= (target_address + size_sz):
+                malloc_chunk(candidate_address - size_sz, fake=True)
         else:
             break
 


### PR DESCRIPTION
This PR leaves most of the `find_fake_fast` command logic intact, whilst addressing the following issues:

Resolve #1363 by introducing a `--glibc-fastbin-bug` option to the command, which changes the width of the candidate size field to search for.

Resolve #1398 by checking if a search region is readable, if not then advancing to the next page and trying again.

Resolve #1631 by separating the amount of memory to search and the maximum size of the candidate field into different variables.

Resolve #1637 by masking chunk sizes with `allocator.malloc_align_mask` rather than a hardcoded value.