### PR TITLE
Add support for Arch Linux ARM in setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -134,7 +134,7 @@ if linux; then
         "opensuse-leap")
             install_zypper
             ;;
-        "arch" | "endeavouros" | "manjaro")
+        "arch" | "archarm" | "endeavouros" | "manjaro")
             install_pacman
             echo "Logging off and in or conducting a power cycle is required to get debuginfod to work."
             echo "Alternatively you can manually set the environment variable: DEBUGINFOD_URLS=https://debuginfod.archlinux.org"
@@ -157,7 +157,7 @@ if linux; then
             elif hash dnf; then
                 install_dnf
             else
-                echo "\"$distro\" is not supported and your distro don't have apt or dnf that we support currently."
+                echo "\"$distro\" is not supported and your distro don't have a package manager that we support currently."
                 exit
             fi
             ;;


### PR DESCRIPTION
Technically Arch Linux ARM is a separate distro from the x86_64 Arch Linux, but it uses pacman and the same package names. So it installs just fine, just needs to be detected properly.

<!-- Please make sure to read the testing and linting instructions at https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md before creating a PR -->
