### PR TITLE
Fix: Undefined info command: "win"

### DIFF
--- a/pwndbg/ui.py
+++ b/pwndbg/ui.py
@@ -96,6 +96,8 @@ def get_cmd_window_size():
     try:
         info_out = gdb.execute("info win", to_string=True).split()
     except gdb.error:
+        # Return None if the command is not compiled into GDB
+        # (gdb.error: Undefined info command: "win".  Try "help info")
         return None, None
     if "cmd" not in info_out:
         # if TUI is not enabled, info win will output "The TUI is not active."

--- a/pwndbg/ui.py
+++ b/pwndbg/ui.py
@@ -93,7 +93,10 @@ def get_cmd_window_size():
     Output of "info win" in non-TUI mode:
     (gdb) info win
     The TUI is not active."""
-    info_out = gdb.execute("info win", to_string=True).split()
+    try:
+        info_out = gdb.execute("info win", to_string=True).split()
+    except gdb.error:
+        return None, None
     if "cmd" not in info_out:
         # if TUI is not enabled, info win will output "The TUI is not active."
         return None, None


### PR DESCRIPTION
When compiling release version of gdb on your own, there is no guarantee that the command `info win` will be available.
For example when compiling release version `gdb-13.2`, there is no such command:
```
(gdb) info win
Undefined info command: "win".  Try "help info".
```

And then when installing and running pwndbg we get:
```
Traceback (most recent call last):
  File "/home/ido/pwndbg/gdbinit.py", line 101, in <module>
    import pwndbg  # noqa: F401
  File "/home/ido/pwndbg/pwndbg/__init__.py", line 55, in <module>
    pwndbg.ui.get_window_size()[1]
  File "/home/ido/pwndbg/pwndbg/ui.py", line 72, in get_window_size
    rows, cols = get_cmd_window_size()
  File "/home/ido/pwndbg/pwndbg/ui.py", line 96, in get_cmd_window_size
    info_out = gdb.execute("info win", to_string=True).split()
gdb.error: Undefined info command: "win".  Try "help info".
```