### PR TITLE
Add return address stack location to context backtrace #1288

### DIFF
--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -800,7 +800,7 @@ def context_backtrace(with_banner=True, target=sys.stdout, width=None):
     bt_prefix = "%s" % pwndbg.gdblib.config.backtrace_prefix
     while True:
         prefix = bt_prefix if frame == this_frame else " " * len(bt_prefix)
-        prefix = " %s" % c.prefix(prefix)
+        prefix = f" {c.prefix(prefix)}"
         frame_pc = frame.pc()
         stackaddr = M.get((pwndbg.gdblib.stack.find_addr_on_stack(frame_pc)))
         addrsz = "(" + stackaddr + ") " + M.get(frame_pc)

--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -805,7 +805,7 @@ def context_backtrace(with_banner=True, target=sys.stdout, width=None):
         frame_pc_on_stack = pwndbg.gdblib.stack.find_addr_on_stack(frame_pc)
         padded_text = "0x" + hex(frame_pc_on_stack)[2:].zfill(pwndbg.gdblib.arch.ptrsize * 2)
         stackaddr = M.get(frame_pc_on_stack, padded_text)
-        addrsz = "(" + stackaddr + ") " + M.get(frame_pc)
+        addrsz = f"({stackaddr}) {M.get(frame_pc)}"
         symbol = c.symbol(pwndbg.gdblib.symbol.get(int(frame_pc)))
         if symbol:
             addrsz = addrsz + " " + symbol

--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -802,7 +802,9 @@ def context_backtrace(with_banner=True, target=sys.stdout, width=None):
         prefix = bt_prefix if frame == this_frame else " " * len(bt_prefix)
         prefix = f" {c.prefix(prefix)}"
         frame_pc = frame.pc()
-        stackaddr = M.get((pwndbg.gdblib.stack.find_addr_on_stack(frame_pc)))
+        frame_pc_on_stack = pwndbg.gdblib.stack.find_addr_on_stack(frame_pc)
+        padded_text = "0x" + hex(frame_pc_on_stack)[2:].zfill(pwndbg.gdblib.arch.ptrsize * 2)
+        stackaddr = M.get(frame_pc_on_stack, padded_text)
         addrsz = "(" + stackaddr + ") " + M.get(frame_pc)
         symbol = c.symbol(pwndbg.gdblib.symbol.get(int(frame_pc)))
         if symbol:

--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -798,12 +798,13 @@ def context_backtrace(with_banner=True, target=sys.stdout, width=None):
     frame = newest_frame
     i = 0
     bt_prefix = "%s" % pwndbg.gdblib.config.backtrace_prefix
+    zero_fill_amount = pwndbg.gdblib.arch.ptrsize * 2
     while True:
         prefix = bt_prefix if frame == this_frame else " " * len(bt_prefix)
         prefix = f" {c.prefix(prefix)}"
         frame_pc = frame.pc()
         frame_pc_on_stack = pwndbg.gdblib.stack.find_addr_on_stack(frame_pc)
-        padded_text = "0x" + hex(frame_pc_on_stack)[2:].zfill(pwndbg.gdblib.arch.ptrsize * 2)
+        padded_text = "0x" + hex(frame_pc_on_stack)[2:].zfill(zero_fill_amount)
         stackaddr = M.get(frame_pc_on_stack, padded_text)
         addrsz = f"({stackaddr}) {M.get(frame_pc)}"
         symbol = c.symbol(pwndbg.gdblib.symbol.get(int(frame_pc)))

--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -41,7 +41,6 @@ c = ColorConfig(
     "backtrace",
     [
         ColorParamSpec("prefix", "none", "color for prefix of current backtrace label"),
-        ColorParamSpec("address", "none", "color for backtrace (address)"),
         ColorParamSpec("symbol", "none", "color for backtrace (symbol)"),
         ColorParamSpec("frame-label", "none", "color for backtrace (frame label)"),
     ],
@@ -805,10 +804,13 @@ def context_backtrace(with_banner=True, target=sys.stdout, width=None):
 
         prefix = bt_prefix if frame == this_frame else " " * len(bt_prefix)
         prefix = " %s" % c.prefix(prefix)
-        addrsz = c.address(pwndbg.ui.addrsz(frame.pc()))
-        symbol = c.symbol(pwndbg.gdblib.symbol.get(int(frame.pc())))
+        frame_pc = frame.pc()
+        stackaddr = M.get((pwndbg.gdblib.stack.find_addr_on_stack(frame_pc)))
+        addrsz = "(" + stackaddr + ") " + M.get(frame_pc)
+        symbol = c.symbol(pwndbg.gdblib.symbol.get(int(frame_pc)))
         if symbol:
             addrsz = addrsz + " " + symbol
+
         line = map(str, (prefix, c.frame_label("%s%i" % (backtrace_frame_label, i)), addrsz))
         line = " ".join(line)
         result.append(line)

--- a/pwndbg/commands/stack.py
+++ b/pwndbg/commands/stack.py
@@ -26,7 +26,7 @@ def retaddr() -> None:
     # Find all of them on the stack
     start = stack.vaddr
     stop = start + stack.memsz
-    while addresses and start < sp < stop:
+    while addresses and start <= sp < stop:
         value = pwndbg.gdblib.memory.u(sp)
 
         if value in addresses:

--- a/pwndbg/gdblib/stack.py
+++ b/pwndbg/gdblib/stack.py
@@ -138,7 +138,7 @@ def is_executable() -> bool:
     return not nx
 
 
-def find_addr_on_stack(addr):
+def find_addr_on_stack(addr) -> int:
     """
     Scans the stack looking to see if it contains the supplied address.
 

--- a/pwndbg/gdblib/stack.py
+++ b/pwndbg/gdblib/stack.py
@@ -152,7 +152,7 @@ def find_addr_on_stack(addr):
     stop = start + stack.memsz
     ptrsize = pwndbg.gdblib.arch.ptrsize
 
-    while start < sp < stop:
+    while start <= sp < stop:
         value = pwndbg.gdblib.memory.u(sp)
         if value == addr:
             stackaddr = sp

--- a/pwndbg/gdblib/stack.py
+++ b/pwndbg/gdblib/stack.py
@@ -136,3 +136,27 @@ def is_executable() -> bool:
             nx = True
 
     return not nx
+
+
+def find_addr_on_stack(addr):
+    """
+    Scans the stack looking to see if it contains the supplied address.
+
+    If the supplied address is found the location on the stack is returned or 0 if it cannot be found.
+    """
+    stackaddr = 0
+
+    sp = pwndbg.gdblib.regs.sp
+    stack = pwndbg.gdblib.vmmap.find(sp)
+    start = stack.vaddr
+    stop = start + stack.memsz
+    ptrsize = pwndbg.gdblib.arch.ptrsize
+
+    while start < sp < stop:
+        value = pwndbg.gdblib.memory.u(sp)
+        if value == addr:
+            stackaddr = sp
+            break
+        sp += ptrsize
+
+    return stackaddr

--- a/tests/gdb-tests/tests/test_context_commands.py
+++ b/tests/gdb-tests/tests/test_context_commands.py
@@ -201,21 +201,19 @@ def test_context_backtrace_show_proper_symbol_names(start_binary):
         == "─────────────────────────────────[ BACKTRACE ]──────────────────────────────────"
     )
 
-    assert re.match(r".*0   0x[0-9a-f]+ A::foo\(int, int\)", backtrace[2])
+    assert re.match(r".* A::foo\(int, int\)", backtrace[2])
 
     # Match A::call_foo()+38 or similar: the offset may change so we match \d+ at the end
-    assert re.match(r".*1   0x[0-9a-f]+ A::call_foo\(\)\+\d+", backtrace[3])
+    assert re.match(r".* A::call_foo\(\)\+\d+", backtrace[3])
 
     # Match main+87 or similar offset
-    assert re.match(r".*2   0x[0-9a-f]+ main\+\d+", backtrace[4])
+    assert re.match(r".* main\+\d+", backtrace[4])
 
     # Match __libc_start_main+243 or similar offset
     # Note: on Ubuntu 22.04 there will be __libc_start_call_main and then __libc_start_main
     # but on older distros there will be only __libc_start_main
     # Let's not bother too much about it and make it the last call assertion here
-    assert re.match(
-        r".*3   0x[0-9a-f]+ (__libc_start_main|__libc_start_call_main)\+\d+", backtrace[5]
-    )
+    assert re.match(r".* (__libc_start_main|__libc_start_call_main)\+\d+", backtrace[5])
 
     assert (
         backtrace[-2]


### PR DESCRIPTION
* Add pwndbg.gdblib.find_addr_on_stack

* Change coloration of context backtrace to use pwnlib.color.memory

* Remove now defunct address color config from context

* Update test_context_backtrace_show_proper_symbol_names regex
