### PR TITLE
enhance decompiler compatible problem with rizin and radare2

### DIFF
--- a/pwndbg/ghidra.py
+++ b/pwndbg/ghidra.py
@@ -22,7 +22,7 @@ def set_r2decompiler() -> None:
         return
     print(
         message.warn(
-            f"Invalid r2decompiler : `{r2decompiler.value}`, you should select from (radare2/rizin)"
+            f"Invalid r2decompiler: `{r2decompiler.value}`, please select from radare2 or rizin"
         )
     )
     r2decompiler.revert_default()

--- a/pwndbg/ghidra.py
+++ b/pwndbg/ghidra.py
@@ -28,12 +28,12 @@ def decompile(func=None):
         if r2decompiler == "radare2":
             r2 = pwndbg.radare2.r2pipe()
             # LD -> list supported decompilers (e cmd.pdc=?)
+            # Outputs for example: pdc\npdg
             if "pdg" not in r2.cmd("LD").split("\n"):
                 raise Exception("radare2 plugin r2ghidra must be installed and available from r2")
         elif r2decompiler == "rizin":
             r2 = pwndbg.rizin.rzpipe()
             # Lc -> list core plugins
-            # Outputs for example: pdc\npdg
             if "ghidra" not in r2.cmd("Lc"):
                 raise Exception("rizin plugin rzghidra must be installed and available from rz")
         else:

--- a/pwndbg/ghidra.py
+++ b/pwndbg/ghidra.py
@@ -9,10 +9,23 @@ import pwndbg.color.syntax_highlight as H
 import pwndbg.gdblib.regs
 import pwndbg.radare2
 import pwndbg.rizin
+from pwndbg.color import message
 
 r2decompiler = pwndbg.gdblib.config.add_param(
     "r2decompiler", "radare2", "framework that your ghidra plugin installed (radare2/rizin)"
 )
+
+
+@pwndbg.gdblib.config.trigger(r2decompiler)
+def set_r2decompiler() -> None:
+    if r2decompiler.value in ["radare2", "rizin"]:
+        return
+    print(
+        message.warn(
+            f"Invalid r2decompiler : `{r2decompiler.value}`, you should select from (radare2/rizin)"
+        )
+    )
+    r2decompiler.revert_default()
 
 
 def decompile(func=None):


### PR DESCRIPTION
<!-- Please make sure to read the testing and linting instructions at https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md before creating a PR -->

![image](https://github.com/pwndbg/pwndbg/assets/79578430/0ac3dcf2-bf4f-403f-801b-d86b0827ded5)

seems like here have a logic problem
I installed both r2 and rizin
but I only installed rz-ghidra
so pwndbg use the r2 to determine whether "pdb" command available rather than rizin which realy installed ghidra-plugin.

The modification is let user to specify what decompiler they want to use. and fix some compatibility problem in rizin and r2.(e.g there are no space between `@` and `symbol` which rizin not able to parse )