### PR TITLE
fix infinite recursion and fail to read proc maps when set debug remo…

### DIFF
--- a/pwndbg/gdblib/file.py
+++ b/pwndbg/gdblib/file.py
@@ -83,7 +83,19 @@ def get_file(path: str, try_local_path: bool = False) -> str:
                 error = str(e)
 
             if error:
-                raise OSError("Could not download remote file %r:\n" "Error: %s" % (path, error))
+                # If the client is configured with set debug remote 1, we need to
+                # skip [remote] lines, and not interpret as missing file. Maybe
+                # better to search for error strings. A real error will say:
+                # "Remote I/O error: No such file or directory"
+                real_error = []
+                for line in error.splitlines():
+                    if not line.startswith("[remote]"):
+                        real_error.append(line)
+                if len(real_error):
+                    error = "\n".join(real_error)
+                    raise OSError(
+                        "Could not download remote file %r:\n" "Error: %s" % (path, error)
+                    )
         else:
             print(
                 message.warn(


### PR DESCRIPTION
This fixes a bug I ran into when `set debug remote 1` was set to debug a separate issue :) The setting will add a bunch of `[remote]` prefixed lines to gdb output, which then breaks proc map reading on remote targets. 

The PR strips [remote] lines in output when reading proc maps. It may be a better longer term solution to have a dedicated read function that's called everywhere by pwndbg that strips out these debug lines, as I suspect other places may break when this setting is on. Can file an issue for that if you're interested.

I also add a escape hatch for infinite recursion, which triggers if the proc mappings fail to be identified. This was originally filed as #1219 and attempted fix by [7175b17](https://github.com/alufers/pwndbg/commit/7175b17def004148b8dcd65561189d53e6b62266), but didn't seem to actually address the issue. Not sure if my solution is a bit too inelegant, but I confirmed that it works if I revert the [remote] handling I added.