### PR TITLE
add `krelease()` function

### DIFF
--- a/pwndbg/gdblib/kernel/__init__.py
+++ b/pwndbg/gdblib/kernel/__init__.py
@@ -1,6 +1,7 @@
 import functools
 import math
 import re
+from typing import Tuple
 
 import gdb
 
@@ -79,7 +80,7 @@ def kversion() -> str:
 
 @requires_debug_syms()
 @pwndbg.lib.memoize.reset_on_start
-def krelease() -> tuple[int, int, int]:
+def krelease() -> Tuple[int, ...]:
     # try to extract (major.minor.patch) version
     match = re.search(r"Linux version (\d+)\.(\d+)\.(\d+)", kversion())
     if match:

--- a/pwndbg/gdblib/kernel/__init__.py
+++ b/pwndbg/gdblib/kernel/__init__.py
@@ -83,7 +83,7 @@ def kversion() -> str:
 def krelease() -> Tuple[int, ...]:
     match = re.search(r"Linux version (\d+)\.(\d+)(?:\.(\d+))?", kversion())
     if match:
-        return tuple([int(x) for x in match.groups() if x])
+        return tuple(int(x) for x in match.groups() if x)
     raise Exception("Linux version tuple not found")
 
 

--- a/pwndbg/gdblib/kernel/__init__.py
+++ b/pwndbg/gdblib/kernel/__init__.py
@@ -81,15 +81,9 @@ def kversion() -> str:
 @requires_debug_syms()
 @pwndbg.lib.memoize.reset_on_start
 def krelease() -> Tuple[int, ...]:
-    # try to extract (major.minor.patch) version
-    match = re.search(r"Linux version (\d+)\.(\d+)\.(\d+)", kversion())
+    match = re.search(r"Linux version (\d+)\.(\d+)(?:\.(\d+))?", kversion())
     if match:
-        return tuple(map(int, match.groups()))
-    # try to extract (major.minor) version and append 0 for patch version
-    match = re.search(r"Linux version (\d+)\.(\d+)", kversion())
-    if match:
-        return tuple(map(int, match.groups())) + (0,)
-    # not found
+        return tuple([int(x) for x in match.groups() if x])
     raise Exception("Linux version tuple not found")
 
 

--- a/tests/qemu-tests/tests/test_qemu_system.py
+++ b/tests/qemu-tests/tests/test_qemu_system.py
@@ -13,3 +13,12 @@ try:
 except Exception:
     traceback.print_exc()
     exit(1)
+
+
+try:
+    release_ver = pwndbg.gdblib.kernel.krelease()
+    # release should be int tuple of form: (major, minor, patch)
+    assert(len(release_ver) == 3)
+except Exception:
+    traceback.print_exc()
+    exit(1)

--- a/tests/qemu-tests/tests/test_qemu_system.py
+++ b/tests/qemu-tests/tests/test_qemu_system.py
@@ -18,7 +18,7 @@ except Exception:
 try:
     release_ver = pwndbg.gdblib.kernel.krelease()
     # release should be int tuple of form: (major, minor, patch)
-    assert(len(release_ver) == 3)
+    assert len(release_ver) == 3
 except Exception:
     traceback.print_exc()
     exit(1)

--- a/tests/qemu-tests/tests/test_qemu_system.py
+++ b/tests/qemu-tests/tests/test_qemu_system.py
@@ -17,8 +17,11 @@ except Exception:
 
 try:
     release_ver = pwndbg.gdblib.kernel.krelease()
-    # release should be int tuple of form: (major, minor, patch)
-    assert len(release_ver) == 3
+    # release should be int tuple of form (major, minor, patch) or (major, minor)
+    assert len(release_ver) >= 2
+    release_str = "Linux version " + ".".join([str(x) for x in release_ver])
+    assert release_str in pwndbg.gdblib.kernel.kversion()
+
 except Exception:
     traceback.print_exc()
     exit(1)


### PR DESCRIPTION
This PR adds the `pwndbg.gdblib.kernel.krelease()` function which allows pwndbg to easily implement linux kernel version specific behavior.

The function returns a tuple of `int`: `(major, minor, patch)`.

It can then be used as follows:

```py
if pwndbg.gdblib.kernel.krelease() >= (5, 17):
    # do something
else:
    # do something else
```

The PR also allows fixing the currently broken `slab info` command (part of splitting up Draft PR #1668)