### PR TITLE
Partially address #1759

### DIFF
--- a/pwndbg/commands/kbase.py
+++ b/pwndbg/commands/kbase.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import argparse
 
+import gdb
+
 import pwndbg.color.message as M
 import pwndbg.commands
 import pwndbg.gdblib.memory
@@ -37,8 +39,15 @@ def kbase() -> None:
         # TODO: Check if the supervisor bit is set for aarch64
         if not mapping.execute:
             continue
-        b = pwndbg.gdblib.memory.byte(mapping.vaddr)
-
+        try:
+            b = pwndbg.gdblib.memory.byte(mapping.vaddr)
+        except gdb.MemoryError:
+            print(
+                M.error(
+                    f"Could not read memory at {mapping.vaddr:#x}. Kernel vmmap may be incorrect."
+                )
+            )
+            continue
         if b == magic:
             print(M.success(f"Found virtual base address: {mapping.vaddr:#x}"))
             break

--- a/pwndbg/commands/kchecksec.py
+++ b/pwndbg/commands/kchecksec.py
@@ -110,7 +110,7 @@ parser = argparse.ArgumentParser(description="Checks for kernel hardening config
 def kchecksec() -> None:
     kconfig = pwndbg.gdblib.kernel.kconfig()
 
-    if len(kconfig) == 0:
+    if not kconfig:
         print(
             M.warn(
                 "No kernel configuration found, make sure the kernel was built with CONFIG_IKCONFIG"

--- a/pwndbg/commands/kconfig.py
+++ b/pwndbg/commands/kconfig.py
@@ -21,7 +21,7 @@ parser.add_argument("config_name", nargs="?", type=str, help="A config name to s
 def kconfig(config_name=None) -> None:
     kconfig_ = pwndbg.gdblib.kernel.kconfig()
 
-    if len(kconfig_) == 0:
+    if not kconfig_:
         print(
             M.warn(
                 "No kernel configuration found, make sure the kernel was built with CONFIG_IKCONFIG"

--- a/pwndbg/gdblib/kernel/__init__.py
+++ b/pwndbg/gdblib/kernel/__init__.py
@@ -10,6 +10,7 @@ from typing import Tuple
 
 import gdb
 
+import pwndbg.color.message as M
 import pwndbg.gdblib.memory
 import pwndbg.gdblib.symbol
 import pwndbg.lib.cache
@@ -32,6 +33,26 @@ def has_debug_syms() -> bool:
     )
 
 
+# NOTE: This implies requires_debug_syms(), as it is needed for kconfig() to return non-None
+def requires_kconfig(default=None):
+    def decorator(f):
+        @functools.wraps(f)
+        def func(*args, **kwargs):
+            if kconfig():
+                return f(*args, **kwargs)
+
+            # If the user doesn't want an exception thrown when CONFIG_IKCONFIG is
+            # not enabled, they can instead provide a default return value
+            if default is not None:
+                return default
+
+            raise Exception(f"Function {f.__name__} requires CONFIG_IKCONFIG enabled in kernel")
+
+        return func
+
+    return decorator
+
+
 def requires_debug_syms(default=None):
     def decorator(f):
         @functools.wraps(f)
@@ -44,7 +65,7 @@ def requires_debug_syms(default=None):
             if default is not None:
                 return default
 
-            raise Exception(f"Function {f.__name__} requires CONFIG_IKCONFIG")
+            raise Exception(f"Function {f.__name__} requires debug symbols")
 
         return func
 
@@ -61,6 +82,8 @@ def nproc() -> int:
 def load_kconfig() -> pwndbg.lib.kernel.kconfig.Kconfig:
     config_start = pwndbg.gdblib.symbol.address("kernel_config_data")
     config_end = pwndbg.gdblib.symbol.address("kernel_config_data_end")
+    if config_start is None or config_end is None:
+        return None
     config_size = config_end - config_start
 
     compressed_config = pwndbg.gdblib.memory.read(config_start, config_size)
@@ -72,6 +95,8 @@ def kconfig() -> pwndbg.lib.kernel.kconfig.Kconfig:
     global _kconfig
     if _kconfig is None:
         _kconfig = load_kconfig()
+    elif len(_kconfig) == 0:
+        return None
     return _kconfig
 
 
@@ -98,7 +123,7 @@ def krelease() -> tuple[int, ...]:
     raise Exception("Linux version tuple not found")
 
 
-@requires_debug_syms()
+@requires_kconfig()
 @pwndbg.lib.cache.cache_until("start")
 def is_kaslr_enabled() -> bool:
     if "CONFIG_RANDOMIZE_BASE" not in kconfig():
@@ -200,6 +225,7 @@ class x86Ops(ArchOps):
 
 
 class i386Ops(x86Ops):
+    @requires_kconfig()
     def __init__(self) -> None:
         # https://elixir.bootlin.com/linux/v6.2/source/arch/x86/include/asm/page_32_types.h#L18
         self._PAGE_OFFSET = int(kconfig()["CONFIG_PAGE_OFFSET"], 16)
@@ -263,6 +289,7 @@ class x86_64Ops(x86Ops):
         # https://elixir.bootlin.com/linux/v6.2/source/arch/x86/include/asm/page_64_types.h#L50
         return 12
 
+    @requires_debug_syms()
     def per_cpu(self, addr: gdb.Value, cpu: int | None = None):
         if cpu is None:
             cpu = gdb.selected_thread().num - 1
@@ -299,14 +326,19 @@ class x86_64Ops(x86Ops):
     def uses_5lvl_paging() -> bool:
         # https://elixir.bootlin.com/linux/v6.2/source/arch/x86/include/asm/cpufeatures.h#L381
         X86_FEATURE_LA57 = 16 * 32 + 16
-        return (
-            kconfig().get("CONFIG_X86_5LEVEL") == "y"
-            and "no5lvl" not in kcmdline()
-            and x86_64Ops.cpu_feature_capability(X86_FEATURE_LA57)
-        )
+        # Separate to avoid using kconfig if possible
+        if not x86_64Ops.cpu_feature_capability(X86_FEATURE_LA57) or "no5lvl" in kcmdline():
+            return False
+        return x86_64Ops._kconfig_5lvl_paging()
+
+    @staticmethod
+    @requires_kconfig()
+    def _kconfig_5lvl_paging() -> bool:
+        return kconfig().get("CONFIG_X86_5LEVEL") == "y"
 
 
 class Aarch64Ops(ArchOps):
+    @requires_kconfig(default={})
     def __init__(self) -> None:
         self.STRUCT_PAGE_SIZE = gdb.lookup_type("struct page").sizeof
         self.STRUCT_PAGE_SHIFT = int(math.log2(self.STRUCT_PAGE_SIZE))
@@ -332,6 +364,7 @@ class Aarch64Ops(ArchOps):
     def page_size(self) -> int:
         return 1 << self.PAGE_SHIFT
 
+    @requires_debug_syms()
     def per_cpu(self, addr: gdb.Value, cpu: int | None = None):
         if cpu is None:
             cpu = gdb.selected_thread().num - 1
@@ -371,7 +404,6 @@ class Aarch64Ops(ArchOps):
 _arch_ops: ArchOps = None
 
 
-@requires_debug_syms(default={})
 @pwndbg.lib.cache.cache_until("start")
 def arch_ops() -> ArchOps:
     global _arch_ops
@@ -386,7 +418,6 @@ def arch_ops() -> ArchOps:
     return _arch_ops
 
 
-@requires_debug_syms()
 def page_size() -> int:
     ops = arch_ops()
     if ops:
@@ -395,7 +426,6 @@ def page_size() -> int:
         raise NotImplementedError()
 
 
-@requires_debug_syms()
 def per_cpu(addr: gdb.Value, cpu: int | None = None):
     ops = arch_ops()
     if ops:
@@ -404,7 +434,6 @@ def per_cpu(addr: gdb.Value, cpu: int | None = None):
         raise NotImplementedError()
 
 
-@requires_debug_syms()
 def virt_to_phys(virt: int) -> int:
     ops = arch_ops()
     if ops:
@@ -413,7 +442,6 @@ def virt_to_phys(virt: int) -> int:
         raise NotImplementedError()
 
 
-@requires_debug_syms()
 def phys_to_virt(phys: int) -> int:
     ops = arch_ops()
     if ops:
@@ -422,7 +450,6 @@ def phys_to_virt(phys: int) -> int:
         raise NotImplementedError()
 
 
-@requires_debug_syms()
 def phys_to_pfn(phys: int) -> int:
     ops = arch_ops()
     if ops:
@@ -431,7 +458,6 @@ def phys_to_pfn(phys: int) -> int:
         raise NotImplementedError()
 
 
-@requires_debug_syms()
 def pfn_to_phys(pfn: int) -> int:
     ops = arch_ops()
     if ops:
@@ -440,7 +466,6 @@ def pfn_to_phys(pfn: int) -> int:
         raise NotImplementedError()
 
 
-@requires_debug_syms()
 def pfn_to_page(pfn: int) -> int:
     ops = arch_ops()
     if ops:
@@ -449,7 +474,6 @@ def pfn_to_page(pfn: int) -> int:
         raise NotImplementedError()
 
 
-@requires_debug_syms()
 def page_to_pfn(page: int) -> int:
     ops = arch_ops()
     if ops:
@@ -458,7 +482,6 @@ def page_to_pfn(page: int) -> int:
         raise NotImplementedError()
 
 
-@requires_debug_syms()
 def phys_to_page(phys: int) -> int:
     ops = arch_ops()
     if ops:
@@ -467,7 +490,6 @@ def phys_to_page(phys: int) -> int:
         raise NotImplementedError()
 
 
-@requires_debug_syms()
 def page_to_phys(page: int) -> int:
     ops = arch_ops()
     if ops:
@@ -476,7 +498,6 @@ def page_to_phys(page: int) -> int:
         raise NotImplementedError()
 
 
-@requires_debug_syms()
 def virt_to_page(virt: int) -> int:
     ops = arch_ops()
     if ops:
@@ -485,7 +506,6 @@ def virt_to_page(virt: int) -> int:
         raise NotImplementedError()
 
 
-@requires_debug_syms()
 def page_to_virt(page: int) -> int:
     ops = arch_ops()
     if ops:
@@ -494,7 +514,6 @@ def page_to_virt(page: int) -> int:
         raise NotImplementedError()
 
 
-@requires_debug_syms()
 def pfn_to_virt(pfn: int) -> int:
     ops = arch_ops()
     if ops:
@@ -503,7 +522,6 @@ def pfn_to_virt(pfn: int) -> int:
         raise NotImplementedError()
 
 
-@requires_debug_syms()
 def virt_to_pfn(virt: int) -> int:
     ops = arch_ops()
     if ops:
@@ -528,6 +546,15 @@ def paging_enabled() -> bool:
 def num_numa_nodes() -> int:
     """Returns the number of NUMA nodes that are online on the system"""
     kc = kconfig()
+    if kc is None:
+        # if no config, we can still try one other way
+        node_states = gdb.lookup_global_symbol("node_states")
+        if node_states is None:
+            return 1
+        node_states = gdb.lookup_global_symbol("node_states").value()
+        node_mask = node_states[1]["bits"][0]  # 1 means N_ONLINE
+        return bin(node_mask).count("1")
+
     if "CONFIG_NUMA" not in kc:
         return 1
 

--- a/pwndbg/gdblib/kernel/slab.py
+++ b/pwndbg/gdblib/kernel/slab.py
@@ -4,6 +4,7 @@ from typing import Generator
 
 import gdb
 
+import pwndbg.color.message as M
 from pwndbg.gdblib import kernel
 from pwndbg.gdblib import memory
 from pwndbg.gdblib.kernel.macros import compound_head
@@ -116,6 +117,12 @@ class SlabCache:
 
     @property
     def random(self) -> int:
+        if not kernel.kconfig():
+            try:
+                return int(self._slab_cache["random"])
+            except gdb.error:
+                return 0
+
         return (
             int(self._slab_cache["random"]) if "SLAB_FREELIST_HARDENED" in kernel.kconfig() else 0
         )

--- a/pwndbg/gdblib/kernel/slab.py
+++ b/pwndbg/gdblib/kernel/slab.py
@@ -4,7 +4,6 @@ from typing import Generator
 
 import gdb
 
-import pwndbg.color.message as M
 from pwndbg.gdblib import kernel
 from pwndbg.gdblib import memory
 from pwndbg.gdblib.kernel.macros import compound_head


### PR DESCRIPTION
There were various problems running commands on kernels without CONFIG_IKCONFIG support. This attempts to naively fix some of them, although possibly not exhaustively.

Fix kconfig to not crash if the required symbols aren't found.

Introduce a new requires_kconfig() that is more strict than the old requires_debug_symbols(). Move required decorators into the __init__ method of each architecture class, as it's ultimately what decides requirements and differs between archs (ex: x86_64 is doable with just debug symbols, whereas aarch64 seems to need kconfig).

Tweaks a couple commands so slab dumping works on kernels without kconfig. Also gracefully handle kbase failure if vmmap is invalid (due to gdb-pt-dump failure, etc).

I've run tests-qemu/tests.sh, and done basic testing on x86_64 kernel without CONFIG_IKCONFIG, but I think ultimately
https://github.com/pwndbg/linux-exploit-dev-env needs to be updated to include test kernels without it as well.

<!-- Please make sure to read the testing and linting instructions at https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md before creating a PR -->
