### PR TITLE
Add new search arguments

### DIFF
--- a/pwndbg/commands/search.py
+++ b/pwndbg/commands/search.py
@@ -45,9 +45,13 @@ def print_search_hit(address) -> None:
 auto_save = pwndbg.gdblib.config.add_param(
     "auto-save-search", False, 'automatically pass --save to "search" command'
 )
-
 parser = argparse.ArgumentParser(
-    description="Search memory for byte sequences, strings, pointers, and integer values."
+    formatter_class=argparse.RawTextHelpFormatter,
+    description="""Search memory for byte sequences, strings, pointers, and integer values.
+
+By default search results are cached. If you want to cache all results, but only print a subset, use --trunc-out. If you want to cache only a subset of results, and print the results immediately, use --limit. The latter is specially useful if you're searching a huge section of memory.
+
+""",
 )
 parser.add_argument(
     "-t",
@@ -105,6 +109,23 @@ parser.add_argument(
     "-e", "--executable", action="store_true", help="Search executable segments only"
 )
 parser.add_argument("-w", "--writable", action="store_true", help="Search writable segments only")
+parser.add_argument(
+    "-s",
+    "--step",
+    default=None,
+    type=str,
+    help="Step search address forward to next alignment after each hit (ex: 0x1000)",
+)
+parser.add_argument(
+    "-l",
+    "--limit",
+    default=None,
+    type=str,
+    help="Max results before quitting the search. Differs from --trunc-out in that it will not save all search results before quitting",
+)
+parser.add_argument(
+    "-a", "--aligned", default=None, type=str, help="Result must be aligned to this byte boundary"
+)
 parser.add_argument("value", type=str, help="Value to search for")
 parser.add_argument(
     "mapping_name", type=str, nargs="?", default=None, help="Mapping to search [e.g. libc]"
@@ -126,13 +147,29 @@ parser.add_argument(
     help="Search only locations returned by previous search with --save",
 )
 parser.add_argument(
-    "--trunc-out", action="store_true", default=False, help="Truncate the output to 20 results"
+    "--trunc-out",
+    action="store_true",
+    default=False,
+    help="Truncate the output to 20 results. Differs from --limit in that it will first save all search results",
 )
 
 
 @pwndbg.commands.ArgparsedCommand(parser, category=CommandCategory.MEMORY)
 @pwndbg.commands.OnlyWhenRunning
-def search(type, hex, executable, writable, value, mapping_name, save, next, trunc_out) -> None:
+def search(
+    type,
+    hex,
+    executable,
+    writable,
+    step,
+    limit,
+    aligned,
+    value,
+    mapping_name,
+    save,
+    next,
+    trunc_out,
+) -> None:
     global saved
     if next and not saved:
         print(
@@ -155,6 +192,14 @@ def search(type, hex, executable, writable, value, mapping_name, save, next, tru
             print(f"invalid input for type hex: {e}")
             return
 
+    if step:
+        step = pwndbg.commands.fix_int(step)
+
+    if aligned:
+        aligned = pwndbg.commands.fix_int(aligned)
+
+    if limit:
+        limit = pwndbg.commands.fix_int(limit)
     # Convert to an integer if needed, and pack to bytes
     if type not in ("string", "bytes"):
         value = pwndbg.commands.fix_int(value)
@@ -217,7 +262,13 @@ def search(type, hex, executable, writable, value, mapping_name, save, next, tru
     # Perform the search
     i = 0
     for address in pwndbg.search.search(
-        value, mappings=mappings, executable=executable, writable=writable
+        value,
+        mappings=mappings,
+        executable=executable,
+        writable=writable,
+        step=step,
+        aligned=aligned,
+        limit=limit,
     ):
         if save:
             saved.add(address)

--- a/tests/gdb-tests/tests/binaries/search_memory.c
+++ b/tests/gdb-tests/tests/binaries/search_memory.c
@@ -1,0 +1,31 @@
+/* For testing the search command.
+ *
+ * We just spray some known patterns into memory
+ */
+
+#include <stdlib.h>
+
+void break_here(void) {}
+
+int main(void)
+{
+    void *p;
+
+    p = malloc(0x100000);
+    memset(p, 0x0, 0x100000);
+
+    // Pattern we want to find with -i 0x1000
+    for (int i = 0; i < 0x100000; i += 0x100) {
+        *(unsigned int *)(p + i) = 0xd00dbeef;
+    }
+
+    // Pattern we want to avoid with -a 0x8 
+    for (int i = 0; i < 0x100000; i += 0x100) {
+        *(unsigned int *)(p + i + 0x17) = 0xd00dbeef;
+    }
+
+    break_here();
+
+    return 0;
+}
+

--- a/tests/gdb-tests/tests/test_command_search.py
+++ b/tests/gdb-tests/tests/test_command_search.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import gdb
+
+import tests
+
+SEARCH_BINARY = tests.binaries.get("search_memory.out")
+SEARCH_PATTERN = 0xD00DBEEF
+
+
+def test_command_search_limit(start_binary):
+    """
+    Tests simple search limit
+    """
+    start_binary(SEARCH_BINARY)
+
+    gdb.execute("break break_here")
+    gdb.execute("run")
+
+    search_limit = 10
+    result_str = gdb.execute(
+        f"search --dword {SEARCH_PATTERN} -l {search_limit} -w", to_string=True
+    )
+    result_count = 0
+    result_value = None
+    for line in result_str.split("\n"):
+        if line.startswith("[anon_"):
+            if not result_value:
+                result_value = line.split(" ")[2]
+            result_count += 1
+
+    assert result_count == search_limit
+    assert result_value == hex(SEARCH_PATTERN)
+
+
+def test_command_search_alignment(start_binary):
+    """
+    Tests aligned search
+    """
+    start_binary(SEARCH_BINARY)
+
+    gdb.execute("break break_here")
+    gdb.execute("run")
+
+    alignment = 8
+    result_str = gdb.execute(f"search --dword {SEARCH_PATTERN} -a {alignment} -w", to_string=True)
+    for line in result_str.split("\n"):
+        if line.startswith("[anon_"):
+            result_address = line.split(" ")[1]
+            assert int(result_address, 16) % alignment == 0
+
+
+def test_command_search_step(start_binary):
+    """
+    Tests stepped search
+    """
+    start_binary(SEARCH_BINARY)
+
+    gdb.execute("break break_here")
+    gdb.execute("run")
+
+    step = 0x1000
+    result_str = gdb.execute(f"search --dword {SEARCH_PATTERN} -s {step} -w", to_string=True)
+    result_count = 0
+    for line in result_str.split("\n"):
+        if line.startswith("[anon_"):
+            result_count += 1
+
+    # We allocate 0x100000 bytes
+    assert result_count == 0x100
+
+
+def test_command_search_byte_width(start_binary):
+    """
+    Tests 1-byte search
+    """
+    start_binary(SEARCH_BINARY)
+
+    gdb.execute("break break_here")
+    gdb.execute("run")
+
+    result_str = gdb.execute(f"search --byte 0xef -w", to_string=True)
+    result_count = 0
+    for line in result_str.split("\n"):
+        if line.startswith("[anon_"):
+            result_count += 1
+
+    assert result_count > 0x100
+
+
+def test_command_search_word_width(start_binary):
+    """
+    Tests 2-byte word search
+    """
+    start_binary(SEARCH_BINARY)
+
+    gdb.execute("break break_here")
+    gdb.execute("run")
+
+    result_str = gdb.execute(f"search --word 0xbeef -w", to_string=True)
+    result_count = 0
+    for line in result_str.split("\n"):
+        if line.startswith("[anon_"):
+            result_count += 1
+
+    assert result_count > 0x100
+
+
+def test_command_search_dword_width(start_binary):
+    """
+    Tests 4-byte dword search
+    """
+    start_binary(SEARCH_BINARY)
+
+    gdb.execute("break break_here")
+    gdb.execute("run")
+
+    result_str = gdb.execute(f"search --dword 0xd00dbeef -w", to_string=True)
+    result_count = 0
+    for line in result_str.split("\n"):
+        if line.startswith("[anon_"):
+            result_count += 1
+
+    assert result_count > 0x100
+
+
+def test_command_search_qword_width(start_binary):
+    """
+    Tests 8-byte qword search
+    """
+    start_binary(SEARCH_BINARY)
+
+    gdb.execute("break break_here")
+    gdb.execute("run")
+
+    result_str = gdb.execute(f"search --dword 0x00000000d00dbeef -w", to_string=True)
+    result_count = 0
+    for line in result_str.split("\n"):
+        if line.startswith("[anon_"):
+            result_count += 1
+
+    assert result_count > 0x100
+
+
+def test_command_search_rwx(start_binary):
+    """
+    Tests searching for rwx memory only
+    """
+    start_binary(SEARCH_BINARY)
+
+    gdb.execute("break break_here")
+    gdb.execute("run")
+
+    result_str = gdb.execute(f"search --dword 0x00000000d00dbeef -w -x", to_string=True)
+    result_count = 0
+    for line in result_str.split("\n"):
+        if line.startswith("[anon_"):
+            result_count += 1
+
+    assert result_count == 0


### PR DESCRIPTION
This pull request adds three additional search features:

- `-i`/`--interval` to specify the interval between each search result. This is
  useful if you're analyzing something like heap spray where you mostly just
  care if the memory you sprayed exists within some address range, and aren't
  interested in any of the subsequent search hits within that same range. So for instance
  if we're spraying a bunch of data and we want to make sure that every 1MB we hit some
  target address we can do:

```
pwndbg> search -i 0x100000 -t qword 0x0000000000010c00 [anon_97d82]
Searching for value: b'\x00\x0c\x01\x00\x00\x00\x00\x00'
[anon_97d82]    0x982e4d13 0x10c00
[anon_97d82]    0x98327dcf 0x10c00
[anon_97d82]    0x98400038 0x10c00
[anon_97d82]    0x98500038 0x10c00
[anon_97d82]    0x98600038 0x10c00
...
```

We can see that it only prints the first result from each 0x100000 block.

There's two annoyances with doing a search like this, which are addressed by the
other two features.

First, it can be exceptionally slow if the region of memory
are searching in is large (and doing remote debugging), and if you're only
interested in say the first ten results, you don't want to wait around to search 
through the entire region. The existing `trunc_out` feature doesn't help here
because it only truncates the output after a complete search is already completed.

Any example I'm using above the region is 512MB, and it takes a while to search remotely.

```
0x97d82000 0xb674c000 rw-p 1e9ca000      0 [anon_97d82]
```

This problem is addressed by this new option:

- `-l`/`--limit` to specify the maximum number of search results to return.
  This is useful if you're only interested in the first few results, and don't
  want to wait for the entire search to complete. For instance if we're
  spraying a bunch and we want to make sure that every 1MB we hit the target
  address we can do:

```
pwndbg> search -i 0x100000 -l 5 -t qword 0x0000000000010c00 [anon_97d82]
Searching for value: b'\x00\x0c\x01\x00\x00\x00\x00\x00'
[anon_97d82]    0x982e4d13 0x10c00
[anon_97d82]    0x98327dcf 0x10c00
[anon_97d82]    0x98400038 0x10c00
[anon_97d82]    0x98500038 0x10c00
[anon_97d82]    0x98600038 0x10c00
```

Second, some of the results above are not actually the data that were interested in,
for instance the two examples above happen to be the wanted value but at an
alignment that our spray will never actually hit, as in my example case I know
that what I spray will always be 8-byte aligned.

- `-a`/`--align` to specify the alignment of the search results. This is useful
  if you're only interested in results that are aligned to a certain value.
  For instance if we're spraying a bunch and we want to make sure that every
  1MB we hit the target address we can do:

```
pwndbg> search -i 0x100000 -a 0x8 -l 5 -t qword 0x0000000000010c00 [anon_97d82]
Searching for value: b'\x00\x0c\x01\x00\x00\x00\x00\x00'
[anon_97d82]    0x98387510 0x10c00
[anon_97d82]    0x98400038 0x10c00
[anon_97d82]    0x98500038 0x10c00
[anon_97d82]    0x98600038 0x10c00
[anon_97d82]    0x98700f78 0x10c00
```

You can see that earlier results that were at unwanted alignments no
longer show up.

I've included tests which pass on my machine.

As for the name of the commands, I suspect people might not like interval for
instance, I'm happy to change them to whatever you want.

Lastly the try except around the search_memory() call may be a bit questionable, and probably the format of the warning is wrong, so happy to change that if needed. 