### PR TITLE
flake.nix: use poetry2nix from nix-community

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
   inputs.poetry2nix = {
-    url = "github:disconnect3d/poetry2nix";
+    url = "github:nix-community/poetry2nix";
     inputs.nixpkgs.follows = "nixpkgs";
   };
 


### PR DESCRIPTION
I had to switch to my private repo with poetry2nix because they missed a hash for cryptography==41.0.3 dependency that we updated throughout the dependabot alert about this dependency.

The missing hash was added to the upstream repo in https://github.com/nix-community/poetry2nix/pull/1249

We don't really use this dependency directly, but I went ahead and updated it just in case.
