### PR TITLE
get_one_instruction: clear "cont" cache on mem/reg changed

### DIFF
--- a/pwndbg/gdblib/hooks.py
+++ b/pwndbg/gdblib/hooks.py
@@ -62,7 +62,11 @@ pwndbg.lib.cache.connect_clear_caching_events(
         "exit": (pwndbg.gdblib.events.exit,),
         "objfile": (pwndbg.gdblib.events.new_objfile,),
         "start": (pwndbg.gdblib.events.start,),
-        "cont": (pwndbg.gdblib.events.cont,),
+        "cont": (
+            pwndbg.gdblib.events.cont,
+            pwndbg.gdblib.events.mem_changed,
+            pwndbg.gdblib.events.reg_changed,
+        ),
         "thread": (pwndbg.gdblib.events.thread,),
         "prompt": (pwndbg.gdblib.events.before_prompt,),
         "forever": (),

--- a/pwndbg/gdblib/memory.py
+++ b/pwndbg/gdblib/memory.py
@@ -96,6 +96,12 @@ def write(addr, data) -> None:
     # Throws an exception if can't access memory
     gdb.selected_inferior().write_memory(addr, data)
 
+    # Clear caches which are hooked to gdb.MemoryChanged events
+    # We do this explicitly because `write_memory` does not fire off
+    # the gdb.MemoryChanged event (see #1818)
+    pwndbg.lib.cache.clear_cache("stop")
+    pwndbg.lib.cache.clear_cache("cont")
+
 
 def peek(address):
     """peek(address) -> str

--- a/pwndbg/lib/cache.py
+++ b/pwndbg/lib/cache.py
@@ -62,7 +62,7 @@ class _CacheUntilEvent:
 
     def connect_event_hooks(self, event_hooks) -> None:
         """
-        A given cache until event may require multiple debugger events
+        A given _CacheUntilEvent object may require multiple debugger events
         to be handled properly. E.g. our `stop` cache needs to be handled
         by `stop`, `mem_changed` and `reg_changed` events.
         """


### PR DESCRIPTION
Fixes #1818.

Note that this makes a substantial change: it changes all caches that are refreshed on `gdb.ContinueEvent` to also be cleared on memory/regs changed.

This change is needed so that the `get_one_instruction` function which uses this cache will get its cache cleared when user invokes a command that changes memory or registers.

While this may sound as too big change: we are changing the whole "cont" cache to be cleared on two additional events, this should not be an issue. This is because:
1. We should notice it if we start clearing an important cache too often
2. The "cont" cache is currently only used by the `get_one_instruction` at this moment.

The 2) also creates a question: when should one use "cont" vs "start" caches? It is not so clear to me right now.

