### PR TITLE
[heap info] impl of `hi` command, which search any chunk belods to linear address

### DIFF
--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -199,13 +199,16 @@ parser.add_argument(
 parser.add_argument(
     "-s", "--simple", action="store_true", help="Simply print malloc_chunk struct's contents."
 )
+parser.add_argument(
+    "-a", "--all", action="store_true", help="Do not stop after first hit"
+)
 
 
 @pwndbg.commands.ArgparsedCommand(parser, category=CommandCategory.HEAP)
 @pwndbg.commands.OnlyWhenRunning
 @pwndbg.commands.OnlyWithResolvedHeapSyms
 @pwndbg.commands.OnlyWhenHeapIsInitialized
-def hi(addr, verbose=False, simple=False) -> None:
+def hi(addr, verbose=False, simple=False, all=False) -> None:
     """Iteratively search all heaps for contain current address in their chunks bodys.
     """
     allocator = pwndbg.heap.current
@@ -217,6 +220,8 @@ def hi(addr, verbose=False, simple=False) -> None:
                 for chunk in heap:
                     if chunk.address <= addr and (chunk.address + chunk.size) > addr:
                         malloc_chunk(chunk.address, verbose=verbose, simple=simple)
+                        if all == False:
+                            return
 
 parser = argparse.ArgumentParser(
     formatter_class=argparse.RawTextHelpFormatter,

--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -184,7 +184,7 @@ def heap(addr=None, verbose=False, simple=False) -> None:
 
 parser = argparse.ArgumentParser(
     formatter_class=argparse.RawTextHelpFormatter,
-    description="""Try to find if an address belonds to a heap chunk. If yes -- print chunk. Search all heaps.""",
+    description="""Searches all heaps to find if an address belongs to a chunk. If yes, prints the chunk.""",
 )
 parser.add_argument(
     "addr",
@@ -198,19 +198,19 @@ parser.add_argument(
     "-s", "--simple", action="store_true", help="Simply print malloc_chunk struct's contents."
 )
 parser.add_argument(
-    "-f", "--fake", action="store_true", help="Allow fake chunks. If not set (default) would only display real chunks, else would try to display any memory as chunk."
+    "-f",
+    "--fake",
+    action="store_true",
+    help="Allow fake chunks. If set, displays any memory as a heap chunk (even if its not a real chunk).",
 )
 
+ 
 @pwndbg.commands.ArgparsedCommand(parser, category=CommandCategory.HEAP)
 @pwndbg.commands.OnlyWhenRunning
 @pwndbg.commands.OnlyWithResolvedHeapSyms
 @pwndbg.commands.OnlyWhenHeapIsInitialized
 def hi(addr, verbose=False, simple=False, fake=False) -> None:
-    """Iteratively search all heaps for contain current address in their chunks bodys.
-    """
     allocator = pwndbg.heap.current
-    #sbrk_region = allocator.get_sbrk_heap_region()
-    #if fast or addr in sbrk_region:
     heap = Heap(addr)
     if fake is False and heap.arena is None:
         return
@@ -218,7 +218,7 @@ def hi(addr, verbose=False, simple=False, fake=False) -> None:
         if chunk.real_size and chunk.address <= addr and (chunk.address + chunk.real_size) > addr:
             malloc_chunk(chunk.address, verbose=verbose, simple=simple)
             break
-    return
+
 
 parser = argparse.ArgumentParser(
     formatter_class=argparse.RawTextHelpFormatter,


### PR DESCRIPTION
as for me this feature should present in pwndbg, because sometime it's really needed to understand if this address is chunk, or if it been corrupted/free after some activity/breaks.

little demo:
```
pwndbg> vis

0x55555567d000  0x0000000000000000      0x0000000000000291      ................
0x55555567d010  0x0000000000000001      0x0000000000000000      ................
0x55555567d020  0x0000000000000000      0x0000000000000000      ................
0x55555567d030  0x0000000000000000      0x0000000000000000      ................
0x55555567d040  0x0000000000000000      0x0000000000000000      ................
0x55555567d050  0x0000000000000000      0x0000000000000000      ................
0x55555567d060  0x0000000000000000      0x0000000000000000      ................
0x55555567d070  0x0000000000000000      0x0000000000000000      ................
0x55555567d080  0x0000000000000000      0x0000000000000000      ................
0x55555567d090  0x000055555567d2a0      0x0000000000000000      ..gUUU..........
0x55555567d0a0  0x0000000000000000      0x0000000000000000      ................
0x55555567d0b0  0x0000000000000000      0x0000000000000000      ................
0x55555567d0c0  0x0000000000000000      0x0000000000000000      ................
0x55555567d0d0  0x0000000000000000      0x0000000000000000      ................
0x55555567d0e0  0x0000000000000000      0x0000000000000000      ................
0x55555567d0f0  0x0000000000000000      0x0000000000000000      ................
..............
0x55555567d190  0x0000000000000000      0x0000000000000000      ................
0x55555567d1a0  0x0000000000000000      0x0000000000000000      ................
0x55555567d1b0  0x0000000000000000      0x0000000000000000      ................
0x55555567d1c0  0x0000000000000000      0x0000000000000000      ................
0x55555567d1d0  0x0000000000000000      0x0000000000000000      ................
0x55555567d1e0  0x0000000000000000      0x0000000000000000      ................
0x55555567d1f0  0x0000000000000000      0x0000000000000000      ................
0x55555567d200  0x0000000000000000      0x0000000000000000      ................
0x55555567d210  0x0000000000000000      0x0000000000000000      ................
0x55555567d220  0x0000000000000000      0x0000000000000000      ................
0x55555567d230  0x0000000000000000      0x0000000000000000      ................
0x55555567d240  0x0000000000000000      0x0000000000000000      ................
0x55555567d250  0x0000000000000000      0x0000000000000000      ................
0x55555567d260  0x0000000000000000      0x0000000000000000      ................
0x55555567d270  0x0000000000000000      0x0000000000000000      ................
0x55555567d280  0x0000000000000000      0x0000000000000000      ................
0x55555567d290  0x0000000000000000      0x0000000000000021      ........!.......
0x55555567d2a0  0x000000055555567d      0xd35af8fd222f1505      }VUU....../"..Z.         <-- tcachebins[0x20][0/1]
0x55555567d2b0  0x0000000000000000      0x0000000000000081      ................
0x55555567d2c0  0x0000000000000000      0x0000000000000000      ................
0x55555567d2d0  0x0000000000000000      0x0000000000000000      ................
0x55555567d2e0  0x0000000000000000      0x0000000000000000      ................
0x55555567d2f0  0x0000000000000000      0x0000000000000000      ................
0x55555567d300  0x0000000000000000      0x0000000000000000      ................
0x55555567d310  0x0000000000000000      0x0000000000000000      ................
0x55555567d320  0x0000000000000000      0x0000000000000000      ................
0x55555567d330  0x0000000000000000      0x0000000000020cd1      ................         <-- Top chunk
pwndbg> hi 0x55555567d2e0
Allocated chunk | PREV_INUSE
Addr: 0x55555567d2b0
Size: 0x81

pwndbg> hi -v
usage: hi [-h] [-v] [-s] addr
hi: error: the following arguments are required: addr
pwndbg> hi 0x55555567d2e0 -v
Allocated chunk | PREV_INUSE
Addr: 0x55555567d2b0
prev_size: 0x00
size: 0x81
fd: 0x00
bk: 0x00
fd_nextsize: 0x00
bk_nextsize: 0x00

pwndbg> hi --help
usage: hi [-h] [-v] [-s] addr

Try to find if an address is belond to a heap chunk.

If yes -- print chunk. Search all heaps.

positional arguments:
  addr           Address of the interest.

options:
  -h, --help     show this help message and exit
  -v, --verbose  Print all chunk fields, even unused ones. (default: False)
  -s, --simple   Simply print malloc_chunk struct's contents. (default: False)
pwndbg> hi 0x55555567d2e0 -s
0x55555567d2b0 | PREV_INUSE
prev_size: 0x00
size: 0x81
fd: 0x00
bk: 0x00
fd_nextsize: 0x00
bk_nextsize: 0x00
```