### PR TITLE
Allow Garuda Linux install in setup

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -134,7 +134,7 @@ if linux; then
         "opensuse-leap")
             install_zypper
             ;;
-        "arch" | "archarm" | "endeavouros" | "manjaro")
+        "arch" | "archarm" | "endeavouros" | "manjaro" | "garuda")
             install_pacman
             echo "Logging off and in or conducting a power cycle is required to get debuginfod to work."
             echo "Alternatively you can manually set the environment variable: DEBUGINFOD_URLS=https://debuginfod.archlinux.org"


### PR DESCRIPTION
Added [Garuda Linux](https://garudalinux.org/) (an Arch based linux distribution) to the supported Arch distros in the setup script.
The setup worked for me with these changes.

Meta: I see no `beta` or `stable` branches as mentioned in the contributing guidelines, adapt merge branch if I misunderstood something.