### PR TITLE
Add +10min (30min) to qemu-tests CI build

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,7 +51,7 @@ jobs:
 
   qemu-tests:
     runs-on: [ubuntu-22.04]
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
     - uses: actions/checkout@v3
 


### PR DESCRIPTION
This is an attempt to mitigate: "Unit tests / qemu-tests (pull_request) Cancelled after 20m" that occurs in https://github.com/pwndbg/pwndbg/pull/1732

<!-- Please make sure to read the testing and linting instructions at https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md before creating a PR -->
