### PR TITLE
Telescope output - print offset to framepointer

### DIFF
--- a/pwndbg/commands/telescope.py
+++ b/pwndbg/commands/telescope.py
@@ -36,7 +36,9 @@ skip_repeating_values_minimum = pwndbg.gdblib.config.add_param(
     "minimum amount of repeated values before skipping lines",
 )
 print_framepointer_offset = pwndbg.gdblib.config.add_param(
-    "telescope-framepointer-offset", True, "print offset to framepointer for each address, if sufficiently small"
+    "telescope-framepointer-offset",
+    True,
+    "print offset to framepointer for each address, if sufficiently small",
 )
 
 offset_separator = theme.add_param(
@@ -274,9 +276,6 @@ def stack(count, offset, frame) -> None:
     telescope(address=pwndbg.gdblib.regs.sp + offset * ptrsize, count=count, frame=frame)
 
 
-
-
-
 parser = argparse.ArgumentParser(
     description="Dereferences on stack data, printing the entire stack frame with specified count and offset ."
 )
@@ -296,7 +295,6 @@ def stackf(count, offset) -> None:
     ptrsize = pwndbg.gdblib.typeinfo.ptrsize
     telescope.repeat = stack.repeat
     telescope(address=pwndbg.gdblib.regs.sp + offset * ptrsize, count=count, frame=True)
-
 
 
 telescope.last_address = 0

--- a/pwndbg/commands/telescope.py
+++ b/pwndbg/commands/telescope.py
@@ -194,6 +194,7 @@ def telescope(address=None, count=telescope_lines, to_string=False, reverse=Fals
     def regs_or_frame_offset(addr):
         offset = addr - bp
 
+        # len(regs[addr]) == 1 if no registers pointer to address
         if not print_framepointer_offset or len(regs[addr]) > 1 or not -0xFFF <= offset <= 0xFFF:
             return " " + T.register(regs[addr].ljust(longest_regs))
         else:

--- a/pwndbg/commands/telescope.py
+++ b/pwndbg/commands/telescope.py
@@ -229,6 +229,14 @@ def telescope(address=None, count=telescope_lines, to_string=False, reverse=Fals
 parser = argparse.ArgumentParser(
     description="Dereferences on stack data with specified count and offset."
 )
+parser.add_argument(
+    "-f",
+    "--frame",
+    dest="frame",
+    action="store_true",
+    default=False,
+    help="Show the stack frame, from rsp to rbp",
+)
 parser.add_argument("count", nargs="?", default=8, type=int, help="number of element to dump")
 parser.add_argument(
     "offset",
@@ -241,10 +249,35 @@ parser.add_argument(
 
 @pwndbg.commands.ArgparsedCommand(parser, category=CommandCategory.STACK)
 @pwndbg.commands.OnlyWhenRunning
-def stack(count, offset) -> None:
+def stack(count, offset, frame) -> None:
     ptrsize = pwndbg.gdblib.typeinfo.ptrsize
     telescope.repeat = stack.repeat
-    telescope(address=pwndbg.gdblib.regs.sp + offset * ptrsize, count=count)
+    telescope(address=pwndbg.gdblib.regs.sp + offset * ptrsize, count=count, frame=frame)
+
+
+
+
+
+parser = argparse.ArgumentParser(
+    description="Dereferences on stack data, printing the entire stack frame with specified count and offset ."
+)
+parser.add_argument("count", nargs="?", default=8, type=int, help="number of element to dump")
+parser.add_argument(
+    "offset",
+    nargs="?",
+    default=0,
+    type=int,
+    help="Element offset from $sp (support negative offset)",
+)
+
+
+@pwndbg.commands.ArgparsedCommand(parser, category=CommandCategory.STACK)
+@pwndbg.commands.OnlyWhenRunning
+def stackf(count, offset) -> None:
+    ptrsize = pwndbg.gdblib.typeinfo.ptrsize
+    telescope.repeat = stack.repeat
+    telescope(address=pwndbg.gdblib.regs.sp + offset * ptrsize, count=count, frame=True)
+
 
 
 telescope.last_address = 0

--- a/pwndbg/commands/telescope.py
+++ b/pwndbg/commands/telescope.py
@@ -192,7 +192,8 @@ def telescope(address=None, count=telescope_lines, to_string=False, reverse=Fals
         collapse_buffer.clear()
 
     bp = None
-    if print_framepointer_offset and pwndbg.gdblib.regs.frame is not None:
+    if print_framepointer_offset:
+        # If pwndbg.gdblib.regs.frame is None, indexing regs will return None
         bp = pwndbg.gdblib.regs[pwndbg.gdblib.regs.frame]
 
     for i, addr in enumerate(range(start, stop, step)):


### PR DESCRIPTION
This pull request contains changes to the "telescope" function when used to print stack addresses. It adds the ability to print the offset to the frame pointer in the output. 

Telescope will print the offset in the same place that the register strings occupy, but only at addresses where a register currently isn't printed. See images. 

This adds some great context when debugging, letting you know how large a stack frame is and where values are, and gives the ability to pinpoint variables in the case they are referenced via an offset to the base pointer.

![frameoffset](https://github.com/pwndbg/pwndbg/assets/55004530/a811d0d4-2f0f-4666-bb8f-709425b4f6f9)

![frameoffset2](https://github.com/pwndbg/pwndbg/assets/55004530/193a72c0-6dd6-459d-83ff-24ed4b09cd26)

![frameoffset3](https://github.com/pwndbg/pwndbg/assets/55004530/967803db-28d9-41c3-a334-f7a83f090e3b)


I made a setting to enable/disable this, `telescope-frame-offset`, but that's not necessarily needed. Additionally, it will only print if the  distance between a given address and the framepointer is less than 0xFFF, to prevent it from printing extremely large values where the distance between the frame pointer and base pointer is not relevent.

Additionally, the `stack` function, which calls `telescope` , was missing the `-f` flag to print the entire stack frame. It's now added and forwards the argument to the call to `telescope`

Also added is the `stackf` function for convenience, which is equivalent to `stack -f`. 