### PR TITLE
Use `store_true` argparse action on *bins commands

### DIFF
--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -478,15 +478,15 @@ parser = argparse.ArgumentParser(
 
 Default to the current thread's arena.""",
 )
-parser.add_argument("addr", nargs="?", type=int, default=None, help="Address of the arena.")
-parser.add_argument("verbose", nargs="?", type=bool, default=True, help="Show extra detail.")
+parser.add_argument("addr", nargs="?", type=int, help="Address of the arena.")
+parser.add_argument("-v", "--verbose", action="store_true", help="Show extra detail.")
 
 
 @pwndbg.commands.ArgparsedCommand(parser, category=CommandCategory.HEAP)
 @pwndbg.commands.OnlyWhenRunning
 @pwndbg.commands.OnlyWithResolvedHeapSyms
 @pwndbg.commands.OnlyWhenHeapIsInitialized
-def fastbins(addr=None, verbose=True) -> None:
+def fastbins(addr=None, verbose=False) -> None:
     """Print the contents of an arena's fastbins, default to the current
     thread's arena.
     """
@@ -510,15 +510,15 @@ parser = argparse.ArgumentParser(
 
 Default to the current thread's arena.""",
 )
-parser.add_argument("addr", nargs="?", type=int, default=None, help="Address of the arena.")
-parser.add_argument("verbose", nargs="?", type=bool, default=True, help="Show extra detail.")
+parser.add_argument("addr", nargs="?", type=int, help="Address of the arena.")
+parser.add_argument("-v", "--verbose", action="store_true", help="Show extra detail.")
 
 
 @pwndbg.commands.ArgparsedCommand(parser, category=CommandCategory.HEAP)
 @pwndbg.commands.OnlyWhenRunning
 @pwndbg.commands.OnlyWithResolvedHeapSyms
 @pwndbg.commands.OnlyWhenHeapIsInitialized
-def unsortedbin(addr=None, verbose=True) -> None:
+def unsortedbin(addr=None, verbose=False) -> None:
     """Print the contents of an arena's unsortedbin, default to the current
     thread's arena.
     """
@@ -542,8 +542,8 @@ parser = argparse.ArgumentParser(
 
 Default to the current thread's arena.""",
 )
-parser.add_argument("addr", nargs="?", type=int, default=None, help="Address of the arena.")
-parser.add_argument("verbose", nargs="?", type=bool, default=False, help="Show extra detail.")
+parser.add_argument("addr", nargs="?", type=int, help="Address of the arena.")
+parser.add_argument("-v", "--verbose", action="store_true", help="Show extra detail.")
 
 
 @pwndbg.commands.ArgparsedCommand(parser, category=CommandCategory.HEAP)
@@ -574,8 +574,8 @@ parser = argparse.ArgumentParser(
 
 Default to the current thread's arena.""",
 )
-parser.add_argument("addr", nargs="?", type=int, default=None, help="Address of the arena.")
-parser.add_argument("verbose", nargs="?", type=bool, default=False, help="Show extra detail.")
+parser.add_argument("addr", nargs="?", type=int, help="Address of the arena.")
+parser.add_argument("-v", "--verbose", action="store_true", help="Show extra detail.")
 
 
 @pwndbg.commands.ArgparsedCommand(parser, category=CommandCategory.HEAP)
@@ -606,12 +606,8 @@ parser = argparse.ArgumentParser(
 
 Default to the current thread's tcache.""",
 )
-parser.add_argument(
-    "addr", nargs="?", type=int, default=None, help="The address of the tcache bins."
-)
-parser.add_argument(
-    "verbose", nargs="?", type=bool, default=False, help="Whether to show more details or not."
-)
+parser.add_argument("addr", nargs="?", type=int, help="The address of the tcache bins.")
+parser.add_argument("-v", "--verbose", action="store_true", help="Show extra detail.")
 
 
 @pwndbg.commands.ArgparsedCommand(parser, category=CommandCategory.HEAP)


### PR DESCRIPTION
This PR changes the way pwndbg's `*bins` commands handle their `verbose` flag

### Old behavior:
* `verbose` is a positional argument, so an arena or tcache address argument must be supplied before `verbose` can be used
* `verbose` is of `type=bool`, which is discouraged in the argparse documentation. An empty string argument must be supplied to set it to `False` and any non-empty string to set it to `True`
![largebins-old](https://user-images.githubusercontent.com/16000770/228700175-1d7eb062-9b99-4dd3-a131-565ff91c0763.png)
* `verbose` is set to `True`/`False` inconsistently across the `*bins` commands

### New behavior:
* `verbose` is an optional argument, so it can be used without first supplying other positional arguments
* `verbose` uses `action=store_true`, so it behaves as expected
![largebins-new](https://user-images.githubusercontent.com/16000770/228700347-5d9021cd-6950-44cd-8788-a8d9ed1f2e87.png)
* `verbose` is set to `False` across the `*bins` commands

### argparse housekeeping:
* remove `default=False` from the `verbose` argument, `store_true` sets this automatically
* remove `default=None` from the `addr` argument, `default` defaults to `None`

The only commands impacted by defaulting to `verbose=False` are `fastbins` & `unsortedbin`
In the case of `unsortedbin` I think it's clearer when the bin is empty:
![unsortedbin-new](https://user-images.githubusercontent.com/16000770/228699616-defaead8-f50b-4dbc-819a-71e3b7796240.png)
vs.
![unsortedbin-old](https://user-images.githubusercontent.com/16000770/228699625-95acbef8-cc6a-4adf-8a40-a3b3b1965b6f.png)

In the `fastbins` case:
![fastbins-new](https://user-images.githubusercontent.com/16000770/228699927-43173d81-eaf1-45d0-84f7-f38179e6f95b.png)
vs.
![fastbins-old](https://user-images.githubusercontent.com/16000770/228699965-c2b2cdf4-ceda-43ad-8e0d-6d9e18beea2a.png)

Some folks might miss the empty fastbins being printed but I think they just take up space.