### PR TITLE
CI: remove Ubuntu 18.04 from lint and tests builds

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, ubuntu-20.04, ubuntu-18.04]
+        os: [ubuntu-22.04, ubuntu-20.04]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, ubuntu-20.04, ubuntu-18.04]
+        os: [ubuntu-22.04, ubuntu-20.04]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     steps:


### PR DESCRIPTION
The main reason for this is that GH Actions is deprecating Ubuntu 18.04 and some of those build fails or are ignored because of that:
![image](https://user-images.githubusercontent.com/10009354/231240870-ea958b99-719e-43b0-9025-f2e2a3f3538a.png)


To be specific:

> The Ubuntu 18.04 Actions runner image [started our deprecation process](https://github.com/actions/runner-images/issues/6002) on 8/8/22 and will be fully unsupported by 12/1/22.

Source: https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/

