### PR TITLE
Fix stack.update caching bug

### DIFF
--- a/pwndbg/gdblib/stack.py
+++ b/pwndbg/gdblib/stack.py
@@ -62,6 +62,7 @@ def update() -> None:
     try:
         for thread in gdb.selected_inferior().threads():
             thread.switch()
+            pwndbg.gdblib.regs.__getattr__.cache.clear()
             sp = pwndbg.gdblib.regs.sp
 
             # Skip if sp is None or 0


### PR DESCRIPTION
The `pwndbg.gdblib.regs.sp` value is cached and its cache is cleared on a next stop, memory write or register write events.

We keep a dictionary of stacks in Pwndbg, that are updated on each stop by the `stack.update` functionality which reused a cached stack pointer (`gdblib.regs.sp`) value.

As a result, if we had more than one threads, the `pwndbg.gdblib.stacks.stacks` reported the same stack address for all threads and then the `canary` command printed the same addresses N times where N is the number of threads that were running.

This commit fixes this bug by clearing up the registers cache when we switch into a different thread in the loop in the `stacks.update` function.

<!-- Please make sure to read the testing and linting instructions at https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md before creating a PR -->
