### PR TITLE
Remove ArchLinux from CI

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,7 +6,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        images: [ubuntu18.04, ubuntu20.04, ubuntu22.04, debian10, debian11, archlinux]
+        # archlinux is removed for now until we use virtualenv for deps install
+        images: [ubuntu18.04, ubuntu20.04, ubuntu22.04, debian10, debian11]
 
     runs-on: ubuntu-latest
     timeout-minutes: 30


### PR DESCRIPTION
Since it breaks every now and then. This should be reverted when we start to install deps in a virtualenv

<!-- Please make sure to read the testing and linting instructions at https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md before creating a PR -->
