### PR TITLE
Add heuristic to add executable base to vmmap in qemu-user

### DIFF
--- a/pwndbg/gdblib/vmmap.py
+++ b/pwndbg/gdblib/vmmap.py
@@ -675,7 +675,13 @@ def info_auxv(skip_exe=False):
     phdr = auxv.AT_PHDR
 
     if not skip_exe and (entry or phdr):
-        pages.extend(pwndbg.gdblib.elf.map(entry or phdr, exe_name))
+        for addr in [entry, phdr]:
+            if not addr:
+                continue
+            new_pages = pwndbg.gdblib.elf.map(addr, exe_name)
+            if new_pages:
+                pages.extend(new_pages)
+                break
 
     if base:
         pages.extend(pwndbg.gdblib.elf.map(base, "[linker]"))


### PR DESCRIPTION
vmmap would try to add the executable to memory pages if the `info auxv` command contained an address, but the memory maps would be accessed recursively when trying to lookup the start of the ELF based on the given address.

Since qemu doesn't provide memory map info, do a leap of faith and try if the start of the page of the given address contains the ELF magic header.

Since the program headers are more likely to be on the same page as the ELF header than the program entrypoint, try both.