### PR TITLE
Run CI lint only on Ubuntu 22.04

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, ubuntu-20.04]
+        os: [ubuntu-22.04]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
Until now we ran the lint job on CI on both Ubuntu 20.04 and Ubuntu 22.04. I am not sure why exactly we run it on both, but I think we can try running it only on Ubuntu 22.04 unless there are good reasons to keep both.

<!-- Please make sure to read the testing and linting instructions at https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md before creating a PR -->
