### PR TITLE
Fix context without CONFIG_IKCONFIG in kernel

### DIFF
--- a/pwndbg/gdblib/kernel/__init__.py
+++ b/pwndbg/gdblib/kernel/__init__.py
@@ -510,7 +510,6 @@ def virt_to_pfn(virt: int) -> int:
         raise NotImplementedError()
 
 
-@requires_debug_syms(default=False)
 def paging_enabled() -> bool:
     arch_name = pwndbg.gdblib.arch.name
     if arch_name == "i386":

--- a/pwndbg/gdblib/kernel/__init__.py
+++ b/pwndbg/gdblib/kernel/__init__.py
@@ -510,7 +510,7 @@ def virt_to_pfn(virt: int) -> int:
         raise NotImplementedError()
 
 
-@requires_debug_syms()
+@requires_debug_syms(default=False)
 def paging_enabled() -> bool:
     arch_name = pwndbg.gdblib.arch.name
     if arch_name == "i386":


### PR DESCRIPTION
Fix the issue below:
```
pwndbg> context
Traceback (most recent call last):
  File "/home/lonny/pwndbg/pwndbg/commands/__init__.py", line 184, in __call__
    return self.function(*args, **kwargs)
  File "/home/lonny/pwndbg/pwndbg/commands/__init__.py", line 331, in _OnlyWhenRunning
    return function(*a, **kw)
  File "/home/lonny/pwndbg/pwndbg/commands/context.py", line 399, in context
    func(
  File "/home/lonny/pwndbg/pwndbg/commands/context.py", line 507, in context_regs
    regs = get_regs()
  File "/home/lonny/pwndbg/pwndbg/commands/context.py", line 581, in get_regs
    desc = pwndbg.chain.format(value)
  File "/home/lonny/pwndbg/pwndbg/chain.py", line 125, in format
    rest.append(M.get(link, symbol))
  File "/home/lonny/pwndbg/pwndbg/color/memory.py", line 30, in get
    page = pwndbg.gdblib.vmmap.find(int(address))
  File "/home/lonny/pwndbg/pwndbg/lib/cache.py", line 137, in decorator
    value = func(*a, **kw)
  File "/home/lonny/pwndbg/pwndbg/gdblib/vmmap.py", line 154, in find
    for page in get():
  File "/home/lonny/pwndbg/pwndbg/lib/cache.py", line 137, in decorator
    value = func(*a, **kw)
  File "/home/lonny/pwndbg/pwndbg/gdblib/vmmap.py", line 119, in get
    pages.extend(kernel_vmmap_via_page_tables())
  File "/home/lonny/pwndbg/pwndbg/lib/cache.py", line 137, in decorator
    value = func(*a, **kw)
  File "/home/lonny/pwndbg/pwndbg/gdblib/vmmap.py", line 442, in kernel_vmmap_via_page_tables
    if not pwndbg.gdblib.kernel.paging_enabled():
  File "/home/lonny/pwndbg/pwndbg/gdblib/kernel/__init__.py", line 45, in func
    raise Exception(f"Function {f.__name__} requires CONFIG_IKCONFIG")
Exception: Function paging_enabled requires CONFIG_IKCONFIG
```