### PR TITLE
avoid breaking pacman.conf if entries already exist

### DIFF
--- a/setup-dev.sh
+++ b/setup-dev.sh
@@ -112,17 +112,27 @@ install_apt() {
 install_pacman() {
     set_zigpath "$(pwd)/.zig"
 
-    # add debug repo for glibc-debug
-    cat << EOF | sudo tee -a /etc/pacman.conf
-[core-debug]
-Include = /etc/pacman.d/mirrorlist
-
-[extra-debug]
-Include = /etc/pacman.d/mirrorlist
-
-[multilib-debug]
-Include = /etc/pacman.d/mirrorlist
+    # add debug repo for glibc-debug if it doesn't already exist
+    if ! grep -q "\[core-debug\]" /etc/pacman.conf; then
+        cat << EOF | sudo tee -a /etc/pacman.conf
+        [core-debug]
+        Include = /etc/pacman.d/mirrorlist
 EOF
+    fi
+
+    if ! grep -q "\[extra-debug\]" /etc/pacman.conf; then
+        cat << EOF | sudo tee -a /etc/pacman.conf
+        [extra-debug]
+        Include = /etc/pacman.d/mirrorlist
+EOF
+    fi
+
+    if ! grep -q "\[multilib-debug\]" /etc/pacman.conf; then
+        cat << EOF | sudo tee -a /etc/pacman.conf
+        [multilib-debug]
+        Include = /etc/pacman.d/mirrorlist
+EOF
+    fi
 
     sudo pacman -Syu --noconfirm || true
     sudo pacman -S --needed --noconfirm \
@@ -132,8 +142,12 @@ EOF
         curl \
         base-devel \
         gdb \
-        parallel \
-        gnu-netcat
+        parallel
+
+    # check if netcat exists first, as it might it may be installed from some other netcat packages
+    if [ ! -f /usr/bin/nc ]; then
+        sudo pacman -S --needed --noconfirm gnu-netcat
+    fi
 
     command -v go &> /dev/null || sudo pacman -S --noconfirm go
 


### PR DESCRIPTION
When I ran the dev setup script it broke my pacman configuration because it duplicated certain entries, so this pull request adds a check to make sure the lines don't already exist. 

Also netcat might already be installed, but not through gnu-netcat (ex: openbsd-netcat, nmap-netcat, etc) so no longer just blindly try to install gnu-netcat.

A small note on the EOF formatting, although I could use `cat <<-EOF` in order to keep consistent white space within the if condition, the downside is that it will break syntax highlighting, so I settled with the below. I can change it if needed.