### PR TITLE
move `attachp` to be shown under "Start Commands".

### DIFF
--- a/pwndbg/commands/attachp.py
+++ b/pwndbg/commands/attachp.py
@@ -9,8 +9,8 @@ from subprocess import check_output
 import gdb
 
 import pwndbg.commands
-from pwndbg.commands import CommandCategory
 from pwndbg.color import message
+from pwndbg.commands import CommandCategory
 
 parser = argparse.ArgumentParser(
     formatter_class=argparse.RawTextHelpFormatter,

--- a/pwndbg/commands/attachp.py
+++ b/pwndbg/commands/attachp.py
@@ -9,6 +9,7 @@ from subprocess import check_output
 import gdb
 
 import pwndbg.commands
+from pwndbg.commands import CommandCategory
 from pwndbg.color import message
 
 parser = argparse.ArgumentParser(
@@ -36,7 +37,7 @@ Original GDB attach command help:
 parser.add_argument("target", type=str, help="pid, process name or device file to attach to")
 
 
-@pwndbg.commands.ArgparsedCommand(parser)
+@pwndbg.commands.ArgparsedCommand(parser, category=CommandCategory.START)
 def attachp(target) -> None:
     try:
         resolved_target = int(target)


### PR DESCRIPTION
<!-- Please make sure to read the testing and linting instructions at https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md before creating a PR -->
Output:
```pwndbg> pwndbg
Start Commands [Aliases]    Description
--------------------------  --------------------------------------------------------------------
attachp                     Attaches to a given pid, process name or device file.
entry                       Start the debugged program stopping at its entrypoint address.
sstart                      Alias for 'tbreak __libc_start_main; run'.
start [main, init]          Start the debugged program stopping at the first convenient location```