### PR TITLE
fix: allow site installation without enforcing a venv

### DIFF
--- a/gdbinit.py
+++ b/gdbinit.py
@@ -20,7 +20,7 @@ if environ.get("PWNDBG_PROFILE") == "1":
 
 # Get virtualenv's site-packages path
 venv_path = os.environ.get("PWNDBG_VENV_PATH")
-if venv_path == "PWNDBG_PLEASE_SKIP_VENV":
+if venv_path == "PWNDBG_PLEASE_SKIP_VENV" or path.exists(path.dirname(__file__) + "/.skip-venv"):
     pass
 else:
     directory, file = path.split(__file__)


### PR DESCRIPTION
Currently the only way to circumvent the venv checks is setting an environment variable. However, this is not sufficient for distro site packaging:
- if the variable is not set, its a rather bad and unexpected user experience to somehow magically set PWNDBG_PLEASE_SKIP_VENV
- if the variable is set globally as login shell profile, this means skipping venv is always enforced which means if gdb is loaded with a pwndbg gdbinit.py from a git clone, its rather unexpected to skip the venv

This patch checks for a `.skip-venv` file alongside the `gdbinit.py` which means for site installations that use de-vendored dependencies like during distro packaging, this file can simply be touched. It would skip the venv when pwndbg is loaded from the site installation but at the same time would not skip loading the venv when pwndbg is started from a git clone.