### PR TITLE
In malloc_chunk replace size with real_size

### DIFF
--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -420,7 +420,7 @@ def malloc_chunk(addr, fake=False, verbose=False, simple=False) -> None:
     if verbose:
         fields_to_print.update(["prev_size", "size", "fd", "bk", "fd_nextsize", "bk_nextsize"])
     else:
-        out_fields += "Size: 0x{:02x}\n".format(chunk.size)
+        out_fields += "Size: 0x{:02x}\n".format(chunk.real_size)
 
     prev_inuse, is_mmapped, non_main_arena = allocator.chunk_flags(chunk.size)
     if prev_inuse:


### PR DESCRIPTION
`real_size` is the size of chunk without size bits(PREV_INUSE ,IS_MMAPPED, NON_MAIN_ARENA)

