### PR TITLE
Refactor memory.Page to use less properties

### DIFF
--- a/pwndbg/commands/hexdump.py
+++ b/pwndbg/commands/hexdump.py
@@ -33,7 +33,7 @@ def address_or_module_name(s):
         module_name = gdbval_or_str
         pages = list(filter(lambda page: module_name in page.objfile, pwndbg.gdblib.vmmap.get()))
         if pages:
-            return pages[0].vaddr
+            return pages[0].start
         else:
             raise argparse.ArgumentTypeError("Could not find pages for module %s" % module_name)
     elif isinstance(gdbval_or_str, (int, gdb.Value)):

--- a/pwndbg/commands/kbase.py
+++ b/pwndbg/commands/kbase.py
@@ -35,8 +35,8 @@ def kbase() -> None:
         # TODO: Check if the supervisor bit is set for aarch64
         if not mapping.execute:
             continue
-        b = pwndbg.gdblib.memory.byte(mapping.vaddr)
+        b = pwndbg.gdblib.memory.byte(mapping.start)
 
         if b == magic:
-            print(M.success(f"Found virtual base address: {mapping.vaddr:#x}"))
+            print(M.success(f"Found virtual base address: {mapping.start:#x}"))
             break

--- a/pwndbg/commands/pie.py
+++ b/pwndbg/commands/pie.py
@@ -52,9 +52,9 @@ def translate_addr(offset, module):
         )
         return
 
-    first_page = min(pages, key=lambda page: page.vaddr)
+    first_page = min(pages, key=lambda page: page.start)
 
-    addr = first_page.vaddr + offset
+    addr = first_page.start + offset
 
     if not any(addr in p for p in pages):
         print(

--- a/pwndbg/commands/probeleak.py
+++ b/pwndbg/commands/probeleak.py
@@ -138,7 +138,7 @@ def probeleak(
                 right_text = "(%s) %s + 0x%x + 0x%x (outside of the page)" % (
                     page.permstr,
                     mod_name,
-                    page.memsz,
+                    page.size,
                     p - page.end,
                 )
             elif p < page.start:

--- a/pwndbg/commands/stack.py
+++ b/pwndbg/commands/stack.py
@@ -24,8 +24,7 @@ def retaddr() -> None:
         frame = frame.older()
 
     # Find all of them on the stack
-    start = stack.vaddr
-    stop = start + stack.memsz
+    start, stop = stack.start, stack.end
     while addresses and start < sp < stop:
         value = pwndbg.gdblib.memory.u(sp)
 

--- a/pwndbg/commands/vmmap.py
+++ b/pwndbg/commands/vmmap.py
@@ -96,12 +96,12 @@ def vmmap(gdbval_or_str=None, writable=False, executable=False) -> None:
     print_vmmap_table_header()
     if len(pages) == 1 and isinstance(gdbval_or_str, integer_types):
         page = pages[0]
-        print(M.get(page.vaddr, text=str(page) + " +0x%x" % (int(gdbval_or_str) - page.vaddr)))
+        print(M.get(page.start, text=str(page) + " +0x%x" % (int(gdbval_or_str) - page.start)))
     else:
         for page in pages:
             if (executable and not page.execute) or (writable and not page.write):
                 continue
-            print(M.get(page.vaddr, text=str(page)))
+            print(M.get(page.start, text=str(page)))
 
     if pwndbg.gdblib.qemu.is_qemu():
         print("\n[QEMU target detected - vmmap result might not be accurate; see `help vmmap`]")

--- a/pwndbg/commands/xinfo.py
+++ b/pwndbg/commands/xinfo.py
@@ -38,11 +38,11 @@ def xinfo_stack(page, addr) -> None:
     frame = pwndbg.gdblib.regs[pwndbg.gdblib.regs.frame]
     frame_mapping = pwndbg.gdblib.vmmap.find(frame)
 
-    print_line("Stack Top", addr, page.vaddr, addr - page.vaddr, "+")
+    print_line("Stack Top", addr, page.start, addr - page.start, "+")
     print_line("Stack End", addr, page.end, page.end - addr, "-")
     print_line("Stack Pointer", addr, sp, addr - sp, "+")
 
-    if frame_mapping and page.vaddr == frame_mapping.vaddr:
+    if frame_mapping and page.start == frame_mapping.start:
         print_line("Frame Pointer", addr, frame, frame - addr, "-")
 
     canary_value = pwndbg.commands.canary.canary_value()[0]
@@ -65,16 +65,16 @@ def xinfo_mmap_file(page, addr) -> None:
 
     file_name = page.objfile
     objpages = filter(lambda p: p.objfile == file_name, pwndbg.gdblib.vmmap.get())
-    first = sorted(objpages, key=lambda p: p.vaddr)[0]
+    first = sorted(objpages, key=lambda p: p.start)[0]
 
     # print offset from ELF base load address
-    rva = addr - first.vaddr
-    print_line("File (Base)", addr, first.vaddr, rva, "+")
+    rva = addr - first.start
+    print_line("File (Base)", addr, first.start, rva, "+")
 
     # find possible LOAD segments that designate memory and file backings
     containing_loads = [
         seg
-        for seg in pwndbg.gdblib.elf.get_containing_segments(file_name, first.vaddr, addr)
+        for seg in pwndbg.gdblib.elf.get_containing_segments(file_name, first.start, addr)
         if seg["p_type"] == "PT_LOAD"
     ]
 
@@ -92,7 +92,7 @@ def xinfo_mmap_file(page, addr) -> None:
     else:
         print("{} {} = [not file backed]".format("File (Disk)".rjust(20), M.get(addr)))
 
-    containing_sections = pwndbg.gdblib.elf.get_containing_sections(file_name, first.vaddr, addr)
+    containing_sections = pwndbg.gdblib.elf.get_containing_sections(file_name, first.start, addr)
     if len(containing_sections) > 0:
         print("\n Containing ELF sections:")
         for sec in containing_sections:
@@ -101,7 +101,7 @@ def xinfo_mmap_file(page, addr) -> None:
 
 def xinfo_default(page, addr) -> None:
     # Just print the distance to the beginning of the mapping
-    print_line("Mapped Area", addr, page.vaddr, addr - page.vaddr, "+")
+    print_line("Mapped Area", addr, page.start, addr - page.start, "+")
 
 
 @pwndbg.commands.ArgparsedCommand(parser, category=CommandCategory.MEMORY)

--- a/pwndbg/gdblib/elf.py
+++ b/pwndbg/gdblib/elf.py
@@ -432,14 +432,15 @@ def map_inner(ei_class, ehdr, objfile):
     # for binaries that are relocatable / type DYN.
     if ET_DYN == int(ehdr.e_type):
         for page in pages:
-            page.vaddr += base
+            page.start += base
+            page.end += base
 
     # Merge contiguous sections of memory together
     pages.sort()
     prev = pages[0]
     for page in list(pages[1:]):
-        if (prev.flags & PF_W) == (page.flags & PF_W) and prev.vaddr + prev.memsz == page.vaddr:
-            prev.memsz += page.memsz
+        if (prev.flags & PF_W) == (page.flags & PF_W) and prev.end == page.start:
+            prev.size += page.size
             pages.remove(page)
         else:
             prev = page
@@ -449,8 +450,8 @@ def map_inner(ei_class, ehdr, objfile):
     gaps = []
     for i in range(len(pages) - 1):
         a, b = pages[i : i + 2]
-        a_end = a.vaddr + a.memsz
-        b_begin = b.vaddr
+        a_end = a.end
+        b_begin = b.start
         if a_end != b_begin:
             gaps.append(pwndbg.lib.memory.Page(a_end, b_begin - a_end, 0, b.offset))
 

--- a/pwndbg/gdblib/stack.py
+++ b/pwndbg/gdblib/stack.py
@@ -93,10 +93,11 @@ def update() -> None:
 
             # If we *DO* already know about this thread, just
             # update the lower boundary if it got any lower.
-            low = min(page.vaddr, sp_low)
-            if low != page.vaddr:
-                page.memsz += page.vaddr - low
-                page.vaddr = low
+            low = min(page.start, sp_low)
+            if low != page.start:
+                page.size += page.start - low
+                page.start = low
+                page.end = page.start + page.size
     finally:
         if curr_thread:
             curr_thread.switch()

--- a/pwndbg/heap/ptmalloc.py
+++ b/pwndbg/heap/ptmalloc.py
@@ -383,8 +383,8 @@ class Heap:
                         allocator.malloc_state.sizeof, allocator.malloc_alignment
                     )
 
-                heap_region.memsz = heap_region.end - start
-                heap_region.vaddr = start
+                heap_region.size = heap_region.end - start
+                heap_region.start = start
                 self._memory_region = heap_region
                 self._gdbValue = heap_info
             elif main_arena.non_contiguous:
@@ -1462,8 +1462,8 @@ class DebugSymsHeap(GlibcMemoryAllocator):
         )
 
         sbrk_region = self.get_region(sbrk_base)
-        sbrk_region.memsz = sbrk_region.end - sbrk_base
-        sbrk_region.vaddr = sbrk_base
+        sbrk_region.size = sbrk_region.end - sbrk_base
+        sbrk_region.start = sbrk_base
 
         return sbrk_region
 
@@ -1991,8 +1991,8 @@ class HeuristicHeap(GlibcMemoryAllocator):
                 )
 
                 sbrk_region = self.get_region(sbrk_base)
-                sbrk_region.memsz = self.get_region(sbrk_base).end - sbrk_base
-                sbrk_region.vaddr = sbrk_base
+                sbrk_region.size = self.get_region(sbrk_base).end - sbrk_base
+                sbrk_region.start = sbrk_base
 
                 return sbrk_region
             else:

--- a/pwndbg/lib/memory.py
+++ b/pwndbg/lib/memory.py
@@ -114,7 +114,7 @@ class Page:
     def __str__(self) -> str:
         return "{start:#{width}x} {end:#{width}x} {permstr} {size:8x} {offset:6x} {objfile}".format(
             start=self.start,
-            end=self.start + self.size,
+            end=self.end,
             permstr=self.permstr,
             size=self.size,
             offset=self.offset,

--- a/pwndbg/lib/memory.py
+++ b/pwndbg/lib/memory.py
@@ -129,10 +129,10 @@ class Page:
         return self.start <= addr < self.end
 
     def __eq__(self, other) -> bool:
-        return self.start == getattr(other, "start", other)
+        return self.start == other.start
 
     def __lt__(self, other) -> bool:
-        return self.start < getattr(other, "start", other)
+        return self.start < other.start
 
     def __hash__(self):
         return hash((self.start, self.end, self.size, self.flags, self.offset, self.objfile))

--- a/tests/gdb-tests/tests/test_memory.py
+++ b/tests/gdb-tests/tests/test_memory.py
@@ -10,7 +10,7 @@ def test_memory_read_write(start_binary):
     Tests simple pwndbg's memory read/write operations with different argument types
     """
     start_binary(REFERENCE_BINARY)
-    stack_addr = next(iter(pwndbg.gdblib.stack.stacks.values())).vaddr
+    stack_addr = next(iter(pwndbg.gdblib.stack.stacks.values())).start
 
     # Testing write(addr, str)
     val = "X" * 50


### PR DESCRIPTION
Refactors the `pwndbg.gdblib.memory.Page` class to use `__slots__` for faster access.

We didn't use properties in all cases anyway. I think we could even think of computing flags as well, but idk.

<!-- Please make sure to read the testing and linting instructions at https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md before creating a PR -->
