### PR TITLE
Stop using `CS_GRP_CALL` directly to determine what's a call

### DIFF
--- a/pwndbg/arguments.py
+++ b/pwndbg/arguments.py
@@ -3,7 +3,6 @@ Allows describing functions, specifically enumerating arguments which
 may be passed in a combination of registers and stack values.
 """
 import gdb
-from capstone import CS_GRP_CALL
 from capstone import CS_GRP_INT
 
 import pwndbg.chain
@@ -90,7 +89,7 @@ def get(instruction):
     if instruction.address != pwndbg.gdblib.regs.pc:
         return []
 
-    if CS_GRP_CALL in instruction.groups:
+    if pwndbg.disasm.is_call(instruction):
         try:
             abi = pwndbg.lib.abi.ABI.default()
         except KeyError:

--- a/pwndbg/gdblib/next.py
+++ b/pwndbg/gdblib/next.py
@@ -97,7 +97,7 @@ def break_next_call(symbol_regex=None):
             break
 
         # continue if not a call
-        if capstone.CS_GRP_CALL not in ins.groups:
+        if not pwndbg.disasm.is_call(ins):
             continue
 
         # return call if we don't search for a symbol


### PR DESCRIPTION
Fixes #1554.
Fixes #1419.

This commit introduces a new function (`is_call`) to `pwndbg.disasm`, which centralizes the mechanism used to decide what instructions should be considered calls and which ones shouldn't. Additionally, it uses this new mechanism to flag the `bl` family of instructions on ARM as calls, which, as of the time of writing, are not flagged as such by Capstone.