### PR TITLE
patch_list: compact the from/to assembly display

### DIFF
--- a/pwndbg/commands/patch.py
+++ b/pwndbg/commands/patch.py
@@ -85,7 +85,7 @@ def patch_list() -> None:
             message.hint("Patch at"),
             message.warn("%#x:" % addr),
             message.hint("\n  from:"),
-            message.warn(old_insns.replace("\n", "; ")),
+            message.warn(' '.join(old_insns.replace("\n", "; ").split())),
             message.hint("\n  to  :"),
-            message.warn(new_insns.replace("\n", "; ")),
+            message.warn(' '.join(new_insns.replace("\n", "; ").split())),
         )

--- a/pwndbg/commands/patch.py
+++ b/pwndbg/commands/patch.py
@@ -85,7 +85,7 @@ def patch_list() -> None:
             message.hint("Patch at"),
             message.warn("%#x:" % addr),
             message.hint("\n  from:"),
-            message.warn(' '.join(old_insns.replace("\n", "; ").split())),
+            message.warn(" ".join(old_insns.replace("\n", "; ").split())),
             message.hint("\n  to  :"),
-            message.warn(' '.join(new_insns.replace("\n", "; ").split())),
+            message.warn(" ".join(new_insns.replace("\n", "; ").split())),
         )


### PR DESCRIPTION
Before:
<img width="795" alt="image" src="https://github.com/pwndbg/pwndbg/assets/10009354/40af9fc6-7e21-44b2-b358-c6268b87001d">

After:
<img width="557" alt="image" src="https://github.com/pwndbg/pwndbg/assets/10009354/eeef3542-5917-4210-9ff9-b39bd6d6dc67">

I still feel sth is wrong with the 'from' assembly, why isn't it showing the same instruction as disassembled by GDB? Is the arch set properly? To be investigated.

Anyway, the compact enhancement is needed.