### PR TITLE
Fix #1805: clear stop caches on gdblib.bpoint.Breakpoint

### DIFF
--- a/pwndbg/gdblib/bpoint.py
+++ b/pwndbg/gdblib/bpoint.py
@@ -15,7 +15,7 @@ class Breakpoint(gdb.Breakpoint):
 
     def stop(self):
         # Clear the cache for the stop event.
-        pwndbg.gdblib.regs.__getattr__.cache.clear()
+        pwndbg.lib.cache.clear_cache("stop")
         return self.should_stop()
 
     def should_stop(self):

--- a/pwndbg/lib/cache.py
+++ b/pwndbg/lib/cache.py
@@ -163,3 +163,7 @@ def cache_until(*event_names) -> Callable:
 def clear_caches() -> None:
     for cache in _ALL_CACHE_UNTIL_EVENTS.values():
         cache.clear()
+
+
+def clear_cache(cache_name) -> None:
+    _ALL_CACHE_UNTIL_EVENTS[cache_name].clear()


### PR DESCRIPTION
Fixes #1805 