### PR TITLE
Fix slab info command for linux kernel >= 5.16

### DIFF
--- a/pwndbg/commands/kversion.py
+++ b/pwndbg/commands/kversion.py
@@ -12,4 +12,4 @@ parser = argparse.ArgumentParser(description="Outputs the kernel version (/proc/
 @pwndbg.commands.OnlyWithKernelDebugSyms
 @pwndbg.commands.OnlyWhenPagingEnabled
 def kversion() -> None:
-    print(pwndbg.gdblib.kernel.kversion())
+    print(pwndbg.gdblib.kernel.kbanner())

--- a/pwndbg/commands/slab.py
+++ b/pwndbg/commands/slab.py
@@ -5,9 +5,6 @@ Some of the code here was inspired from https://github.com/NeatMonster/slabdbg
 """
 import argparse
 import sys
-from typing import Iterator
-from typing import List
-from typing import Union
 
 import gdb
 from tabulate import tabulate
@@ -18,7 +15,7 @@ import pwndbg.commands
 import pwndbg.gdblib.kernel.slab
 from pwndbg.commands import CommandCategory
 from pwndbg.gdblib.kernel import kconfig
-from pwndbg.gdblib.kernel import kversion
+from pwndbg.gdblib.kernel import krelease
 from pwndbg.gdblib.kernel import per_cpu
 from pwndbg.gdblib.kernel.slab import oo_objects
 from pwndbg.gdblib.kernel.slab import oo_order
@@ -192,7 +189,7 @@ def print_cpu_cache(cpu_cache: gdb.Value, slab_cache: gdb.Value, verbose: bool, 
         freelist = cpu_cache["freelist"]
         indent.print(f"{C.blue('Freelist')}:", _yx(int(freelist)))
 
-        slab_key = "slab" if kversion() >= (5, 17) else "page"
+        slab_key = "slab" if krelease() >= (5, 17) else "page"
         active_slab = cpu_cache[slab_key]
         if active_slab:
             indent.print(f"{C.green('Active Slab')}:")
@@ -210,12 +207,12 @@ def print_cpu_cache(cpu_cache: gdb.Value, slab_cache: gdb.Value, verbose: bool, 
 
         partial_slab = cpu_cache["partial"]
         if partial_slab:
-            slabs_key = "slabs" if kversion() >= (5, 17) else "pages"
-            if kversion() >= (5, 16):
+            slabs_key = "slabs" if krelease() >= (5, 17) else "pages"
+            if krelease() >= (5, 16):
                 # calculate approx obj count in half-full slabs (as done in kernel)
                 # Note, this is a very bad approximation and could/should probably
                 # be replaced by a more exact method or removed from pwndbg
-                oo = oo_objects(slab_cache["oo"]["x"])
+                oo = oo_objects(int(slab_cache["oo"]["x"]))
                 slabs = int(partial_slab[slabs_key])
                 pobjects = (slabs * oo) // 2
             else:

--- a/pwndbg/commands/slab.py
+++ b/pwndbg/commands/slab.py
@@ -5,7 +5,9 @@ Some of the code here was inspired from https://github.com/NeatMonster/slabdbg
 """
 import argparse
 import sys
-from typing import Iterator, List, Union
+from typing import Iterator
+from typing import List
+from typing import Union
 
 import gdb
 from tabulate import tabulate
@@ -15,8 +17,10 @@ import pwndbg.color.message as M
 import pwndbg.commands
 import pwndbg.gdblib.kernel.slab
 from pwndbg.commands import CommandCategory
-from pwndbg.gdblib.kernel import kconfig, per_cpu
-from pwndbg.gdblib.kernel.slab import oo_objects, oo_order
+from pwndbg.gdblib.kernel import kconfig
+from pwndbg.gdblib.kernel import per_cpu
+from pwndbg.gdblib.kernel.slab import oo_objects
+from pwndbg.gdblib.kernel.slab import oo_order
 
 parser = argparse.ArgumentParser(description="Prints information about the SLUB allocator")
 subparsers = parser.add_subparsers(dest="command")
@@ -129,8 +133,12 @@ def _rx(val: int) -> str:
 
 
 def print_slab(
-        slab: gdb.Value, cpu_cache: gdb.Value, slab_cache: gdb.Value, 
-        indent, verbose: bool, is_partial: bool = False
+    slab: gdb.Value,
+    cpu_cache: gdb.Value,
+    slab_cache: gdb.Value,
+    indent,
+    verbose: bool,
+    is_partial: bool = False,
 ) -> None:
     slab_address = int(slab.address)
     offset = int(slab_cache["offset"])
@@ -171,13 +179,13 @@ def print_slab(
                         indent.print("-", hex(int(address)), "(in-use)")
                         continue
                     next_free_idx = cur_freelist.index(address) + 1
-                    next_free = cur_freelist[next_free_idx] if len(cur_freelist) > next_free_idx else 0
+                    next_free = (
+                        cur_freelist[next_free_idx] if len(cur_freelist) > next_free_idx else 0
+                    )
                     indent.print("-", _yx(int(address)), f"(next: {next_free:#018x})")
 
 
-def print_cpu_cache(
-        cpu_cache: gdb.Value, slab_cache: gdb.Value, verbose: bool, indent
-    ) -> None:
+def print_cpu_cache(cpu_cache: gdb.Value, slab_cache: gdb.Value, verbose: bool, indent) -> None:
     indent.print(f"{C.green('Per-CPU Data')} @ {_yx(int(cpu_cache))}:")
     with indent:
         freelist = cpu_cache["freelist"]
@@ -214,7 +222,7 @@ def print_cpu_cache(
             while partial_slab:
                 cur_slab = partial_slab.dereference()
                 print_slab(
-                    cur_slab, 
+                    cur_slab,
                     cpu_cache,
                     slab_cache,
                     indent,
@@ -277,4 +285,3 @@ def slab_list(filter_) -> None:
         )
 
     print(tabulate(results, headers=["Name", "# Objects", "Size", "Obj Size", "# inuse", "order"]))
-

--- a/pwndbg/gdblib/kernel/__init__.py
+++ b/pwndbg/gdblib/kernel/__init__.py
@@ -79,7 +79,7 @@ def kbanner() -> str:
 @requires_debug_syms()
 @pwndbg.lib.memoize.reset_on_start
 def kversion() -> tuple[int, ...]:
-    return tuple([int(x) for x in kversion().split()[2].split(".")])
+    return tuple([int(x) for x in kbanner().split()[2].split(".")])
 
 
 @requires_debug_syms()

--- a/pwndbg/gdblib/kernel/__init__.py
+++ b/pwndbg/gdblib/kernel/__init__.py
@@ -71,9 +71,15 @@ def kcmdline() -> str:
 
 @requires_debug_syms(default="")
 @pwndbg.lib.memoize.reset_on_start
-def kversion() -> str:
+def kbanner() -> str:
     version_addr = pwndbg.gdblib.symbol.address("linux_banner")
     return pwndbg.gdblib.memory.string(version_addr).decode("ascii").strip()
+
+
+@requires_debug_syms()
+@pwndbg.lib.memoize.reset_on_start
+def kversion() -> tuple[int, ...]:
+    return tuple([int(x) for x in kversion().split()[2].split(".")])
 
 
 @requires_debug_syms()
@@ -85,12 +91,16 @@ def is_kaslr_enabled() -> bool:
     return "nokaslr" not in kcmdline()
 
 
+@requires_debug_syms()
+@pwndbg.lib.memoize.reset_on_start
 def cpu_feature_capability(feature: int) -> bool:
     boot_cpu_data = gdb.lookup_global_symbol("boot_cpu_data").value()
     capabilities = boot_cpu_data["x86_capability"]
     return (int(capabilities[feature // 32]) >> (feature % 32)) & 1 == 1
 
 
+@requires_debug_syms()
+@pwndbg.lib.memoize.reset_on_start
 def uses_5lvl_paging() -> bool:
     X86_FEATURE_LA57 = 16 * 32 + 16
     return (

--- a/pwndbg/gdblib/kernel/__init__.py
+++ b/pwndbg/gdblib/kernel/__init__.py
@@ -93,8 +93,11 @@ def cpu_feature_capability(feature: int) -> bool:
 
 def uses_5lvl_paging() -> bool:
     X86_FEATURE_LA57 = 16 * 32 + 16
-    return "CONFIG_X86_5LEVEL = y" in kconfig() and "no5lvl" in kcmdline() and \
-        cpu_feature_capability(X86_FEATURE_LA57)
+    return (
+        "CONFIG_X86_5LEVEL = y" in kconfig()
+        and "no5lvl" in kcmdline()
+        and cpu_feature_capability(X86_FEATURE_LA57)
+    )
 
 
 class ArchOps:
@@ -134,7 +137,7 @@ class ArchOps:
         return phys_to_pfn(virt_to_phys(virt))
 
     # phys <-> page
-    
+
     def phys_to_page(self, phys: int) -> int:
         return pfn_to_page(phys_to_pfn(phys))
 
@@ -327,12 +330,14 @@ def pfn_to_page(pfn: int) -> int:
     else:
         raise NotImplementedError()
 
+
 def pfn_to_phys(pfn: int) -> int:
     ops = arch_ops()
     if ops:
         return ops.pfn_to_phys(pfn)
     else:
         raise NotImplementedError()
+
 
 def pfn_to_virt(pfn: int) -> int:
     ops = arch_ops()
@@ -364,6 +369,7 @@ def page_to_pfn(page: int) -> int:
         return ops.page_to_pfn(page)
     else:
         raise NotImplementedError()
+
 
 def virt_to_page(virt: int) -> int:
     ops = arch_ops()

--- a/pwndbg/gdblib/kernel/__init__.py
+++ b/pwndbg/gdblib/kernel/__init__.py
@@ -71,15 +71,15 @@ def kcmdline() -> str:
 
 @requires_debug_syms(default="")
 @pwndbg.lib.memoize.reset_on_start
-def kbanner() -> str:
+def kversion() -> str:
     version_addr = pwndbg.gdblib.symbol.address("linux_banner")
     return pwndbg.gdblib.memory.string(version_addr).decode("ascii").strip()
 
 
 @requires_debug_syms()
 @pwndbg.lib.memoize.reset_on_start
-def kversion() -> tuple[int, ...]:
-    return tuple([int(x) for x in kbanner().split()[2].split(".")])
+def krelease() -> tuple[int, ...]:
+    return tuple([int(x) for x in kversion().split()[2].split(".")])
 
 
 @requires_debug_syms()


### PR DESCRIPTION
see #1523.

Changes from this PR to `slab info` command:
- Add 5-level paging support for `x86_64`
- Support `struct slab` (introduced in linux 5.17)
- Extract version tuple from linux banner in `pwndbg.gdblib.kernel.krelease()`
- Support `pobjects` calculation formula introduced in linux 5.16
- For active Slab, introduce support for slabs freelist (even if rarely used)
- Simplify function arguments for `print_cpu_cache()`, `print_slab()`
- Extend and Clean Up `ArchOps`
- Display all slab slots instead of just free slots and if free, show next pointer
![image](https://user-images.githubusercontent.com/37738506/231080473-866e8b7c-feef-4df3-9164-5e9bf55bbd66.png)


I have not yet had the time to look at how pwndbgs tests are working and how such a kernel command can be thoroughly tested in the CI, so I just opened this as a Draft PR for now. 
