### PR TITLE
Updated canary.py for better display

### DIFF
--- a/pwndbg/commands/canary.py
+++ b/pwndbg/commands/canary.py
@@ -23,70 +23,79 @@ def canary_value():
 
 
 @pwndbg.commands.ArgparsedCommand(
-    "Print out the current stack canary.",
-    category=CommandCategory.STACK,
+    "Print out the current stack canary.", category=CommandCategory.STACK
 )
 @pwndbg.commands.OnlyWhenRunning
-@pwndbg.commands.ParsedCommand(parser)
-def canary(args):
+@pwndbg.commands.aliases("can")
+@pwndbg.commands.add_argument(
+    "--all",
+    "-a",
+    action="store_true",
+    help="Display all canaries for all threads.",
+)
+def canary(all: bool = False) -> None:
     global_canary, at_random = canary_value()
 
     if global_canary is None or at_random is None:
-        print(
-            message.error("Couldn't find AT_RANDOM - can't display canary.")
-        )
+        print(message.error("Couldn't find AT_RANDOM - can't display canary."))
         return
 
     print(
         message.notice(
-            "AT_RANDOM = %#x # points to (not masked) global canary value"
-            % at_random
+            "AT_RANDOM = %#x # points to (not masked) global canary value" % at_random
         )
     )
     print(
         message.notice(
-            "Canary    = 0x%x (may be incorrect on != glibc)"
-            % global_canary
+            "Canary    = 0x%x (may be incorrect on != glibc)" % global_canary
         )
     )
 
-    if args.all:
-        print(message.success("Found valid canaries on the stacks:"))
-        for stack in pwndbg.gdblib.stack.stacks.values():
-            stack_canary = pwndbg.search.search(pwndbg.gdblib.arch.pack(global_canary), mappings=[stack])
-            if not stack_canary:
-                continue
-            stack_canary = stack_canary[0]
-            thread = pwndbg.proc.get_thread_containing(stack_canary)
-            if thread is None:
-                continue
+    if not all:
+        # Display canary for current thread
+        stack_canary = find_canary_for_thread(pwndbg.procinfo.procs[0].tid)
+        if not stack_canary:
             print(
-                message.success(
-                    f"Thread {thread.num}: {stack_canary - thread.sp} bytes from RSP"
+                message.warn(
+                    "No valid canary found on the stack for current thread."
                 )
             )
-            pwndbg.commands.telescope.telescope(
-                address=stack_canary, count=1
-            )
-        return
+            return
 
-    stack = pwndbg.gdblib.stack.current_stack()
-    stack_canary = pwndbg.search.search(
-        pwndbg.gdblib.arch.pack(global_canary), mappings=[stack]
-    )
-
-    if not stack_canary:
-        print(message.warn("No valid canary found on the stack."))
-        return
-
-    stack_canary = stack_canary[0]
-    thread = pwndbg.proc.get_thread_containing(stack_canary)
-    if thread is None:
-        print(message.warn("No thread found at current canary address."))
-    else:
         print(
             message.success(
-                f"Thread {thread.num}: {stack_canary - thread.sp} bytes from RSP"
+                f"Found valid canary on the stack for current thread ({pwndbg.procinfo.procs[0].tid}):"
             )
         )
-    pwndbg.commands.telescope.telescope(address=stack_canary, count=
+        pwndbg.commands.telescope.telescope(address=stack_canary, count=1)
+
+    else:
+        # Display canaries for all threads
+        found_canaries = False
+        for proc in pwndbg.procinfo.procs:
+            stack_canary = find_canary_for_thread(proc.tid)
+            if stack_canary:
+                found_canaries = True
+                print(
+                    message.success(
+                        f"Found valid canary on the stack for thread {proc.tid}:"
+                    )
+                )
+                pwndbg.commands.telescope.telescope(
+                    address=stack_canary, count=1
+                )
+
+        if not found_canaries:
+            print(message.warn("No valid canaries found on the stacks."))
+
+
+def find_canary_for_thread(thread_id):
+    for stack in pwndbg.gdblib.stack.stacks.values():
+        if stack.thread_id == thread_id:
+            rsp = pwndbg.regs.rsp
+            canary_address = stack.sp - pwndbg.arch.ptrsize
+            if canary_address >= rsp:
+                return pwndbg.memory.u(canary_address)
+
+    return None
+

--- a/pwndbg/commands/canary.py
+++ b/pwndbg/commands/canary.py
@@ -23,49 +23,70 @@ def canary_value():
 
 
 @pwndbg.commands.ArgparsedCommand(
-    "Print out the current stack canary.", category=CommandCategory.STACK
+    "Print out the current stack canary.",
+    category=CommandCategory.STACK,
 )
 @pwndbg.commands.OnlyWhenRunning
-def canary() -> None:
+@pwndbg.commands.ParsedCommand(parser)
+def canary(args):
     global_canary, at_random = canary_value()
 
     if global_canary is None or at_random is None:
-        print(message.error("Couldn't find AT_RANDOM - can't display canary."))
-        return
-
-    print(
-        message.notice("AT_RANDOM = %#x # points to (not masked) global canary value" % at_random)
-    )
-    print(message.notice("Canary    = 0x%x (may be incorrect on != glibc)" % global_canary))
-
-    current_thread = pwndbg.proc.current_thread_id()
-    current_rsp = pwndbg.regs.rsp
-    stack_canaries = []
-
-    for stack in pwndbg.stack.stacks.values():
-        stack_start = stack.start
-        stack_end = stack.end
-        if stack_start <= current_rsp < stack_end:
-            stack_canaries = list(
-                pwndbg.search.search(pwndbg.gdblib.arch.pack(global_canary), mappings=[stack])
-            )
-            break
-
-    if not stack_canaries:
-        print(message.warn("No valid canaries found on the current stack."))
-        return
-
-    print(
-        message.success(
-            f"Found valid canaries on the current stack (thread {current_thread}):"
-        )
-    )
-
-    for stack_canary in stack_canaries:
-        offset_from_rsp = stack_canary - current_rsp
         print(
-            message.address(
-                f"Canary at offset {offset_from_rsp:#x} from RSP: {stack_canary:#x}"
+            message.error("Couldn't find AT_RANDOM - can't display canary.")
+        )
+        return
+
+    print(
+        message.notice(
+            "AT_RANDOM = %#x # points to (not masked) global canary value"
+            % at_random
+        )
+    )
+    print(
+        message.notice(
+            "Canary    = 0x%x (may be incorrect on != glibc)"
+            % global_canary
+        )
+    )
+
+    if args.all:
+        print(message.success("Found valid canaries on the stacks:"))
+        for stack in pwndbg.gdblib.stack.stacks.values():
+            stack_canary = pwndbg.search.search(pwndbg.gdblib.arch.pack(global_canary), mappings=[stack])
+            if not stack_canary:
+                continue
+            stack_canary = stack_canary[0]
+            thread = pwndbg.proc.get_thread_containing(stack_canary)
+            if thread is None:
+                continue
+            print(
+                message.success(
+                    f"Thread {thread.num}: {stack_canary - thread.sp} bytes from RSP"
+                )
+            )
+            pwndbg.commands.telescope.telescope(
+                address=stack_canary, count=1
+            )
+        return
+
+    stack = pwndbg.gdblib.stack.current_stack()
+    stack_canary = pwndbg.search.search(
+        pwndbg.gdblib.arch.pack(global_canary), mappings=[stack]
+    )
+
+    if not stack_canary:
+        print(message.warn("No valid canary found on the stack."))
+        return
+
+    stack_canary = stack_canary[0]
+    thread = pwndbg.proc.get_thread_containing(stack_canary)
+    if thread is None:
+        print(message.warn("No thread found at current canary address."))
+    else:
+        print(
+            message.success(
+                f"Thread {thread.num}: {stack_canary - thread.sp} bytes from RSP"
             )
         )
-        pwndbg.commands.telescope.telescope(address=stack_canary, count=1)
+    pwndbg.commands.telescope.telescope(address=stack_canary, count=

--- a/pwndbg/commands/canary.py
+++ b/pwndbg/commands/canary.py
@@ -38,16 +38,34 @@ def canary() -> None:
     )
     print(message.notice("Canary    = 0x%x (may be incorrect on != glibc)" % global_canary))
 
-    stack_canaries = list(
-        pwndbg.search.search(
-            pwndbg.gdblib.arch.pack(global_canary), mappings=pwndbg.gdblib.stack.stacks.values()
+    current_thread = pwndbg.proc.current_thread_id()
+    current_rsp = pwndbg.regs.rsp
+    stack_canaries = []
+
+    for stack in pwndbg.stack.stacks.values():
+        stack_start = stack.start
+        stack_end = stack.end
+        if stack_start <= current_rsp < stack_end:
+            stack_canaries = list(
+                pwndbg.search.search(pwndbg.gdblib.arch.pack(global_canary), mappings=[stack])
+            )
+            break
+
+    if not stack_canaries:
+        print(message.warn("No valid canaries found on the current stack."))
+        return
+
+    print(
+        message.success(
+            f"Found valid canaries on the current stack (thread {current_thread}):"
         )
     )
 
-    if not stack_canaries:
-        print(message.warn("No valid canaries found on the stacks."))
-        return
-
-    print(message.success("Found valid canaries on the stacks:"))
     for stack_canary in stack_canaries:
+        offset_from_rsp = stack_canary - current_rsp
+        print(
+            message.address(
+                f"Canary at offset {offset_from_rsp:#x} from RSP: {stack_canary:#x}"
+            )
+        )
         pwndbg.commands.telescope.telescope(address=stack_canary, count=1)

--- a/pwndbg/commands/version.py
+++ b/pwndbg/commands/version.py
@@ -157,40 +157,6 @@ If it is somehow unavailable, use:
                 os_info = match.group(1)
 
     current_setup += "OS: %s\n" % os_info
-    
-    # 1. showing osabi
-    osabi_info = platform.uname().version
-    current_setup += "OS ABI: %s\n" % osabi_info
-
-    # 2. showing architecture
-    arch_info = platform.machine()
-    current_setup += "Architecture: %s\n" % arch_info
-
-    # 3. showing endian
-    endian_info = sys.byteorder
-    current_setup += "Endian: %s\n" % endian_info
-
-    # 4. Depending on current arch -- note that those are only available if given arch is supported by current GDB, like gdb-multiarch
-    if arch_info in ["armv7l", "aarch64"]:
-        arm_info = gdb.execute("show arm", to_string=True)
-        current_setup += "ARM: %s\n" % arm_info
-
-    if arch_info in ["mips", "mips64"]:
-        mips_info = gdb.execute("show mips", to_string=True)
-        current_setup += "MIPS: %s\n" % mips_info
-
-    # 7. showing charset
-    charset_info = sys.getdefaultencoding()
-    current_setup += "Charset: %s\n" % charset_info
-
-    # 8. showing width
-    width_info = os.get_terminal_size().columns
-    current_setup += "Width: %s\n" % width_info
-
-    # 9. showing height
-    height_info = os.get_terminal_size().lines
-    current_setup += "Height: %s\n" % height_info
-    
     current_setup += "\n".join(all_info)
     current_setup += "\n" + "\n".join(gdb_config)
 

--- a/pwndbg/commands/version.py
+++ b/pwndbg/commands/version.py
@@ -157,6 +157,40 @@ If it is somehow unavailable, use:
                 os_info = match.group(1)
 
     current_setup += "OS: %s\n" % os_info
+    
+    # 1. showing osabi
+    osabi_info = platform.uname().version
+    current_setup += "OS ABI: %s\n" % osabi_info
+
+    # 2. showing architecture
+    arch_info = platform.machine()
+    current_setup += "Architecture: %s\n" % arch_info
+
+    # 3. showing endian
+    endian_info = sys.byteorder
+    current_setup += "Endian: %s\n" % endian_info
+
+    # 4. Depending on current arch -- note that those are only available if given arch is supported by current GDB, like gdb-multiarch
+    if arch_info in ["armv7l", "aarch64"]:
+        arm_info = gdb.execute("show arm", to_string=True)
+        current_setup += "ARM: %s\n" % arm_info
+
+    if arch_info in ["mips", "mips64"]:
+        mips_info = gdb.execute("show mips", to_string=True)
+        current_setup += "MIPS: %s\n" % mips_info
+
+    # 7. showing charset
+    charset_info = sys.getdefaultencoding()
+    current_setup += "Charset: %s\n" % charset_info
+
+    # 8. showing width
+    width_info = os.get_terminal_size().columns
+    current_setup += "Width: %s\n" % width_info
+
+    # 9. showing height
+    height_info = os.get_terminal_size().lines
+    current_setup += "Height: %s\n" % height_info
+    
     current_setup += "\n".join(all_info)
     current_setup += "\n" + "\n".join(gdb_config)
 


### PR DESCRIPTION
<!-- Please make sure to read the testing and linting instructions at https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md before creating a PR -->

Fixes #1704 

The updated code now has the following changes:

1."current_thread" is obtained by "pwndbg.proc.current_thread_id()" and presented with stack canary information.

2.To acquire the current stack (to which RSP refers), use "current_rsp = pwndbg.regs.rsp." The stack canaries' offsets from RSP are calculated and shown using "offset_from_rsp = stack_canary - current_rsp" and the information is presented using "print()" and "message.address()."
