### PR TITLE
slab: show per-node partial slabs

### DIFF
--- a/pwndbg/commands/slab.py
+++ b/pwndbg/commands/slab.py
@@ -15,6 +15,7 @@ import pwndbg.commands
 import pwndbg.gdblib.kernel.slab
 from pwndbg.commands import CommandCategory
 from pwndbg.gdblib.kernel.slab import CpuCache
+from pwndbg.gdblib.kernel.slab import NodeCache
 from pwndbg.gdblib.kernel.slab import Slab
 from pwndbg.gdblib.kernel.slab import find_containing_slab_cache
 from pwndbg.gdblib.symbol import parse_and_eval
@@ -133,6 +134,21 @@ def print_cpu_cache(cpu_cache: CpuCache, verbose: bool, indent) -> None:
             print_slab(partial_slab, indent, verbose)
 
 
+def print_node_cache(node_cache: NodeCache, verbose: bool, indent) -> None:
+    indent.print(
+        f"{C.green('kmem_cache_node')} @ {_yx(node_cache.address)} [NUMA node {node_cache.node}]:"
+    )
+    with indent:
+        partial_slabs = node_cache.partial_slabs
+        if not partial_slabs:
+            indent.print("Partial Slabs: (none)")
+            return
+
+        indent.print(f"{C.green('Partial Slabs')}:")
+        for slab in partial_slabs:
+            print_slab(slab, indent, verbose)
+
+
 def slab_info(name: str, verbose: bool) -> None:
     slab_cache = pwndbg.gdblib.kernel.slab.get_cache(name)
 
@@ -159,7 +175,8 @@ def slab_info(name: str, verbose: bool) -> None:
         for cpu_cache in slab_cache.cpu_caches:
             print_cpu_cache(cpu_cache, verbose, indent)
 
-        # TODO: print_node_cache
+        for node_cache in slab_cache.node_caches:
+            print_node_cache(node_cache, verbose, indent)
 
 
 def slab_list(filter_) -> None:

--- a/pwndbg/gdblib/kernel/__init__.py
+++ b/pwndbg/gdblib/kernel/__init__.py
@@ -447,3 +447,17 @@ def paging_enabled() -> bool:
         return Aarch64Ops.paging_enabled()
     else:
         raise NotImplementedError()
+
+
+@requires_debug_syms()
+def num_numa_nodes() -> int:
+    """Returns the number of NUMA nodes that are online on the system"""
+    kc = kconfig()
+    if "CONFIG_NUMA" not in kc:
+        return 1
+
+    max_nodes = 1 << int(kc["CONFIG_NODES_SHIFT"])
+    if max_nodes == 1:
+        return 1
+
+    return int(gdb.lookup_global_symbol("nr_online_nodes").value())


### PR DESCRIPTION
SLUB keeps a per-NUMA node list of partial slabs in addition to the per-CPU lists. Print the slabs on those lists as well.
