### PR TITLE
make qemu-system tests more customizable

### DIFF
--- a/tests/qemu-tests/run_qemu_system.sh
+++ b/tests/qemu-tests/run_qemu_system.sh
@@ -1,24 +1,57 @@
 #!/bin/bash
 
-ARCH="$1"
-KERNEL_TYPE="${2:-linux}"
+ARCH=""
+KERNEL_TYPE=""
+CMDLINE=""
+
+VALID_ARCHS=("x86_64" "arm64" "aarch64")
+VALID_TYPES=("linux" "ack")
+
+help_and_exit() {
+    echo "Usage: $0 [options] [-- other qemu options]"
+    echo ""
+    echo "  --arch=<ARCH>      select the architecture to run"
+    echo "          possible values: [${VALID_ARCHS[*]}]"
+    echo ""
+    echo "  --type=<TYPE>      select the kernel type to run"
+    echo "          possible values: [${VALID_TYPES[*]}]"
+    echo ""
+    echo "  --append=<CMDLINE> append something to the kernel's cmdline."
+    echo ""
+    echo "Options after '--' will be passed to QEMU."
+    exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --arch=*) ARCH="${1#--arch=}" ;;
+        --type=*) KERNEL_TYPE="${1#--type=}" ;;
+        --append=*) CMDLINE="${CMDLINE} ${1#--append=}" ;;
+        -h | --help) help_and_exit ;;
+        --)
+            shift
+            QEMU_ARGS_EXT=("$@")
+            break
+            ;;
+    esac
+    shift
+done
 
 CWD=$(dirname -- "$0")
 IMAGE_DIR="${CWD}/images"
 
 if [ -z "$ARCH" ]; then
-    echo "usage: $0 ARCH [ack | linux]"
-    exit 1
+    help_and_exit
 fi
 
-if [[ "${ARCH}" != @(x86_64|arm64|aarch64) ]]; then
-    echo "Invalid arch ${ARCH}"
-    exit 1
+if [[ ! " ${VALID_ARCHS[*]} " =~ " ${ARCH} " ]]; then
+    echo "Invalid arch '${ARCH}'"
+    help_and_exit
 fi
 
-if [[ "${KERNEL_TYPE}" != @(ack|linux) ]]; then
-    echo "Invalid kernel type ${KERNEL_TYPE}"
-    exit 1
+if [[ ! " ${VALID_TYPES[*]} " =~ " ${KERNEL_TYPE} " ]]; then
+    echo "Invalid kernel type '${KERNEL_TYPE}'"
+    help_and_exit
 fi
 
 if [[ "${ARCH}" == @(arm64|aarch64) ]]; then
@@ -30,7 +63,7 @@ if [[ "${ARCH}" == @(arm64|aarch64) ]]; then
     QEMU_ARGS=(
         -cpu max
         -machine virt
-        -append "console=ttyAMA0 root=/dev/vda nokaslr"
+        -append "console=ttyAMA0 root=/dev/vda nokaslr ${CMDLINE}"
     )
 elif [ "$ARCH" == "x86_64" ]; then
     QEMU_BIN=qemu-system-x86_64
@@ -38,15 +71,16 @@ elif [ "$ARCH" == "x86_64" ]; then
     ROOTFS="${IMAGE_DIR}/rootfs-x86_64.img"
 
     QEMU_ARGS=(
-        -append "8250.nr_uarts=1 console=ttyS0 root=/dev/vda nokaslr"
+        -append "8250.nr_uarts=1 console=ttyS0 root=/dev/vda nokaslr ${CMDLINE}"
     )
 fi
 
 QEMU_ARGS+=(
     -kernel $KERNEL
     -nographic
-    -drive file=$ROOTFS,if=virtio,format=qcow2
+    -drive "file=$ROOTFS,if=virtio,format=qcow2"
     -S -s
+    "${QEMU_ARGS_EXT[@]}"
 )
 
 echo "Waiting for GDB to attach (use 'ctrl-a x' to quit)"

--- a/tests/qemu-tests/tests.sh
+++ b/tests/qemu-tests/tests.sh
@@ -12,7 +12,7 @@ KERNEL_TYPE=""
 VMLINUX=""
 
 PLATFORMS=(
-    # ARCH KERNEL_TYPE
+    # ARCH KERNEL_TYPE [QEMU_ARGS]
     "x86_64 linux"
     "x86_64 ack"
     "arm64 linux"
@@ -176,7 +176,13 @@ test_system() {
     FAILED_TESTS=()
     echo "============================ Testing $KERNEL_TYPE-$ARCH ============================"
 
-    "${CWD}/run_qemu_system.sh" "$ARCH" "$KERNEL_TYPE" > /dev/null 2>&1 &
+    if [[ ! -z ${QEMU_ARGS} ]]; then
+        echo "Additional QEMU parameters used: '${QEMU_ARGS[*]}'"
+    fi
+
+    echo ""
+
+    "${CWD}/run_qemu_system.sh" --arch="$ARCH" --type="$KERNEL_TYPE" -- "${QEMU_ARGS[@]}" > /dev/null 2>&1 &
 
     init_gdb
     start=$(date +%s)
@@ -211,10 +217,11 @@ test_system() {
 }
 
 for platform in "${PLATFORMS[@]}"; do
-    read -r arch kernel_type <<< "$platform"
+    read -r arch kernel_type qemu_args <<< "$platform"
 
     ARCH="$arch"
     KERNEL_TYPE="$kernel_type"
+    QEMU_ARGS=($qemu_args)
     VMLINUX="${IMAGE_DIR}/vmlinux-${KERNEL_TYPE}-${ARCH}"
 
     test_system


### PR DESCRIPTION
This PR adds the capability to quickly comment/uncomment different qemu-system configuration combinations and makes it easily possible to add custom QEMU cli arguments.

Once a Linux kernel image which has `CONFIG_X86_5LEVEL = y` set was added to pwndbgs images, testing a system with 5-level paging is as easy as:

- Adding the string `"x86_64 linux -cpu qemu64,+la57"` to the `PLATFORMS` array in `tests/qemu-tests/tests.sh`

This causes qemu to be called with the additional argument `-cpu qemu64,+la57` which enables the necessary hardware support for 5-level paging.
