### PR TITLE
lint.sh: update vermin to target Python >= 3.8

### DIFF
--- a/lint.sh
+++ b/lint.sh
@@ -56,7 +56,7 @@ else
 fi
 
 # Checking minimum python version
-vermin -vvv --no-tips -q -t=3.6 --violations ./pwndbg/
+vermin -vvv --no-tips -q -t=3.8 --violations ./pwndbg/
 
 ruff check --show-source ${LINT_FILES}
 


### PR DESCRIPTION
This is done as part of dropping support for Py 3.6/3.7 as described in https://github.com/pwndbg/pwndbg/issues/1744

<!-- Please make sure to read the testing and linting instructions at https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md before creating a PR -->
