### PR TITLE
Enable thread context by default

### DIFF
--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -78,7 +78,7 @@ config_output = pwndbg.gdblib.config.add_param(
 )
 config_context_sections = pwndbg.gdblib.config.add_param(
     "context-sections",
-    "regs disasm code ghidra stack backtrace expressions",
+    "regs disasm code ghidra stack backtrace expressions threads",
     "which context sections are displayed (controls order)",
 )
 
@@ -852,6 +852,9 @@ def get_thread_status(thread):
 
 def context_threads(with_banner=True, target=sys.stdout, width=None):
     threads = gdb.selected_inferior().threads()[::-1]
+
+    if len(threads) < 2:
+        return []
 
     selected_thread = gdb.selected_thread()
     selected_frame = gdb.selected_frame()

--- a/tests/gdb-tests/tests/test_context_commands.py
+++ b/tests/gdb-tests/tests/test_context_commands.py
@@ -81,7 +81,7 @@ def test_empty_context_sections(start_binary, sections):
     start_binary(USE_FDS_BINARY)
 
     # Sanity check
-    default_ctx_sects = "regs disasm code ghidra stack backtrace expressions"
+    default_ctx_sects = "regs disasm code ghidra stack backtrace expressions threads"
     assert pwndbg.gdblib.config.context_sections.value == default_ctx_sects
     assert gdb.execute("context", to_string=True) != ""
 


### PR DESCRIPTION
Context will now show threads section by default when there's more than one

Fixes: #1802 