### PR TITLE
refactor: move slab business logic to gdblib

### DIFF
--- a/pwndbg/commands/slab.py
+++ b/pwndbg/commands/slab.py
@@ -1,12 +1,11 @@
 """
-Commands for dealing with Linux kernel SLAB memory allocator
+Commands for dealing with Linux kernel slab allocator. Currently, only SLUB is supported.
 
 Some of the code here was inspired from https://github.com/NeatMonster/slabdbg
 """
 import argparse
 import sys
 
-import gdb
 from tabulate import tabulate
 
 import pwndbg.color as C
@@ -14,14 +13,10 @@ import pwndbg.color.message as M
 import pwndbg.commands
 import pwndbg.gdblib.kernel.slab
 from pwndbg.commands import CommandCategory
-from pwndbg.gdblib.kernel import kconfig
-from pwndbg.gdblib.kernel import krelease
-from pwndbg.gdblib.kernel import per_cpu
-from pwndbg.gdblib.kernel.slab import get_slab_key
-from pwndbg.gdblib.kernel.slab import oo_objects
-from pwndbg.gdblib.kernel.slab import oo_order
+from pwndbg.gdblib.kernel.slab import CpuCache
+from pwndbg.gdblib.kernel.slab import Slab
 
-parser = argparse.ArgumentParser(description="Prints information about the SLUB allocator")
+parser = argparse.ArgumentParser(description="Prints information about the slab allocator")
 subparsers = parser.add_subparsers(dest="command")
 
 # The command will still work on 3.6 and earlier, but the help won't be shown
@@ -45,19 +40,6 @@ parser_info.add_argument("names", metavar="name", type=str, nargs="+", help="")
 parser_info.add_argument("-v", "--verbose", action="store_true", help="")
 
 
-def swab(x):
-    return int(
-        ((x & 0x00000000000000FF) << 56)
-        | ((x & 0x000000000000FF00) << 40)
-        | ((x & 0x0000000000FF0000) << 24)
-        | ((x & 0x00000000FF000000) << 8)
-        | ((x & 0x000000FF00000000) >> 8)
-        | ((x & 0x0000FF0000000000) >> 24)
-        | ((x & 0x00FF000000000000) >> 40)
-        | ((x & 0xFF00000000000000) >> 56)
-    )
-
-
 @pwndbg.commands.ArgparsedCommand(parser, category=CommandCategory.KERNEL)
 @pwndbg.commands.OnlyWhenQemuKernel
 @pwndbg.commands.OnlyWithKernelDebugSyms
@@ -68,35 +50,6 @@ def slab(command, filter_=None, names=None, verbose=False) -> None:
     elif command == "info":
         for name in names:
             slab_info(name, verbose)
-
-
-_flags = {
-    "SLAB_DEBUG_FREE": 0x00000100,
-    "SLAB_RED_ZONE": 0x00000400,
-    "SLAB_POISON": 0x00000800,
-    "SLAB_HWCACHE_ALIGN": 0x00002000,
-    "SLAB_CACHE_DMA": 0x00004000,
-    "SLAB_STORE_USER": 0x00010000,
-    "SLAB_RECLAIM_ACCOUNT": 0x00020000,
-    "SLAB_PANIC": 0x00040000,
-    "SLAB_DESTROY_BY_RCU": 0x00080000,
-    "SLAB_MEM_SPREAD": 0x00100000,
-    "SLAB_TRACE": 0x00200000,
-    "SLAB_DEBUG_OBJECTS": 0x00400000,
-    "SLAB_NOLEAKTRACE": 0x00800000,
-    "SLAB_NOTRACK": 0x01000000,
-    "SLAB_FAILSLAB": 0x02000000,
-}
-
-
-def get_flags_list(flags: int):
-    flags_list = []
-
-    for flag_name, mask in _flags.items():
-        if flags & mask:
-            flags_list.append(flag_name)
-
-    return flags_list
 
 
 class IndentContextManager:
@@ -114,15 +67,6 @@ class IndentContextManager:
         print("    " * self.indent, *a, **kw)
 
 
-def walk_freelist(freelist, offset, random):
-    while freelist:
-        address = int(freelist)
-        yield address
-        freelist = pwndbg.gdblib.memory.pvoid(address + offset)
-        if random:
-            freelist ^= random ^ swab(address + offset)
-
-
 def _yx(val: int) -> str:
     return C.yellow(hex(val))
 
@@ -131,163 +75,100 @@ def _rx(val: int) -> str:
     return C.red(hex(val))
 
 
-def print_slab(
-    slab: gdb.Value,
-    cpu_cache: gdb.Value,
-    slab_cache: gdb.Value,
-    indent,
-    verbose: bool,
-    is_partial: bool = False,
-) -> None:
-    slab_address = int(slab.address)
-    offset = int(slab_cache["offset"])
-    random = int(slab_cache["random"]) if "SLAB_FREELIST_HARDENED" in kconfig() else 0
-    address = pwndbg.gdblib.kernel.page_to_virt(slab_address)
-
-    indent.print(f"- {C.green('Slab')} @ {_yx(address)} [{_rx(slab_address)}]:")
+def print_slab(slab: Slab, indent, verbose: bool) -> None:
+    indent.print(f"- {C.green('Slab')} @ {_yx(slab.virt_address)} [{_rx(slab.slab_address)}]:")
 
     with indent:
-        if is_partial:
-            freelists = [list(walk_freelist(slab["freelist"], offset, random))]
-            inuse = slab["inuse"]
-        else:
-            # `freelist` is a generator, we need to evaluate it now and save the
-            # result in case we want to print it later
-            freelists = [
-                list(walk_freelist(cpu_cache["freelist"], offset, random)),
-                list(walk_freelist(slab["freelist"], offset, random)),
-            ]
-
-            # `inuse` will always equal `objects` for the active slab, so we
-            # need to subtract the length of the freelist
-            inuse = int(slab["inuse"]) - len(freelists[0])
-
-        objects = int(slab["objects"])
-        indent.print(f"{C.blue('In-Use')}: {inuse}/{objects}")
-
-        indent.print(f"{C.blue('Frozen')}:", slab["frozen"])
-        indent.print(f"{C.blue('Freelist')}:", _yx(int(slab["freelist"])))
+        indent.print(f"{C.blue('In-Use')}: {slab.inuse}/{slab.object_count}")
+        indent.print(f"{C.blue('Frozen')}: {slab.frozen}")
+        indent.print(f"{C.blue('Freelist')}: {_yx(int(slab.freelist))}")
 
         if verbose:
             with indent:
-                size = int(slab_cache["size"])
-                for address in range(address, address + objects * size, size):
-                    cur_freelist = next(
-                        (freelist for freelist in freelists if address in freelist), None
-                    )
-                    if cur_freelist is None:
-                        indent.print("-", hex(int(address)), "(in-use)")
+                free_objects = slab.free_objects
+                for addr in slab.objects:
+                    if addr not in free_objects:
+                        indent.print(f"- {addr:#x} (in-use)")
                         continue
-                    next_free_idx = cur_freelist.index(address) + 1
-                    next_free = (
-                        cur_freelist[next_free_idx] if len(cur_freelist) > next_free_idx else 0
-                    )
-                    indent.print("-", _yx(int(address)), f"(next: {next_free:#018x})")
+                    for freelist in slab.freelists:
+                        next_free = freelist.find_next(addr)
+                        if next_free:
+                            indent.print(f"- {_yx(addr)} (next: {next_free:#x})")
+                            break
+                    else:
+                        indent.print(f"- {_yx(addr)} (no next)")
 
 
-def print_cpu_cache(cpu_cache: gdb.Value, slab_cache: gdb.Value, verbose: bool, indent) -> None:
-    indent.print(f"{C.green('Per-CPU Data')} @ {_yx(int(cpu_cache))}:")
+def print_cpu_cache(cpu_cache: CpuCache, verbose: bool, indent) -> None:
+    indent.print(f"{C.green('Per-CPU Data')} @ {_yx(cpu_cache.address)}:")
     with indent:
-        freelist = cpu_cache["freelist"]
-        indent.print(f"{C.blue('Freelist')}:", _yx(int(freelist)))
+        indent.print(f"{C.blue('Freelist')}:", _yx(int(cpu_cache.freelist)))
 
-        slab_key = get_slab_key()
-        active_slab = cpu_cache[slab_key]
-
+        active_slab = cpu_cache.active_slab
         if active_slab:
             indent.print(f"{C.green('Active Slab')}:")
             with indent:
-                print_slab(
-                    active_slab.dereference(),
-                    cpu_cache,
-                    slab_cache,
-                    indent,
-                    verbose,
-                    is_partial=False,
-                )
+                print_slab(active_slab, indent, verbose)
         else:
             indent.print("Active Slab: (none)")
 
-        partial_slab = cpu_cache["partial"]
-        if partial_slab:
-            slabs_key = f"{get_slab_key()}s"
-            if krelease() >= (5, 16):
-                # calculate approx obj count in half-full slabs (as done in kernel)
-                # Note, this is a very bad approximation and could/should probably
-                # be replaced by a more accurate method os removed from pwndbg
-                oo = oo_objects(int(slab_cache["oo"]["x"]))
-                slabs = int(partial_slab[slabs_key])
-                pobjects = (slabs * oo) // 2
-            else:
-                pobjects = partial_slab["pobjects"]
-
-            cpu_partial = int(slab_cache["cpu_partial"])
-            indent.print(
-                f"{C.green('Partial Slabs')} [{partial_slab[slabs_key]}] [PO: ~{pobjects}/{cpu_partial}]:"
-            )
-
-            while partial_slab:
-                cur_slab = partial_slab.dereference()
-                print_slab(
-                    cur_slab,
-                    cpu_cache,
-                    slab_cache,
-                    indent,
-                    verbose,
-                    is_partial=True,
-                )
-                partial_slab = cur_slab["next"]
-        else:
+        partial_slabs = cpu_cache.partial_slabs
+        if not partial_slabs:
             indent.print("Partial Slabs: (none)")
+            return
+        slabs = partial_slabs[0].slabs
+        pobjects = partial_slabs[0].pobjects
+        cpu_partial = partial_slabs[0].slab_cache.cpu_partial
+        indent.print(f"{C.green('Partial Slabs')} [{slabs}] [PO: ~{pobjects}/{cpu_partial}]:")
+        for partial_slab in partial_slabs:
+            print_slab(partial_slab, indent, verbose)
 
 
 def slab_info(name: str, verbose: bool) -> None:
-    cache = pwndbg.gdblib.kernel.slab.get_cache(name)
+    slab_cache = pwndbg.gdblib.kernel.slab.get_cache(name)
 
-    if cache is None:
+    if slab_cache is None:
         print(M.error(f"Cache {name} not found"))
         return
 
     indent = IndentContextManager()
 
-    indent.print(f"{C.green('Slab Cache')} @ {_yx(int(cache))}")
+    indent.print(f"{C.green('Slab Cache')} @ {_yx(slab_cache.address)}")
     with indent:
-        indent.print(f"{C.blue('Name')}:", cache["name"].string())
-        flags_list = get_flags_list(int(cache["flags"]))
+        indent.print(f"{C.blue('Name')}: {slab_cache.name}")
+        flags_list = slab_cache.flags
         if flags_list:
             indent.print(f"{C.blue('Flags')}: {' | '.join(flags_list)}")
         else:
             indent.print(f"{C.blue('Flags')}: (none)")
 
-        indent.print(f"{C.blue('Offset')}:", int(cache["offset"]))
-        indent.print(f"{C.blue('Size')}:", int(cache["size"]))
-        indent.print(f"{C.blue('Align')}:", int(cache["align"]))
-        indent.print(f"{C.blue('Object Size')}:", int(cache["object_size"]))
+        indent.print(f"{C.blue('Offset')}: {slab_cache.offset}")
+        indent.print(f"{C.blue('Size')}: {slab_cache.size}")
+        indent.print(f"{C.blue('Align')}: {slab_cache.align}")
+        indent.print(f"{C.blue('Object Size')}: {slab_cache.object_size}")
 
         # TODO: Handle multiple CPUs
-        cpu_cache = per_cpu(cache["cpu_slab"])
+        cpu_cache = slab_cache.cpu_cache
 
-        print_cpu_cache(cpu_cache, cache, verbose, indent)
+        print_cpu_cache(cpu_cache, verbose, indent)
 
         # TODO: print_node_cache
 
 
 def slab_list(filter_) -> None:
     results = []
-    for cache in pwndbg.gdblib.kernel.slab.caches():
-        name = cache["name"].string()
+    for slab_cache in pwndbg.gdblib.kernel.slab.caches():
+        name = slab_cache.name
         if filter_ and filter_ not in name:
             continue
-        order = oo_order(int(cache["oo"]["x"]))
-        objects = oo_objects(int(cache["oo"]["x"]))
         results.append(
             [
                 name,
-                objects,
-                int(cache["size"]),
-                int(cache["object_size"]),
-                int(cache["inuse"]),
-                order,
+                slab_cache.oo_objects,
+                slab_cache.size,
+                slab_cache.object_size,
+                slab_cache.inuse,
+                slab_cache.oo_order,
             ]
         )
 

--- a/pwndbg/commands/slab.py
+++ b/pwndbg/commands/slab.py
@@ -156,20 +156,17 @@ def slab_info(name: str, verbose: bool) -> None:
 
 
 def slab_list(filter_) -> None:
-    results = []
-    for slab_cache in pwndbg.gdblib.kernel.slab.caches():
-        name = slab_cache.name
-        if filter_ and filter_ not in name:
-            continue
-        results.append(
-            [
-                name,
-                slab_cache.oo_objects,
-                slab_cache.size,
-                slab_cache.object_size,
-                slab_cache.inuse,
-                slab_cache.oo_order,
-            ]
-        )
+    results = [
+        [
+            slab_cache.name,
+            slab_cache.oo_objects,
+            slab_cache.size,
+            slab_cache.object_size,
+            slab_cache.inuse,
+            slab_cache.oo_order,
+        ]
+        for slab_cache in pwndbg.gdblib.kernel.slab.caches()
+        if not filter_ or filter_ in slab_cache.name
+    ]
 
     print(tabulate(results, headers=["Name", "# Objects", "Size", "Obj Size", "# inuse", "order"]))

--- a/pwndbg/gdblib/kernel/__init__.py
+++ b/pwndbg/gdblib/kernel/__init__.py
@@ -305,6 +305,14 @@ def arch_ops() -> ArchOps:
     return _arch_ops
 
 
+def page_size() -> int:
+    ops = arch_ops()
+    if ops:
+        return ops.page_size()
+    else:
+        raise NotImplementedError()
+
+
 def per_cpu(addr: gdb.Value, cpu=None):
     ops = arch_ops()
     if ops:

--- a/pwndbg/gdblib/kernel/macros.py
+++ b/pwndbg/gdblib/kernel/macros.py
@@ -18,3 +18,16 @@ def for_each_entry(head, typename, field):
     while addr != head.address:
         yield container_of(addr, typename, field)
         addr = addr.dereference()["next"]
+
+
+def swab(x):
+    return int(
+        ((x & 0x00000000000000FF) << 56)
+        | ((x & 0x000000000000FF00) << 40)
+        | ((x & 0x0000000000FF0000) << 24)
+        | ((x & 0x00000000FF000000) << 8)
+        | ((x & 0x000000FF00000000) >> 8)
+        | ((x & 0x0000FF0000000000) >> 24)
+        | ((x & 0x00FF000000000000) >> 40)
+        | ((x & 0xFF00000000000000) >> 56)
+    )

--- a/pwndbg/gdblib/kernel/slab.py
+++ b/pwndbg/gdblib/kernel/slab.py
@@ -186,7 +186,7 @@ class CpuCache:
     def active_slab(self) -> Optional["Slab"]:
         slab_key = slab_struct_type()
         _slab = self._cpu_cache[slab_key].dereference()
-        if not _slab:
+        if not int(_slab.address):
             return None
         return Slab(_slab, self)
 
@@ -194,7 +194,7 @@ class CpuCache:
     def partial_slabs(self) -> List["Slab"]:
         partial_slabs = []
         cur_slab = self._cpu_cache["partial"]
-        while cur_slab:
+        while int(cur_slab.address):
             _slab = cur_slab.dereference()
             partial_slabs.append(Slab(_slab, self, is_partial=True))
             cur_slab = _slab["next"]

--- a/pwndbg/gdblib/kernel/slab.py
+++ b/pwndbg/gdblib/kernel/slab.py
@@ -68,13 +68,7 @@ _flags = {
 
 
 def get_flags_list(flags: int) -> List[str]:
-    flags_list = []
-
-    for flag_name, mask in _flags.items():
-        if flags & mask:
-            flags_list.append(flag_name)
-
-    return flags_list
+    return [flag_name for flag_name, mask in _flags.items() if flags & mask]
 
 
 class Freelist:
@@ -94,6 +88,9 @@ class Freelist:
 
     def __int__(self) -> int:
         return self.start_addr
+
+    def __len__(self) -> int:
+        return sum(1 for _ in self)
 
     def find_next(self, addr: int) -> int:
         freelist_iter = iter(self)
@@ -223,11 +220,11 @@ class Slab:
         return int(self._slab["objects"])
 
     @property
-    def objects(self) -> List[int]:
+    def objects(self) -> Generator[int, None, None]:
         object_size = self.slab_cache.object_size
         start = self.virt_address
         end = start + self.object_count * object_size
-        return list(range(start, end, object_size))
+        return (i for i in range(start, end, object_size))
 
     @property
     def frozen(self) -> int:
@@ -240,7 +237,7 @@ class Slab:
             # `inuse` will always equal `objects` for the active slab, so we
             # need to subtract the length of the freelists
             for freelist in self.freelists:
-                inuse -= len(list(freelist))
+                inuse -= len(freelist)
         return inuse
 
     @property

--- a/pwndbg/gdblib/kernel/slab.py
+++ b/pwndbg/gdblib/kernel/slab.py
@@ -222,10 +222,10 @@ class Slab:
 
     @property
     def objects(self) -> Generator[int, None, None]:
-        object_size = self.slab_cache.object_size
+        size = self.slab_cache.size
         start = self.virt_address
-        end = start + self.object_count * object_size
-        return (i for i in range(start, end, object_size))
+        end = start + self.object_count * size
+        return (i for i in range(start, end, size))
 
     @property
     def frozen(self) -> int:

--- a/pwndbg/gdblib/kernel/slab.py
+++ b/pwndbg/gdblib/kernel/slab.py
@@ -185,16 +185,16 @@ class CpuCache:
     @property
     def active_slab(self) -> Optional["Slab"]:
         slab_key = slab_struct_type()
-        _slab = self._cpu_cache[slab_key].dereference()
-        if not int(_slab.address):
+        _slab = self._cpu_cache[slab_key]
+        if not _slab:
             return None
-        return Slab(_slab, self)
+        return Slab(_slab.dereference(), self)
 
     @property
     def partial_slabs(self) -> List["Slab"]:
         partial_slabs = []
         cur_slab = self._cpu_cache["partial"]
-        while int(cur_slab.address):
+        while cur_slab:
             _slab = cur_slab.dereference()
             partial_slabs.append(Slab(_slab, self, is_partial=True))
             cur_slab = _slab["next"]

--- a/pwndbg/gdblib/kernel/slab.py
+++ b/pwndbg/gdblib/kernel/slab.py
@@ -118,9 +118,7 @@ class SlabCache:
     @property
     def random(self) -> int:
         return (
-            int(self._slab_cache["random"])
-            if kernel.kconfig().get("SLAB_FREELIST_HARDENED") == "y"
-            else 0
+            int(self._slab_cache["random"]) if "SLAB_FREELIST_HARDENED" in kernel.kconfig() else 0
         )
 
     @property

--- a/pwndbg/gdblib/symbol.py
+++ b/pwndbg/gdblib/symbol.py
@@ -6,6 +6,7 @@ Uses IDA when available if there isn't sufficient symbol
 information available.
 """
 import re
+from typing import Optional
 
 import gdb
 
@@ -206,3 +207,11 @@ def selected_frame_source_absolute_filename():
         return None
 
     return symtab.fullname()
+
+
+def parse_and_eval(expression: str) -> Optional[gdb.Value]:
+    """Error handling wrapper for GDBs parse_and_eval function"""
+    try:
+        return gdb.parse_and_eval(expression)
+    except gdb.error:
+        return None

--- a/tests/qemu-tests/tests.sh
+++ b/tests/qemu-tests/tests.sh
@@ -119,7 +119,7 @@ init_gdb() {
     local arch="$3"
 
     gdb_connect_qemu=(-ex "file ${IMAGE_DIR}/vmlinux-${kernel_type}-${kernel_version}-${arch}" -ex "target remote :1234")
-    gdb_args=("${gdb_connect_qemu[@]}" -ex 'break *start_kernel' -ex 'continue')
+    gdb_args=("${gdb_connect_qemu[@]}" -ex 'break *rest_init' -ex 'continue')
     run_gdb "${arch}" "${gdb_args[@]}" > /dev/null 2>&1
 }
 

--- a/tests/qemu-tests/tests/system/test_commands_kernel.py
+++ b/tests/qemu-tests/tests/system/test_commands_kernel.py
@@ -56,9 +56,11 @@ def test_command_slab_info():
         assert "may only be run when debugging a Linux kernel with debug" in res
         return
 
-    res = gdb.execute("slab info -v kmalloc-512", to_string=True)
-    assert "kmalloc-512" in res
-    assert "Freelist" in res
+    for cache in pwndbg.gdblib.kernel.slab.caches():
+        cache_name = cache.name
+        res = gdb.execute(f"slab info -v {cache_name}", to_string=True)
+        assert cache_name in res
+        assert "Freelist" in res
 
     res = gdb.execute("slab info -v does_not_exit", to_string=True)
     assert "not found" in res

--- a/tests/qemu-tests/tests/system/test_commands_kernel.py
+++ b/tests/qemu-tests/tests/system/test_commands_kernel.py
@@ -84,7 +84,7 @@ def get_slab_object_address():
 
     caches = pwndbg.gdblib.kernel.slab.caches()
     for cache in caches:
-        cache_name = cache["name"].string()
+        cache_name = cache.name
         info = gdb.execute(f"slab info -v {cache_name}", to_string=True)
         matches = re.findall(r"- (0x[0-9a-fA-F]+)", info)
         if len(matches) > 0:


### PR DESCRIPTION
As I was trying to extend the `slab` command logic further and wanted to re-use it in some custom scripts I noticed that we have mixed "frontend" and "backend" logic. To allow these computations to be re-used and further extended, I separated the concerns and refactored the business logic into `gdblib` with this PR.

This is a pure refactor PR without any changing functionality in the "frontend".

There will be some merge conflicts with the currently open #1707 PR which I will resolve once one of these two PRs have been merged into `dev`.