### PR TITLE
emu/emulator.py: small code cleanup

### DIFF
--- a/pwndbg/emu/emulator.py
+++ b/pwndbg/emu/emulator.py
@@ -52,25 +52,19 @@ arch_to_UC_consts = {
     "rv64": parse_consts(U.riscv_const),
 }
 
-# Map our internal architecture names onto Unicorn Engine's architecture types.
-arch_to_CS = {
-    "i386": C.CS_ARCH_X86,
-    "x86-64": C.CS_ARCH_X86,
-    "mips": C.CS_ARCH_MIPS,
-    "sparc": C.CS_ARCH_SPARC,
-    "arm": C.CS_ARCH_ARM,
-    "aarch64": C.CS_ARCH_ARM64,
-    # 'powerpc': C.CS_ARCH_PPC,
-    "rv32": C.CS_ARCH_RISCV,
-    "rv64": C.CS_ARCH_RISCV,
-}
 
 DEBUG = False
 
 
-def debug(fmt, args=()) -> None:
-    if DEBUG:
+if DEBUG:
+
+    def debug(fmt, args=()) -> None:
         print(fmt % args)
+
+else:
+
+    def debug(fmt, args=()) -> None:
+        pass
 
 
 # Until Unicorn Engine provides full information about the specific instruction


### PR DESCRIPTION
Fixes https://github.com/pwndbg/pwndbg/issues/1793. Turned out that `arch_to_CS` is unused...

Also, moving the `debug` to be conditionally enabled instead of what was done previously.