### PR TITLE
By default remove the context backtrace f prefix #1288

### DIFF
--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -767,7 +767,7 @@ backtrace_lines = pwndbg.gdblib.config.add_param(
     "context-backtrace-lines", 8, "number of lines to print in the backtrace context"
 )
 backtrace_frame_label = theme.add_param(
-    "backtrace-frame-label", "f ", "frame number label for backtrace"
+    "backtrace-frame-label", "", "frame number label for backtrace"
 )
 
 

--- a/tests/gdb-tests/tests/test_context_commands.py
+++ b/tests/gdb-tests/tests/test_context_commands.py
@@ -201,20 +201,20 @@ def test_context_backtrace_show_proper_symbol_names(start_binary):
         == "─────────────────────────────────[ BACKTRACE ]──────────────────────────────────"
     )
 
-    assert re.match(r" ► f 0   0x[0-9a-f]+ A::foo\(int, int\)", backtrace[2])
+    assert re.match(r".*0   0x[0-9a-f]+ A::foo\(int, int\)", backtrace[2])
 
     # Match A::call_foo()+38 or similar: the offset may change so we match \d+ at the end
-    assert re.match(r"   f 1   0x[0-9a-f]+ A::call_foo\(\)\+\d+", backtrace[3])
+    assert re.match(r".*1   0x[0-9a-f]+ A::call_foo\(\)\+\d+", backtrace[3])
 
     # Match main+87 or similar offset
-    assert re.match(r"   f 2   0x[0-9a-f]+ main\+\d+", backtrace[4])
+    assert re.match(r".*2   0x[0-9a-f]+ main\+\d+", backtrace[4])
 
     # Match __libc_start_main+243 or similar offset
     # Note: on Ubuntu 22.04 there will be __libc_start_call_main and then __libc_start_main
     # but on older distros there will be only __libc_start_main
     # Let's not bother too much about it and make it the last call assertion here
     assert re.match(
-        r"   f 3   0x[0-9a-f]+ (__libc_start_main|__libc_start_call_main)\+\d+", backtrace[5]
+        r".*3   0x[0-9a-f]+ (__libc_start_main|__libc_start_call_main)\+\d+", backtrace[5]
     )
 
     assert (


### PR DESCRIPTION
* Tests: update context backtrace test to respect the theme

<!-- Please make sure to read the testing and linting instructions at https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md before creating a PR -->
