### PR TITLE
flake.nix: fix syntax error

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -9,7 +9,7 @@
 
   outputs = { self, nixpkgs, poetry2nix }:
     let
-      // Self contained packages for: Debian, RHEL-like (yum, rpm), Alpine, Arch packages
+      # Self contained packages for: Debian, RHEL-like (yum, rpm), Alpine, Arch packages
       forAllSystems = nixpkgs.lib.genAttrs nixpkgs.lib.systems.flakeExposed;
       forPortables = nixpkgs.lib.genAttrs [ "deb" "rpm" "apk" "archlinux" ];
 


### PR DESCRIPTION
flake.nix: fix syntax error