### PR TITLE
 Add `telescope --frame` command #1195 

### DIFF
--- a/pwndbg/commands/telescope.py
+++ b/pwndbg/commands/telescope.py
@@ -115,7 +115,9 @@ def telescope(address=None, count=telescope_lines, to_string=False, reverse=Fals
 
         for page in pwndbg.gdblib.vmmap.get():
             if sp in page and bp not in page:
-                print("Cannot display stack frame because base pointer is not on the same page with stack pointer")
+                print(
+                    "Cannot display stack frame because base pointer is not on the same page with stack pointer"
+                )
                 return
 
         address = sp

--- a/pwndbg/commands/telescope.py
+++ b/pwndbg/commands/telescope.py
@@ -59,6 +59,15 @@ parser.add_argument(
 )
 
 parser.add_argument(
+    "-f",
+    "--frame",
+    dest="frame",
+    action="store_true",
+    default=False,
+    help="Show the stack frame, from rsp to rbp",
+)
+
+parser.add_argument(
     "address", nargs="?", default="$sp", type=int, help="The address to telescope at."
 )
 
@@ -69,7 +78,7 @@ parser.add_argument(
 
 @pwndbg.commands.ArgparsedCommand(parser, category=CommandCategory.MEMORY)
 @pwndbg.commands.OnlyWhenRunning
-def telescope(address=None, count=telescope_lines, to_string=False, reverse=False):
+def telescope(address=None, count=telescope_lines, to_string=False, reverse=False, frame=False):
     """
     Recursively dereferences pointers starting at the specified address
     ($sp by default)
@@ -95,6 +104,22 @@ def telescope(address=None, count=telescope_lines, to_string=False, reverse=Fals
     # Allow invocation of telescope -r to dump previous addresses
     if reverse:
         address -= (count - 1) * ptrsize
+
+    # Allow invocation of telescope -f (--frame) to dump frame addresses
+    if frame:
+        sp = pwndbg.gdblib.regs.sp
+        bp = pwndbg.gdblib.regs[pwndbg.gdblib.regs.frame]
+        if sp > bp:
+            print("Cannot display stack frame because base pointer is below stack pointer")
+            return
+
+        for page in pwndbg.gdblib.vmmap.get():
+            if sp in page and bp not in page:
+                print("Cannot display stack frame because base pointer is not on the same page with stack pointer")
+                return
+
+        address = sp
+        count = int((bp - sp) / ptrsize) + 1
 
     # Allow invocation of "telescope a b" to dump all bytes from A to B
     if int(address) <= int(count):

--- a/tests/gdb-tests/tests/test_command_telescope.py
+++ b/tests/gdb-tests/tests/test_command_telescope.py
@@ -133,7 +133,7 @@ def test_command_telescope_frame_bp_below_sp(start_binary):
     gdb.execute("run")
     gdb.execute("memoize")  # turn off cache
 
-    pwndbg.gdblib.regs.sp = (pwndbg.gdblib.regs[pwndbg.gdblib.regs.frame] + 1)
+    pwndbg.gdblib.regs.sp = pwndbg.gdblib.regs[pwndbg.gdblib.regs.frame] + 1
 
     result_str = gdb.execute("telescope --frame", to_string=True)
 
@@ -157,4 +157,7 @@ def test_command_telescope_frame_bp_sp_different_vmmaps(start_binary):
 
     result_str = gdb.execute("telescope --frame", to_string=True)
 
-    assert "Cannot display stack frame because base pointer is not on the same page with stack pointer" in result_str
+    assert (
+        "Cannot display stack frame because base pointer is not on the same page with stack pointer"
+        in result_str
+    )

--- a/tests/gdb-tests/tests/test_command_telescope.py
+++ b/tests/gdb-tests/tests/test_command_telescope.py
@@ -102,3 +102,59 @@ def test_command_telescope_reverse_skipped_records_shows_input_address(start_bin
     result_lines = result_str.strip("\n").split("\n")
 
     assert expected_value in result_lines[-1]
+
+
+def test_command_telescope_frame(start_binary):
+    """
+    Tests telescope --frame
+    """
+    start_binary(TELESCOPE_BINARY)
+
+    gdb.execute("break break_here")
+    gdb.execute("run")
+
+    rsp = hex(pwndbg.gdblib.regs.sp)
+    rbp = hex(pwndbg.gdblib.regs[pwndbg.gdblib.regs.frame])
+
+    result_str = gdb.execute("telescope --frame", to_string=True)
+    result_lines = result_str.strip().split("\n")
+
+    assert rsp in result_lines[0]
+    assert rbp in result_lines[-1]
+
+
+def test_command_telescope_frame_bp_below_sp(start_binary):
+    """
+    Tests telescope --frame when base pointer is below stack pointer
+    """
+    start_binary(TELESCOPE_BINARY)
+
+    gdb.execute("break break_here")
+    gdb.execute("run")
+    gdb.execute("memoize")  # turn off cache
+
+    pwndbg.gdblib.regs.sp = (pwndbg.gdblib.regs[pwndbg.gdblib.regs.frame] + 1)
+
+    result_str = gdb.execute("telescope --frame", to_string=True)
+
+    assert "Cannot display stack frame because base pointer is below stack pointer" in result_str
+
+
+def test_command_telescope_frame_bp_sp_different_vmmaps(start_binary):
+    """
+    Tests telescope --frame when base pointer and stack pointer are on different vmmap pages
+    """
+    start_binary(TELESCOPE_BINARY)
+
+    gdb.execute("break break_here")
+    gdb.execute("run")
+    gdb.execute("memoize")  # turn off cache
+
+    pages = pwndbg.gdblib.vmmap.get()
+
+    pwndbg.gdblib.regs.sp = pages[0].start
+    pwndbg.gdblib.regs.bp = pages[1].start
+
+    result_str = gdb.execute("telescope --frame", to_string=True)
+
+    assert "Cannot display stack frame because base pointer is not on the same page with stack pointer" in result_str


### PR DESCRIPTION
Added argument `--frame` to telescope command that prints out the stack frame, from `rsp` to `rbp`

```
pwndbg> telescope --frame
00:0000│ rsp 0x7fffffffd910 ◂— 0x140000
01:0008│     0x7fffffffd918 ◂— 0x14
02:0010│     0x7fffffffd920 ◂— 0x0
03:0018│     0x7fffffffd928 ◂— 0x40 /* '@' */
04:0020│     0x7fffffffd930 ◂— 0xc /* '\x0c' */
05:0028│     0x7fffffffd938 ◂— 0x40 /* '@' */
06:0030│     0x7fffffffd940 ◂— 0x8000
07:0038│     0x7fffffffd948 ◂— 0xf1af032800000000
08:0040│     0x7fffffffd950 ◂— 0x0
09:0048│     0x7fffffffd958 ◂— 0x8c00000006
0a:0050│     0x7fffffffd960 ◂— 0x400000001
0b:0058│     0x7fffffffd968 ◂— 0x0
... ↓        7 skipped
13:0098│     0x7fffffffd9a8 —▸ 0x7ffff7fe6220 (dl_main) ◂— endbr64 
14:00a0│     0x7fffffffd9b0 ◂— 0x0
15:00a8│     0x7fffffffd9b8 —▸ 0x7ffff7ffdab0 (_rtld_global+2736) —▸ 0x7ffff7fca000 ◂— 0x3010102464c457f
16:00b0│ rbp 0x7fffffffd9c0 ◂— 0x1
```

Fixes #1195