### PR TITLE
lint.sh: use tools from .venv

### DIFF
--- a/lint.sh
+++ b/lint.sh
@@ -28,8 +28,25 @@ done
 
 set -o xtrace
 
+# Use Python virtual env for all programs used here
+if [[ -z "${PWNDBG_VENV_PATH}" ]]; then
+    PWNDBG_VENV_PATH="./.venv"
+fi
+
+# shfmt is not a Python program but a system binary
+# so let's hack it into the virtualenv
+# This is not great, but we can't add a single binary to $PATH
+SHFMT_PATH=$(which shfmt)
+if [[ ! -z "${SHFMT_PATH}" ]]; then
+    ln -s ${SHFMT_PATH} ${PWNDBG_VENV_PATH}/bin/shfmt 2> /dev/null || true
+fi
+
+# Override PATH because we don't want any system-level binaries to be used
+PATH="${PWNDBG_VENV_PATH}/bin/"
+source "${PWNDBG_VENV_PATH}/bin/activate"
+
 LINT_FILES="pwndbg tests *.py"
-LINT_TOOLS="isort black ruff vermin"
+LINT_TOOLS="isort black ruff vermin mypy"
 
 if ! type ${LINT_TOOLS} &> /dev/null; then
     PIP_CMD="pip install -Ur dev-requirements.txt"
@@ -39,20 +56,25 @@ if ! type ${LINT_TOOLS} &> /dev/null; then
     $PIP_CMD
 fi
 
+call_shfmt() {
+    FLAGS=$1
+    if [ -x "$(command -v shfmt)" ]; then
+        # Indents are four spaces, binary ops can start a line, indent switch cases,
+        # and allow spaces following a redirect
+        shfmt ${FLAGS} -i 4 -bn -ci -sr -d .
+    else
+        echo "shfmt not installed, skipping"
+    fi
+}
+
 if [[ $FORMAT == 1 ]]; then
     isort ${LINT_FILES}
     black ${LINT_FILES}
+    call_shfmt -w
 else
     isort --check-only --diff ${LINT_FILES}
     black --check --diff ${LINT_FILES}
-fi
-
-if [ -x "$(command -v shfmt)" ]; then
-    # Indents are four spaces, binary ops can start a line, indent switch cases,
-    # and allow spaces following a redirect
-    shfmt -i 4 -bn -ci -sr -d .
-else
-    echo "shfmt not installed, skipping"
+    call_shfmt
 fi
 
 # Checking minimum python version
@@ -60,8 +82,4 @@ vermin -vvv --no-tips -t=3.8- --violations ./pwndbg/
 
 ruff check --show-source ${LINT_FILES}
 
-if [ -x "$(command -v mypy)" ]; then
-    mypy pwndbg
-else
-    echo "mypy not installed, skipping"
-fi
+mypy pwndbg


### PR DESCRIPTION
Fixes #1858

It additionally puts shfmt binary as a symlink into the venv if it exists, so it will be used from it.