### PR TITLE
Update tests to gracefully handle multiple qemu processess running

### DIFF
--- a/pwndbg/gdblib/vmmap.py
+++ b/pwndbg/gdblib/vmmap.py
@@ -434,7 +434,7 @@ def kernel_vmmap_via_page_tables():
     p = pt.PageTableDump()
     try:
         p.lazy_init()
-    except PermissionError:
+    except Exception:
         print(
             M.error(
                 "Permission error when attempting to parse page tables with gdb-pt-dump.\n"


### PR DESCRIPTION
Previously test scripts would just indiscriminately kill all qemu processes on the system. This would kill other debug sessions I had running. These changes make the test scripts record the qemu pids they run and only kill those.

The old scripts would also not allow you to specify a gdb port, so if you were already running a debug session with port 1234, the tests would fail. This update allows you to pass --gdb-port=NNNN to use a non-default port.

Also update gdb-pt-dump submodule as it has been updated recently to not throw an exception when multiple qemu processes are running. The exception thrown in the event of a failure also changed, so this has also been updated on the pwndbg side.

<!-- Please make sure to read the testing and linting instructions at https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md before creating a PR -->
