### PR TITLE
Support slab command for all available cpus

### DIFF
--- a/pwndbg/commands/slab.py
+++ b/pwndbg/commands/slab.py
@@ -109,7 +109,7 @@ def print_slab(slab: Slab, indent, verbose: bool) -> None:
 
 
 def print_cpu_cache(cpu_cache: CpuCache, verbose: bool, indent) -> None:
-    indent.print(f"{C.green('Per-CPU Data')} @ {_yx(cpu_cache.address)}:")
+    indent.print(f"{C.green('kmem_cache_cpu')} @ {_yx(cpu_cache.address)} [CPU {cpu_cache.cpu}]:")
     with indent:
         indent.print(f"{C.blue('Freelist')}:", _yx(int(cpu_cache.freelist)))
 
@@ -157,9 +157,8 @@ def slab_info(name: str, verbose: bool) -> None:
         indent.print(f"{C.blue('Object Size')}: {slab_cache.object_size}")
 
         # TODO: Handle multiple CPUs
-        cpu_cache = slab_cache.cpu_cache
-
-        print_cpu_cache(cpu_cache, verbose, indent)
+        for cpu_cache in slab_cache.cpu_caches:
+            print_cpu_cache(cpu_cache, verbose, indent)
 
         # TODO: print_node_cache
 

--- a/pwndbg/commands/slab.py
+++ b/pwndbg/commands/slab.py
@@ -156,7 +156,6 @@ def slab_info(name: str, verbose: bool) -> None:
         indent.print(f"{C.blue('Align')}: {slab_cache.align}")
         indent.print(f"{C.blue('Object Size')}: {slab_cache.object_size}")
 
-        # TODO: Handle multiple CPUs
         for cpu_cache in slab_cache.cpu_caches:
             print_cpu_cache(cpu_cache, verbose, indent)
 

--- a/pwndbg/gdblib/kernel/__init__.py
+++ b/pwndbg/gdblib/kernel/__init__.py
@@ -1,6 +1,7 @@
 import functools
 import math
 import re
+from typing import Optional
 from typing import Tuple
 
 import gdb
@@ -44,6 +45,12 @@ def requires_debug_syms(default=None):
         return func
 
     return decorator
+
+
+@requires_debug_syms(default=1)
+def nproc() -> int:
+    """Returns the number of processing units available, similar to nproc(1)"""
+    return int(gdb.lookup_global_symbol("nr_cpu_ids").value())
 
 
 @requires_debug_syms(default={})
@@ -171,7 +178,7 @@ class x86_64Ops(ArchOps):
     def page_size(self) -> int:
         return 1 << self.PAGE_SHIFT
 
-    def per_cpu(self, addr: gdb.Value, cpu=None):
+    def per_cpu(self, addr: gdb.Value, cpu: Optional[int] = None):
         if cpu is None:
             cpu = gdb.selected_thread().num - 1
 
@@ -253,7 +260,7 @@ class Aarch64Ops(ArchOps):
     def page_size(self) -> int:
         return 1 << self.PAGE_SHIFT
 
-    def per_cpu(self, addr: gdb.Value, cpu=None):
+    def per_cpu(self, addr: gdb.Value, cpu: Optional[int] = None):
         if cpu is None:
             cpu = gdb.selected_thread().num - 1
 
@@ -313,7 +320,7 @@ def page_size() -> int:
         raise NotImplementedError()
 
 
-def per_cpu(addr: gdb.Value, cpu=None):
+def per_cpu(addr: gdb.Value, cpu: Optional[int] = None):
     ops = arch_ops()
     if ops:
         return ops.per_cpu(addr, cpu)

--- a/tests/qemu-tests/tests.sh
+++ b/tests/qemu-tests/tests.sh
@@ -185,7 +185,7 @@ test_system() {
     printf "============================ Testing %-20s  ============================\n" "${kernel_type}-${kernel_version}-${arch}"
 
     if [[ ! -z ${qemu_args} ]]; then
-        echo "Additional QEMU parameters used: '${qemu_args[*]}'"
+        echo "Additional QEMU parameters used: '${qemu_args[@]}'"
     fi
     echo ""
 
@@ -235,7 +235,7 @@ for vmlinux in "${VMLINUX_LIST[@]}"; do
 
     if [[ "${ARCH}" == @("x86_64") ]]; then
         # additional test with extra QEMU flags
-        QEMU_ARGS=(-cpu qemu64,+la57)
+        QEMU_ARGS+=(-cpu qemu64,+la57)
         test_system "${KERNEL_TYPE}" "${KERNEL_VERSION}" "${ARCH}" "${QEMU_ARGS[@]}"
     fi
 done

--- a/tests/qemu-tests/tests/system/test_commands_kernel.py
+++ b/tests/qemu-tests/tests/system/test_commands_kernel.py
@@ -61,6 +61,8 @@ def test_command_slab_info():
         res = gdb.execute(f"slab info -v {cache_name}", to_string=True)
         assert cache_name in res
         assert "Freelist" in res
+        for cpu in range(pwndbg.gdblib.kernel.nproc()):
+            assert f"[CPU {cpu}]" in res
 
     res = gdb.execute("slab info -v does_not_exit", to_string=True)
     assert "not found" in res

--- a/tests/qemu-tests/tests/system/test_gdblib_kernel.py
+++ b/tests/qemu-tests/tests/system/test_gdblib_kernel.py
@@ -44,3 +44,9 @@ def test_gdblib_kernel_krelease():
 @pytest.mark.skipif(not pwndbg.gdblib.kernel.has_debug_syms(), reason="test requires debug symbols")
 def test_gdblib_kernel_is_kaslr_enabled():
     pwndbg.gdblib.kernel.is_kaslr_enabled()
+
+
+@pytest.mark.skipif(not pwndbg.gdblib.kernel.has_debug_syms(), reason="test requires debug symbols")
+def test_gdblib_kernel_nproc():
+    # make sure no exception occurs
+    pwndbg.gdblib.kernel.nproc()


### PR DESCRIPTION
This PR adds support for all available cpus to the `slab` commands.

![image](https://github.com/pwndbg/pwndbg/assets/37738506/bf4b6a32-31b1-4971-9c49-04c0309adca0)


- Add `pwndbg.gdblib.kernel.nproc()` to retrieve number of available cores/processors
- Add `pwndbg.gdblib.kernel.slab.slab_caches` to retrieve a generator of `CpuCache` for all available cores
- Slightly modify output of `slab info` to also include the cpu number
- Add test to check if `pwndbg.gdblib.kernel.nproc()` raises an exception
- Add capability for tests to check if output was generated for all cores

The PR does not actually add test for multiple cores to the CI as this would involve adding the qemu arguments `-smp cpus=N` and I wasn't sure whether adding these qemu configurations and then re-running all tests makes sense as it would double the number of systems to test. I have instead tested it locally for now with 1, 4, 8 and 16 cores and it worked without issues.

For the future it would be nice to modify the qemu test infrastructure in a way that single tests can be run with different qemu configurations (instead of all of them).

It might also be interesting to rework the commandline flags of `slab info` to give the user better control over what she/he wants to see (e.g. `--cpu=N`)