### PR TITLE
switch to an editable environment

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -189,7 +189,7 @@ PYTHON=${PWNDBG_VENV_PATH}/bin/python
 ${PYTHON} -m pip install --upgrade pip
 
 # Create Python virtual environment and install dependencies in it
-${PWNDBG_VENV_PATH}/bin/pip install -U .
+${PWNDBG_VENV_PATH}/bin/pip install -e .
 
 # pyproject.toml install itself "pwndbg"/"gdb-pt-dump" into site-packages, for "caching" dockerfile we need remove it
 PYTHON_VERSION=$(ls "${PWNDBG_VENV_PATH}/lib/")


### PR DESCRIPTION
Addresses the problem mentioned in #1866 and on discord were using the virtual environment would create a copy of the pwndbg files, which made development somewhat inconvenient. 

I don't know all the differences between `-U` and `-e`, but can confirm that using `-e` at least addresses the editable problem. The two options can't be used together, so it's probably good for other people to test that not using `-U` won't have any weird side effects.
