### PR TITLE
Include opensuse-tumbleweed in setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -131,7 +131,7 @@ if linux; then
         "clear-linux-os")
             install_swupd
             ;;
-        "opensuse-leap")
+        "opensuse-leap" | "opensuse-tumbleweed")
             install_zypper
             ;;
         "arch" | "archarm" | "endeavouros" | "manjaro" | "garuda")


### PR DESCRIPTION
<!-- Please make sure to read the testing and linting instructions at https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md before creating a PR -->
AS title says, the install commands for `opensuse-leap` work also for `opensuse-tumbleweed`.

PS. Is python2 still required? I don't see it in `install_apt`. If it not required lmk and since I am at it I will add a commit for the opensuse family.