### PR TITLE
Add `slab contains` command

### DIFF
--- a/pwndbg/commands/slab.py
+++ b/pwndbg/commands/slab.py
@@ -309,13 +309,12 @@ def slab_contains(address: str) -> None:
         print(M.error(f"Could not parse '{address}'"))
         return
 
-    # TODO: handle cases when min_low_pfn and max_low_pfn symbols are not found
-    min_low_pfn = gdb.lookup_global_symbol("min_low_pfn")
-    max_low_pfn = gdb.lookup_global_symbol("max_low_pfn")
+    min_pfn = 0
+    max_pfn = int(gdb.lookup_global_symbol("max_pfn").value())
 
-    start_addr = pwndbg.gdblib.kernel.pfn_to_virt(int(min_low_pfn.value()))
+    start_addr = pwndbg.gdblib.kernel.pfn_to_virt(min_pfn)
     end_addr = pwndbg.gdblib.kernel.pfn_to_virt(
-        int(max_low_pfn.value()) + pwndbg.gdblib.kernel.arch_ops().page_size()
+        max_pfn + pwndbg.gdblib.kernel.arch_ops().page_size()
     )
 
     if not start_addr <= addr <= end_addr:

--- a/pwndbg/commands/slab.py
+++ b/pwndbg/commands/slab.py
@@ -317,7 +317,7 @@ def slab_contains(address: str) -> None:
         max_pfn + pwndbg.gdblib.kernel.arch_ops().page_size()
     )
 
-    if not start_addr <= addr <= end_addr:
+    if not start_addr <= addr < end_addr:
         print(M.error(f"{addr:#x}: address out of range"))
         return
 

--- a/pwndbg/gdblib/kernel/__init__.py
+++ b/pwndbg/gdblib/kernel/__init__.py
@@ -242,7 +242,13 @@ class Aarch64Ops(ArchOps):
         PAGE_END = (-1 << (VA_BITS_MIN - 1)) + 2**64
         VMEMMAP_SIZE = (PAGE_END - self.PAGE_OFFSET) >> (self.PAGE_SHIFT - self.STRUCT_PAGE_SHIFT)
 
-        self.VMEMMAP_START = (-VMEMMAP_SIZE - 2 * 1024 * 1024) + 2**64
+        if pwndbg.gdblib.kernel.krelease() >= (5, 11):
+            # Linux 5.11 changed the calculation for VMEMMAP_START
+            # https://elixir.bootlin.com/linux/v5.11/source/arch/arm64/include/asm/memory.h#L53
+            self.VMEMMAP_SHIFT = self.PAGE_SHIFT - self.STRUCT_PAGE_SHIFT
+            self.VMEMMAP_START = -(1 << (self.VA_BITS - self.VMEMMAP_SHIFT)) % (1 << 64)
+        else:
+            self.VMEMMAP_START = (-VMEMMAP_SIZE - 2 * 1024 * 1024) + 2**64
 
     def page_size(self) -> int:
         return 1 << self.PAGE_SHIFT

--- a/pwndbg/gdblib/kernel/__init__.py
+++ b/pwndbg/gdblib/kernel/__init__.py
@@ -104,6 +104,9 @@ class ArchOps:
     # use through kernel configuration, enabling support for additional models
     # in the page_to_pfn() and pfn_to_page() methods in the future.
 
+    def page_size(self) -> int:
+        raise NotImplementedError()
+
     def per_cpu(self, addr: gdb.Value, cpu=None):
         raise NotImplementedError()
 
@@ -164,6 +167,9 @@ class x86_64Ops(ArchOps):
         self.START_KERNEL_map = 0xFFFFFFFF80000000
         self.PAGE_SHIFT = 12
         self.phys_base = 0x1000000
+
+    def page_size(self) -> int:
+        return 1 << self.PAGE_SHIFT
 
     def per_cpu(self, addr: gdb.Value, cpu=None):
         if cpu is None:
@@ -228,7 +234,6 @@ class Aarch64Ops(ArchOps):
 
         self.VA_BITS = int(kconfig()["ARM64_VA_BITS"])
         self.PAGE_SHIFT = int(kconfig()["CONFIG_ARM64_PAGE_SHIFT"])
-        self.PAGE_SIZE = 1 << self.PAGE_SHIFT
 
         self.PHYS_OFFSET = pwndbg.gdblib.memory.u(pwndbg.gdblib.symbol.address("memstart_addr"))
         self.PAGE_OFFSET = (-1 << self.VA_BITS) + 2**64
@@ -238,6 +243,9 @@ class Aarch64Ops(ArchOps):
         VMEMMAP_SIZE = (PAGE_END - self.PAGE_OFFSET) >> (self.PAGE_SHIFT - self.STRUCT_PAGE_SHIFT)
 
         self.VMEMMAP_START = (-VMEMMAP_SIZE - 2 * 1024 * 1024) + 2**64
+
+    def page_size(self) -> int:
+        return 1 << self.PAGE_SHIFT
 
     def per_cpu(self, addr: gdb.Value, cpu=None):
         if cpu is None:

--- a/pwndbg/gdblib/kernel/__init__.py
+++ b/pwndbg/gdblib/kernel/__init__.py
@@ -221,8 +221,8 @@ class x86_64Ops(ArchOps):
         # https://elixir.bootlin.com/linux/v6.2/source/arch/x86/include/asm/cpufeatures.h#L381
         X86_FEATURE_LA57 = 16 * 32 + 16
         return (
-            "CONFIG_X86_5LEVEL = y" in kconfig()
-            and "no5lvl" in kcmdline()
+            kconfig().get("CONFIG_X86_5LEVEL") == "y"
+            and "no5lvl" not in kcmdline()
             and x86_64Ops.cpu_feature_capability(X86_FEATURE_LA57)
         )
 

--- a/pwndbg/gdblib/kernel/macros.py
+++ b/pwndbg/gdblib/kernel/macros.py
@@ -22,7 +22,7 @@ def for_each_entry(head, typename, field):
 
 def _arr(x: gdb.Value, n: int) -> gdb.Value:
     """returns the nth element of type x, starting at address of x"""
-    ptr = x.address.case(x.type.pointer())
+    ptr = x.address.cast(x.type.pointer())
     return (ptr + n).dereference()
 
 

--- a/pwndbg/gdblib/kernel/macros.py
+++ b/pwndbg/gdblib/kernel/macros.py
@@ -32,7 +32,7 @@ def compound_head(page: gdb.Value) -> gdb.Value:
     # https://elixir.bootlin.com/linux/v6.2/source/include/linux/page-flags.h#L249
     head = page["compound_head"]
     if int(head) & 1:
-        return (head - 1).cast(page.type.pointer())
+        return (head - 1).cast(page.type.pointer()).dereference()
 
     pg_head = int(gdb.lookup_static_symbol("PG_head").value())
     # https://elixir.bootlin.com/linux/v6.2/source/include/linux/page-flags.h#L212
@@ -41,6 +41,6 @@ def compound_head(page: gdb.Value) -> gdb.Value:
 
         head = next_page["compound_head"]
         if int(head) & 1:
-            return (head - 1).cast(page.type.pointer())
+            return (head - 1).cast(page.type.pointer()).dereference()
 
     return page

--- a/pwndbg/gdblib/kernel/macros.py
+++ b/pwndbg/gdblib/kernel/macros.py
@@ -18,3 +18,29 @@ def for_each_entry(head, typename, field):
     while addr != head.address:
         yield container_of(addr, typename, field)
         addr = addr.dereference()["next"]
+
+
+def _arr(x: gdb.Value, n: int) -> gdb.Value:
+    """returns the nth element of type x, starting at address of x"""
+    ptr = x.address.case(x.type.pointer())
+    return (ptr + n).dereference()
+
+
+def compound_head(page: gdb.Value) -> gdb.Value:
+    """returns the head page of compound pages"""
+    assert page.type.name == "page"
+    # https://elixir.bootlin.com/linux/v6.2/source/include/linux/page-flags.h#L249
+    head = page["compound_head"]
+    if int(head) & 1:
+        return (head - 1).cast(page.type.pointer())
+
+    pg_head = int(gdb.lookup_static_symbol("PG_head").value())
+    # https://elixir.bootlin.com/linux/v6.2/source/include/linux/page-flags.h#L212
+    if int(page["flags"]) & (1 << pg_head):
+        next_page = _arr(page, 1)
+
+        head = next_page["compound_head"]
+        if int(head) & 1:
+            return (head - 1).cast(page.type.pointer())
+
+    return page

--- a/tests/qemu-tests/tests.sh
+++ b/tests/qemu-tests/tests.sh
@@ -119,7 +119,9 @@ init_gdb() {
     local arch="$3"
 
     gdb_connect_qemu=(-ex "file ${IMAGE_DIR}/vmlinux-${kernel_type}-${kernel_version}-${arch}" -ex "target remote :1234")
-    gdb_args=("${gdb_connect_qemu[@]}" -ex 'break *start_kernel' -ex 'continue')
+    # using 'rest_init' instead of 'start_kernel' to make sure that kernel
+    # initialization has progressed sufficiently for testing purposes
+    gdb_args=("${gdb_connect_qemu[@]}" -ex 'break *rest_init' -ex 'continue')
     run_gdb "${arch}" "${gdb_args[@]}" > /dev/null 2>&1
 }
 

--- a/tests/qemu-tests/tests/system/test_commands_kernel.py
+++ b/tests/qemu-tests/tests/system/test_commands_kernel.py
@@ -62,3 +62,20 @@ def test_command_slab_info():
 
     res = gdb.execute("slab info -v does_not_exit", to_string=True)
     assert "not found" in res
+
+
+def test_command_slab_contains():
+    if not pwndbg.gdblib.kernel.has_debug_syms():
+        res = gdb.execute("slab contains 0x123", to_string=True)
+        assert "may only be run when debugging a Linux kernel with debug" in res
+        return
+
+    slab_cache = "kmalloc-512"
+
+    # retrieve a valid slab object address (first address from freelist)
+    info = gdb.execute(f"slab info -v {slab_cache}", to_string=True)
+    addr = __import__("re").findall(r"- (0x[0-9a-fA-F]+)", info)[0]
+
+    res = gdb.execute(f"slab contains {addr}", to_string=True)
+
+    assert f"{addr} @ {slab_cache}" in res, f"{info}"


### PR DESCRIPTION
This PR adds a new command: `slab contains addr [addr ...]` which returns the name of the slab cache for each of the addresses provided.

![image](https://github.com/pwndbg/pwndbg/assets/37738506/d3d1c3eb-5d8f-4e15-bfc5-13715decd53c)

Also, the PR fixes a faulty 5-level paging detection on x86_64 which became apparent while adding a test for the new subcommand.

EDIT:
- The PR also fixes the address translations for aarch64 kernels >= 5.11 by updating the `VMEMMAP_START` calculation from that version on.
- Furthermore, there was an issue where some parts of the kernel were not sufficiently initialized when reaching the `start_kernel` function and thereby the qemu test infrastructure was modified to run until `rest_init` instead (which is called around the end of the kernel initialization).