### PR TITLE
Fix Ubuntu 22.04 CI build by installing libgcc-s1:i386

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -25,7 +25,7 @@ install_apt() {
     if uname -m | grep x86_64 > /dev/null; then
         sudo dpkg --add-architecture i386 || true
         sudo apt-get update || true
-        sudo apt-get install -y libc6-dbg:i386 || true
+        sudo apt-get install -y libc6-dbg:i386 libgcc-s1:i386 || true
     fi
 }
 


### PR DESCRIPTION
<!-- Please make sure to read the testing and linting instructions at https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md before creating a PR -->
