### PR TITLE
Fix glibc-fastbin-bug option of find_fake_fast

### DIFF
--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -758,7 +758,7 @@ def find_fake_fast(
         candidate = search_region[i : i + size_field_width]
 
         if len(candidate) == size_field_width:
-            size_field = pwndbg.gdblib.arch.unpack(candidate)
+            size_field = pwndbg.gdblib.arch.unpack(candidate, size_field_width)
             size_field &= ~(allocator.malloc_align_mask)
 
             if size_field < min_chunk_size or size_field > max_candidate_size:

--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -758,7 +758,7 @@ def find_fake_fast(
         candidate = search_region[i : i + size_field_width]
 
         if len(candidate) == size_field_width:
-            size_field = pwndbg.gdblib.arch.unpack(candidate, size_field_width)
+            size_field = pwndbg.gdblib.arch.unpack_size(candidate, size_field_width)
             size_field &= ~(allocator.malloc_align_mask)
 
             if size_field < min_chunk_size or size_field > max_candidate_size:

--- a/pwndbg/lib/arch.py
+++ b/pwndbg/lib/arch.py
@@ -4,7 +4,6 @@ from typing import Optional
 
 from typing_extensions import Literal
 
-
 FMT_LITTLE_ENDIAN = {1: "B", 2: "<H", 4: "<I", 8: "<Q"}
 FMT_BIG_ENDIAN = {1: "B", 2: ">H", 4: ">I", 8: ">Q"}
 

--- a/pwndbg/lib/arch.py
+++ b/pwndbg/lib/arch.py
@@ -5,6 +5,9 @@ from typing import Optional
 from typing_extensions import Literal
 
 
+FMT_LITTLE_ENDIAN = {1: "B", 2: "<H", 4: "<I", 8: "<Q"}
+FMT_BIG_ENDIAN = {1: "B", 2: ">H", 4: ">I", 8: ">Q"}
+
 class Arch:
     def __init__(self, arch_name: str, ptrsize: int, endian: Literal["little", "big"]) -> None:
         self.update(arch_name, ptrsize, endian)
@@ -21,10 +24,8 @@ class Arch:
         self.ptrmask = (1 << 8 * ptrsize) - 1
         self.endian = endian
 
-        if self.endian == "little":
-            self.fmts = {1: "B", 2: "<H", 4: "<I", 8: "<Q"}
-        else:
-            self.fmts = {1: "B", 2: ">H", 4: ">I", 8: ">Q"}
+        self.fmts = FMT_LITTLE_ENDIAN if endian == "little" else FMT_BIG_ENDIAN
+        self.fmt = self.fmts[self.ptrsize]
 
         if self.name == "arm" and self.endian == "big":
             self.qemu = "armeb"
@@ -33,15 +34,14 @@ class Arch:
         else:
             self.qemu = self.name
 
-    def pack(self, integer: int, size: Optional[int] = None) -> bytes:
-        fmt = self._get_fmt(size)
-        return struct.pack(fmt, integer & self.ptrmask)
+    def pack(self, integer: int) -> bytes:
+        return struct.pack(self.fmt, integer & self.ptrmask)
 
-    def unpack(self, data: bytes, size: Optional[int] = None) -> int:
-        fmt = self._get_fmt(size)
-        return struct.unpack(fmt, data)[0]
+    def unpack(self, data: bytes) -> int:
+        return struct.unpack(self.fmt, data)[0]
 
-    def _get_fmt(self, size: Optional[int]) -> str:
-        if size is None:
-            size = self.ptrsize
-        return self.fmts[size]
+    def pack_size(self, integer: int, size: int) -> bytes:
+        return struct.pack(self.fmts[size], integer & self.ptrmask)
+
+    def unpack_size(self, data: bytes, size: int) -> int:
+        return struct.unpack(self.fmts[size], data)[0]

--- a/pwndbg/lib/arch.py
+++ b/pwndbg/lib/arch.py
@@ -7,6 +7,7 @@ from typing_extensions import Literal
 FMT_LITTLE_ENDIAN = {1: "B", 2: "<H", 4: "<I", 8: "<Q"}
 FMT_BIG_ENDIAN = {1: "B", 2: ">H", 4: ">I", 8: ">Q"}
 
+
 class Arch:
     def __init__(self, arch_name: str, ptrsize: int, endian: Literal["little", "big"]) -> None:
         self.update(arch_name, ptrsize, endian)

--- a/pwndbg/lib/arch.py
+++ b/pwndbg/lib/arch.py
@@ -1,6 +1,5 @@
 import struct
 import sys
-from typing import Optional
 
 from typing_extensions import Literal
 

--- a/pwndbg/lib/arch.py
+++ b/pwndbg/lib/arch.py
@@ -1,5 +1,6 @@
 import struct
 import sys
+from typing import Optional
 
 from typing_extensions import Literal
 
@@ -20,9 +21,10 @@ class Arch:
         self.ptrmask = (1 << 8 * ptrsize) - 1
         self.endian = endian
 
-        self.fmt = {(4, "little"): "<I", (4, "big"): ">I", (8, "little"): "<Q", (8, "big"): ">Q"}[
-            (self.ptrsize, self.endian)
-        ]
+        if self.endian == "little":
+            self.fmts = {1: "B", 2: "<H", 4: "<I", 8: "<Q"}
+        else:
+            self.fmts = {1: "B", 2: ">H", 4: ">I", 8: ">Q"}
 
         if self.name == "arm" and self.endian == "big":
             self.qemu = "armeb"
@@ -31,8 +33,15 @@ class Arch:
         else:
             self.qemu = self.name
 
-    def pack(self, integer: int) -> bytes:
-        return struct.pack(self.fmt, integer & self.ptrmask)
+    def pack(self, integer: int, size: Optional[int] = None) -> bytes:
+        fmt = self._get_fmt(size)
+        return struct.pack(fmt, integer & self.ptrmask)
 
-    def unpack(self, data: bytes) -> int:
-        return struct.unpack(self.fmt, data)[0]
+    def unpack(self, data: bytes, size: Optional[int] = None) -> int:
+        fmt = self._get_fmt(size)
+        return struct.unpack(fmt, data)[0]
+
+    def _get_fmt(self, size: Optional[int]) -> str:
+        if size is None:
+            size = self.ptrsize
+        return self.fmts[size]

--- a/tests/gdb-tests/tests/binaries/heap_find_fake_fast.c
+++ b/tests/gdb-tests/tests/binaries/heap_find_fake_fast.c
@@ -128,4 +128,9 @@ int main(void) {
     // range of the target address
     setup_mem(0x100, 0x100);
     break_here();
+
+    // A fastbin chunk with a size that has top 4 bytes clobbered, due to glibc
+    // fastbin size bug, this is still valid
+    setup_mem(0xAABBCCDD00000020, 0x8);
+    break_here();
 }

--- a/tests/gdb-tests/tests/heap/test_find_fake_fast.py
+++ b/tests/gdb-tests/tests/heap/test_find_fake_fast.py
@@ -150,3 +150,11 @@ def test_find_fake_fast_command(start_binary):
     result = gdb.execute("find_fake_fast &target_address 0x100", to_string=True)
     check_no_results(result)
     gdb.execute("continue")
+
+    # setup_mem(0xAABBCCDD00000020, 0x8)
+    result = gdb.execute("find_fake_fast &target_address", to_string=True)
+    check_no_results(result)
+
+    result = gdb.execute("find_fake_fast &target_address -b", to_string=True)
+    check_result(result, 0xAABBCCDD00000020)
+    gdb.execute("continue")

--- a/tests/gdb-tests/tests/heap/test_find_fake_fast.py
+++ b/tests/gdb-tests/tests/heap/test_find_fake_fast.py
@@ -155,6 +155,6 @@ def test_find_fake_fast_command(start_binary):
     result = gdb.execute("find_fake_fast &target_address", to_string=True)
     check_no_results(result)
 
-    result = gdb.execute("find_fake_fast &target_address -b", to_string=True)
+    result = gdb.execute("find_fake_fast &target_address --glibc-fastbin-bug", to_string=True)
     check_result(result, 0xAABBCCDD00000020)
     gdb.execute("continue")


### PR DESCRIPTION
Using the `find_fake_fast --glibc-fastbin-bug` command always resulted in an error, at least on 64-bit platforms. This was because the option caused only 4 bytes to be read for the size, but then that gets passed to unpack() which expects 8 bytes.

Closes #1773

<!-- Please make sure to read the testing and linting instructions at https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md before creating a PR -->
