### PR TITLE
fix: Issue 1874 - Colorize checksec output

### DIFF
--- a/pwndbg/commands/checksec.py
+++ b/pwndbg/commands/checksec.py
@@ -19,7 +19,7 @@ def color_line(line: str) -> str:
 
 
 def color_lines(output: str) -> str:
-    return NEW_LINE.join(list(map(color_line, output.split(NEW_LINE))))
+    return "\n".join(map(color_line, output.split(NEW_LINE)))
 
 
 @pwndbg.commands.ArgparsedCommand("Prints out the binary security settings using `checksec`.")

--- a/pwndbg/commands/checksec.py
+++ b/pwndbg/commands/checksec.py
@@ -9,7 +9,7 @@ import pwndbg.wrappers.checksec
 
 
 def color_line(line: str) -> str:
-    return (
+    return pwndbg.color.normal(
         line.replace("*", pwndbg.color.green("*"))
         .replace(":", f":{pwndbg.color.GREEN}")
         .replace("No", f"{pwndbg.color.RED}No")

--- a/pwndbg/commands/checksec.py
+++ b/pwndbg/commands/checksec.py
@@ -2,39 +2,29 @@ from __future__ import annotations
 
 from typing import cast
 
+import pwndbg.color
 import pwndbg.commands
 import pwndbg.gdblib.file
 import pwndbg.wrappers.checksec
 
-NEW_LINE = "\n"
-
-
-class colors:
-    RED = "\033[31m"
-    GREEN = "\033[32m"
-    BLUE = "\033[34m"
-    RESET = "\033[0m"
-
 
 def color_line(line: str) -> str:
     return (
-        line.replace("*", colors.BLUE + "*" + colors.RESET)
-        .replace(":", ":" + colors.GREEN)
-        .replace("No", colors.RED + "No")
-    ) + colors.RESET
+        line.replace("*", pwndbg.color.green("*"))
+        .replace(":", f":{pwndbg.color.GREEN}")
+        .replace("No", f"{pwndbg.color.RED}No")
+    )
 
 
-def color_lines(lines: list[str]) -> str:
-    return NEW_LINE.join(list(map(color_line, lines)))
+NEW_LINE = "\n"
+
+
+def color_lines(output: str) -> str:
+    return NEW_LINE.join(list(map(color_line, output.split(NEW_LINE))))
 
 
 @pwndbg.commands.ArgparsedCommand("Prints out the binary security settings using `checksec`.")
 @pwndbg.commands.OnlyWithFile
 def checksec() -> None:
-    print(
-        color_lines(
-            cast(
-                str, pwndbg.wrappers.checksec.get_raw_out(pwndbg.gdblib.file.get_proc_exe_file())
-            ).split(NEW_LINE)
-        )
-    )
+    output = cast(str, pwndbg.wrappers.checksec.get_raw_out(pwndbg.gdblib.file.get_proc_exe_file()))
+    print(color_lines(output))

--- a/pwndbg/commands/checksec.py
+++ b/pwndbg/commands/checksec.py
@@ -1,11 +1,31 @@
 from __future__ import annotations
+from typing import cast
 
 import pwndbg.commands
 import pwndbg.gdblib.file
 import pwndbg.wrappers.checksec
 
+NEW_LINE = '\n'
+
+class colors():
+    RED = '\033[31m'
+    GREEN = '\033[32m'
+    BLUE = '\033[34m'
+    RESET = '\033[0m'
+
+def color_line(line: str) -> str:
+    return (
+        line
+        .replace('*', colors.BLUE + '*' + colors.RESET)
+        .replace(':', ':' + colors.GREEN)
+        .replace('No', colors.RED + 'No')
+    ) + colors.RESET
+
+def color_lines(lines: list[str]) -> str:
+    return NEW_LINE.join(list(map(color_line, lines)))
+
 
 @pwndbg.commands.ArgparsedCommand("Prints out the binary security settings using `checksec`.")
 @pwndbg.commands.OnlyWithFile
 def checksec() -> None:
-    print(pwndbg.wrappers.checksec.get_raw_out(pwndbg.gdblib.file.get_proc_exe_file()))
+    print(color_lines(cast(str, pwndbg.wrappers.checksec.get_raw_out(pwndbg.gdblib.file.get_proc_exe_file())).split(NEW_LINE)))

--- a/pwndbg/commands/checksec.py
+++ b/pwndbg/commands/checksec.py
@@ -6,21 +6,23 @@ import pwndbg.commands
 import pwndbg.gdblib.file
 import pwndbg.wrappers.checksec
 
-NEW_LINE = '\n'
+NEW_LINE = "\n"
 
-class colors():
-    RED = '\033[31m'
-    GREEN = '\033[32m'
-    BLUE = '\033[34m'
-    RESET = '\033[0m'
+
+class colors:
+    RED = "\033[31m"
+    GREEN = "\033[32m"
+    BLUE = "\033[34m"
+    RESET = "\033[0m"
+
 
 def color_line(line: str) -> str:
     return (
-        line
-        .replace('*', colors.BLUE + '*' + colors.RESET)
-        .replace(':', ':' + colors.GREEN)
-        .replace('No', colors.RED + 'No')
+        line.replace("*", colors.BLUE + "*" + colors.RESET)
+        .replace(":", ":" + colors.GREEN)
+        .replace("No", colors.RED + "No")
     ) + colors.RESET
+
 
 def color_lines(lines: list[str]) -> str:
     return NEW_LINE.join(list(map(color_line, lines)))
@@ -29,4 +31,10 @@ def color_lines(lines: list[str]) -> str:
 @pwndbg.commands.ArgparsedCommand("Prints out the binary security settings using `checksec`.")
 @pwndbg.commands.OnlyWithFile
 def checksec() -> None:
-    print(color_lines(cast(str, pwndbg.wrappers.checksec.get_raw_out(pwndbg.gdblib.file.get_proc_exe_file())).split(NEW_LINE)))
+    print(
+        color_lines(
+            cast(
+                str, pwndbg.wrappers.checksec.get_raw_out(pwndbg.gdblib.file.get_proc_exe_file())
+            ).split(NEW_LINE)
+        )
+    )

--- a/pwndbg/commands/checksec.py
+++ b/pwndbg/commands/checksec.py
@@ -17,7 +17,7 @@ def color_line(line: str) -> str:
 
 
 def color_lines(output: str) -> str:
-    return "\n".join(map(color_line, output.split(NEW_LINE)))
+    return "\n".join(map(color_line, output.split("\n")))
 
 
 @pwndbg.commands.ArgparsedCommand("Prints out the binary security settings using `checksec`.")

--- a/pwndbg/commands/checksec.py
+++ b/pwndbg/commands/checksec.py
@@ -16,7 +16,6 @@ def color_line(line: str) -> str:
     )
 
 
-NEW_LINE = "\n"
 
 
 def color_lines(output: str) -> str:

--- a/pwndbg/commands/checksec.py
+++ b/pwndbg/commands/checksec.py
@@ -16,7 +16,6 @@ def color_line(line: str) -> str:
     )
 
 
-
 def color_lines(output: str) -> str:
     return "\n".join(map(color_line, output.split(NEW_LINE)))
 

--- a/pwndbg/commands/checksec.py
+++ b/pwndbg/commands/checksec.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from typing import cast
 
 import pwndbg.commands

--- a/pwndbg/commands/checksec.py
+++ b/pwndbg/commands/checksec.py
@@ -17,7 +17,6 @@ def color_line(line: str) -> str:
 
 
 
-
 def color_lines(output: str) -> str:
     return "\n".join(map(color_line, output.split(NEW_LINE)))
 


### PR DESCRIPTION
Hello there! I took a look at #1874 and I decided to start my first contribution to this cool project. My approach was to parse the result of `call_cmd` which the output of `checksec`. I parsed the output and added the color in a similar way to the response of `checksec`.

![image](https://github.com/pwndbg/pwndbg/assets/8370088/096b9eb9-2397-4d12-bced-d985ef467e2e)


*NOTE:* Maybe there is another approach that doesn't involve parsing the command output since that is a little bit flaky. I tried making a call to `os.system` but it didn't work.

Solves issue #1874 

---

As part of [Stack Builders Inc.](https://www.stackbuilders.com) Hacktoberfest 2023 event.