### PR TITLE
Optimize vis_heap_chunks command

### DIFF
--- a/profiling/benchmark_vis_heap_chunks/README.md
+++ b/profiling/benchmark_vis_heap_chunks/README.md
@@ -1,0 +1,2 @@
+This benchmark was used to investigate performance problems with the `vis_heap_chunks` command described in https://github.com/pwndbg/pwndbg/issues/1675
+

--- a/profiling/benchmark_vis_heap_chunks/bench.sh
+++ b/profiling/benchmark_vis_heap_chunks/bench.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+gdb --batch --ex 'break exit' --ex 'run' --ex 'source gdbscript.py' --args `which python3` -c 'import sys; sys.exit(0)'

--- a/profiling/benchmark_vis_heap_chunks/bench.sh
+++ b/profiling/benchmark_vis_heap_chunks/bench.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-gdb --batch --ex 'break exit' --ex 'run' --ex 'source gdbscript.py' --args `which python3` -c 'import sys; sys.exit(0)'
+gdb --batch --ex 'break exit' --ex 'run' --ex 'source gdbscript.py' --args $(which python3) -c 'import sys; sys.exit(0)'

--- a/profiling/benchmark_vis_heap_chunks/gdbscript.py
+++ b/profiling/benchmark_vis_heap_chunks/gdbscript.py
@@ -1,0 +1,9 @@
+import gdb, pwndbg
+
+pwndbg.profiling.profiler.start()
+result = gdb.execute("vis 2000", to_string=True)
+pwndbg.profiling.profiler.stop('profile.prof')
+
+# Save result in case user wants to inspect it
+with open("result", "w") as f:
+    f.write(result)

--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -914,7 +914,7 @@ def vis_heap_chunks(
         >> 1
     )
 
-    bin_labels_map = bin_labels_mapping(bin_collections)
+    bin_labels_map: Dict[int, List[str]] = bin_labels_mapping(bin_collections)
 
     for c, stop in enumerate(chunk_delims):
         color_func = color_funcs[c % len(color_funcs)]

--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -942,7 +942,8 @@ def vis_heap_chunks(
             if printed % 2 == 0:
                 out += "\n0x%x" % cursor
 
-            cell = pwndbg.gdblib.arch.unpack(pwndbg.gdblib.memory.read(cursor, ptr_size))
+            data = pwndbg.gdblib.memory.read(cursor, ptr_size)
+            cell = pwndbg.gdblib.arch.unpack(data)
             cell_hex = "\t0x{:0{n}x}".format(cell, n=ptr_size * 2)
 
             out += color_func(cell_hex)
@@ -952,7 +953,7 @@ def vis_heap_chunks(
             if cursor == arena.top:
                 labels.append("Top chunk")
 
-            asc += bin_ascii(pwndbg.gdblib.memory.read(cursor, ptr_size))
+            asc += bin_ascii(data)
             if printed % 2 == 0:
                 out += "\t" + color_func(asc) + ("\t <-- " + ", ".join(labels) if labels else "")
                 asc = ""

--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -3,6 +3,7 @@ import ctypes
 
 import gdb
 from tabulate import tabulate
+from typing import Dict, List
 
 import pwndbg.color.context as C
 import pwndbg.color.memory as M

--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -998,9 +998,9 @@ def bin_labels_mapping(collections):
             chunks = b.fd_chain
             for chunk_addr in chunks:
                 labels_mapping.setdefault(chunk_addr, []).append(
-                        "{:s}[{:s}][{:d}{}]".format(
-                            bins_type, size, chunks.index(chunk_addr), count or ""
-                        )
+                    "{:s}[{:s}][{:d}{}]".format(
+                        bins_type, size, chunks.index(chunk_addr), count or ""
+                    )
                 )
 
     return labels_mapping

--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -914,6 +914,8 @@ def vis_heap_chunks(
         >> 1
     )
 
+    bin_labels_map = bin_labels_mapping(bin_collections)
+
     for c, stop in enumerate(chunk_delims):
         color_func = color_funcs[c % len(color_funcs)]
 
@@ -946,7 +948,7 @@ def vis_heap_chunks(
             out += color_func(cell_hex)
             printed += 1
 
-            labels.extend(bin_labels(cursor, bin_collections))
+            labels.extend(bin_labels_map.get(cursor, []))
             if cursor == arena.top:
                 labels.append("Top chunk")
 
@@ -975,8 +977,14 @@ def bin_ascii(bs):
     return "".join(chr(c) if c in valid_chars else "." for c in bs)
 
 
-def bin_labels(addr, collections):
-    labels = []
+def bin_labels_mapping(collections):
+    """
+    Returns all potential bin labels for all potential addresses
+    We precompute all of them because doing this on demand was too slow and inefficient
+    See #1675 for more details
+    """
+    labels_mapping = {}
+
     for bins in collections:
         if not bins:
             continue
@@ -989,14 +997,13 @@ def bin_labels(addr, collections):
             count = "/{:d}".format(b.count) if bins_type == BinType.TCACHE else None
             chunks = b.fd_chain
             for chunk_addr in chunks:
-                if addr == chunk_addr:
-                    labels.append(
+                labels_mapping.setdefault(chunk_addr, []).append(
                         "{:s}[{:s}][{:d}{}]".format(
-                            bins_type, size, chunks.index(addr), count or ""
+                            bins_type, size, chunks.index(chunk_addr), count or ""
                         )
-                    )
+                )
 
-    return labels
+    return labels_mapping
 
 
 try_free_parser = argparse.ArgumentParser(

--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -983,7 +983,7 @@ def bin_labels_mapping(collections):
     We precompute all of them because doing this on demand was too slow and inefficient
     See #1675 for more details
     """
-    labels_mapping = {}
+    labels_mapping: Dict[int, List[str]] = {}
 
     for bins in collections:
         if not bins:

--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -1,9 +1,10 @@
 import argparse
 import ctypes
+from typing import Dict
+from typing import List
 
 import gdb
 from tabulate import tabulate
-from typing import Dict, List
 
 import pwndbg.color.context as C
 import pwndbg.color.memory as M


### PR DESCRIPTION
This commit optimizes the vis_heap_chunks command by precalculating bin labels instead of computing them on demand for each chunk.

For `vis 2000` command ran when debugging python3 shell, those changed cut down the execution time from almost 20s to 5s.

The benchmark done is included in this commit in
profiling/benchmark_vis_heap_chunks/ so that it can be reproduced e.g. to optimize the function further or to reproduce my results.

The profiling results from my initial benchmarking of this issue on the old code can be seen here: https://github.com/pwndbg/pwndbg/issues/1675#issuecomment-1515360405

To pull up the relevant results:
```
$ python3 ../pwndbg/profiling/print_stats.py ./pwndbg-1681937259.pstats
Wed Apr 19 21:47:39 2023    ./pwndbg-1681937259.pstats

         24929221 function calls (24913554 primitive calls) in 9.356 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000    9.356    9.356 {built-in method _gdb.execute}
        1    0.000    0.000    9.355    9.355 __init__.py:128(invoke)
        1    0.000    0.000    9.355    9.355 __init__.py:182(__call__)
        1    0.000    0.000    9.355    9.355 __init__.py:317(_OnlyWhenRunning)
        1    0.000    0.000    9.354    9.354 __init__.py:394(_OnlyWithResolvedHeapSyms)
        1    0.000    0.000    9.348    9.348 __init__.py:358(_try2run_heap_command)
        1    0.000    0.000    9.348    9.348 __init__.py:342(_OnlyWhenHeapIsInitialized)
        1    0.400    0.400    9.347    9.347 heap.py:823(vis_heap_chunks)
    49435    4.477    0.000    6.361    0.000 heap.py:982(bin_labels)
    49435    0.711    0.000    1.207    0.000 heap.py:975(bin_ascii)
    98872    0.210    0.000    0.727    0.000 memory.py:18(read)
  3213288    0.699    0.000    0.699    0.000 {method 'format' of 'str' objects}
  9689260    0.668    0.000    0.668    0.000 {built-in method builtins.hex}
  9764888    0.599    0.000    0.612    0.000 {built-in method builtins.isinstance}
    98872    0.462    0.000    0.462    0.000 {method 'read_memory' of 'gdb.Inferior' objects}
    49451    0.064    0.000    0.417    0.000 {method 'join' of 'str' objects}
   444915    0.341    0.000    0.353    0.000 heap.py:979(<genexpr>)
     1299    0.002    0.000    0.176    0.000 ptmalloc.py:310(is_top_chunk)
    74152    0.044    0.000    0.175    0.000 __init__.py:138(wrapper)
     1299    0.001    0.000    0.165    0.000 ptmalloc.py:303(arena)
     1299    0.001    0.000    0.164    0.000 ptmalloc.py:296(heap)
     1301    0.009    0.000    0.164    0.000 ptmalloc.py:346(__init__)
    74152    0.045    0.000    0.102    0.000 __init__.py:125(colorize)
```

In this case we spent 9.3 seconds on visualizing chunks and out of this time 6.3 seconds were spent on 49435 calls to `bin_labels` which is certainly way too much!

With this PR this function is called only once but it precomputes labels for ALL possible addresses, so it certainly takes more memory now but things got way faster.