### PR TITLE
Remove pacman partial upgrades

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -61,8 +61,13 @@ install_emerge() {
 }
 
 install_pacman() {
-    sudo pacman -Syy --noconfirm || true
-    sudo pacman -S --needed --noconfirm git gdb python python-pip python-capstone python-unicorn python-pycparser python-psutil python-ptrace python-pyelftools python-six python-pygments which debuginfod
+    read -p "Do you want to do a full system update? (y/n) [n] " answer
+    # user want to perfom a full system upgrade
+    answer=${answer:-n} # n is default
+    if [[ "$answer" == "y" ]]; then
+        sudo pacman -Syu || true
+    fi
+    sudo pacman -S --needed git gdb python python-pip python-capstone python-unicorn python-pycparser python-psutil python-ptrace python-pyelftools python-six python-pygments which debuginfod
     if ! grep -q "^set debuginfod enabled on" ~/.gdbinit; then
         echo "set debuginfod enabled on" >> ~/.gdbinit
     fi


### PR DESCRIPTION
When performing `pacman -Syy` we are performing a partial upgrade that shouldn't be done, it is better to ask the user and then perform a full system upgrade. Since arch based distros should be relative up to date the install script can proceed even without performing a full system upgrade.
More info about partial upgrade [here](https://wiki.archlinux.org/title/Pacman).