### PR TITLE
Distance command can now print the offset to the addresses's page base

### DIFF
--- a/pwndbg/commands/distance.py
+++ b/pwndbg/commands/distance.py
@@ -22,11 +22,9 @@ def distance(a, b) -> None:
         total_pages = pwndbg.gdblib.vmmap.get()
 
         if not total_pages:
-            print(
-                "There are no memory pages in `vmmap`"
-            )
+            print("There are no memory pages in `vmmap`")
             return
-        
+
         # Find the page the address belongs to
         for page in total_pages:
             if a >= page.vaddr and a < page.end:

--- a/pwndbg/commands/distance.py
+++ b/pwndbg/commands/distance.py
@@ -2,24 +2,49 @@ from __future__ import annotations
 
 import argparse
 
+import pwndbg.color.memory as M
 import pwndbg.commands
 import pwndbg.gdblib.arch
 from pwndbg.commands import CommandCategory
 
-parser = argparse.ArgumentParser(description="Print the distance between the two arguments.")
+parser = argparse.ArgumentParser(
+    description="Print the distance between the two arguments, or print the offset to the address's page base."
+)
 parser.add_argument("a", type=int, help="The first address.")
-parser.add_argument("b", type=int, help="The second address.")
+parser.add_argument("b", nargs="?", default=None, type=int, help="The second address.")
 
 
 @pwndbg.commands.ArgparsedCommand(parser, category=CommandCategory.MEMORY)
 def distance(a, b) -> None:
     """Print the distance between the two arguments"""
-    a = int(a) & pwndbg.gdblib.arch.ptrmask
-    b = int(b) & pwndbg.gdblib.arch.ptrmask
 
-    distance = b - a
+    if b is None:
+        total_pages = pwndbg.gdblib.vmmap.get()
 
-    print(
-        "%#x->%#x is %#x bytes (%#x words)"
-        % (a, b, distance, distance // pwndbg.gdblib.arch.ptrsize)
-    )
+        # Find the page the address belongs to
+        for page in total_pages:
+            if a >= page.vaddr and a < page.end:
+                # a is a gdb.Value, explicitely convert to it
+                distance = int(a) - page.vaddr
+
+                display_text = "%#x->%#x is %#x bytes (%#x words)" % (
+                    page.vaddr,
+                    a,
+                    distance,
+                    distance // pwndbg.gdblib.arch.ptrsize,
+                )
+
+                print(M.get(page.vaddr, text=display_text))
+                return
+
+        print("%#x does not belong to a mapped page in memory" % (a))
+    else:
+        a = int(a) & pwndbg.gdblib.arch.ptrmask
+        b = int(b) & pwndbg.gdblib.arch.ptrmask
+
+        distance = b - a
+
+        print(
+            "%#x->%#x is %#x bytes (%#x words)"
+            % (a, b, distance, distance // pwndbg.gdblib.arch.ptrsize)
+        )

--- a/pwndbg/commands/distance.py
+++ b/pwndbg/commands/distance.py
@@ -21,10 +21,16 @@ def distance(a, b) -> None:
     if b is None:
         total_pages = pwndbg.gdblib.vmmap.get()
 
+        if not total_pages:
+            print(
+                "There are no memory pages in `vmmap`"
+            )
+            return
+        
         # Find the page the address belongs to
         for page in total_pages:
             if a >= page.vaddr and a < page.end:
-                # a is a gdb.Value, explicitely convert to it
+                # a is a gdb.Value, explicitely convert to int
                 distance = int(a) - page.vaddr
 
                 display_text = "%#x->%#x is %#x bytes (%#x words)" % (

--- a/pwndbg/commands/distance.py
+++ b/pwndbg/commands/distance.py
@@ -19,29 +19,22 @@ def distance(a, b) -> None:
     """Print the distance between the two arguments"""
 
     if b is None:
-        total_pages = pwndbg.gdblib.vmmap.get()
+        page = pwndbg.gdblib.vmmap.find(a)
 
-        if not total_pages:
-            print("There are no memory pages in `vmmap`")
-            return
+        if not page:
+            print("%#x does not belong to a mapped page in memory" % (a))
+        else:
+            # a is a gdb.Value, explicitely convert to int
+            distance = int(a) - page.vaddr
 
-        # Find the page the address belongs to
-        for page in total_pages:
-            if a >= page.vaddr and a < page.end:
-                # a is a gdb.Value, explicitely convert to int
-                distance = int(a) - page.vaddr
+            display_text = "%#x->%#x is %#x bytes (%#x words)" % (
+                page.vaddr,
+                a,
+                distance,
+                distance // pwndbg.gdblib.arch.ptrsize,
+            )
 
-                display_text = "%#x->%#x is %#x bytes (%#x words)" % (
-                    page.vaddr,
-                    a,
-                    distance,
-                    distance // pwndbg.gdblib.arch.ptrsize,
-                )
-
-                print(M.get(page.vaddr, text=display_text))
-                return
-
-        print("%#x does not belong to a mapped page in memory" % (a))
+            print(M.get(page.vaddr, text=display_text))
     else:
         a = int(a) & pwndbg.gdblib.arch.ptrmask
         b = int(b) & pwndbg.gdblib.arch.ptrmask


### PR DESCRIPTION
This makes a change to the `distance` command that I find myself often needing. When used with a single argument, `distance` will now print the offset of the address from the base address of the page it belongs to.

![distance](https://github.com/pwndbg/pwndbg/assets/55004530/ab3a6524-0be2-4ee1-b70e-88e7db78ff63)
