### PR TITLE
gdblib.memory.write: revert cache-clear since its already fired

### DIFF
--- a/pwndbg/gdblib/memory.py
+++ b/pwndbg/gdblib/memory.py
@@ -96,12 +96,6 @@ def write(addr, data) -> None:
     # Throws an exception if can't access memory
     gdb.selected_inferior().write_memory(addr, data)
 
-    # Clear caches which are hooked to gdb.MemoryChanged events
-    # We do this explicitly because `write_memory` does not fire off
-    # the gdb.MemoryChanged event (see #1818)
-    pwndbg.lib.cache.clear_cache("stop")
-    pwndbg.lib.cache.clear_cache("cont")
-
 
 def peek(address):
     """peek(address) -> str


### PR DESCRIPTION
It turned out that cache is already cleared due to the following changes:

```diff
-        "cont": (pwndbg.gdblib.events.cont,),
+        "cont": (
+            pwndbg.gdblib.events.cont,
+            pwndbg.gdblib.events.mem_changed,
+            pwndbg.gdblib.events.reg_changed,
+        ),
```

So: `gdblib.write` is writing to memory -> GDB fires of MemoryChanged event -> this is clearing the cache for "cont" cache and so the disasm context works properly.

This finally closes https://github.com/pwndbg/pwndbg/issues/1818

<!-- Please make sure to read the testing and linting instructions at https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md before creating a PR -->
