### PR TITLE
Fixed a crash that caused formatting failure in readlink when qemu returns None as the pid.

### DIFF
--- a/pwndbg/arguments.py
+++ b/pwndbg/arguments.py
@@ -231,7 +231,7 @@ def format_args(instruction):
             else:
                 print(
                     message.hint(
-                        "Cannot find the PID of the program, maybe there is no permission to connect to the privileged QEMU."
+                        "Cannot find PID of the QEMU program: perhaps it is in a different pid namespace or we have no permission to read the QEMU process' /proc/$pid/fd/$fd file."
                     )
                 )
 

--- a/pwndbg/arguments.py
+++ b/pwndbg/arguments.py
@@ -19,6 +19,7 @@ import pwndbg.lib.abi
 import pwndbg.lib.funcparser
 import pwndbg.lib.functions
 from pwndbg.gdblib.nearpc import c as N
+from pwndbg.color import message
 
 ida_replacements = {
     "__int64": "signed long long int",
@@ -221,9 +222,12 @@ def format_args(instruction):
 
         # Enhance args display
         if arg.name == "fd" and isinstance(value, int):
-            path = pwndbg.gdblib.file.readlink("/proc/%d/fd/%d" % (pwndbg.gdblib.proc.pid, value))
-            if path:
-                pretty += " (%s)" % path
+            if pwndbg.gdblib.proc.pid is not None:
+                path = pwndbg.gdblib.file.readlink("/proc/%d/fd/%d" % (pwndbg.gdblib.proc.pid, value))
+                if path:
+                    pretty += " (%s)" % path
+            else:
+                print(message.hint("Cannot find the PID of the program, maybe there is no permission to connect to the privileged QEMU."))
 
         result.append("%-10s %s" % (N.argument(arg.name) + ":", pretty))
     return result

--- a/pwndbg/arguments.py
+++ b/pwndbg/arguments.py
@@ -222,9 +222,10 @@ def format_args(instruction):
 
         # Enhance args display
         if arg.name == "fd" and isinstance(value, int):
-            if pwndbg.gdblib.proc.pid is not None:
+            pid = pwndbg.gdblib.proc.pid
+            if pid is not None:
                 path = pwndbg.gdblib.file.readlink(
-                    "/proc/%d/fd/%d" % (pwndbg.gdblib.proc.pid, value)
+                    "/proc/%d/fd/%d" % (pid, value)
                 )
                 if path:
                     pretty += " (%s)" % path

--- a/pwndbg/arguments.py
+++ b/pwndbg/arguments.py
@@ -18,7 +18,6 @@ import pwndbg.ida
 import pwndbg.lib.abi
 import pwndbg.lib.funcparser
 import pwndbg.lib.functions
-from pwndbg.color import message
 from pwndbg.gdblib.nearpc import c as N
 
 ida_replacements = {
@@ -222,6 +221,7 @@ def format_args(instruction):
 
         # Enhance args display
         if arg.name == "fd" and isinstance(value, int):
+            # Cannot find PID of the QEMU program: perhaps it is in a different pid namespace or we have no permission to read the QEMU process' /proc/$pid/fd/$fd file.
             pid = pwndbg.gdblib.proc.pid
             if pid is not None:
                 path = pwndbg.gdblib.file.readlink("/proc/%d/fd/%d" % (pid, value))

--- a/pwndbg/arguments.py
+++ b/pwndbg/arguments.py
@@ -227,12 +227,6 @@ def format_args(instruction):
                 path = pwndbg.gdblib.file.readlink("/proc/%d/fd/%d" % (pid, value))
                 if path:
                     pretty += " (%s)" % path
-            else:
-                print(
-                    message.hint(
-                        "Cannot find PID of the QEMU program: perhaps it is in a different pid namespace or we have no permission to read the QEMU process' /proc/$pid/fd/$fd file."
-                    )
-                )
 
         result.append("%-10s %s" % (N.argument(arg.name) + ":", pretty))
     return result

--- a/pwndbg/arguments.py
+++ b/pwndbg/arguments.py
@@ -224,9 +224,7 @@ def format_args(instruction):
         if arg.name == "fd" and isinstance(value, int):
             pid = pwndbg.gdblib.proc.pid
             if pid is not None:
-                path = pwndbg.gdblib.file.readlink(
-                    "/proc/%d/fd/%d" % (pid, value)
-                )
+                path = pwndbg.gdblib.file.readlink("/proc/%d/fd/%d" % (pid, value))
                 if path:
                     pretty += " (%s)" % path
             else:

--- a/pwndbg/arguments.py
+++ b/pwndbg/arguments.py
@@ -18,8 +18,8 @@ import pwndbg.ida
 import pwndbg.lib.abi
 import pwndbg.lib.funcparser
 import pwndbg.lib.functions
-from pwndbg.gdblib.nearpc import c as N
 from pwndbg.color import message
+from pwndbg.gdblib.nearpc import c as N
 
 ida_replacements = {
     "__int64": "signed long long int",
@@ -223,11 +223,17 @@ def format_args(instruction):
         # Enhance args display
         if arg.name == "fd" and isinstance(value, int):
             if pwndbg.gdblib.proc.pid is not None:
-                path = pwndbg.gdblib.file.readlink("/proc/%d/fd/%d" % (pwndbg.gdblib.proc.pid, value))
+                path = pwndbg.gdblib.file.readlink(
+                    "/proc/%d/fd/%d" % (pwndbg.gdblib.proc.pid, value)
+                )
                 if path:
                     pretty += " (%s)" % path
             else:
-                print(message.hint("Cannot find the PID of the program, maybe there is no permission to connect to the privileged QEMU."))
+                print(
+                    message.hint(
+                        "Cannot find the PID of the program, maybe there is no permission to connect to the privileged QEMU."
+                    )
+                )
 
         result.append("%-10s %s" % (N.argument(arg.name) + ":", pretty))
     return result


### PR DESCRIPTION
<!-- Please make sure to read the testing and linting instructions at https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md before creating a PR -->
All connections will failed in psutil.process_iter() with exception AccessDenied when qemu is launched with privileged. (e.g. `sudo chroot ./qemu ...`)
It will cause subsequent crash cuz this function doesn't return anything. (i.e. return a None)
https://github.com/pwndbg/pwndbg/blob/59e759e0363cd474e662f28503f8de726baf7d20/pwndbg/gdblib/qemu.py#L76-L99

The function format_args will use pid as a int to format a string. It will cause a crash here in line 224.
https://github.com/pwndbg/pwndbg/blob/59e759e0363cd474e662f28503f8de726baf7d20/pwndbg/arguments.py#L216-L229
