### PR TITLE
Fixed null thread name

### DIFF
--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -863,8 +863,11 @@ def context_threads(with_banner=True, target=sys.stdout, width=None):
     max_name_length = 0
 
     for thread in threads:
-        if len(thread.name) > max_name_length:
-            max_name_length = len(thread.name)
+        name = thread.name
+        if name is None:
+            name = "null"
+        if len(name) > max_name_length:
+            max_name_length = len(name)
 
     for thread in threads:
         thread.switch()
@@ -875,11 +878,16 @@ def context_threads(with_banner=True, target=sys.stdout, width=None):
         symbol = pwndbg.gdblib.symbol.get(frame.pc())
         status = get_thread_status(thread)
 
-        padding = max_name_length - len(thread.name)
+        name = thread.name
+        if name is None:
+            name = pwndbg.color.gray("null")
+        else:
+            name = pwndbg.color.cyan(thread.name)
+        padding = max_name_length - len(name)
 
         line = (
             f" {selected} {thread.global_num}\t"
-            f'"{pwndbg.color.cyan(thread.name)}" '
+            f'"{name}" '
             f'{" " * padding}'
             f"{status}: {M.get(frame.pc())} "
         )

--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -861,12 +861,11 @@ def context_threads(with_banner=True, target=sys.stdout, width=None):
 
     out = []
     max_name_length = 0
-    color_length = 9  # len(pwndbg.color.cyan(""))
 
     for thread in threads:
         name = thread.name or ""
-        if name_len := len(name) > max_name_length:
-            max_name_length = name_len
+        if len(name) > max_name_length:
+            max_name_length = len(name)
 
     for thread in threads:
         thread.switch()
@@ -877,12 +876,12 @@ def context_threads(with_banner=True, target=sys.stdout, width=None):
         symbol = pwndbg.gdblib.symbol.get(frame.pc())
         status = get_thread_status(thread)
 
-        name = pwndbg.color.cyan(thread.name) if thread.name is not None else ""
-        padding = max_name_length - len(name) + color_length
+        name = thread.name if thread.name is not None else ""
+        padding = max_name_length - len(name)
 
         line = (
             f" {selected} {thread.global_num}\t"
-            f'"{name}" '
+            f'"{pwndbg.color.cyan(name)}" '
             f'{" " * padding}'
             f"{status}: {M.get(frame.pc())}"
         )

--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -861,6 +861,7 @@ def context_threads(with_banner=True, target=sys.stdout, width=None):
 
     out = []
     max_name_length = 0
+    color_length = 9  # len(pwndbg.color.cyan(""))
 
     for thread in threads:
         name = thread.name
@@ -883,7 +884,7 @@ def context_threads(with_banner=True, target=sys.stdout, width=None):
             name = pwndbg.color.gray("null")
         else:
             name = pwndbg.color.cyan(thread.name)
-        padding = max_name_length - len(name)
+        padding = max_name_length - len(name) + color_length
 
         line = (
             f" {selected} {thread.global_num}\t"

--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -864,11 +864,9 @@ def context_threads(with_banner=True, target=sys.stdout, width=None):
     color_length = 9  # len(pwndbg.color.cyan(""))
 
     for thread in threads:
-        name = thread.name
-        if name is None:
-            name = "null"
-        if len(name) > max_name_length:
-            max_name_length = len(name)
+        name = thread.name or ""
+        if name_len := len(name) > max_name_length:
+            max_name_length = name_len
 
     for thread in threads:
         thread.switch()
@@ -879,21 +877,17 @@ def context_threads(with_banner=True, target=sys.stdout, width=None):
         symbol = pwndbg.gdblib.symbol.get(frame.pc())
         status = get_thread_status(thread)
 
-        name = thread.name
-        if name is None:
-            name = pwndbg.color.gray("null")
-        else:
-            name = pwndbg.color.cyan(thread.name)
+        name = pwndbg.color.cyan(thread.name) if thread.name is not None else ""
         padding = max_name_length - len(name) + color_length
 
         line = (
             f" {selected} {thread.global_num}\t"
             f'"{name}" '
             f'{" " * padding}'
-            f"{status}: {M.get(frame.pc())} "
+            f"{status}: {M.get(frame.pc())}"
         )
         if symbol:
-            line += f"<{pwndbg.color.bold(pwndbg.color.green(symbol))}> "
+            line += f" <{pwndbg.color.bold(pwndbg.color.green(symbol))}> "
         out.append(line)
 
     out.insert(0, pwndbg.ui.banner("threads", target=target, width=width))


### PR DESCRIPTION
Added edge case handling for null/none thread names, now it will be displayed like this:
![2023-08-01-211833_280x113_scrot](https://github.com/pwndbg/pwndbg/assets/84835312/74743a55-cbc5-4195-92dd-3ba30e356ba7)

Fixes the bug reported in #1802 
