### PR TITLE
Add types-request to dev-requirements.txt

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -16,6 +16,7 @@ types-gdb==12.1.4.1
 types-psutil==5.9.5
 types-Pygments==2.12.1
 types-tabulate==0.9.0.0
+types-requests==2.28.11.17
 vermin==1.5.1
 rich==12.6.0; python_version < '3.7'
 rich==13.3.1; python_version >= '3.7'


### PR DESCRIPTION
Was getting the following exception without this:
```
pwndbg/commands/ai.py:15: error: Library stubs not installed for "requests"  [import]
    import requests
    ^
pwndbg/commands/ai.py:15: note: Hint: "python3 -m pip install types-requests"
pwndbg/commands/ai.py:15: note: (or run "mypy --install-types" to install all missing stub packages)
pwndbg/commands/ai.py:15: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
Found 1 error in 1 file (checked 179 source files)
```