### PR TITLE
`vmmap -A / -B` improvements

### DIFF
--- a/pwndbg/color/memory.py
+++ b/pwndbg/color/memory.py
@@ -16,7 +16,7 @@ c = ColorConfig(
 )
 
 
-def get(address, text=None) -> str:
+def get(address, text=None, prefix=None) -> str:
     """
     Returns a colorized string representing the provided address.
 
@@ -24,6 +24,7 @@ def get(address, text=None) -> str:
         address(int): Address to look up
         text(str): Optional text to use in place of the address
               in the return value string.
+        prefix(str): Optional text to set at beginning in the return value string.
     """
     address = int(address)
 
@@ -50,6 +51,10 @@ def get(address, text=None) -> str:
         text = hex(int(address))
     if text is None:
         text = str(int(address))
+
+    if prefix:
+        # Replace first N characters with the provided prefix
+        text = prefix + text[len(prefix) :]
 
     return color(text)
 

--- a/pwndbg/commands/vmmap.py
+++ b/pwndbg/commands/vmmap.py
@@ -15,6 +15,7 @@ from pwndbg.commands import CommandCategory
 
 integer_types = (int, gdb.Value)
 
+
 def pages_filter(gdbval_or_str):
     # returns a module filter
     if isinstance(gdbval_or_str, str):
@@ -67,14 +68,21 @@ parser.add_argument(
 )
 parser.add_argument("-w", "--writable", action="store_true", help="Display writable maps only")
 parser.add_argument("-x", "--executable", action="store_true", help="Display executable maps only")
-parser.add_argument("-A", "--lines-after", type=int, help="Number of pages to display after result", default=1)
-parser.add_argument("-B", "--lines-before", type=int, help="Number of pages to display before result", default=1)
+parser.add_argument(
+    "-A", "--lines-after", type=int, help="Number of pages to display after result", default=1
+)
+parser.add_argument(
+    "-B", "--lines-before", type=int, help="Number of pages to display before result", default=1
+)
+
 
 @pwndbg.commands.ArgparsedCommand(
     parser, aliases=["lm", "address", "vprot", "libs"], category=CommandCategory.MEMORY
 )
 @pwndbg.commands.OnlyWhenRunning
-def vmmap(gdbval_or_str=None, writable=False, executable=False, lines_after=1, lines_before=1) -> None:
+def vmmap(
+    gdbval_or_str=None, writable=False, executable=False, lines_after=1, lines_before=1
+) -> None:
     pages = pwndbg.gdblib.vmmap.get()
 
     if gdbval_or_str:
@@ -88,14 +96,14 @@ def vmmap(gdbval_or_str=None, writable=False, executable=False, lines_after=1, l
             matched_index = pages.index(matched_page)
 
             # Include number of pages preceeding the matched page
-            for before_index in range(1, lines_before+1):
+            for before_index in range(1, lines_before + 1):
                 if matched_index - before_index >= 0:
-                    filtered_pages.insert(0, pages[matched_index-before_index])
-            
+                    filtered_pages.insert(0, pages[matched_index - before_index])
+
             # Include number of pages proceeding the matched page
-            for after_index in range(1, lines_after+1):
+            for after_index in range(1, lines_after + 1):
                 if matched_index + after_index < len(pages) - 1:
-                    filtered_pages.append(pages[matched_index+after_index])
+                    filtered_pages.append(pages[matched_index + after_index])
 
         pages = filtered_pages
 

--- a/pwndbg/commands/vmmap.py
+++ b/pwndbg/commands/vmmap.py
@@ -83,44 +83,74 @@ parser.add_argument(
 def vmmap(
     gdbval_or_str=None, writable=False, executable=False, lines_after=1, lines_before=1
 ) -> None:
-    pages = pwndbg.gdblib.vmmap.get()
+    lookaround_lines_limit = 64
 
-    if gdbval_or_str:
-        filter_predicate = pages_filter(gdbval_or_str)
+    # Implement a sane limit
+    lines_after = min(lookaround_lines_limit, lines_after)
+    lines_before = min(lookaround_lines_limit, lines_before)
 
+    # All displayed pages, including lines after and lines before
+    total_pages = pwndbg.gdblib.vmmap.get()
+
+    # Filtered memory pages, indicated by an backtrace arrow in results
+    filtered_pages = list()
+
+    # Only filter when -A and -B arguments are valid
+    if gdbval_or_str and lines_after >= 0 and lines_before >= 0:
         # Find matching page in memory
-        filtered_pages = list(filter(pages_filter(gdbval_or_str), pages))
+        filtered_pages = list(filter(pages_filter(gdbval_or_str), total_pages))
+        pages_to_display = list()
 
-        if filtered_pages:
-            matched_page = filtered_pages[0]
-            matched_index = pages.index(matched_page)
+        for matched_page in filtered_pages:
+            # Append matched page
+            pages_to_display.append(matched_page)
+            index_in_displayed = len(pages_to_display)
+            matched_index = total_pages.index(matched_page)
 
             # Include number of pages preceeding the matched page
             for before_index in range(1, lines_before + 1):
-                if matched_index - before_index >= 0:
-                    filtered_pages.insert(0, pages[matched_index - before_index])
+                # Guard index, and only insert the page if it is not displayed yet
+                if (
+                    matched_index - before_index >= 0
+                    and total_pages[matched_index - before_index] not in pages_to_display
+                ):
+                    pages_to_display.insert(
+                        index_in_displayed - 1, total_pages[matched_index - before_index]
+                    )
 
             # Include number of pages proceeding the matched page
             for after_index in range(1, lines_after + 1):
-                if matched_index + after_index < len(pages) - 1:
-                    filtered_pages.append(pages[matched_index + after_index])
+                if (
+                    matched_index + after_index < len(total_pages) - 1
+                    and total_pages[matched_index + after_index] not in pages_to_display
+                ):
+                    pages_to_display.append(total_pages[matched_index + after_index])
 
-        pages = filtered_pages
+        total_pages = pages_to_display
 
-    if not pages:
+    if not total_pages:
         print("There are no mappings for specified address or module.")
         return
 
     print(M.legend())
     print_vmmap_table_header()
-    if len(pages) == 1 and isinstance(gdbval_or_str, integer_types):
-        page = pages[0]
-        print(M.get(page.vaddr, text=str(page) + " +0x%x" % (int(gdbval_or_str) - page.vaddr)))
-    else:
-        for page in pages:
-            if (executable and not page.execute) or (writable and not page.write):
-                continue
-            print(M.get(page.vaddr, text=str(page)))
+
+    for page in total_pages:
+        if (executable and not page.execute) or (writable and not page.write):
+            continue
+
+        backtrace_prefix = None
+        display_text = str(page)
+
+        if page in filtered_pages:
+            # If page was one of the original results, add an arrow for clarity
+            backtrace_prefix = str(pwndbg.gdblib.config.backtrace_prefix)
+
+            # If the page is the only filtered page, insert offset
+            if len(filtered_pages) == 1 and isinstance(gdbval_or_str, integer_types):
+                display_text = str(page) + " +0x%x" % (int(gdbval_or_str) - page.vaddr)
+
+        print(M.get(page.vaddr, text=display_text, prefix=backtrace_prefix))
 
     if pwndbg.gdblib.qemu.is_qemu():
         print("\n[QEMU target detected - vmmap result might not be accurate; see `help vmmap`]")

--- a/pwndbg/commands/vmmap.py
+++ b/pwndbg/commands/vmmap.py
@@ -104,7 +104,6 @@ def vmmap(
         for matched_page in filtered_pages:
             # Append matched page
             pages_to_display.append(matched_page)
-            index_in_displayed = len(pages_to_display)
             matched_index = total_pages.index(matched_page)
 
             # Include number of pages preceeding the matched page
@@ -114,9 +113,7 @@ def vmmap(
                     matched_index - before_index >= 0
                     and total_pages[matched_index - before_index] not in pages_to_display
                 ):
-                    pages_to_display.insert(
-                        index_in_displayed - 1, total_pages[matched_index - before_index]
-                    )
+                    pages_to_display.append(total_pages[matched_index - before_index])
 
             # Include number of pages proceeding the matched page
             for after_index in range(1, lines_after + 1):
@@ -126,7 +123,8 @@ def vmmap(
                 ):
                     pages_to_display.append(total_pages[matched_index + after_index])
 
-        total_pages = pages_to_display
+        # Sort results by address
+        total_pages = sorted(pages_to_display, key=lambda page: page.vaddr)
 
     if not total_pages:
         print("There are no mappings for specified address or module.")

--- a/pwndbg/commands/vmmap.py
+++ b/pwndbg/commands/vmmap.py
@@ -86,8 +86,6 @@ def vmmap(
     pages = pwndbg.gdblib.vmmap.get()
 
     if gdbval_or_str:
-        filter_predicate = pages_filter(gdbval_or_str)
-
         # Find matching page in memory
         filtered_pages = list(filter(pages_filter(gdbval_or_str), pages))
 

--- a/pwndbg/commands/vmmap.py
+++ b/pwndbg/commands/vmmap.py
@@ -15,7 +15,6 @@ from pwndbg.commands import CommandCategory
 
 integer_types = (int, gdb.Value)
 
-
 def pages_filter(gdbval_or_str):
     # returns a module filter
     if isinstance(gdbval_or_str, str):
@@ -68,17 +67,37 @@ parser.add_argument(
 )
 parser.add_argument("-w", "--writable", action="store_true", help="Display writable maps only")
 parser.add_argument("-x", "--executable", action="store_true", help="Display executable maps only")
-
+parser.add_argument("-A", "--lines-after", type=int, help="Number of pages to display after result", default=1)
+parser.add_argument("-B", "--lines-before", type=int, help="Number of pages to display before result", default=1)
 
 @pwndbg.commands.ArgparsedCommand(
     parser, aliases=["lm", "address", "vprot", "libs"], category=CommandCategory.MEMORY
 )
 @pwndbg.commands.OnlyWhenRunning
-def vmmap(gdbval_or_str=None, writable=False, executable=False) -> None:
+def vmmap(gdbval_or_str=None, writable=False, executable=False, lines_after=1, lines_before=1) -> None:
     pages = pwndbg.gdblib.vmmap.get()
 
     if gdbval_or_str:
-        pages = list(filter(pages_filter(gdbval_or_str), pages))
+        filter_predicate = pages_filter(gdbval_or_str)
+
+        # Find matching page in memory
+        filtered_pages = list(filter(pages_filter(gdbval_or_str), pages))
+
+        if filtered_pages:
+            matched_page = filtered_pages[0]
+            matched_index = pages.index(matched_page)
+
+            # Include number of pages preceeding the matched page
+            for before_index in range(1, lines_before+1):
+                if matched_index - before_index >= 0:
+                    filtered_pages.insert(0, pages[matched_index-before_index])
+            
+            # Include number of pages proceeding the matched page
+            for after_index in range(1, lines_after+1):
+                if matched_index + after_index < len(pages) - 1:
+                    filtered_pages.append(pages[matched_index+after_index])
+
+        pages = filtered_pages
 
     if not pages:
         print("There are no mappings for specified address or module.")

--- a/pwndbg/commands/vmmap.py
+++ b/pwndbg/commands/vmmap.py
@@ -15,6 +15,7 @@ from pwndbg.commands import CommandCategory
 
 integer_types = (int, gdb.Value)
 
+
 def pages_filter(gdbval_or_str):
     # returns a module filter
     if isinstance(gdbval_or_str, str):

--- a/pwndbg/commands/vmmap.py
+++ b/pwndbg/commands/vmmap.py
@@ -15,7 +15,6 @@ from pwndbg.commands import CommandCategory
 
 integer_types = (int, gdb.Value)
 
-
 def pages_filter(gdbval_or_str):
     # returns a module filter
     if isinstance(gdbval_or_str, str):


### PR DESCRIPTION
Implements improvements over https://github.com/pwndbg/pwndbg/pull/1810
- `vmmap -A / -B` now handles multiple results gracefully
- printed pages now prepend an backtrace arrow before the results that were actually filtered, to make it more readable
- Fixed displaying of address offset in filtered pages

Fixes: https://github.com/pwndbg/pwndbg/issues/1821 and https://github.com/pwndbg/pwndbg/issues/1766