### PR TITLE
vmmap: make linux kernel pages searchable via name

### DIFF
--- a/pwndbg/gdblib/vmmap.py
+++ b/pwndbg/gdblib/vmmap.py
@@ -453,7 +453,8 @@ def kernel_vmmap_via_page_tables():
             flags |= 2
         if page.pwndbg_is_executable():
             flags |= 1
-        retpages.append(pwndbg.lib.memory.Page(start, size, flags, 0, "<pt>"))
+        objfile = f"[pt_{hex(start)[2:-3]}]"
+        retpages.append(pwndbg.lib.memory.Page(start, size, flags, 0, objfile))
     return tuple(retpages)
 
 

--- a/pwndbg/lib/memory.py
+++ b/pwndbg/lib/memory.py
@@ -94,7 +94,7 @@ class Page:
 
     @property
     def is_memory_mapped_file(self) -> bool:
-        return len(self.objfile) != 0 and self.objfile[0] != "[" and self.objfile != "<pt>"
+        return len(self.objfile) != 0 and self.objfile[0] != "["
 
     @property
     def read(self) -> bool:


### PR DESCRIPTION
This commit changes the name of linux kernel memory pages fetched via gdb-pt-dump from `"<pt>"` to `"[pt_<addr>]"` to make it possible to use those memory pages with other commands that take memory map names as arguments, like the search command:
```
search <value> <mapping-name>
```

Fixes https://github.com/pwndbg/pwndbg/issues/1835
