### PR TITLE
Prevent exception occasionally seen when running reload

### DIFF
--- a/pwndbg/gdblib/events.py
+++ b/pwndbg/gdblib/events.py
@@ -179,15 +179,19 @@ gdb.events.new_objfile.connect(log_objfiles)
 
 def after_reload(start=True) -> None:
     if gdb.selected_inferior().pid:
-        for f in registered[gdb.events.stop]:
-            f()
-        for f in registered[gdb.events.start]:
-            if start:
+        if gdb.events.stop in registered:
+            for f in registered[gdb.events.stop]:
                 f()
-        for f in registered[gdb.events.new_objfile]:
-            f()
-        for f in registered[gdb.events.before_prompt]:
-            f()
+        if gdb.events.start in registered:
+            for f in registered[gdb.events.start]:
+                if start:
+                    f()
+        if gdb.events.new_objfile in registered:
+            for f in registered[gdb.events.new_objfile]:
+                f()
+        if gdb.events.before_prompt in registered:
+            for f in registered[gdb.events.before_prompt]:
+                f()
 
 
 def on_reload() -> None:


### PR DESCRIPTION
I didn't really look into why this was happening, but just wanted to get rid of the exceptions every time I reload pwndbg:

```
╭─────────────────────────────── Traceback (most recent call last) ────────────────────────────────╮
│ /home/aa/source/pwndbg/pwndbg/commands/__init__.py:190 in __call__                               │
│                                                                                                  │
│   187 │                                                                                          │
│   188 │   def __call__(self, *args, **kwargs):                                                   │
│   189 │   │   try:                                                                               │
│ ❱ 190 │   │   │   return self.function(*args, **kwargs)                                          │
│   191 │   │   except TypeError as te:                                                            │
│   192 │   │   │   print(f"{self.function.__name__.strip()!r}: {self.function.__doc__.strip()}"   │
│   193 │   │   │   pwndbg.exception.handle(self.function.__name__)                                │
│                                                                                                  │
│ /home/aa/source/pwndbg/pwndbg/commands/reload.py:32 in reload                                    │
│                                                                                                  │
│   29 def reload(*a) -> None:                                                                     │
│   30 │   pwndbg.gdblib.events.on_reload()                                                        │
│   31 │   rreload(pwndbg)                                                                         │
│ ❱ 32 │   pwndbg.gdblib.events.after_reload()                                                     │
│   33                                                                                             │
│   34                                                                                             │
│   35 @pwndbg.commands.ArgparsedCommand(                                                          │
│                                                                                                  │
│ /home/aa/source/pwndbg/pwndbg/gdblib/events.py:184 in after_reload                               │
│                                                                                                  │
│   181 │   if gdb.selected_inferior().pid:                                                        │
│   182 │   │   for f in registered[gdb.events.stop]:                                              │
│   183 │   │   │   f()                                                                            │
│ ❱ 184 │   │   for f in registered[gdb.events.start]:                                             │
│   185 │   │   │   if start:                                                                      │
│   186 │   │   │   │   f()                                                                        │
│   187 │   │   for f in registered[gdb.events.new_objfile]:                                       │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
KeyError: <pwndbg.gdblib.events.StartEvent object at 0x7fad19681550>
```