### PR TITLE
Updated heap.py with --dump for malloc_chunk

### DIFF
--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -155,9 +155,7 @@ parser.add_argument(
 parser.add_argument(
     "-s", "--simple", action="store_true", help="Simply print malloc_chunk struct's contents."
 )
-parser.add_argument(
-    "--dump", action="store_true", help="Print a hexdump of the chunk bytes."
-)
+parser.add_argument("--dump", action="store_true", help="Print a hexdump of the chunk bytes.")
 
 
 @pwndbg.commands.ArgparsedCommand(parser, category=CommandCategory.HEAP)

--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -157,7 +157,6 @@ parser.add_argument(
 )
 
 
-
 @pwndbg.commands.ArgparsedCommand(parser, category=CommandCategory.HEAP)
 @pwndbg.commands.OnlyWhenRunning
 @pwndbg.commands.OnlyWithResolvedHeapSyms
@@ -369,9 +368,7 @@ parser.add_argument(
 parser.add_argument(
     "-s", "--simple", action="store_true", help="Simply print malloc_chunk struct's contents."
 )
-parser.add_argument(
-    "--dump", action="store_true", help="Print a hexdump of the chunk bytes."
-)
+parser.add_argument("--dump", action="store_true", help="Print a hexdump of the chunk bytes.")
 
 
 @pwndbg.commands.ArgparsedCommand(parser, category=CommandCategory.HEAP)

--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -155,7 +155,7 @@ parser.add_argument(
 parser.add_argument(
     "-s", "--simple", action="store_true", help="Simply print malloc_chunk struct's contents."
 )
-parser.add_argument("--dump", action="store_true", help="Print a hexdump of the chunk bytes.")
+
 
 
 @pwndbg.commands.ArgparsedCommand(parser, category=CommandCategory.HEAP)
@@ -368,6 +368,9 @@ parser.add_argument(
 )
 parser.add_argument(
     "-s", "--simple", action="store_true", help="Simply print malloc_chunk struct's contents."
+)
+parser.add_argument(
+    "--dump", action="store_true", help="Print a hexdump of the chunk bytes."
 )
 
 

--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -1,4 +1,5 @@
 import argparse
+import binascii
 import ctypes
 from string import printable
 from typing import Dict
@@ -373,7 +374,7 @@ parser.add_argument(
 @pwndbg.commands.OnlyWhenRunning
 @pwndbg.commands.OnlyWithResolvedHeapSyms
 @pwndbg.commands.OnlyWhenHeapIsInitialized
-def malloc_chunk(addr, fake=False, verbose=False, simple=False) -> None:
+def malloc_chunk(addr, fake=False, verbose=False, simple=False, dump=False) -> None:
     """Print a malloc_chunk struct's contents."""
     allocator = pwndbg.heap.current
 
@@ -439,6 +440,11 @@ def malloc_chunk(addr, fake=False, verbose=False, simple=False) -> None:
             out_fields += message.system(field_to_print) + ": 0x{:02x}\n".format(
                 getattr(chunk, field_to_print)
             )
+
+    if dump:
+        chunk_data = pwndbg.memory.read(chunk.address, chunk.real_size)
+        hexdump = binascii.hexlify(chunk_data).decode()
+        out_fields += "Dump:\n{}\n".format(hexdump)
 
     print(" | ".join(headers_to_print) + "\n" + out_fields)
 

--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -155,6 +155,9 @@ parser.add_argument(
 parser.add_argument(
     "-s", "--simple", action="store_true", help="Simply print malloc_chunk struct's contents."
 )
+parser.add_argument(
+    "--dump", action="store_true", help="Print a hexdump of the chunk bytes."
+)
 
 
 @pwndbg.commands.ArgparsedCommand(parser, category=CommandCategory.HEAP)


### PR DESCRIPTION
<!-- Please make sure to read the testing and linting instructions at https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md before creating a PR -->


Implementation of the --dump flag for the malloc_chunk function which will print a hexdump of the chunk bytes after printing the header information.

Fixes #1238 