### PR TITLE
Sigreturn command to print Sigreturn frame in x86_64

### DIFF
--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -658,6 +658,7 @@ def load_commands() -> None:
     import pwndbg.commands.search
     import pwndbg.commands.segments
     import pwndbg.commands.shell
+    import pwndbg.commands.sigreturn
     import pwndbg.commands.slab
     import pwndbg.commands.spray
     import pwndbg.commands.stack

--- a/pwndbg/commands/sigreturn.py
+++ b/pwndbg/commands/sigreturn.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import argparse
+
+import pwndbg.color.context as C
+import pwndbg.color.message
+import pwndbg.commands
+import pwndbg.gdblib.arch
+import pwndbg.gdblib.memory
+import pwndbg.gdblib.regs
+
+parser = argparse.ArgumentParser(description="Display the SigreturnFrame at the specific address")
+
+parser.add_argument(
+    "address", nargs="?", default=None, type=int, help="The address to read the frame"
+)
+
+parser.add_argument(
+    "-a",
+    "--all",
+    dest="display_all",
+    action="store_true",
+    default=False,
+    help="Show all values in the frame in addition to registers",
+)
+
+
+@pwndbg.commands.ArgparsedCommand(parser)
+@pwndbg.commands.OnlyWhenRunning
+@pwndbg.commands.OnlyWithArch(["x86-64"])
+def sigreturn(address: int = None, display_all=False):
+    address = pwndbg.gdblib.regs.sp if address is None else address
+
+    arch_name = pwndbg.gdblib.arch.name
+    if arch_name == "x86-64":
+        sigreturn_x86_64(address, display_all)
+    else:
+        print(
+            pwndbg.color.message.error(f"sigreturn does not support the {arch_name} architecture")
+        )
+
+
+SIGRETURN_FRAME_SIZE_x86_64 = 248
+
+# Registers layout from pwntools: https://github.com/Gallopsled/pwntools/blob/e4d3c82501c03de44458ae498a830fe66594f66d/pwnlib/rop/srop.py#L256
+SIGRETURN_FRAME_LAYOUT_x86_64 = {
+    "uc_flags": 0,
+    "&uc": 8,
+    "uc_stack.ss_sp": 16,
+    "uc_stack.ss_flags": 24,
+    "uc_stack.ss_size": 32,
+    "r8": 40,
+    "r9": 48,
+    "r10": 56,
+    "r11": 64,
+    "r12": 72,
+    "r13": 80,
+    "r14": 88,
+    "r15": 96,
+    "rdi": 104,
+    "rsi": 112,
+    "rbp": 120,
+    "rbx": 128,
+    "rdx": 136,
+    "rax": 144,
+    "rcx": 152,
+    "rsp": 160,
+    "rip": 168,
+    "eflags": 176,
+    "csgsfs": 184,
+    "err": 192,
+    "trapno": 200,
+    "oldmask": 208,
+    "cr2": 216,
+    "&fpstate": 224,
+    "__reserved": 232,
+    "sigmask": 240,
+}
+
+SIGRETURN_REGISTERS_x86_64 = [
+    "r8",
+    "r9",
+    "r10",
+    "r11",
+    "r12",
+    "r13",
+    "r14",
+    "r15",
+    "rdi",
+    "rsi",
+    "rbp",
+    "rbx",
+    "rdx",
+    "rax",
+    "rcx",
+    "rsp",
+    "rip",
+]
+
+
+def sigreturn_x86_64(address: int, display_all: bool):
+    # TODO: make print output a lot nicer (similar to regs, with all the colors)
+    # TODO: do a validation check to ensure the frame is valid
+    # https://www.cs.vu.nl/~herbertb/papers/srop_sp14.pdf
+    # page 8 - code segment register should be 0x33
+    #  fpstate points to the saved floating point state, or NULL
+
+    # x86_64
+    ptr_size = 8
+
+    # Display registers
+    mem = pwndbg.gdblib.memory.read(address, SIGRETURN_FRAME_SIZE_x86_64)
+
+    for reg in SIGRETURN_REGISTERS_x86_64:
+        offset = SIGRETURN_FRAME_LAYOUT_x86_64[reg]
+        regname = C.register(reg.ljust(4).upper())
+
+        value = pwndbg.gdblib.arch.unpack(mem[offset : offset + ptr_size])
+        desc = pwndbg.chain.format(value)
+
+        print(f"{regname} {desc}")
+
+    # Display eflags
+    regname = C.register("eflags".ljust(4).upper())
+    eflags_offset = SIGRETURN_FRAME_LAYOUT_x86_64["eflags"]
+    value = pwndbg.gdblib.arch.unpack(mem[eflags_offset : eflags_offset + ptr_size])
+    reg_flags = pwndbg.gdblib.regs.flags["eflags"]
+
+    desc = C.format_flags(value, reg_flags)
+
+    print(f"{regname} {desc}")

--- a/pwndbg/commands/sigreturn.py
+++ b/pwndbg/commands/sigreturn.py
@@ -42,7 +42,8 @@ def sigreturn(address: int = None, display_all=False):
 
 SIGRETURN_FRAME_SIZE_x86_64 = 256
 
-# Grab frame values from pwntools, offsets and names are from "CONFIG_X86_64 struct rt_sigframe, Linux Kernel /arch/x86/include/asm/sigframe.h
+# Grab frame values from pwntools. Offsets are defined as the offset to stack pointer when syscall instruction is called
+# Offsets and names are from "CONFIG_X86_64 struct rt_sigframe, Linux Kernel /arch/x86/include/asm/sigframe.h
 SIGRETURN_FRAME_LAYOUT_x86_64 = sorted(
     [(-8, "&pretcode")] + list(pwnlib.rop.srop.SigreturnFrame(arch="amd64").registers.items())
 )

--- a/pwndbg/commands/sigreturn.py
+++ b/pwndbg/commands/sigreturn.py
@@ -15,7 +15,7 @@ from pwndbg.lib.regs import amd64 as amd64_regset
 parser = argparse.ArgumentParser(description="Display the SigreturnFrame at the specific address")
 
 parser.add_argument(
-    "address", nargs="?", default=None, type=int, help="The address to read the frame"
+    "address", nargs="?", default=None, type=int, help="The address to read the frame from"
 )
 
 parser.add_argument(
@@ -24,7 +24,7 @@ parser.add_argument(
     dest="display_all",
     action="store_true",
     default=False,
-    help="Show all values in the frame in addition to registers",
+    help="Show all values in the frame in addition to common registers",
 )
 
 
@@ -93,10 +93,10 @@ SIGRETURN_REGISTERS_x86_64 = set(
 def sigreturn_x86_64(address: int, display_all: bool):
     ptr_size = 8  # x86_64
 
-    # Offset by -8, where the frame begins (in relation to stack pointer)
+    # Offset by -8, where the frame begins (in relation to stack pointer when `syscall` is executed)
+    # The pointer before stack pointer is the address of the signal trampoline
     mem = pwndbg.gdblib.memory.read(address - 8, SIGRETURN_FRAME_SIZE_x86_64)
 
-    # The pointer before stack pointer is address of signal trampoline
     # Display registers
     for reg, offset in SIGRETURN_FRAME_LAYOUT_x86_64.items():
         if reg in SIGRETURN_REGISTERS_x86_64:

--- a/pwndbg/commands/sigreturn.py
+++ b/pwndbg/commands/sigreturn.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import argparse
-import collections
+
+import pwnlib.rop.srop
 
 import pwndbg.color.context as C
 import pwndbg.color.memory as M
@@ -37,84 +38,50 @@ def sigreturn(address: int = None, display_all=False):
     arch_name = pwndbg.gdblib.arch.name
     if arch_name == "x86-64":
         sigreturn_x86_64(address, display_all)
-    else:
-        print(
-            pwndbg.color.message.error(f"sigreturn does not support the {arch_name} architecture")
-        )
 
 
 SIGRETURN_FRAME_SIZE_x86_64 = 256
 
-# Original registers layout from pwntools, modified below : https://github.com/Gallopsled/pwntools/blob/e4d3c82501c03de44458ae498a830fe66594f66d/pwnlib/rop/srop.py#L256
-# Offsets and names from "CONFIG_X86_64 struct rt_sigframe, Linux Kernel /arch/x86/include/asm/sigframe.h
-SIGRETURN_FRAME_LAYOUT_x86_64 = collections.OrderedDict(
-    [
-        ("&pretcode", 0),
-        ("uc_flags", 8),
-        ("&uc", 16),
-        ("uc_stack.ss_sp", 24),
-        ("uc_stack.ss_flags", 32),
-        ("uc_stack.ss_size", 40),
-        ("r8", 48),
-        ("r9", 56),
-        ("r10", 64),
-        ("r11", 72),
-        ("r12", 80),
-        ("r13", 88),
-        ("r14", 96),
-        ("r15", 104),
-        ("rdi", 112),
-        ("rsi", 120),
-        ("rbp", 128),
-        ("rbx", 136),
-        ("rdx", 144),
-        ("rax", 152),
-        ("rcx", 160),
-        ("rsp", 168),
-        ("rip", 176),
-        ("eflags", 184),
-        ("csgsfs", 192),
-        ("err", 200),
-        ("trapno", 208),
-        ("oldmask", 216),
-        ("cr2", 224),
-        ("&fpstate", 232),
-        ("__reserved", 240),
-        ("sigmask", 248),
-    ]
+# Grab frame values from pwntools, offsets and names are from "CONFIG_X86_64 struct rt_sigframe, Linux Kernel /arch/x86/include/asm/sigframe.h
+SIGRETURN_FRAME_LAYOUT_x86_64 = sorted(
+    [(-8, "&pretcode")] + list(pwnlib.rop.srop.SigreturnFrame(arch="amd64").registers.items())
 )
 
 # Core registers
-SIGRETURN_REGISTERS_x86_64 = set(
-    [*amd64_regset.gpr, amd64_regset.frame, amd64_regset.stack, amd64_regset.pc]
-)
+SIGRETURN_REGISTERS_x86_64 = {
+    *amd64_regset.gpr,
+    amd64_regset.frame,
+    amd64_regset.stack,
+    amd64_regset.pc,
+}
 
 
 def sigreturn_x86_64(address: int, display_all: bool):
-    ptr_size = 8  # x86_64
+    ptr_size = pwndbg.gdblib.arch.ptrsize
 
-    # Offset by -8, where the frame begins (in relation to stack pointer when `syscall` is executed)
-    # The pointer before stack pointer is the address of the signal trampoline
-    mem = pwndbg.gdblib.memory.read(address - 8, SIGRETURN_FRAME_SIZE_x86_64)
+    # Offset to the stack pointer where the frame values really begins. Start reading memory there.
+    # Can be negative, 0, or positive
+    frame_start_offset = SIGRETURN_FRAME_LAYOUT_x86_64[0][0]
 
-    # Display registers
-    for reg, offset in SIGRETURN_FRAME_LAYOUT_x86_64.items():
+    mem = pwndbg.gdblib.memory.read(address + frame_start_offset, SIGRETURN_FRAME_SIZE_x86_64)
+
+    for offset, reg in SIGRETURN_FRAME_LAYOUT_x86_64:
+        # Subtract the offset of start of frame, to get the correct offset into "mem"
+        offset -= frame_start_offset
+
+        regname = C.register(reg.ljust(4).upper())
+        value = pwndbg.gdblib.arch.unpack(mem[offset : offset + ptr_size])
+
         if reg in SIGRETURN_REGISTERS_x86_64:
-            regname = C.register(reg.ljust(4).upper())
-            value = pwndbg.gdblib.arch.unpack(mem[offset : offset + ptr_size])
             desc = pwndbg.chain.format(value)
 
             print(f"{regname} {desc}")
 
         elif reg == "eflags":
-            regname = C.register("eflags".ljust(4).upper())
-            value = pwndbg.gdblib.arch.unpack(mem[offset : offset + ptr_size])
             reg_flags = pwndbg.gdblib.regs.flags["eflags"]
             desc = C.format_flags(value, reg_flags)
 
             print(f"{regname} {desc}")
 
         elif display_all:
-            desc = pwndbg.gdblib.arch.unpack(mem[offset : offset + ptr_size])
-
-            print(f"{reg} {M.get(desc)}")
+            print(f"{reg} {M.get(value)}")

--- a/pwndbg/commands/sigreturn.py
+++ b/pwndbg/commands/sigreturn.py
@@ -20,10 +20,10 @@ from pwndbg.lib.regs import i386
 # Grab frame values from pwntools. Offsets are defined as the offset to stack pointer when syscall instruction is called
 # Offsets and names are from Linux kernel source. For example x86_64 is defined in CONFIG_X86_64 struct rt_sigframe (Linux Kernel /arch/x86/include/asm/sigframe.h)
 SIGRETURN_FRAME_LAYOUTS: dict[str, list[Tuple[int, str]]] = {
-    "x86-64": [(-8, "&pretcode")] + list(pwnlib.rop.srop.registers["amd64"].items()),
-    "i386": list(pwnlib.rop.srop.registers["i386"].items()),
-    "aarch64": list(pwnlib.rop.srop.registers["aarch64"].items()),
-    "arm": list(pwnlib.rop.srop.registers["arm"].items()),
+    "x86-64": sorted([(-8, "&pretcode")] + list(pwnlib.rop.srop.registers["amd64"].items())),
+    "i386": sorted(list(pwnlib.rop.srop.registers["i386"].items())),
+    "aarch64": sorted(list(pwnlib.rop.srop.registers["aarch64"].items())),
+    "arm": sorted(list(pwnlib.rop.srop.registers["arm"].items())),
 }
 
 # Always print these registers (as well as flag register, eflags / cpsr)

--- a/pwndbg/commands/sigreturn.py
+++ b/pwndbg/commands/sigreturn.py
@@ -66,11 +66,9 @@ SIGRETURN_REGISTERS_x86_64 = {
 }
 
 
-
-
 def print_value(string: str, address: int, print_address):
     addr = ""
-    if(print_address):
+    if print_address:
         addr = f"{M.get(address)}: "
     print(f"{addr}{string}")
 
@@ -94,14 +92,13 @@ def sigreturn_x86_64(address: int, display_all: bool, print_address: bool):
         if reg in SIGRETURN_REGISTERS_x86_64:
             desc = pwndbg.chain.format(value)
 
-            print_value(f"{regname} {desc}", address+stack_offset, print_address)
+            print_value(f"{regname} {desc}", address + stack_offset, print_address)
 
         elif reg == "eflags":
             reg_flags = pwndbg.gdblib.regs.flags["eflags"]
             desc = C.format_flags(value, reg_flags)
 
-            print_value(f"{regname} {desc}", address+stack_offset, print_address)
+            print_value(f"{regname} {desc}", address + stack_offset, print_address)
 
         elif display_all:
-
-            print_value(f"{reg} {M.get(value)}", address+stack_offset, print_address)
+            print_value(f"{reg} {M.get(value)}", address + stack_offset, print_address)

--- a/pwndbg/commands/sigreturn.py
+++ b/pwndbg/commands/sigreturn.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+from typing import Tuple
 
 import pwnlib.rop.srop
 
@@ -11,7 +12,23 @@ import pwndbg.commands
 import pwndbg.gdblib.arch
 import pwndbg.gdblib.memory
 import pwndbg.gdblib.regs
-from pwndbg.lib.regs import amd64 as amd64_regset
+from pwndbg.lib.regs import amd64, arm, aarch64, i386
+
+
+# Grab frame values from pwntools. Offsets are defined as the offset to stack pointer when syscall instruction is called
+# Offsets and names are from Linux kernel source. x86_64, for example, from CONFIG_X86_64 struct rt_sigframe (Linux Kernel /arch/x86/include/asm/sigframe.h)
+SIGRETURN_FRAME_LAYOUTS: dict[str,list[Tuple[int, str]]] = {
+    "x86-64":[(-8, "&pretcode")] + list(pwnlib.rop.srop.registers["amd64"].items()),
+    "i386":list(pwnlib.rop.srop.registers["i386"].items()),
+    "aarch64":list(pwnlib.rop.srop.registers["aarch64"].items()),
+}
+
+SIGRETURN_CORE_REGISTER: dict[str, set[str]] = {
+    "x86-64":{ *amd64.gpr, amd64.frame, amd64.stack, amd64.pc },
+    "i386": { *i386.gpr,i386.frame, i386.stack, i386.pc },
+    "aarch64": { *aarch64.gpr, "sp", "pc"},
+}
+
 
 parser = argparse.ArgumentParser(description="Display the SigreturnFrame at the specific address")
 
@@ -40,56 +57,31 @@ parser.add_argument(
 
 @pwndbg.commands.ArgparsedCommand(parser)
 @pwndbg.commands.OnlyWhenRunning
-@pwndbg.commands.OnlyWithArch(["x86-64"])
+@pwndbg.commands.OnlyWithArch(["x86-64", "i386", "aarch64"])
 def sigreturn(address: int = None, display_all=False, print_address=False):
     address = pwndbg.gdblib.regs.sp if address is None else address
 
-    arch_name = pwndbg.gdblib.arch.name
-    if arch_name == "x86-64":
-        sigreturn_x86_64(address, display_all, print_address)
-
-
-SIGRETURN_FRAME_SIZE_x86_64 = 256
-
-# Grab frame values from pwntools. Offsets are defined as the offset to stack pointer when syscall instruction is called
-# Offsets and names are from "CONFIG_X86_64 struct rt_sigframe, Linux Kernel /arch/x86/include/asm/sigframe.h
-SIGRETURN_FRAME_LAYOUT_x86_64 = sorted(
-    [(-8, "&pretcode")] + list(pwnlib.rop.srop.SigreturnFrame(arch="amd64").registers.items())
-)
-
-# Core registers
-SIGRETURN_REGISTERS_x86_64 = {
-    *amd64_regset.gpr,
-    amd64_regset.frame,
-    amd64_regset.stack,
-    amd64_regset.pc,
-}
-
-
-def print_value(string: str, address: int, print_address):
-    addr = ""
-    if print_address:
-        addr = f"{M.get(address)}: "
-    print(f"{addr}{string}")
-
-
-def sigreturn_x86_64(address: int, display_all: bool, print_address: bool):
     ptr_size = pwndbg.gdblib.arch.ptrsize
+
+    frame_layout = SIGRETURN_FRAME_LAYOUTS[pwndbg.gdblib.arch.name]
+    core_registers = SIGRETURN_CORE_REGISTER[pwndbg.gdblib.arch.name]
 
     # Offset to the stack pointer where the frame values really begins. Start reading memory there.
     # Can be negative, 0, or positive
-    frame_start_offset = SIGRETURN_FRAME_LAYOUT_x86_64[0][0]
+    frame_start_offset = frame_layout[0][0]
 
-    mem = pwndbg.gdblib.memory.read(address + frame_start_offset, SIGRETURN_FRAME_SIZE_x86_64)
+    read_size = frame_layout[-1][0] - frame_start_offset + ptr_size
 
-    for stack_offset, reg in SIGRETURN_FRAME_LAYOUT_x86_64:
+    mem = pwndbg.gdblib.memory.read(address + frame_start_offset, read_size)
+
+    for stack_offset, reg in frame_layout:
         # Subtract the offset of start of frame, to get the correct offset into "mem"
         mem_offset = stack_offset - frame_start_offset
 
         regname = C.register(reg.ljust(4).upper())
         value = pwndbg.gdblib.arch.unpack(mem[mem_offset : mem_offset + ptr_size])
 
-        if reg in SIGRETURN_REGISTERS_x86_64:
+        if reg in core_registers:
             desc = pwndbg.chain.format(value)
 
             print_value(f"{regname} {desc}", address + stack_offset, print_address)
@@ -102,3 +94,10 @@ def sigreturn_x86_64(address: int, display_all: bool, print_address: bool):
 
         elif display_all:
             print_value(f"{reg} {M.get(value)}", address + stack_offset, print_address)
+
+
+def print_value(string: str, address: int, print_address):
+    addr = ""
+    if print_address:
+        addr = f"{M.get(address)}: "
+    print(f"{addr}{string}")

--- a/pwndbg/commands/sigreturn.py
+++ b/pwndbg/commands/sigreturn.py
@@ -16,7 +16,7 @@ from pwndbg.lib.regs import amd64, arm, aarch64, i386
 
 
 # Grab frame values from pwntools. Offsets are defined as the offset to stack pointer when syscall instruction is called
-# Offsets and names are from Linux kernel source. x86_64, for example, from CONFIG_X86_64 struct rt_sigframe (Linux Kernel /arch/x86/include/asm/sigframe.h)
+# Offsets and names are from Linux kernel source. For example x86_64 is defined in CONFIG_X86_64 struct rt_sigframe (Linux Kernel /arch/x86/include/asm/sigframe.h)
 SIGRETURN_FRAME_LAYOUTS: dict[str,list[Tuple[int, str]]] = {
     "x86-64":[(-8, "&pretcode")] + list(pwnlib.rop.srop.registers["amd64"].items()),
     "i386":list(pwnlib.rop.srop.registers["i386"].items()),

--- a/pwndbg/commands/sigreturn.py
+++ b/pwndbg/commands/sigreturn.py
@@ -12,24 +12,26 @@ import pwndbg.commands
 import pwndbg.gdblib.arch
 import pwndbg.gdblib.memory
 import pwndbg.gdblib.regs
-from pwndbg.lib.regs import amd64, arm, aarch64, i386
-
+from pwndbg.lib.regs import aarch64
+from pwndbg.lib.regs import amd64
+from pwndbg.lib.regs import arm
+from pwndbg.lib.regs import i386
 
 # Grab frame values from pwntools. Offsets are defined as the offset to stack pointer when syscall instruction is called
 # Offsets and names are from Linux kernel source. For example x86_64 is defined in CONFIG_X86_64 struct rt_sigframe (Linux Kernel /arch/x86/include/asm/sigframe.h)
-SIGRETURN_FRAME_LAYOUTS: dict[str,list[Tuple[int, str]]] = {
-    "x86-64":[(-8, "&pretcode")] + list(pwnlib.rop.srop.registers["amd64"].items()),
-    "i386":list(pwnlib.rop.srop.registers["i386"].items()),
-    "aarch64":list(pwnlib.rop.srop.registers["aarch64"].items()),
-    "arm":list(pwnlib.rop.srop.registers["arm"].items()),
+SIGRETURN_FRAME_LAYOUTS: dict[str, list[Tuple[int, str]]] = {
+    "x86-64": [(-8, "&pretcode")] + list(pwnlib.rop.srop.registers["amd64"].items()),
+    "i386": list(pwnlib.rop.srop.registers["i386"].items()),
+    "aarch64": list(pwnlib.rop.srop.registers["aarch64"].items()),
+    "arm": list(pwnlib.rop.srop.registers["arm"].items()),
 }
 
 # Always print these registers (as well as flag register, eflags / cpsr)
 SIGRETURN_CORE_REGISTER: dict[str, set[str]] = {
-    "x86-64":{ *amd64.gpr, amd64.frame, amd64.stack, amd64.pc },
-    "i386": { *i386.gpr,i386.frame, i386.stack, i386.pc },
-    "aarch64": { *aarch64.gpr, "sp", "pc"},
-    "arm": { *arm.gpr, "fp" "ip", "sp", "lr", "pc" },
+    "x86-64": {*amd64.gpr, amd64.frame, amd64.stack, amd64.pc},
+    "i386": {*i386.gpr, i386.frame, i386.stack, i386.pc},
+    "aarch64": {*aarch64.gpr, "sp", "pc"},
+    "arm": {*arm.gpr, "fp" "ip", "sp", "lr", "pc"},
 }
 
 
@@ -89,7 +91,7 @@ def sigreturn(address: int = None, display_all=False, print_address=False):
 
             print_value(f"{regname} {desc}", address + stack_offset, print_address)
 
-        elif reg in pwndbg.gdblib.regs.flags: # eflags or cpsr
+        elif reg in pwndbg.gdblib.regs.flags:  # eflags or cpsr
             reg_flags = pwndbg.gdblib.regs.flags[reg]
             desc = C.format_flags(value, reg_flags)
 


### PR DESCRIPTION
This pull requests continues the work started in #1557 to print a Sigreturn frame at the top of the stack (or at a specified address).

`sigreturn [address]` will print the values of the common registers in the x86_64 architecture (GPR's, as well as instruction, stack, and frame pointer). Adding the `-a` or `--all` flag will print all the other values of the [rt_sigframe](https://sbexr.rabexc.org/latest/sources/7e/135b6608584cf2.html#0003b00100040001) structure as well. 

![sigreturn](https://github.com/pwndbg/pwndbg/assets/55004530/2913baf3-6006-45ec-8ef1-eaff822ffec0)
![sigreturnall](https://github.com/pwndbg/pwndbg/assets/55004530/6a466187-e05f-4202-9c1a-bb52c7871522)
