### PR TITLE
Improvements to spray command

### DIFF
--- a/pwndbg/commands/spray.py
+++ b/pwndbg/commands/spray.py
@@ -1,26 +1,57 @@
 import argparse
 
 import gdb
-from pwnlib.util.cyclic import cyclic_gen
+from pwnlib.util.cyclic import cyclic
 
+import pwndbg.color.message as M
 import pwndbg.commands
 
-parser = argparse.ArgumentParser(description="Spray memory with a cyclic_gen() generated values")
+parser = argparse.ArgumentParser(description="Spray memory with cyclic() generated values")
 parser.add_argument("addr", help="Address to spray")
-parser.add_argument("length", nargs="?", help="Length of byte sequence", type=int, default=0)
+parser.add_argument(
+    "length",
+    help="Length of byte sequence, when unspecified sprays until the end of vmmap which address belongs to",
+    type=int,
+    nargs="?",
+    default=0,
+)
+parser.add_argument("--value", help="Value to spray memory with", type=str, required=False)
 
 
 @pwndbg.commands.ArgparsedCommand(parser)
-def spray(addr, length) -> None:
+def spray(addr, length, value) -> None:
     if length == 0:
-        try:
-            last_addr = next(p for p in pwndbg.gdblib.vmmap.get() if addr in p).end
-        except StopIteration:
-            last_addr = addr + 1  # Throw exception later when trying to write
+        last_addr = addr
+        for p in pwndbg.gdblib.vmmap.get():
+            if addr in p:
+                last_addr = p.end
+                break
         length = last_addr - int(addr)
 
-    valueBytes = cyclic_gen().get(length)
+        if length == 0:
+            print(M.error("Invalid address, can't find end of vmmap"))
+            return
+
+    value_bytes = b""
+
+    if value:
+        if value.startswith("0x"):
+            strlen = len(value[2:])
+            if strlen & 1:  # 0x1, 0x123...
+                strlen += 1
+            value_bytes = int(value, 16).to_bytes(int(strlen / 2), byteorder="big")
+        else:
+            value_bytes = bytes(value, "utf-8")
+
+        value_length = len(value_bytes)
+        value_bytes = value_bytes * int(length / value_length)
+
+        if length % value_length != 0:
+            value_bytes += value_bytes[: (length % value_length)]
+    else:
+        value_bytes = cyclic(length, n=pwndbg.gdblib.arch.ptrsize)
+
     try:
-        pwndbg.gdblib.memory.write(addr, valueBytes)
+        pwndbg.gdblib.memory.write(addr, value_bytes)
     except gdb.MemoryError as e:
-        print(e)
+        print(M.error(e))

--- a/pwndbg/commands/spray.py
+++ b/pwndbg/commands/spray.py
@@ -21,11 +21,11 @@ parser.add_argument("--value", help="Value to spray memory with", type=str, requ
 @pwndbg.commands.ArgparsedCommand(parser)
 def spray(addr, length, value) -> None:
     if length == 0:
-        last_page = pwndbg.gdblib.vmmap.find(addr)
-        if last_page is None:
-            print(M.error("Invalid address, can't find end of vmmap"))
+        page = pwndbg.gdblib.vmmap.find(addr)
+        if page is None:
+            print(M.error(f"Invalid address {addr}: can't find vmmap containing it to determine the spray length"))
             return
-        length = last_page.end - int(addr)
+        length = page.end - int(addr)
 
     value_bytes = b""
 

--- a/pwndbg/commands/spray.py
+++ b/pwndbg/commands/spray.py
@@ -15,7 +15,12 @@ parser.add_argument(
     nargs="?",
     default=0,
 )
-parser.add_argument("--value", help="Value to spray memory with", type=str, required=False)
+parser.add_argument(
+    "--value",
+    help="Value to spray memory with, when prefixed with '0x' treated as hex string encoded big-endian",
+    type=str,
+    required=False,
+)
 
 
 @pwndbg.commands.ArgparsedCommand(parser)
@@ -23,7 +28,11 @@ def spray(addr, length, value) -> None:
     if length == 0:
         page = pwndbg.gdblib.vmmap.find(addr)
         if page is None:
-            print(M.error(f"Invalid address {addr}: can't find vmmap containing it to determine the spray length"))
+            print(
+                M.error(
+                    f"Invalid address {addr}: can't find vmmap containing it to determine the spray length"
+                )
+            )
             return
         length = page.end - int(addr)
 


### PR DESCRIPTION
* Changed cyclic_gen() function to cyclic(), so it can (theoritically) spray entire memory space
* Added `--value` parameter
* Made code more clear, and error commands nicer