### PR TITLE
Fix banner width for TUI mode with horizontal split for cmd window

### DIFF
--- a/pwndbg/ui.py
+++ b/pwndbg/ui.py
@@ -81,6 +81,18 @@ def get_window_size(target=sys.stdin):
 
 
 def get_cmd_window_size():
+    """Get the size of the command window in TUI mode which could be different than the terminal window width \
+    with horizontal split "tui new-layout hsrc { -horizontal src 1 cmd 1 } 1".
+
+    Possible output of "info win" in TUI mode:
+    (gdb) info win
+    Name       Lines Columns Focus
+    src           77     104 (has focus)
+    cmd           77     105
+
+    Output of "info win" in non-TUI mode:
+    (gdb) info win
+    The TUI is not active."""
     info_out = gdb.execute("info win", to_string=True).split()
     if "cmd" not in info_out:
         # if TUI is not enabled, info win will output "The TUI is not active."

--- a/pwndbg/ui.py
+++ b/pwndbg/ui.py
@@ -70,7 +70,7 @@ def get_window_size(target=sys.stdin):
     if not target.isatty():
         return fallback
     rows, cols = get_cmd_window_size()
-    if rows != None and cols != None:
+    if rows is not None and cols is not None:
         return rows, cols
     try:
         # get terminal size and force ret buffer len of 4 bytes for safe unpacking by passing equally long arg
@@ -78,6 +78,7 @@ def get_window_size(target=sys.stdin):
     except Exception:
         rows, cols = fallback
     return rows, cols
+
 
 def get_cmd_window_size():
     info_out = gdb.execute("info win", to_string=True).split()

--- a/pwndbg/ui.py
+++ b/pwndbg/ui.py
@@ -8,6 +8,8 @@ import struct
 import sys
 import termios
 
+import gdb
+
 import pwndbg.color.context as C
 import pwndbg.gdblib.arch
 from pwndbg.color import ljust_colored
@@ -67,9 +69,26 @@ def get_window_size(target=sys.stdin):
     fallback = (int(os.environ.get("LINES", 20)), int(os.environ.get("COLUMNS", 80)))
     if not target.isatty():
         return fallback
+    rows, cols = get_cmd_window_size()
+    if rows != None and cols != None:
+        return rows, cols
     try:
         # get terminal size and force ret buffer len of 4 bytes for safe unpacking by passing equally long arg
         rows, cols = struct.unpack("hh", fcntl.ioctl(target.fileno(), termios.TIOCGWINSZ, b"1234"))
     except Exception:
         rows, cols = fallback
     return rows, cols
+
+def get_cmd_window_size():
+    info_out = gdb.execute("info win", to_string=True).split()
+    if "cmd" not in info_out:
+        # if TUI is not enabled, info win will output "The TUI is not active."
+        return None, None
+    # parse cmd window size from the output of "info win"
+    cmd_win_index = info_out.index("cmd")
+    if len(info_out) <= cmd_win_index + 2:
+        return None, None
+    elif not info_out[cmd_win_index + 1].isdigit() and not info_out[cmd_win_index + 2].isdigit():
+        return None, None
+    else:
+        return int(info_out[cmd_win_index + 1]), int(info_out[cmd_win_index + 2])


### PR DESCRIPTION
<!-- Please make sure to read the testing and linting instructions at https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md before creating a PR -->

With TUI enabled and horizontal layout applied like with below command in GDB, the banner still renders the full width of the current window like below screenshot which makes it occupy 2 rows. This could be fixed by reading the actual cmd window width from the output of `info cmd` command.

```shell
tui new-layout hsrc { -horizontal src 1 cmd 1 } 1
tui layout hsrc
```


![image](https://github.com/pwndbg/pwndbg/assets/1041795/3e30d102-95ca-41c3-9ecd-9b0d17637245)

