### PR TITLE
remove check_dependencies #1865

### DIFF
--- a/pwndbg/exception.py
+++ b/pwndbg/exception.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import functools
-import os
 import sys
 import traceback
 

--- a/pwndbg/exception.py
+++ b/pwndbg/exception.py
@@ -52,25 +52,6 @@ def inform_unmet_dependencies(errors) -> None:
 
 
 @pwndbg.lib.cache.cache_until("forever")
-def check_dependencies():
-    """
-    Checks if there are any unmet dependencies in requirements.txt
-    """
-    project_path = os.path.dirname(os.path.abspath(__file__))
-    requirements_path = os.path.join(project_path, os.pardir, "requirements.txt")
-    with open(requirements_path, "r") as f:
-        errors = []
-        for line in f.readlines():
-            try:
-                pkg_resources.require(line)
-            except (pkg_resources.VersionConflict, pkg_resources.DistributionNotFound) as e:
-                errors.append(e)
-
-        if errors:
-            inform_unmet_dependencies(errors)
-
-
-@pwndbg.lib.cache.cache_until("forever")
 def inform_report_issue(exception_msg) -> None:
     """
     Informs user that he can report an issue.
@@ -112,9 +93,6 @@ def handle(name="Error"):
         e = E(V)
         e.__traceback__ = T
         raise e
-
-    # Check dependencies against requirements.txt and warn user
-    check_dependencies()
 
     # Display the error
     if debug or verbose:


### PR DESCRIPTION
i spent a while trying to make this work but i think without

```
poetry export -f requirements.txt -o requirements.txt
```

its going to be hard

not sure its suitable even as a short term fix
