### PR TITLE
Enhance thread context

### DIFF
--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -856,7 +856,7 @@ def context_threads(with_banner=True, target=sys.stdout, width=None):
     if len(threads) < 2:
         return []
 
-    selected_thread = gdb.selected_thread()
+    original_thread = gdb.selected_thread()
 
     out = []
     max_name_length = 0
@@ -870,7 +870,7 @@ def context_threads(with_banner=True, target=sys.stdout, width=None):
         thread.switch()
         frame = gdb.selected_frame()
 
-        selected = " ►" if thread is selected_thread else "  "
+        selected = " ►" if thread is original_thread else "  "
 
         symbol = pwndbg.gdblib.symbol.get(frame.pc())
         status = get_thread_status(thread)
@@ -890,7 +890,7 @@ def context_threads(with_banner=True, target=sys.stdout, width=None):
 
     out.insert(0, pwndbg.ui.banner("threads", target=target, width=width))
 
-    selected_thread.switch()
+    original_thread.switch()
 
     return out
 

--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -888,12 +888,12 @@ def context_threads(with_banner=True, target=sys.stdout, width=None):
 
         if thread.is_stopped():
             thread.switch()
-            frame = gdb.selected_frame()
+            pc = gdb.selected_frame().pc()
 
-            pc = M.get(frame.pc())
-            symbol = pwndbg.gdblib.symbol.get(frame.pc())
+            pc_colored = M.get(pc)
+            symbol = pwndbg.gdblib.symbol.get(pc)
 
-            line += f"{pc}"
+            line += f"{pc_colored}"
             if symbol:
                 line += f" <{pwndbg.color.bold(pwndbg.color.green(symbol))}> "
 

--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -858,7 +858,7 @@ def context_threads(with_banner=True, target=sys.stdout, width=None):
 
     original_thread = gdb.selected_thread()
 
-    out = []
+    out = [pwndbg.ui.banner("threads", target=target, width=width)]
     max_name_length = 0
 
     for thread in threads:
@@ -891,8 +891,6 @@ def context_threads(with_banner=True, target=sys.stdout, width=None):
                 line += f" <{pwndbg.color.bold(pwndbg.color.green(symbol))}> "
 
         out.append(line)
-
-    out.insert(0, pwndbg.ui.banner("threads", target=target, width=width))
 
     original_thread.switch()
 

--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -866,7 +866,7 @@ def context_threads(with_banner=True, target=sys.stdout, width=None):
         if len(name) > max_name_length:
             max_name_length = len(name)
 
-    for thread in threads:
+    for thread in filter(lambda t: t.is_valid(), threads):
         thread.switch()
         frame = gdb.selected_frame()
 

--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -857,7 +857,6 @@ def context_threads(with_banner=True, target=sys.stdout, width=None):
         return []
 
     selected_thread = gdb.selected_thread()
-    selected_frame = gdb.selected_frame()
 
     out = []
     max_name_length = 0
@@ -892,7 +891,6 @@ def context_threads(with_banner=True, target=sys.stdout, width=None):
     out.insert(0, pwndbg.ui.banner("threads", target=target, width=width))
 
     selected_thread.switch()
-    selected_frame.select()
 
     return out
 

--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -867,25 +867,29 @@ def context_threads(with_banner=True, target=sys.stdout, width=None):
             max_name_length = len(name)
 
     for thread in filter(lambda t: t.is_valid(), threads):
-        thread.switch()
-        frame = gdb.selected_frame()
-
         selected = " ►" if thread is original_thread else "  "
-
-        symbol = pwndbg.gdblib.symbol.get(frame.pc())
-        status = get_thread_status(thread)
-
         name = thread.name if thread.name is not None else ""
         padding = max_name_length - len(name)
+        status = get_thread_status(thread)
 
         line = (
             f" {selected} {thread.global_num}\t"
             f'"{pwndbg.color.cyan(name)}" '
             f'{" " * padding}'
-            f"{status}: {M.get(frame.pc())}"
+            f"{status}: "
         )
-        if symbol:
-            line += f" <{pwndbg.color.bold(pwndbg.color.green(symbol))}> "
+
+        if thread.is_stopped():
+            thread.switch()
+            frame = gdb.selected_frame()
+
+            pc = M.get(frame.pc())
+            symbol = pwndbg.gdblib.symbol.get(frame.pc())
+
+            line += f"{pc}"
+            if symbol:
+                line += f" <{pwndbg.color.bold(pwndbg.color.green(symbol))}> "
+
         out.append(line)
 
     out.insert(0, pwndbg.ui.banner("threads", target=target, width=width))


### PR DESCRIPTION
This PR makes the following changes to the "threads" section of the `context` command's output:
* Add total thread count to banner
* Limit number of threads displayed
* Add `context-max-threads` config variable
* No longer attempt to get frames from running threads (causes an error)

Old behaviour:
![ctx-threads-old](https://github.com/pwndbg/pwndbg/assets/16000770/e8882262-14c4-4750-834c-61b963ffaf2e)

New behaviour:
![ctx-threads-new](https://github.com/pwndbg/pwndbg/assets/16000770/205128e8-965a-4672-97b5-30e7df5dd201)
![ctx-threads-new-running](https://github.com/pwndbg/pwndbg/assets/16000770/2d1cadc1-ef4e-407a-adc6-a8a595224730)

Resolves #1904 