### PR TITLE
pwndbg module must be in search path for site-installations

### DIFF
--- a/gdbinit.py
+++ b/gdbinit.py
@@ -18,15 +18,18 @@ if environ.get("PWNDBG_PROFILE") == "1":
     _start_time = time.time()
     _profiler.enable()
 
+directory, file = path.split(__file__)
+directory = path.expanduser(directory)
+directory = path.abspath(directory)
+
+# Add pwndbg directory to sys.path so it can be imported
+sys.path.insert(0, directory)
+
 # Get virtualenv's site-packages path
 venv_path = os.environ.get("PWNDBG_VENV_PATH")
 if venv_path == "PWNDBG_PLEASE_SKIP_VENV" or path.exists(path.dirname(__file__) + "/.skip-venv"):
     pass
 else:
-    directory, file = path.split(__file__)
-    directory = path.expanduser(directory)
-    directory = path.abspath(directory)
-
     if not venv_path:
         venv_path = os.path.join(directory, ".venv")
 
@@ -47,9 +50,6 @@ else:
     # Set virtualenv's bin path (needed for utility tools like ropper, pwntools etc)
     bin_path = os.path.join(venv_path, "bin")
     os.environ["PATH"] = bin_path + os.pathsep + os.environ.get("PATH")
-
-    # Add pwndbg directory to sys.path so it can be imported
-    sys.path.insert(0, directory)
 
     # Push virtualenv's site-packages to the front
     sys.path.remove(site_pkgs_path)


### PR DESCRIPTION
When using site packages instead of an venv, the pwndbg install directory is not longer part of the search path list since commit f3914e26968ca3cc0a1f06a29cd54913beb662ff. Thus the `pwndbg` module cannot be found when starting the application, when installed as a distro package (Gentoo in this case).

```
$ pwndbg /bin/ls
GNU gdb (Gentoo 13.2 vanilla) 13.2
Copyright (C) 2023 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Type "show copying" and "show warranty" for details.
This GDB was configured as "x86_64-pc-linux-gnu".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<https://bugs.gentoo.org/>.
Find the GDB manual and other documentation resources online at:
    <http://www.gnu.org/software/gdb/documentation/>.

For help, type "help".
Type "apropos word" to search for commands related to "word"...
Reading symbols from /bin/ls...
Reading symbols from /usr/lib/debug//bin/ls.debug...
(No debugging symbols found in /usr/lib/debug//bin/ls.debug)
Traceback (most recent call last):
  File "/usr/share/pwndbg/gdbinit.py", line 74, in <module>
    import pwndbg  # noqa: F401
    ^^^^^^^^^^^^^
ModuleNotFoundError: No module named 'pwndbg'
(gdb) 
```

This PR adds the `pwndbg` back to the search path in both cases: site-package installation and venv-installation.