### PR TITLE
Add OnlyWithLibraryLoaded decorator

### DIFF
--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -8,6 +8,7 @@ from typing import List
 import gdb
 
 import pwndbg.exception
+import pwndbg.gdblib.info
 import pwndbg.gdblib.kernel
 import pwndbg.gdblib.regs
 import pwndbg.heap
@@ -284,6 +285,24 @@ def OnlyWithArch(arch_names: List[str]):
                 )
 
         return _OnlyWithArch
+
+    return decorator
+
+
+def OnlyWithLibraryLoaded(library):
+    """Decorates function to work only when the specified library is loaded."""
+
+    def decorator(function):
+        @functools.wraps(function)
+        def _OnlyWithLibraryLoaded(*a, **kw):
+            if library in pwndbg.gdblib.info.sharedlibrary():
+                return function(*a, **kw)
+            else:
+                print(
+                    f"%s: This command may only be run when {library} is loaded" % function.__name__
+                )
+
+        return _OnlyWithLibraryLoaded
 
     return decorator
 

--- a/pwndbg/commands/misc.py
+++ b/pwndbg/commands/misc.py
@@ -28,6 +28,7 @@ parser.add_argument(
 
 @pwndbg.commands.ArgparsedCommand(parser, command_name="errno", category=CommandCategory.LINUX)
 @pwndbg.commands.OnlyWhenRunning
+@pwndbg.commands.OnlyWithLibraryLoaded("libc.so")
 def errno_(err) -> None:
     if err is None:
         # Try to get the `errno` variable value

--- a/pwndbg/commands/tls.py
+++ b/pwndbg/commands/tls.py
@@ -24,6 +24,7 @@ parser.add_argument(
 
 @pwndbg.commands.ArgparsedCommand(parser, category=CommandCategory.LINUX)
 @pwndbg.commands.OnlyWhenRunning
+@pwndbg.commands.OnlyWithLibraryLoaded("libc.so")
 def tls(pthread_self=False) -> None:
     tls_base = (
         pwndbg.gdblib.tls.find_address_with_register()

--- a/tests/gdb-tests/tests/test_command_errno.py
+++ b/tests/gdb-tests/tests/test_command_errno.py
@@ -16,10 +16,7 @@ def test_command_errno(start_binary):
     # the errno is not yet an available symbol, because the libc library it is
     # defined in is not yet loaded
     result = "".join(gdb.execute("errno", to_string=True).splitlines())
-    assert (
-        result
-        == "Could not determine error code automatically: neither `errno` nor `__errno_location` symbols were provided (perhaps libc.so hasn't been not loaded yet?)"
-    )
+    assert result == "errno_: This command may only be run when libc.so is loaded"
 
     gdb.execute("break main")
     gdb.execute("continue")


### PR DESCRIPTION
* Applied decorator to errno and tls commands

* Tests: updated expected output of errno command test

Testing with a binary that loads libc:

![image](https://github.com/pwndbg/pwndbg/assets/93072266/68e0c694-bdb1-4435-8b69-59ed3c1fa6ee)
![image](https://github.com/pwndbg/pwndbg/assets/93072266/71cb151a-c3b3-49ab-9f7a-e54cbccefc91)

Testing with a binary that doesn't load libc:

![image](https://github.com/pwndbg/pwndbg/assets/93072266/e32c077c-af02-46c6-ad01-4744a2bd8351)
![image](https://github.com/pwndbg/pwndbg/assets/93072266/39317b9d-38a9-4f2d-b586-9adbed6a5d30)


