### PR TITLE
Fix/ignore venv restrict bind mount

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+# venv
+.venv/

--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,6 @@ tests/qemu-tests/images
 
 .zig/
 gdb.txt
+
+# venv
+.venv/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,16 @@
 version: "3.8"
 services:
-  main: &base-spec
+  base: &base-spec
     build: .
-    volumes:
-      - .:/pwndbg
     platform: linux/amd64
     security_opt:
       - seccomp:unconfined
     cap_add:
       - SYS_PTRACE
+  main:
+    <<: *base-spec
+    volumes:
+      - .:/pwndbg
 
   ubuntu18.04:
     <<: *base-spec


### PR DESCRIPTION
Bind mounting `.` in every case would interfere with .dockerignore
We want to ignore `.venv` so that the venv of the built docker image
is used. Otherwise we would use the venv of the host inside docker.
This would negate the whole point of testing in a docker container.

Bind mounting `.` is however useful if one wants to use docker just
for "sandboxing" while running the tests on the local machine.