### PR TITLE
procinfo: fix embedded null byte in cmdline args

### DIFF
--- a/pwndbg/commands/procinfo.py
+++ b/pwndbg/commands/procinfo.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import shlex
 import string
 
 import pwndbg.auxv
@@ -87,8 +88,7 @@ class Process:
     @pwndbg.lib.cache.cache_until("stop")
     def cmdline(self):
         raw = pwndbg.gdblib.file.get(f"/proc/{self.pid}/cmdline")
-        cmdline = raw.decode().rstrip("\x00").strip()
-        return f"'{cmdline}'"
+        return " ".join(map(shlex.quote, raw.decode().split("\x00")))
 
     @property
     @pwndbg.lib.cache.cache_until("stop")


### PR DESCRIPTION
Fixes a bug with procinfo

```
pwndbg> procinfo
exe        '/opt/teamviewer/tv_bin/teamviewerd'
Exception occurred: procinfo: embedded null character (<class 'ValueError'>)
For more info invoke `set exception-verbose on` and rerun the command
or debug it by yourself with `set exception-debugger on`
pwndbg> set exception-debugger on
Set whether to debug exceptions raised in Pwndbg commands to 'on'.
...
(Pdb) up
> /home/dc/pwndbg/pwndbg/commands/procinfo.py(227)procinfo()
-> print("%-10s %s" % ("cmdline", proc.cmdline))
(Pdb) print(proc.cmdline)
'/opt/teamviewer/tv_bin/teamviewerd\x00-d'
```

<!-- Please make sure to read the testing and linting instructions at https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md before creating a PR -->
