### PR TITLE
Covert printf format strings to f-strings

### DIFF
--- a/gdbinit.py
+++ b/gdbinit.py
@@ -47,26 +47,22 @@ if virtual_env:
         if len(possible_site_packages) > 1:
             venv_warn("*** Found multiple site packages in virtualenv:")
             for site_pkg in possible_site_packages:
-                venv_warn("    - %s" % site_pkg)
+                venv_warn(f"    - {site_pkg}")
 
             virtualenv_site_packages = possible_site_packages[-1]
-            venv_warn("*** Using the last one: %s" % virtualenv_site_packages)
+            venv_warn(f"*** Using the last one: {virtualenv_site_packages}")
 
         elif len(possible_site_packages) == 1:
             virtualenv_site_packages = possible_site_packages[-1]
-            venv_warn("*** Using the only site packages dir found: %s" % virtualenv_site_packages)
+            venv_warn(f"*** Using the only site packages dir found: {virtualenv_site_packages}")
 
         else:
-            guessed_python_directory = "python%s.%s" % (
-                sys.version_info.major,
-                sys.version_info.minor,
-            )
+            guessed_python_directory = f"python{sys.version_info.major}.{sys.version_info.minor}"
             virtualenv_site_packages = path.join(
                 virtual_env, "lib", guessed_python_directory, "site-packages"
             )
             venv_warn(
-                "***  Not found site-packages in virtualenv, using guessed site packages Python dir: %s"
-                % virtualenv_site_packages
+                f"***  Not found site-packages in virtualenv, using guessed site packages Python dir: {virtualenv_site_packages}"
             )
 
         venv_warn("  Added detected virtualenv's Python site packages to sys.path")

--- a/ida_script.py
+++ b/ida_script.py
@@ -35,10 +35,10 @@ def create_marshaller(use_format=None, just_to_str=False):
         if use_format:
             marshalled = use_format % value
         elif just_to_str:
-            marshalled = "<value><string>%s</string></value>" % escape(str(value))
+            marshalled = f"<value><string>{escape(str(value))}</string></value>"
 
         if DEBUG_MARSHALLING:
-            print("Marshalled: '%s'" % marshalled)
+            print(f"Marshalled: '{marshalled}'")
 
         appender(marshalled)
 
@@ -170,7 +170,7 @@ server.register_function(wrap(decompile_context), "decompile_context")  # suppor
 server.register_function(wrap(versions))
 server.register_introspection_functions()
 
-print("IDA Pro xmlrpc hosted on http://%s:%s" % (host, port))
+print(f"IDA Pro xmlrpc hosted on http://{host}:{port}")
 print("Call `shutdown()` to shutdown the IDA Pro xmlrpc server.")
 
 thread = threading.Thread(target=server.serve_forever)

--- a/pwndbg/arguments.py
+++ b/pwndbg/arguments.py
@@ -226,7 +226,7 @@ def format_args(instruction):
             if pid is not None:
                 path = pwndbg.gdblib.file.readlink("/proc/%d/fd/%d" % (pid, value))
                 if path:
-                    pretty += " (%s)" % path
+                    pretty += f" ({path})"
 
         result.append("%-10s %s" % (N.argument(arg.name) + ":", pretty))
     return result

--- a/pwndbg/chain.py
+++ b/pwndbg/chain.py
@@ -113,8 +113,8 @@ def format(value, limit=LIMIT, code=True, offset=0, hard_stop=None, hard_end=0, 
     else:
         chain = get(value, limit, offset, hard_stop, hard_end, safe_linking=safe_linking)
 
-    arrow_left = c.arrow(" %s " % config_arrow_left)
-    arrow_right = c.arrow(" %s " % config_arrow_right)
+    arrow_left = c.arrow(f" {config_arrow_left} ")
+    arrow_right = c.arrow(f" {config_arrow_right} ")
 
     # Colorize the chain
     rest = []
@@ -143,7 +143,7 @@ def format(value, limit=LIMIT, code=True, offset=0, hard_stop=None, hard_end=0, 
         enhanced = pwndbg.enhance.enhance(chain[-2] + offset, code=code, safe_linking=safe_linking)
 
     else:
-        enhanced = c.contiguous_marker("%s" % config_contiguous)
+        enhanced = c.contiguous_marker(f"{config_contiguous}")
 
     if len(chain) == 1:
         return enhanced

--- a/pwndbg/color/context.py
+++ b/pwndbg/color/context.py
@@ -104,4 +104,4 @@ def format_flags(value, flags, last=None):
             name = flag_changed(name)
         names.append(name)
 
-    return "%s %s %s %s" % (desc, flag_bracket("["), " ".join(names), flag_bracket("]"))
+    return f"{desc} {flag_bracket('[')} {' '.join(names)} {flag_bracket(']')}"

--- a/pwndbg/color/disasm.py
+++ b/pwndbg/color/disasm.py
@@ -44,23 +44,23 @@ def instruction(ins):
 
         # If it's a constant expression, color it directly in the asm.
         if const:
-            asm = "%s <%s>" % (ljust_colored(asm, 36), target)
+            asm = f"{ljust_colored(asm, 36)} <{target}>"
             asm = asm.replace(hex(ins.target), sym or target)
 
         # It's not a constant expression, but we've calculated the target
         # address by emulation or other means (for example showing ret instruction target)
         elif sym:
-            asm = "%s <%s; %s>" % (ljust_colored(asm, 36), target, sym)
+            asm = f"{ljust_colored(asm, 36)} <{target}; {sym}>"
 
         # We were able to calculate the target, but there is no symbol
         # name for it.
         else:
-            asm += "<%s>" % (target)
+            asm += f"<{(target)}>"
 
     # not a branch
     elif ins.symbol:
         if is_branch and not ins.target:
-            asm = "%s <%s>" % (asm, ins.symbol)
+            asm = f"{asm} <{ins.symbol}>"
 
             # XXX: not sure when this ever happens
             asm += "<-- file a pwndbg bug for this"

--- a/pwndbg/color/syntax_highlight.py
+++ b/pwndbg/color/syntax_highlight.py
@@ -37,9 +37,7 @@ def check_style() -> None:
         get_highlight_source._reset()
     except pygments.util.ClassNotFound:
         print(
-            message.warn(
-                "The pygment formatter style '%s' is not found, restore to default" % style
-            )
+            message.warn(f"The pygment formatter style '{style}' is not found, restore to default")
         )
         style.revert_default()
 

--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -60,7 +60,7 @@ def list_current_commands():
             continue
         command = line.split()[0]
         existing_commands.add(command)
-    gdb.execute("set pagination %s" % current_pagination)  # Restore original setting
+    gdb.execute(f"set pagination {current_pagination}")  # Restore original setting
     return existing_commands
 
 
@@ -100,13 +100,13 @@ class Command(gdb.Command):
         self.function = function
 
         if command_name in command_names:
-            raise Exception("Cannot add command %s: already exists." % command_name)
+            raise Exception(f"Cannot add command {command_name}: already exists.")
         if (
             command_name in GDB_BUILTIN_COMMANDS
             and command_name not in self.builtin_override_whitelist
             and not pwndbg_is_reloading
         ):
-            raise Exception('Cannot override non-whitelisted built-in command "%s"' % command_name)
+            raise Exception(f'Cannot override non-whitelisted built-in command "{command_name}"')
 
         command_names.add(command_name)
         commands.append(self)
@@ -244,7 +244,7 @@ def OnlyWithFile(function):
             if pwndbg.gdblib.qemu.is_qemu():
                 print(message.error("Could not determine the target binary on QEMU."))
             else:
-                print(message.error("%s: There is no file loaded." % function.__name__))
+                print(message.error(f"{function.__name__}: There is no file loaded."))
 
     return _OnlyWithFile
 
@@ -256,8 +256,7 @@ def OnlyWhenQemuKernel(function):
             return function(*a, **kw)
         else:
             print(
-                "%s: This command may only be run when debugging the Linux kernel in QEMU."
-                % function.__name__
+                f"{function.__name__}: This command may only be run when debugging the Linux kernel in QEMU."
             )
 
     return _OnlyWhenQemuKernel
@@ -270,8 +269,7 @@ def OnlyWhenUserspace(function):
             return function(*a, **kw)
         else:
             print(
-                "%s: This command may only be run when not debugging a QEMU kernel target."
-                % function.__name__
+                f"{function.__name__}: This command may only be run when not debugging a QEMU kernel target."
             )
 
     return _OnlyWhenUserspace
@@ -309,8 +307,7 @@ def OnlyWithKernelDebugSyms(function):
             return function(*a, **kw)
         else:
             print(
-                "%s: This command may only be run when debugging a Linux kernel with debug symbols."
-                % function.__name__
+                f"{function.__name__}: This command may only be run when debugging a Linux kernel with debug symbols."
             )
 
     return _OnlyWithKernelDebugSyms
@@ -322,7 +319,7 @@ def OnlyWhenPagingEnabled(function):
         if pwndbg.gdblib.kernel.paging_enabled():
             return function(*a, **kw)
         else:
-            print("%s: This command may only be run when paging is enabled." % function.__name__)
+            print(f"{function.__name__}: This command may only be run when paging is enabled.")
 
     return _OnlyWhenPagingEnabled
 
@@ -333,7 +330,7 @@ def OnlyWhenRunning(function):
         if pwndbg.gdblib.proc.alive:
             return function(*a, **kw)
         else:
-            print("%s: The program is not being run." % function.__name__)
+            print(f"{function.__name__}: The program is not being run.")
 
     return _OnlyWhenRunning
 
@@ -345,8 +342,7 @@ def OnlyWithTcache(function):
             return function(*a, **kw)
         else:
             print(
-                "%s: This version of GLIBC was not compiled with tcache support."
-                % function.__name__
+                f"{function.__name__}: This version of GLIBC was not compiled with tcache support."
             )
 
     return _OnlyWithTcache
@@ -358,7 +354,7 @@ def OnlyWhenHeapIsInitialized(function):
         if pwndbg.heap.current.is_initialized():
             return function(*a, **kw)
         else:
-            print("%s: Heap is not initialized yet." % function.__name__)
+            print(f"{function.__name__}: Heap is not initialized yet.")
 
     return _OnlyWhenHeapIsInitialized
 
@@ -593,7 +589,7 @@ def AddressExpr(s):
     val = sloppy_gdb_parse(s)
 
     if not isinstance(val, int):
-        raise argparse.ArgumentTypeError("Incorrect address (or GDB expression): %s" % s)
+        raise argparse.ArgumentTypeError(f"Incorrect address (or GDB expression): {s}")
 
     return val
 

--- a/pwndbg/commands/argv.py
+++ b/pwndbg/commands/argv.py
@@ -52,7 +52,7 @@ def envp(name=None):
     Prints out the contents of the environment.
     """
     if name is not None:
-        gdb.execute('p $environ("%s")' % name)
+        gdb.execute(f'p $environ("{name}")')
         return
 
     start = pwndbg.gdblib.argv.envp

--- a/pwndbg/commands/aslr.py
+++ b/pwndbg/commands/aslr.py
@@ -30,7 +30,7 @@ parser.add_argument(
 @pwndbg.commands.ArgparsedCommand(parser, category=CommandCategory.LINUX)
 def aslr(state=None) -> None:
     if state:
-        gdb.execute("set disable-randomization %s" % options[state], from_tty=False, to_string=True)
+        gdb.execute(f"set disable-randomization {options[state]}", from_tty=False, to_string=True)
 
         if pwndbg.gdblib.proc.alive:
             print("Change will take effect when the process restarts")
@@ -44,4 +44,4 @@ def aslr(state=None) -> None:
     else:
         status = message.off("???")
 
-    print("ASLR is %s (%s)" % (status, method))
+    print(f"ASLR is {status} ({method})")

--- a/pwndbg/commands/attachp.py
+++ b/pwndbg/commands/attachp.py
@@ -64,20 +64,20 @@ def attachp(target) -> None:
                 pids = []
 
             if not pids:
-                print(message.error("Process %s not found" % target))
+                print(message.error(f"Process {target} not found"))
                 return
 
             if len(pids) > 1:
-                print(message.warn("Found pids: %s (use `attach <pid>`)" % ", ".join(pids)))
+                print(message.warn(f"Found pids: {', '.join(pids)} (use `attach <pid>`)"))
                 return
 
             resolved_target = int(pids[0])
 
-    print(message.on("Attaching to %s" % resolved_target))
+    print(message.on(f"Attaching to {resolved_target}"))
     try:
-        gdb.execute("attach %s" % resolved_target)
+        gdb.execute(f"attach {resolved_target}")
     except gdb.error as e:
-        print(message.error("Error: %s" % e))
+        print(message.error(f"Error: {e}"))
 
 
 def _is_device(path) -> bool:

--- a/pwndbg/commands/comments.py
+++ b/pwndbg/commands/comments.py
@@ -26,7 +26,7 @@ def comm(addr=None, comment=None) -> None:
                 print(message.error("Invalid Address %#x" % target))
 
             else:
-                f.write("file:%s=" % pwndbg.gdblib.proc.exe)
+                f.write(f"file:{pwndbg.gdblib.proc.exe}=")
                 f.write("%#x:%s\n" % (target, comment))
                 if pwndbg.gdblib.proc.exe not in file_lists:
                     file_lists[pwndbg.gdblib.proc.exe] = {}

--- a/pwndbg/commands/config.py
+++ b/pwndbg/commands/config.py
@@ -24,7 +24,7 @@ def print_row(name, value, default, set_show_doc, ljust_optname, ljust_value, em
 
 def extend_value_with_default(value, default):
     if strip(value) != strip(default):
-        return "%s (%s)" % (value, default)
+        return f"{value} ({default})"
     return value
 
 
@@ -156,9 +156,9 @@ def configfile_print_scope(scope, show_all=False) -> None:
             native_value = pwndbg.gdblib.config_mod.Parameter._value_to_gdb_native(
                 p.value, param_class=p.param_class
             )
-            print("# %s: %s" % (p.name, p.set_show_doc))
-            print("# default: %s" % native_default)
-            print("set %s %s" % (p.name, native_value))
+            print(f"# {p.name}: {p.set_show_doc}")
+            print(f"# default: {native_default}")
+            print(f"set {p.name} {native_value}")
             print()
     else:
-        print(hint("No changed values. To see current values use `%s`." % scope))
+        print(hint(f"No changed values. To see current values use `{scope}`."))

--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -106,7 +106,7 @@ def validate_context_sections() -> None:
         config_context_sections.value = ""
         print(
             message.warn(
-                "Sections set to be empty. FYI valid values are: %s" % ", ".join(valid_values)
+                f"Sections set to be empty. FYI valid values are: {', '.join(valid_values)}"
             )
         )
         return
@@ -114,9 +114,7 @@ def validate_context_sections() -> None:
     for section in config_context_sections.split():
         if section not in valid_values:
             print(
-                message.warn(
-                    "Invalid section: %s, valid values: %s" % (section, ", ".join(valid_values))
-                )
+                message.warn(f"Invalid section: {section}, valid values: {', '.join(valid_values)}")
             )
             print(message.warn("(setting none of them like '' will make sections not appear)"))
             config_context_sections.revert_default()
@@ -582,7 +580,7 @@ def get_regs(*regs):
         else:
             desc = pwndbg.chain.format(value)
 
-        result.append("%s%s %s" % (m, regname, desc))
+        result.append(f"{m}{regname} {desc}")
     return result
 
 
@@ -804,7 +802,7 @@ def context_backtrace(with_banner=True, target=sys.stdout, width=None):
     while True:
 
         prefix = bt_prefix if frame == this_frame else " " * len(bt_prefix)
-        prefix = " %s" % c.prefix(prefix)
+        prefix = f" {c.prefix(prefix)}"
         addrsz = c.address(pwndbg.ui.addrsz(frame.pc()))
         symbol = c.symbol(pwndbg.gdblib.symbol.get(int(frame.pc())))
         if symbol:
@@ -847,7 +845,7 @@ def save_signal(signal) -> None:
             result.append(message.exit("Exited: %r" % signal.exit_code))
 
     elif isinstance(signal, gdb.SignalEvent):
-        msg = "Program received signal %s" % signal.stop_signal
+        msg = f"Program received signal {signal.stop_signal}"
 
         if signal.stop_signal == "SIGSEGV":
 
@@ -866,7 +864,7 @@ def save_signal(signal) -> None:
 
     elif isinstance(signal, gdb.BreakpointEvent):
         for bkpt in signal.breakpoints:
-            result.append(message.breakpoint("Breakpoint %s" % (bkpt.location)))
+            result.append(message.breakpoint(f"Breakpoint {(bkpt.location)}"))
 
 
 gdb.events.cont.connect(save_signal)

--- a/pwndbg/commands/elf.py
+++ b/pwndbg/commands/elf.py
@@ -87,7 +87,7 @@ def print_symbols_in_section(section_name, filter_text="") -> None:
     symbols = get_symbols_in_region(start, end, filter_text)
 
     if not symbols:
-        print(message.error("No symbols found in section %s" % section_name))
+        print(message.error(f"No symbols found in section {section_name}"))
 
     for symbol, addr in symbols:
         print(hex(int(addr)) + ": " + symbol)

--- a/pwndbg/commands/flags.py
+++ b/pwndbg/commands/flags.py
@@ -59,4 +59,4 @@ def setflag(flag, value) -> None:
                 )
                 return
 
-    print("The %s not a valid/recognized flag" % flag)
+    print(f"The {flag} not a valid/recognized flag")

--- a/pwndbg/commands/hexdump.py
+++ b/pwndbg/commands/hexdump.py
@@ -35,7 +35,7 @@ def address_or_module_name(s):
         if pages:
             return pages[0].vaddr
         else:
-            raise argparse.ArgumentTypeError("Could not find pages for module %s" % module_name)
+            raise argparse.ArgumentTypeError(f"Could not find pages for module {module_name}")
     elif isinstance(gdbval_or_str, (int, gdb.Value)):
         addr = gdbval_or_str
         return addr

--- a/pwndbg/commands/memoize.py
+++ b/pwndbg/commands/memoize.py
@@ -22,4 +22,4 @@ def memoize() -> None:
     if pwndbg.lib.cache.IS_CACHING:
         status = message.on("ON")
 
-    print("Caching is now %s" % status)
+    print(f"Caching is now {status}")

--- a/pwndbg/commands/misc.py
+++ b/pwndbg/commands/misc.py
@@ -62,7 +62,7 @@ def errno_(err) -> None:
                 return
 
     msg = errno.errorcode.get(int(err), "Unknown error code")
-    print("Errno %s: %s" % (err, msg))
+    print(f"Errno {err}: {msg}")
 
 
 parser = argparse.ArgumentParser(description="Prints out a list of all pwndbg commands.")

--- a/pwndbg/commands/p2p.py
+++ b/pwndbg/commands/p2p.py
@@ -66,7 +66,7 @@ def address_range(section):
     if pages:
         return [AddrRange(page.start, page.end) for page in pages]
     else:
-        parser.error('Memory page with name "%s" does not exist!' % pwndbg.color.red(section))
+        parser.error(f'Memory page with name "{pwndbg.color.red(section)}" does not exist!')
 
 
 parser = argparse.ArgumentParser(

--- a/pwndbg/commands/peda.py
+++ b/pwndbg/commands/peda.py
@@ -34,9 +34,9 @@ def xuntil(target) -> None:
     except (TypeError, ValueError):
         # The following gdb command will throw an error if the symbol is not defined.
         try:
-            result = gdb.execute("info address %s" % target, to_string=True, from_tty=False)
+            result = gdb.execute(f"info address {target}", to_string=True, from_tty=False)
         except gdb.error:
-            print(message.error("Unable to resolve %s" % target))
+            print(message.error(f"Unable to resolve {target}"))
             return
         spec = target
 

--- a/pwndbg/commands/probeleak.py
+++ b/pwndbg/commands/probeleak.py
@@ -152,11 +152,11 @@ def probeleak(
 
             offset_text = "0x%0*x" % (off_zeros, i)
             p_text = "0x%0*x" % (int(ptrsize * 2), p)
-            text = "%s: %s = %s" % (offset_text, M.get(p, text=p_text), M.get(p, text=right_text))
+            text = f"{offset_text}: {M.get(p, text=p_text)} = {M.get(p, text=right_text)}"
 
             symbol = pwndbg.gdblib.symbol.get(p)
             if symbol:
-                text += " (%s)" % symbol
+                text += f" ({symbol})"
             print(text)
 
             find_cnt += 1

--- a/pwndbg/commands/rop.py
+++ b/pwndbg/commands/rop.py
@@ -27,7 +27,7 @@ def rop(grep, argument) -> None:
         # If the process is running, dump a corefile so we get actual addresses.
         if pwndbg.gdblib.proc.alive:
             filename = corefile.name
-            gdb.execute("gcore %s" % filename)
+            gdb.execute(f"gcore {filename}")
         else:
             filename = pwndbg.gdblib.proc.exe
 

--- a/pwndbg/commands/ropper.py
+++ b/pwndbg/commands/ropper.py
@@ -23,7 +23,7 @@ def ropper(argument) -> None:
         # If the process is running, dump a corefile so we get actual addresses.
         if pwndbg.gdblib.proc.alive:
             filename = corefile.name
-            gdb.execute("gcore %s" % filename)
+            gdb.execute(f"gcore {filename}")
         else:
             filename = pwndbg.gdblib.proc.exe
 

--- a/pwndbg/commands/shell.py
+++ b/pwndbg/commands/shell.py
@@ -72,8 +72,7 @@ def register_shell_function(cmd, deprecated=False) -> None:
             os.execvp(cmd, (cmd,) + a)
         os.wait()
         print(
-            "This command is deprecated in Pwndbg. Please use the GDB's built-in syntax for running shell commands instead: !%s <args>"
-            % cmd
+            f"This command is deprecated in Pwndbg. Please use the GDB's built-in syntax for running shell commands instead: !{cmd} <args>"
         )
 
     doc = "Invokes `{}` shell command".format(cmd)

--- a/pwndbg/commands/version.py
+++ b/pwndbg/commands/version.py
@@ -52,21 +52,21 @@ def unicorn_version():
 
 
 def all_versions():
-    gdb_str = "Gdb:      %s" % _gdb_version()
-    py_str = "Python:   %s" % _py_version()
-    pwndbg_str = "Pwndbg:   %s" % pwndbg.__version__
+    gdb_str = f"Gdb:      {_gdb_version()}"
+    py_str = f"Python:   {_py_version()}"
+    pwndbg_str = f"Pwndbg:   {pwndbg.__version__}"
 
-    capstone_str = "Capstone: %s" % capstone_version()
-    unicorn_str = "Unicorn:  %s" % unicorn_version()
+    capstone_str = f"Capstone: {capstone_version()}"
+    unicorn_str = f"Unicorn:  {unicorn_version()}"
 
     all_versions = (gdb_str, py_str, pwndbg_str, capstone_str, unicorn_str)
 
     ida_versions = pwndbg.ida.get_ida_versions()
 
     if ida_versions is not None:
-        ida_version = "IDA PRO:  %s" % ida_versions["ida"]
-        ida_py_ver = "IDA Py:   %s" % ida_versions["python"]
-        ida_hr_ver = "Hexrays:  %s" % ida_versions["hexrays"]
+        ida_version = f"IDA PRO:  {ida_versions['ida']}"
+        ida_py_ver = f"IDA Py:   {ida_versions['python']}"
+        ida_hr_ver = f"Hexrays:  {ida_versions['hexrays']}"
         all_versions += (ida_version, ida_py_ver, ida_hr_ver)
     return all_versions
 
@@ -147,7 +147,7 @@ If it is somehow unavailable, use:
     all_info = all_versions()
     os_info = platform.system()
 
-    current_setup = "Platform: %s\n" % platform.platform()
+    current_setup = f"Platform: {platform.platform()}\n"
 
     if os_info.lower() == "linux" and os.path.isfile("/etc/os-release"):
         with open("/etc/os-release", "r") as os_release:
@@ -156,40 +156,40 @@ If it is somehow unavailable, use:
             if match:
                 os_info = match.group(1)
 
-    current_setup += "OS: %s\n" % os_info
+    current_setup += f"OS: {os_info}\n"
 
     # 1. showing osabi
     osabi_info = platform.uname().version
-    current_setup += "OS ABI: %s\n" % osabi_info
+    current_setup += f"OS ABI: {osabi_info}\n"
 
     # 2. showing architecture
     arch_info = platform.machine()
-    current_setup += "Architecture: %s\n" % arch_info
+    current_setup += f"Architecture: {arch_info}\n"
 
     # 3. showing endian
     endian_info = sys.byteorder
-    current_setup += "Endian: %s\n" % endian_info
+    current_setup += f"Endian: {endian_info}\n"
 
     # 4. Depending on current arch -- note that those are only available if given arch is supported by current GDB, like gdb-multiarch
     if arch_info in ["armv7l", "aarch64"]:
         arm_info = gdb.execute("show arm", to_string=True)
-        current_setup += "ARM: %s\n" % arm_info
+        current_setup += f"ARM: {arm_info}\n"
 
     elif arch_info in ["mips", "mips64"]:
         mips_info = gdb.execute("show mips", to_string=True)
-        current_setup += "MIPS: %s\n" % mips_info
+        current_setup += f"MIPS: {mips_info}\n"
 
     # 7. showing charset
     charset_info = sys.getdefaultencoding()
-    current_setup += "Charset: %s\n" % charset_info
+    current_setup += f"Charset: {charset_info}\n"
 
     # 8. showing width
     width_info = os.get_terminal_size().columns
-    current_setup += "Width: %s\n" % width_info
+    current_setup += f"Width: {width_info}\n"
 
     # 9. showing height
     height_info = os.get_terminal_size().lines
-    current_setup += "Height: %s\n" % height_info
+    current_setup += f"Height: {height_info}\n"
 
     current_setup += "\n".join(all_info)
     current_setup += "\n" + "\n".join(gdb_config)

--- a/pwndbg/commands/vmmap.py
+++ b/pwndbg/commands/vmmap.py
@@ -163,7 +163,7 @@ def vmmap_load(filename) -> None:
     if filename is None:
         filename = pwndbg.gdblib.file.get_proc_exe_file()
 
-    print('Load "%s" ...' % filename)
+    print(f'Load "{filename}" ...')
 
     # TODO: Add an argument to let use to choose loading the page information from sections or segments
 

--- a/pwndbg/commands/windbg.py
+++ b/pwndbg/commands/windbg.py
@@ -371,7 +371,7 @@ def bd(which="*") -> None:
     if which == "*":
         gdb.execute("disable breakpoints")
     else:
-        gdb.execute("disable breakpoints %s" % which)
+        gdb.execute(f"disable breakpoints {which}")
 
 
 parser = argparse.ArgumentParser(description="Enable the breakpoint with the specified index.")
@@ -388,7 +388,7 @@ def be(which="*") -> None:
     if which == "*":
         gdb.execute("enable breakpoints")
     else:
-        gdb.execute("enable breakpoints %s" % which)
+        gdb.execute(f"enable breakpoints {which}")
 
 
 parser = argparse.ArgumentParser(description="Clear the breakpoint with the specified index.")
@@ -405,7 +405,7 @@ def bc(which="*") -> None:
     if which == "*":
         gdb.execute("delete breakpoints")
     else:
-        gdb.execute("delete breakpoints %s" % which)
+        gdb.execute(f"delete breakpoints {which}")
 
 
 parser = argparse.ArgumentParser(description="Set a breakpoint at the specified address.")

--- a/pwndbg/disasm/arch.py
+++ b/pwndbg/disasm/arch.py
@@ -13,7 +13,7 @@ access = {v: k for k, v in globals().items() if k.startswith("CS_AC_")}
 for value1, name1 in dict(access).items():
     for value2, name2 in dict(access).items():
         # novermin
-        access.setdefault(value1 | value2, "%s | %s" % (name1, name2))
+        access.setdefault(value1 | value2, f"{name1} | {name2}")
 
 
 class DisassemblyAssistant:
@@ -240,7 +240,7 @@ class DisassemblyAssistant:
         """
         ins = instruction
         rv = []
-        rv.append("%s %s" % (ins.mnemonic, ins.op_str))
+        rv.append(f"{ins.mnemonic} {ins.op_str}")
 
         for i, group in enumerate(ins.groups):
             rv.append("   groups[%i]   = %s" % (i, groups.get(group, group)))
@@ -255,9 +255,9 @@ class DisassemblyAssistant:
             if op.int is not None:
                 rv.append("            int = %#x" % (op.int))
             if op.symbol is not None:
-                rv.append("            sym = %s" % (op.symbol))
+                rv.append(f"            sym = {(op.symbol)}")
             if op.str is not None:
-                rv.append("            str = %s" % (op.str))
+                rv.append(f"            str = {(op.str)}")
 
         return "\n".join(rv)
 

--- a/pwndbg/disasm/arm.py
+++ b/pwndbg/disasm/arm.py
@@ -23,7 +23,7 @@ class DisassemblyAssistant(pwndbg.disasm.arch.DisassemblyAssistant):
             scale = op.mem.scale
             parts.append("%s*%#x" % (index, scale))
 
-        return "[%s]" % (", ".join(parts))
+        return f"[{(', '.join(parts))}]"
 
     def immediate_sz(self, instruction, operand):
         return "#" + super().immediate_sz(instruction, operand)

--- a/pwndbg/disasm/x86.py
+++ b/pwndbg/disasm/x86.py
@@ -67,7 +67,7 @@ class DisassemblyAssistant(pwndbg.disasm.arch.DisassemblyAssistant):
         sz = ""
 
         if segment != 0:
-            sz += "%s:" % instruction.reg_name(segment)
+            sz += f"{instruction.reg_name(segment)}:"
 
         if base != 0:
             sz += instruction.reg_name(base)
@@ -88,7 +88,7 @@ class DisassemblyAssistant(pwndbg.disasm.arch.DisassemblyAssistant):
                 sz += " + "
             sz += "%#x" % abs(op.mem.disp)
 
-        sz = "[%s]" % sz
+        sz = f"[{sz}]"
         return sz
 
     def register(self, instruction, operand):

--- a/pwndbg/emu/emulator.py
+++ b/pwndbg/emu/emulator.py
@@ -102,7 +102,7 @@ class Emulator:
         self.arch = pwndbg.gdblib.arch.current
 
         if self.arch not in arch_to_UC:
-            raise NotImplementedError("Cannot emulate code for %s" % self.arch)
+            raise NotImplementedError(f"Cannot emulate code for {self.arch}")
 
         self.consts = arch_to_UC_consts[self.arch]
 
@@ -151,7 +151,7 @@ class Emulator:
             if value == 0:
                 continue
 
-            name = "U.x86_const.UC_X86_REG_%s" % reg.upper()
+            name = f"U.x86_const.UC_X86_REG_{reg.upper()}"
             debug("uc.reg_write(%(name)s, %(value)#x)", locals())
             self.uc.reg_write(enum, value)
 
@@ -468,7 +468,7 @@ class Emulator:
                 debug("# Could not dump register %r", reg)
                 continue
 
-            name = "U.x86_const.UC_X86_REG_%s" % reg.upper()
+            name = f"U.x86_const.UC_X86_REG_{reg.upper()}"
             value = self.uc.reg_read(enum)
             debug("uc.reg_read(%(name)s) ==> %(value)x", locals())
 

--- a/pwndbg/enhance.py
+++ b/pwndbg/enhance.py
@@ -89,7 +89,7 @@ def enhance(value: int, code: bool = True, safe_linking: bool = False) -> str:
     if exe:
         instr = pwndbg.disasm.one(value)
         if instr:
-            instr = "%s %s" % (instr.mnemonic, instr.op_str)
+            instr = f"{instr.mnemonic} {instr.op_str}"
             if pwndbg.gdblib.config.syntax_highlight:
                 instr = syntax_highlight(instr)
 

--- a/pwndbg/gdblib/arch.py
+++ b/pwndbg/gdblib/arch.py
@@ -48,7 +48,7 @@ def _get_arch(ptrsize):
             return match, ptrsize, endian
 
     if not_exactly_arch:
-        raise RuntimeError("Could not deduce architecture from: %s" % arch)
+        raise RuntimeError(f"Could not deduce architecture from: {arch}")
 
     return arch, ptrsize, endian
 

--- a/pwndbg/gdblib/config.py
+++ b/pwndbg/gdblib/config.py
@@ -116,7 +116,7 @@ class Parameter(gdb.Parameter):
 
     def __get_show_string_gdb_gte_9(self, svalue) -> str:
         """Handles the GDB `show <param>` command for GDB >= 9"""
-        more_information_hint = " See `help set %s` for more information." % self.param.name
+        more_information_hint = f" See `help set {self.param.name}` for more information."
         return "%s is %r.%s" % (
             self.param.set_show_doc.capitalize(),
             svalue,

--- a/pwndbg/gdblib/dt.py
+++ b/pwndbg/gdblib/dt.py
@@ -92,7 +92,7 @@ def dt(name="", addr=None, obj=None):
 
     # If it's not a struct (e.g. int or char*), bail
     if t.code not in (gdb.TYPE_CODE_STRUCT, gdb.TYPE_CODE_TYPEDEF, gdb.TYPE_CODE_UNION):
-        raise Exception("Not a structure: %s" % t)
+        raise Exception(f"Not a structure: {t}")
 
     # If an address was specified, create a Value of the
     # specified type at that address.
@@ -102,7 +102,7 @@ def dt(name="", addr=None, obj=None):
     # Header, optionally include the name
     header = name
     if obj:
-        header = "%s @ %s" % (header, hex(int(obj.address)))
+        header = f"{header} @ {hex(int(obj.address))}"
     rv.append(header)
 
     if t.strip_typedefs().code == gdb.TYPE_CODE_ARRAY:

--- a/pwndbg/gdblib/events.py
+++ b/pwndbg/gdblib/events.py
@@ -142,7 +142,7 @@ def connect(func, event_handler, name=""):
 
         if a and isinstance(a[0], gdb.NewObjFileEvent):
             objfile = a[0].new_objfile
-            handler = "%s.%s" % (func.__module__, func.__name__)
+            handler = f"{func.__module__}.{func.__name__}"
             path = objfile.filename
             dispatched = objfile_cache.get(path, set())
 

--- a/pwndbg/gdblib/file.py
+++ b/pwndbg/gdblib/file.py
@@ -76,7 +76,7 @@ def get_file(path: str, try_local_path: bool = False) -> str:
             local_path = tempfile.mktemp(dir=remote_files_dir())
             error = None
             try:
-                error = gdb.execute('remote get "%s" "%s"' % (path, local_path), to_string=True)
+                error = gdb.execute(f'remote get "{path}" "{local_path}"', to_string=True)
             except gdb.error as e:
                 error = str(e)
 
@@ -85,8 +85,7 @@ def get_file(path: str, try_local_path: bool = False) -> str:
         else:
             print(
                 message.warn(
-                    "pwndbg.gdblib.file.get_file(%s) returns local path as we can't download file from QEMU"
-                    % path
+                    f"pwndbg.gdblib.file.get_file({path}) returns local path as we can't download file from QEMU"
                 )
             )
 

--- a/pwndbg/gdblib/nearpc.py
+++ b/pwndbg/gdblib/nearpc.py
@@ -137,7 +137,7 @@ def nearpc(pc=None, lines=None, emulate=False, repeat=False) -> List[str]:
     nearpc.next_pc = instructions[-1].address + instructions[-1].size if instructions else 0
 
     # Format the symbol name for each instruction
-    symbols = ["<%s> " % sym if sym else "" for sym in symbols]
+    symbols = [f"<{sym}> " if sym else "" for sym in symbols]
 
     # Pad out all of the symbols and addresses
     if pwndbg.gdblib.config.left_pad_disasm and not repeat:
@@ -198,7 +198,7 @@ def nearpc(pc=None, lines=None, emulate=False, repeat=False) -> List[str]:
         # If there was a branch before this instruction which was not
         # contiguous, put in some ellipses.
         if prev and prev.address + prev.size != instr.address:
-            result.append(c.branch_marker("%s" % nearpc_branch_marker))
+            result.append(c.branch_marker(f"{nearpc_branch_marker}"))
 
         # Otherwise if it's a branch and it *is* contiguous, just put
         # and empty line.

--- a/pwndbg/gdblib/next.py
+++ b/pwndbg/gdblib/next.py
@@ -105,11 +105,11 @@ def break_next_call(symbol_regex=None):
             return ins
 
         # return call if we match target address
-        if ins.target_const and re.match("%s$" % symbol_regex, hex(ins.target)):
+        if ins.target_const and re.match(f"{symbol_regex}$", hex(ins.target)):
             return ins
 
         # return call if we match symbol name
-        if ins.symbol and re.match("%s$" % symbol_regex, ins.symbol):
+        if ins.symbol and re.match(f"{symbol_regex}$", ins.symbol):
             return ins
 
 

--- a/pwndbg/gdblib/prompt.py
+++ b/pwndbg/gdblib/prompt.py
@@ -21,7 +21,7 @@ num_shell_cmds = sum(1 for _ in filter(lambda c: c.shell, pwndbg.commands.comman
 hint_lines = (
     "loaded %i pwndbg commands and %i shell commands. Type %s for a list."
     % (num_pwndbg_cmds, num_shell_cmds, message.notice("pwndbg [--shell | --all] [filter]")),
-    "created %s GDB functions (can be used with print/break)" % funcs_list_str,
+    f"created {funcs_list_str} GDB functions (can be used with print/break)",
 )
 
 for line in hint_lines:
@@ -88,7 +88,7 @@ def set_prompt() -> None:
         prompt = message.prompt(prompt)
         prompt = "\x01" + prompt + "\x02"  # SOH + prompt + STX
 
-    gdb.execute("set prompt %s" % prompt)
+    gdb.execute(f"set prompt {prompt}")
 
 
 if pwndbg.gdblib.events.before_prompt_event.is_real_event:

--- a/pwndbg/gdblib/qemu.py
+++ b/pwndbg/gdblib/qemu.py
@@ -63,7 +63,7 @@ def root() -> Optional[Any]:
     if not is_qemu_usermode():
         return None
 
-    binfmt_root = "/etc/qemu-binfmt/%s/" % pwndbg.gdblib.arch.qemu
+    binfmt_root = f"/etc/qemu-binfmt/{pwndbg.gdblib.arch.qemu}/"
 
     if not os.path.isdir(binfmt_root):
         return None

--- a/pwndbg/gdblib/regs.py
+++ b/pwndbg/gdblib/regs.py
@@ -158,7 +158,7 @@ class module(ModuleType):
 
     def fix(self, expression):
         for regname in set(self.all + ["sp", "pc"]):
-            expression = re.sub(r"\$?\b%s\b" % regname, r"$" + regname, expression)
+            expression = re.sub(rf"\$?\b{regname}\b", r"$" + regname, expression)
         return expression
 
     def items(self):

--- a/pwndbg/gdblib/scheduler.py
+++ b/pwndbg/gdblib/scheduler.py
@@ -20,7 +20,7 @@ def lock_scheduler():
     if old_config != "on":
         gdb.execute("set scheduler-locking on")
         yield
-        gdb.execute("set scheduler-locking %s" % old_config)
+        gdb.execute(f"set scheduler-locking {old_config}")
     else:
         yield
 

--- a/pwndbg/gdblib/symbol.py
+++ b/pwndbg/gdblib/symbol.py
@@ -44,13 +44,13 @@ def _get_debug_file_directory():
 
 
 def _set_debug_file_directory(d) -> None:
-    gdb.execute("set debug-file-directory %s" % d, to_string=True, from_tty=False)
+    gdb.execute(f"set debug-file-directory {d}", to_string=True, from_tty=False)
 
 
 def _add_debug_file_directory(d) -> None:
     current = _get_debug_file_directory()
     if current:
-        _set_debug_file_directory("%s:%s" % (current, d))
+        _set_debug_file_directory(f"{current}:{d}")
     else:
         _set_debug_file_directory(d)
 

--- a/pwndbg/gdblib/typeinfo.py
+++ b/pwndbg/gdblib/typeinfo.py
@@ -81,7 +81,7 @@ def update():
 
     # Rust workaround part 2
     if restore_lang:
-        gdb.execute("set language %s" % restore_lang)
+        gdb.execute(f"set language {restore_lang}")
 
 
 # TODO: Remove this global initialization, or move it somewhere else

--- a/pwndbg/gdblib/vmmap.py
+++ b/pwndbg/gdblib/vmmap.py
@@ -372,9 +372,9 @@ def proc_pid_maps():
 
     pid = pwndbg.gdblib.proc.pid
     locations = [
-        "/proc/%s/maps" % pid,
-        "/proc/%s/map" % pid,
-        "/usr/compat/linux/proc/%s/maps" % pid,
+        f"/proc/{pid}/maps",
+        f"/proc/{pid}/map",
+        f"/usr/compat/linux/proc/{pid}/maps",
     ]
 
     for location in locations:

--- a/pwndbg/glibc.py
+++ b/pwndbg/glibc.py
@@ -42,8 +42,7 @@ def get_version() -> Optional[Tuple[int, ...]]:
             return tuple(int(_) for _ in ret.groups())
         else:
             raise ValueError(
-                "Invalid GLIBC version: `%s`, you should provide something like: 2.31 or 2.34"
-                % glibc_version.value
+                f"Invalid GLIBC version: `{glibc_version.value}`, you should provide something like: 2.31 or 2.34"
             )
     return _get_version()
 
@@ -179,7 +178,7 @@ def OnlyWhenGlibcLoaded(function):
         if get_version() is not None:
             return function(*a, **kw)
         else:
-            print("%s: GLibc not loaded yet." % function.__name__)
+            print(f"{function.__name__}: GLibc not loaded yet.")
 
     return _OnlyWhenGlibcLoaded
 

--- a/pwndbg/heap/ptmalloc.py
+++ b/pwndbg/heap/ptmalloc.py
@@ -1755,11 +1755,7 @@ class HeuristicHeap(GlibcMemoryAllocator):
                     value, address = found
                     print(
                         message.notice(
-                            "Found matching arena address %s at %s\n"
-                            % (
-                                message.hint(hex(value)),
-                                message.hint(hex(address)),
-                            )
+                            f"Found matching arena address {message.hint(hex(value))} at {message.hint(hex(address))}\n"
                         )
                     )
                     arena = Arena(value)
@@ -1768,8 +1764,7 @@ class HeuristicHeap(GlibcMemoryAllocator):
 
                 print(
                     message.notice(
-                        "Cannot find %s, the arena might be not allocated yet.\n"
-                        % message.hint("thread_arena")
+                        f"Cannot find {message.hint('thread_arena')}, the arena might be not allocated yet.\n"
                     )
                 )
                 return None
@@ -1837,11 +1832,7 @@ class HeuristicHeap(GlibcMemoryAllocator):
                         value, address = found
                         print(
                             message.notice(
-                                "Found possible tcache at %s with value: %s\n"
-                                % (
-                                    message.hint(hex(address)),
-                                    message.hint(hex(value)),
-                                )
+                                f"Found possible tcache at {message.hint(hex(address))} with value: {message.hint(hex(value))}\n"
                             )
                         )
                         self._thread_cache = self.tcache_perthread_struct(value)

--- a/pwndbg/heap/structs.py
+++ b/pwndbg/heap/structs.py
@@ -153,7 +153,7 @@ class CStruct2GDB:
         """
         output = "{\n"
         for f in self._c_struct._fields_:
-            output += "  %s = %s,\n" % (f[0], self.read_field(f[0]))
+            output += f"  {f[0]} = {self.read_field(f[0])},\n"
         output += "}"
         return output
 

--- a/pwndbg/hexdump.py
+++ b/pwndbg/hexdump.py
@@ -52,9 +52,7 @@ def load_color_scheme() -> None:
     ):
         color_scheme[c] = H.printable("%02x" % c)
         printable[c] = (
-            H.printable("%s" % chr(c))
-            if pwndbg.gdblib.config.hexdump_colorize_ascii
-            else "%s" % chr(c)
+            H.printable(f"{chr(c)}") if pwndbg.gdblib.config.hexdump_colorize_ascii else f"{chr(c)}"
         )
 
     for c in bytearray(b"\x00"):

--- a/pwndbg/ida.py
+++ b/pwndbg/ida.py
@@ -71,7 +71,7 @@ def init_ida_rpc_client() -> None:
     exception = None  # (type, value, traceback)
     try:
         _ida.here()
-        print(message.success("Pwndbg successfully connected to Ida Pro xmlrpc: %s" % addr))
+        print(message.success(f"Pwndbg successfully connected to Ida Pro xmlrpc: {addr}"))
     except TimeoutError:
         exception = sys.exc_info()
         _ida = None

--- a/pwndbg/lib/android.py
+++ b/pwndbg/lib/android.py
@@ -89,4 +89,4 @@ def aid_name(uid):  # types: (int) -> str
     else:
         return str(uid)
 
-    return "%s+%s" % (KNOWN_AIDS[closest], uid - closest)
+    return f"{KNOWN_AIDS[closest]}+{uid - closest}"

--- a/pwndbg/lib/config.py
+++ b/pwndbg/lib/config.py
@@ -182,4 +182,4 @@ class Config:
         if name in self.params:
             return self.params[name]
         else:
-            raise AttributeError("'Config' object has no attribute '%s'" % name)
+            raise AttributeError(f"'Config' object has no attribute '{name}'")

--- a/pwndbg/lib/funcparser.py
+++ b/pwndbg/lib/funcparser.py
@@ -36,7 +36,7 @@ Argument = collections.namedtuple("Argument", ("type", "derefcnt", "name"))
 
 
 def Stringify(X) -> str:
-    return "%s %s %s" % (X.type, X.derefcnt * "*", X.name)
+    return f"{X.type} {X.derefcnt * '*'} {X.name}"
 
 
 def ExtractFuncDecl(node, verbose=False):

--- a/pwndbg/lib/gcc.py
+++ b/pwndbg/lib/gcc.py
@@ -65,7 +65,7 @@ def _which_binutils(util, arch, **kwargs):
 
             # e.g. aarch64-linux-gnu-objdump
             else:
-                pattern = "%s*linux*-%s" % (arch, gutil)
+                pattern = f"{arch}*linux*-{gutil}"
 
             for dir in os.environ["PATH"].split(":"):
                 res = sorted(glob.glob(os.path.join(dir, pattern)))

--- a/pwndbg/lib/net.py
+++ b/pwndbg/lib/net.py
@@ -42,17 +42,12 @@ class Connection(inode):
     family = None
 
     def __str__(self) -> str:
-        return "%s %s:%s => %s:%s (%s)" % (
-            self.family,
-            self.lhost,
-            self.lport,
-            self.rhost,
-            self.rport,
-            self.status,
+        return (
+            f"{self.family} {self.lhost}:{self.lport} => {self.rhost}:{self.rport} ({self.status})"
         )
 
     def __repr__(self) -> str:
-        return 'Connection("%s")' % self
+        return f'Connection("{self}")'
 
 
 class UnixSocket(inode):
@@ -62,7 +57,7 @@ class UnixSocket(inode):
         return "unix %r" % self.path
 
     def __repr__(self) -> str:
-        return "UnixSocket(%s)" % self
+        return f"UnixSocket({self})"
 
 
 def tcp(data: str):
@@ -200,7 +195,7 @@ class Netlink(inode):
         return NETLINK_TYPES.get(self.eth, "(unknown netlink)")
 
     def __repr__(self) -> str:
-        return "Netlink(%s)" % self
+        return f"Netlink({self})"
 
 
 def netlink(data: str):

--- a/pwndbg/lib/version.py
+++ b/pwndbg/lib/version.py
@@ -28,4 +28,4 @@ __version__ = "2023.03.19"
 b_id = build_id()
 
 if b_id:
-    __version__ += " %s" % b_id
+    __version__ += f" {b_id}"

--- a/pwndbg/ui.py
+++ b/pwndbg/ui.py
@@ -31,8 +31,7 @@ def check_title_position() -> None:
     if title_position not in valid_values:
         print(
             message.warn(
-                "Invalid title position: %s, must be one of: %s"
-                % (title_position, ", ".join(valid_values))
+                f"Invalid title position: {title_position}, must be one of: {', '.join(valid_values)}"
             )
         )
         title_position.revert_default()

--- a/pwndbg/wrappers/__init__.py
+++ b/pwndbg/wrappers/__init__.py
@@ -25,7 +25,7 @@ class OnlyWithCommand:
             if self.cmd_path:
                 return function(*a, **kw)
             else:
-                raise OSError("Could not find command(s) %s in $PATH" % ", ".join(self.all_cmds))
+                raise OSError(f"Could not find command(s) {', '.join(self.all_cmds)} in $PATH")
 
         return _OnlyWithCommand
 

--- a/tests/gdb-tests/pytests_launcher.py
+++ b/tests/gdb-tests/pytests_launcher.py
@@ -18,7 +18,7 @@ args = [test, "-vvv", "-s", "--showlocals", "--color=yes"]
 if use_pdb:
     args.append("--pdb")
 
-print("Launching pytest with args: %s" % args)
+print(f"Launching pytest with args: {args}")
 
 return_code = pytest.main(args)
 

--- a/tests/gdb-tests/tests/heap/test_vis_heap_chunks.py
+++ b/tests/gdb-tests/tests/heap/test_vis_heap_chunks.py
@@ -37,7 +37,7 @@ def test_vis_heap_chunk_command(start_binary):
     def hexdump_16B(gdb_symbol):
         from pwndbg.commands.heap import bin_ascii
 
-        first, second = gdb.execute("x/16xb %s" % gdb_symbol, to_string=True).splitlines()
+        first, second = gdb.execute(f"x/16xb {gdb_symbol}", to_string=True).splitlines()
         first = [int(v, 16) for v in first.split(":")[1].split("\t")[1:]]
         second = [int(v, 16) for v in second.split(":")[1].split("\t")[1:]]
 

--- a/tests/gdb-tests/tests/test_attachp.py
+++ b/tests/gdb-tests/tests/test_attachp.py
@@ -42,24 +42,24 @@ def test_attachp_command_attaches_to_procname(launched_bash_binary):
     pid, binary_path = launched_bash_binary
 
     binary_name = binary_path.split("/")[-1]
-    result = run_gdb_with_script(pyafter="attachp %s" % binary_name)
+    result = run_gdb_with_script(pyafter=f"attachp {binary_name}")
 
     matches = re.search(r"Attaching to ([0-9]+)", result).groups()
     assert matches == (str(pid),)
 
-    assert re.search(r"Detaching from program: %s, process %s" % (binary_path, pid), result)
+    assert re.search(rf"Detaching from program: {binary_path}, process {pid}", result)
 
 
 @pytest.mark.skipif(can_attach is False, reason=REASON_CANNOT_ATTACH)
 def test_attachp_command_attaches_to_pid(launched_bash_binary):
     pid, binary_path = launched_bash_binary
 
-    result = run_gdb_with_script(pyafter="attachp %s" % pid)
+    result = run_gdb_with_script(pyafter=f"attachp {pid}")
 
     matches = re.search(r"Attaching to ([0-9]+)", result).groups()
     assert matches == (str(pid),)
 
-    assert re.search(r"Detaching from program: %s, process %s" % (binary_path, pid), result)
+    assert re.search(rf"Detaching from program: {binary_path}, process {pid}", result)
 
 
 @pytest.mark.skipif(can_attach is False, reason=REASON_CANNOT_ATTACH)
@@ -69,7 +69,7 @@ def test_attachp_command_attaches_to_procname_too_many_pids(launched_bash_binary
     process = subprocess.Popen([binary_path], stdout=subprocess.PIPE, stdin=subprocess.PIPE)
 
     binary_name = binary_path.split("/")[-1]
-    result = run_gdb_with_script(pyafter="attachp %s" % binary_name)
+    result = run_gdb_with_script(pyafter=f"attachp {binary_name}")
 
     process.kill()
 

--- a/tests/gdb-tests/tests/test_command_vmmap.py
+++ b/tests/gdb-tests/tests/test_command_vmmap.py
@@ -85,7 +85,7 @@ def test_command_vmmap_on_coredump_on_crash_simple_binary(start_binary, unload_f
 
     # Now, generate core file, so we can then test coredump vmmap
     core = tempfile.mktemp()
-    gdb.execute("generate-core-file %s" % core)
+    gdb.execute(f"generate-core-file {core}")
 
     # The test should work fine even if we unload the original binary
     if unload_file:
@@ -93,7 +93,7 @@ def test_command_vmmap_on_coredump_on_crash_simple_binary(start_binary, unload_f
 
     #### TEST COREDUMP VMMAP
     # Now, let's load the generated core file
-    gdb.execute("core-file %s" % core)
+    gdb.execute(f"core-file {core}")
 
     old_len_vmmaps = len(vmmaps)
     vmmaps = gdb.execute("vmmap", to_string=True).splitlines()

--- a/tests/gdb-tests/tests/test_loads.py
+++ b/tests/gdb-tests/tests/test_loads.py
@@ -24,7 +24,7 @@ def test_loads_binary_without_crashing():
 
     for h in HELLO:
         assert h in output
-    assert any("Reading symbols from %s..." % BINARY in line for line in output)
+    assert any(f"Reading symbols from {BINARY}..." in line for line in output)
     assert any("pwndbg: loaded" in line for line in output)
 
 
@@ -35,7 +35,7 @@ def test_loads_binary_with_core_without_crashing():
         assert os.path.isfile(CORE)
     output = run_gdb_with_script(binary=BINARY, core=CORE).splitlines()
 
-    assert any("Reading symbols from %s..." % BINARY in line for line in output)
+    assert any(f"Reading symbols from {BINARY}..." in line for line in output)
     assert any("pwndbg: loaded" in line for line in output)
     assert "Program terminated with signal SIGFPE, Arithmetic exception." in output
     for h in HELLO:

--- a/tests/gdb-tests/tests/test_triggers.py
+++ b/tests/gdb-tests/tests/test_triggers.py
@@ -6,9 +6,9 @@ from pwndbg.gdblib import config
 
 
 def set_show(param_name, value):
-    gdb.execute("show %s" % param_name)
-    gdb.execute("set %s %s" % (param_name, value))
-    gdb.execute("show %s" % param_name)
+    gdb.execute(f"show {param_name}")
+    gdb.execute(f"set {param_name} {value}")
+    gdb.execute(f"show {param_name}")
 
 
 def test_triggers():

--- a/tests/gdb-tests/tests/test_windbg.py
+++ b/tests/gdb-tests/tests/test_windbg.py
@@ -36,8 +36,8 @@ def test_windbg_dX_commands(start_binary):
     # Try `dq` with symbol, &symbol, 0x<address> and <address> without 0x prefix (treated as hex!)
     dq1 = gdb.execute("dq data", to_string=True)
     dq2 = gdb.execute("dq &data", to_string=True)
-    dq3 = gdb.execute("dq %s" % data_addr, to_string=True)
-    dq4 = gdb.execute("dq %s" % data_addr.replace("0x", ""), to_string=True)
+    dq3 = gdb.execute(f"dq {data_addr}", to_string=True)
+    dq4 = gdb.execute(f"dq {data_addr.replace('0x', '')}", to_string=True)
     assert (
         dq1
         == dq2
@@ -54,7 +54,7 @@ def test_windbg_dX_commands(start_binary):
     # Try `dq` with different counts
     dq_count1 = gdb.execute("dq data 2", to_string=True)
     dq_count2 = gdb.execute("dq &data 2", to_string=True)
-    dq_count3 = gdb.execute("dq %s 2" % data_addr, to_string=True)
+    dq_count3 = gdb.execute(f"dq {data_addr} 2", to_string=True)
     assert (
         dq_count1
         == dq_count2
@@ -92,8 +92,8 @@ def test_windbg_dX_commands(start_binary):
     #################################################
     dd1 = gdb.execute("dd data", to_string=True)
     dd2 = gdb.execute("dd &data", to_string=True)
-    dd3 = gdb.execute("dd %s" % data_addr, to_string=True)
-    dd4 = gdb.execute("dd %s" % data_addr.replace("0x", ""), to_string=True)
+    dd3 = gdb.execute(f"dd {data_addr}", to_string=True)
+    dd4 = gdb.execute(f"dd {data_addr.replace('0x', '')}", to_string=True)
     assert (
         dd1
         == dd2
@@ -120,8 +120,8 @@ def test_windbg_dX_commands(start_binary):
     #################################################
     dw1 = gdb.execute("dw data", to_string=True)
     dw2 = gdb.execute("dw &data", to_string=True)
-    dw3 = gdb.execute("dw %s" % data_addr, to_string=True)
-    dw4 = gdb.execute("dw %s" % data_addr.replace("0x", ""), to_string=True)
+    dw3 = gdb.execute(f"dw {data_addr}", to_string=True)
+    dw4 = gdb.execute(f"dw {data_addr.replace('0x', '')}", to_string=True)
     assert (
         dw1
         == dw2
@@ -153,8 +153,8 @@ def test_windbg_dX_commands(start_binary):
     #################################################
     db1 = gdb.execute("db data", to_string=True)
     db2 = gdb.execute("db &data", to_string=True)
-    db3 = gdb.execute("db %s" % data_addr, to_string=True)
-    db4 = gdb.execute("db %s" % data_addr.replace("0x", ""), to_string=True)
+    db3 = gdb.execute(f"db {data_addr}", to_string=True)
+    db4 = gdb.execute(f"db {data_addr.replace('0x', '')}", to_string=True)
     assert (
         db1
         == db2
@@ -180,8 +180,8 @@ def test_windbg_dX_commands(start_binary):
     #################################################
     dc1 = gdb.execute("dc data", to_string=True)
     dc2 = gdb.execute("dc &data", to_string=True)
-    dc3 = gdb.execute("dc %s" % data_addr, to_string=True)
-    dc4 = gdb.execute("dc %s" % data_addr.replace("0x", ""), to_string=True)
+    dc3 = gdb.execute(f"dc {data_addr}", to_string=True)
+    dc4 = gdb.execute(f"dc {data_addr.replace('0x', '')}", to_string=True)
     assert (
         dc1
         == dc2

--- a/tests/gdb-tests/tests/utils.py
+++ b/tests/gdb-tests/tests/utils.py
@@ -32,7 +32,7 @@ def run_gdb_with_script(binary="", core="", pybefore=None, pyafter=None, timeout
 
     command += ["--eval-command", "quit"]
 
-    print("Launching command: %s" % command)
+    print(f"Launching command: {command}")
     output = subprocess.check_output(command, stderr=subprocess.STDOUT, timeout=timeout)
 
     # Python 3 returns bytes-like object so lets have it consistent

--- a/tests/qemu-tests/pytests_launcher.py
+++ b/tests/qemu-tests/pytests_launcher.py
@@ -18,7 +18,7 @@ args = [test, "-vvv", "-s", "--showlocals", "--color=yes"]
 if use_pdb:
     args.append("--pdb")
 
-print("Launching pytest with args: %s" % args)
+print(f"Launching pytest with args: {args}")
 
 return_code = pytest.main(args)
 


### PR DESCRIPTION
I found [this tool](https://libcst.readthedocs.io/en/latest/codemods_tutorial.html#setting-up-and-running-codemods), and ran the following command:
```
python3 -m libcst.tool codemod convert_percent_format_to_fstring.ConvertPercentFormatStringCommand .
```

f-strings are supported since Python 3.6 and are used in other places in the code, so this should not introduce any problems.