### PR TITLE
Implement a way to resolve multiple process in attachp

### DIFF
--- a/pwndbg/commands/attachp.py
+++ b/pwndbg/commands/attachp.py
@@ -49,7 +49,7 @@ Original GDB attach command help:
     to specify the program, and to load its symbol table.""",
 )
 
-parser.add_argument("--no-truncate", action="store_true", help="not truncate command name")
+parser.add_argument("--no-truncate", action="store_true", help="dont truncate command args")
 parser.add_argument("target", type=str, help="pid, process name or device file to attach to")
 
 

--- a/pwndbg/commands/attachp.py
+++ b/pwndbg/commands/attachp.py
@@ -142,7 +142,7 @@ def attachp(no_truncate, target) -> None:
                     # calculate max_col_widths to fit window width
                     test_table = tabulate(proc_infos, headers=headers, showindex=showindex)
                     table_orig_width = len(test_table.splitlines()[1])
-                    max_command_width = max([len(command) for _, _, _, command in proc_infos])
+                    max_command_width = max(len(command) for _, _, _, command in proc_infos)
                     max_col_widths = max(
                         max_command_width - (table_orig_width - get_window_size()[1]), 10
                     )

--- a/pwndbg/commands/attachp.py
+++ b/pwndbg/commands/attachp.py
@@ -23,8 +23,8 @@ _OPTIONS = [_NONE, _OLDEST, _NEWEST, _ASK]
 
 pwndbg.gdblib.config.add_param(
     "attachp-resolve-method",
-    _NONE,
-    f'how to determine the process to attach when multiple candidates exists ("{_OLDEST}", "{_NEWEST}", "{_ASK}" or "{_NONE}"(default))',
+    _ASK,
+    f'how to determine the process to attach when multiple candidates exists ("{_OLDEST}", "{_NEWEST}", "{_NONE}" or "{_ASK}"(default))',
 )
 
 parser = argparse.ArgumentParser(
@@ -92,10 +92,10 @@ def attachp(no_truncate, target) -> None:
                 if method not in _OPTIONS:
                     print(
                         message.warn(
-                            f'Invalid value for `attachp-resolve-method` config. Fallback to default value("{_NONE}").'
+                            f'Invalid value for `attachp-resolve-method` config. Fallback to default value("{_ASK}").'
                         )
                     )
-                    method = _NONE
+                    method = _ASK
 
                 try:
                     ps_output = check_output(

--- a/pwndbg/commands/attachp.py
+++ b/pwndbg/commands/attachp.py
@@ -169,9 +169,11 @@ def attachp(no_truncate, target) -> None:
                         return
                     elif method == _ASK:
                         while True:
-                            inp = input(
-                                message.notice(f"which process to attach?(1-{len(proc_infos)}) ")
-                            ).strip()
+                            msg = message.notice(f"which process to attach?(1-{len(proc_infos)}) ")
+                            try:
+                                inp = input(msg).strip()
+                            except EOFError:
+                                return
                             try:
                                 choice = int(inp)
                                 if not (1 <= choice <= len(proc_infos)):

--- a/pwndbg/commands/attachp.py
+++ b/pwndbg/commands/attachp.py
@@ -201,24 +201,6 @@ def _is_device(path) -> bool:
     return False
 
 
-def _parse_ps_output(output: str, separator: str):
-    rows = output.rstrip("\n").split("\n")
-    header, rows = rows[0], rows[1:]
-
-    col_ranges = []
-    current_pos = 0
-    while True:
-        separator_pos = header.find(separator, current_pos)
-        if separator_pos == -1:
-            separator_pos = None
-        col_ranges.append((current_pos, separator_pos))
-        if separator_pos is None:
-            break
-        current_pos = separator_pos + 1
-
-    return [[row[begin:end].strip() for begin, end in col_ranges] for row in rows]
-
-
 def _truncate_string(s: str, length: int):
     TRUNCATE_FILLER = " ... "
     if len(s) < length:

--- a/pwndbg/commands/attachp.py
+++ b/pwndbg/commands/attachp.py
@@ -16,15 +16,15 @@ from pwndbg.commands import CommandCategory
 from pwndbg.ui import get_window_size
 
 _NONE = "none"
-_FIRST = "first"
-_LAST = "last"
+_OLDEST = "oldest"
+_NEWEST = "newest"
 _ASK = "ask"
-_OPTIONS = [_NONE, _FIRST, _LAST, _ASK]
+_OPTIONS = [_NONE, _OLDEST, _NEWEST, _ASK]
 
 pwndbg.gdblib.config.add_param(
     "attachp-resolve-method",
     _NONE,
-    f'how to determine the process to attach when multiple candidates exists ("{_FIRST}", "{_LAST}", "{_ASK}" or "{_NONE}"(default))',
+    f'how to determine the process to attach when multiple candidates exists ("{_OLDEST}", "{_NEWEST}", "{_ASK}" or "{_NONE}"(default))',
 )
 
 parser = argparse.ArgumentParser(
@@ -127,9 +127,9 @@ def attachp(no_truncate, target) -> None:
                 # Here, we can safely use split to capture each field
                 # since none of the columns except args can contain spaces
                 proc_infos = [row.split(maxsplit=3) for row in ps_output.splitlines()]
-                if method == _FIRST:
+                if method == _OLDEST:
                     resolved_target = int(proc_infos[0][0])
-                elif method == _LAST:
+                elif method == _NEWEST:
                     resolved_target = int(proc_infos[-1][0])
                 else:
                     print(message.notice("Multiple process found:"))

--- a/pwndbg/commands/attachp.py
+++ b/pwndbg/commands/attachp.py
@@ -101,11 +101,12 @@ def attachp(no_truncate, target) -> None:
                     ps_output = check_output(
                         [
                             "ps",
+                            "--no-headers",
                             "-ww",
                             "-p",
                             ",".join(pids),
                             "-o",
-                            "%p|%u|%t|%a",
+                            "pid,ruser,etime,args",
                             "--sort",
                             "+lstart",
                         ]
@@ -123,7 +124,9 @@ def attachp(no_truncate, target) -> None:
                     )
                     return
 
-                proc_infos = _parse_ps_output(ps_output, "|")
+                # Here, we can safely use split to capture each field
+                # since none of the columns except args can contain spaces
+                proc_infos = [row.split(maxsplit=3) for row in ps_output.splitlines()]
                 if method == _FIRST:
                     resolved_target = int(proc_infos[0][0])
                 elif method == _LAST:

--- a/tests/gdb-tests/tests/test_attachp.py
+++ b/tests/gdb-tests/tests/test_attachp.py
@@ -82,8 +82,8 @@ def test_attachp_command_attaches_to_procname_resolve_none(launched_bash_binary)
 
     regex = r"pid +user +elapsed +command\n"
     regex += r"-+  -+  -+  -+\n"
-    regex += r"([0-9]+) +(\S+) +[0-9:-]+ +(.*)\n"
-    regex += r"([0-9]+) +(\S+) +[0-9:-]+ +(.*)\n"
+    regex += r" *([0-9]+) +(\S+) +[0-9:-]+ +(.*)\n"
+    regex += r" *([0-9]+) +(\S+) +[0-9:-]+ +(.*)\n"
     regex += r"use `attach \<pid\>` to attach\n"
     matches = re.search(regex, result).groups()
 
@@ -110,9 +110,9 @@ def test_attachp_command_attaches_to_procname_resolve_none_no_truncate(launched_
 
     regex = r"pid +user +elapsed +command\n"
     regex += r"-+  -+  -+  -+\n"
-    regex += r"([0-9]+) +(\S+) +[0-9:-]+ +(.*)\n"
-    regex += r"([0-9]+) +(\S+) +[0-9:-]+ +(.*)\n"
-    regex += r"(?: +(?:-|-i)?(?: -i)+(?: | -)?\n)+"
+    regex += r" *([0-9]+) +(\S+) +[0-9:-]+ +(.*)\n"
+    regex += r" *([0-9]+) +(\S+) +[0-9:-]+ +(.*)\n"
+    regex += r"(?: +-?(?: -i)+(?: | -)?\n)+"
     regex += r"use `attach \<pid\>` to attach\n"
     matches = re.search(regex, result).groups()
 

--- a/tests/gdb-tests/tests/test_attachp.py
+++ b/tests/gdb-tests/tests/test_attachp.py
@@ -69,10 +69,14 @@ def test_attachp_command_attaches_to_pid(launched_bash_binary):
 def test_attachp_command_attaches_to_procname_resolve_none(launched_bash_binary):
     pid, binary_path = launched_bash_binary
 
-    process = subprocess.Popen([binary_path] + ["-i"] * 1000, stdout=subprocess.PIPE, stdin=subprocess.PIPE)
+    process = subprocess.Popen(
+        [binary_path] + ["-i"] * 1000, stdout=subprocess.PIPE, stdin=subprocess.PIPE
+    )
 
     binary_name = binary_path.split("/")[-1]
-    result = run_gdb_with_script(pyafter=["set attachp-resolve-method none", f"attachp {binary_name}"])
+    result = run_gdb_with_script(
+        pyafter=["set attachp-resolve-method none", f"attachp {binary_name}"]
+    )
 
     process.kill()
 
@@ -83,22 +87,24 @@ def test_attachp_command_attaches_to_procname_resolve_none(launched_bash_binary)
     regex += r"use `attach \<pid\>` to attach\n"
     matches = re.search(regex, result).groups()
 
-    expected = (
-        str(pid), getpass.getuser(), binary_path,
-        str(process.pid), getpass.getuser()
-    )
+    expected = (str(pid), getpass.getuser(), binary_path, str(process.pid), getpass.getuser())
 
     assert matches[:-1] == expected
     assert matches[-1].startswith(f"{binary_path} -i -i") and " ... " in matches[-1]
+
 
 @pytest.mark.skipif(can_attach is False, reason=REASON_CANNOT_ATTACH)
 def test_attachp_command_attaches_to_procname_resolve_none_no_truncate(launched_bash_binary):
     pid, binary_path = launched_bash_binary
 
-    process = subprocess.Popen([binary_path] + ["-i"] * 1000, stdout=subprocess.PIPE, stdin=subprocess.PIPE)
+    process = subprocess.Popen(
+        [binary_path] + ["-i"] * 1000, stdout=subprocess.PIPE, stdin=subprocess.PIPE
+    )
 
     binary_name = binary_path.split("/")[-1]
-    result = run_gdb_with_script(pyafter=["set attachp-resolve-method none", f"attachp --no-truncate {binary_name}"])
+    result = run_gdb_with_script(
+        pyafter=["set attachp-resolve-method none", f"attachp --no-truncate {binary_name}"]
+    )
 
     process.kill()
 
@@ -110,10 +116,7 @@ def test_attachp_command_attaches_to_procname_resolve_none_no_truncate(launched_
     regex += r"use `attach \<pid\>` to attach\n"
     matches = re.search(regex, result).groups()
 
-    expected = (
-        str(pid), getpass.getuser(), binary_path,
-        str(process.pid), getpass.getuser()
-    )
+    expected = (str(pid), getpass.getuser(), binary_path, str(process.pid), getpass.getuser())
 
     assert matches[:-1] == expected
     assert matches[-1].startswith(f"{binary_path} -i -i")
@@ -123,10 +126,14 @@ def test_attachp_command_attaches_to_procname_resolve_none_no_truncate(launched_
 def test_attachp_command_attaches_to_procname_resolve_ask(launched_bash_binary):
     pid, binary_path = launched_bash_binary
 
-    process = subprocess.Popen([binary_path] + ["-i"] * 1000, stdout=subprocess.PIPE, stdin=subprocess.PIPE)
+    process = subprocess.Popen(
+        [binary_path] + ["-i"] * 1000, stdout=subprocess.PIPE, stdin=subprocess.PIPE
+    )
 
     binary_name = binary_path.split("/")[-1]
-    result = run_gdb_with_script(pyafter=[f"set attachp-resolve-method ask", f"attachp {binary_name}"], input=b"0\n1\n")
+    result = run_gdb_with_script(
+        pyafter=["set attachp-resolve-method ask", f"attachp {binary_name}"], stdin_input=b"0\n1\n"
+    )
 
     process.kill()
 
@@ -137,10 +144,13 @@ def test_attachp_command_attaches_to_procname_resolve_ask(launched_bash_binary):
     regex += r"which process to attach\?\(1-2\) "
     regex += r"which process to attach\?\(1-2\) "
     matches = re.search(regex, result).groups()
-    
+
     expected = (
-        str(pid), getpass.getuser(), binary_path,
-        str(process.pid), getpass.getuser(),
+        str(pid),
+        getpass.getuser(),
+        binary_path,
+        str(process.pid),
+        getpass.getuser(),
     )
 
     assert matches[:-1] == expected
@@ -156,10 +166,14 @@ def test_attachp_command_attaches_to_procname_resolve_ask(launched_bash_binary):
 def test_attachp_command_attaches_to_procname_resolve_first(launched_bash_binary):
     pid, binary_path = launched_bash_binary
 
-    process = subprocess.Popen([binary_path] + ["-i"] * 1000, stdout=subprocess.PIPE, stdin=subprocess.PIPE)
+    process = subprocess.Popen(
+        [binary_path] + ["-i"] * 1000, stdout=subprocess.PIPE, stdin=subprocess.PIPE
+    )
 
     binary_name = binary_path.split("/")[-1]
-    result = run_gdb_with_script(pyafter=["set attachp-resolve-method first", f"attachp {binary_name}"])
+    result = run_gdb_with_script(
+        pyafter=["set attachp-resolve-method first", f"attachp {binary_name}"]
+    )
 
     process.kill()
 
@@ -173,10 +187,14 @@ def test_attachp_command_attaches_to_procname_resolve_first(launched_bash_binary
 def test_attachp_command_attaches_to_procname_resolve_last(launched_bash_binary):
     pid, binary_path = launched_bash_binary
 
-    process = subprocess.Popen([binary_path] + ["-i"] * 1000, stdout=subprocess.PIPE, stdin=subprocess.PIPE)
+    process = subprocess.Popen(
+        [binary_path] + ["-i"] * 1000, stdout=subprocess.PIPE, stdin=subprocess.PIPE
+    )
 
     binary_name = binary_path.split("/")[-1]
-    result = run_gdb_with_script(pyafter=["set attachp-resolve-method last", f"attachp {binary_name}"])
+    result = run_gdb_with_script(
+        pyafter=["set attachp-resolve-method last", f"attachp {binary_name}"]
+    )
 
     process.kill()
 

--- a/tests/gdb-tests/tests/test_attachp.py
+++ b/tests/gdb-tests/tests/test_attachp.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import getpass
 import os
 import re
 import subprocess
@@ -65,24 +66,124 @@ def test_attachp_command_attaches_to_pid(launched_bash_binary):
 
 
 @pytest.mark.skipif(can_attach is False, reason=REASON_CANNOT_ATTACH)
-def test_attachp_command_attaches_to_procname_too_many_pids(launched_bash_binary):
+def test_attachp_command_attaches_to_procname_resolve_none(launched_bash_binary):
     pid, binary_path = launched_bash_binary
 
-    process = subprocess.Popen([binary_path], stdout=subprocess.PIPE, stdin=subprocess.PIPE)
+    process = subprocess.Popen([binary_path] + ["-i"] * 1000, stdout=subprocess.PIPE, stdin=subprocess.PIPE)
 
     binary_name = binary_path.split("/")[-1]
-    result = run_gdb_with_script(pyafter=f"attachp {binary_name}")
+    result = run_gdb_with_script(pyafter=["set attachp-resolve-method none", f"attachp {binary_name}"])
 
     process.kill()
 
-    matches = re.search(r"Found pids: ([0-9]+), ([0-9]+) \(use `attach <pid>`\)", result).groups()
-    matches = list(map(int, matches))
-    matches.sort()
+    regex = r"pid +user +elapsed +command\n"
+    regex += r"-+  -+  -+  -+\n"
+    regex += r"([0-9]+) +(\S+) +[0-9:-]+ +(.*)\n"
+    regex += r"([0-9]+) +(\S+) +[0-9:-]+ +(.*)\n"
+    regex += r"use `attach \<pid\>` to attach\n"
+    matches = re.search(regex, result).groups()
 
-    expected_pids = [pid, process.pid]
-    expected_pids.sort()
+    expected = (
+        str(pid), getpass.getuser(), binary_path,
+        str(process.pid), getpass.getuser()
+    )
 
-    assert matches == expected_pids
+    assert matches[:-1] == expected
+    assert matches[-1].startswith(f"{binary_path} -i -i") and " ... " in matches[-1]
+
+@pytest.mark.skipif(can_attach is False, reason=REASON_CANNOT_ATTACH)
+def test_attachp_command_attaches_to_procname_resolve_none_no_truncate(launched_bash_binary):
+    pid, binary_path = launched_bash_binary
+
+    process = subprocess.Popen([binary_path] + ["-i"] * 1000, stdout=subprocess.PIPE, stdin=subprocess.PIPE)
+
+    binary_name = binary_path.split("/")[-1]
+    result = run_gdb_with_script(pyafter=["set attachp-resolve-method none", f"attachp --no-truncate {binary_name}"])
+
+    process.kill()
+
+    regex = r"pid +user +elapsed +command\n"
+    regex += r"-+  -+  -+  -+\n"
+    regex += r"([0-9]+) +(\S+) +[0-9:-]+ +(.*)\n"
+    regex += r"([0-9]+) +(\S+) +[0-9:-]+ +(.*)\n"
+    regex += r"(?: +(?:-|-i)?(?: -i)+(?: | -)?\n)+"
+    regex += r"use `attach \<pid\>` to attach\n"
+    matches = re.search(regex, result).groups()
+
+    expected = (
+        str(pid), getpass.getuser(), binary_path,
+        str(process.pid), getpass.getuser()
+    )
+
+    assert matches[:-1] == expected
+    assert matches[-1].startswith(f"{binary_path} -i -i")
+
+
+@pytest.mark.skipif(can_attach is False, reason=REASON_CANNOT_ATTACH)
+def test_attachp_command_attaches_to_procname_resolve_ask(launched_bash_binary):
+    pid, binary_path = launched_bash_binary
+
+    process = subprocess.Popen([binary_path] + ["-i"] * 1000, stdout=subprocess.PIPE, stdin=subprocess.PIPE)
+
+    binary_name = binary_path.split("/")[-1]
+    result = run_gdb_with_script(pyafter=[f"set attachp-resolve-method ask", f"attachp {binary_name}"], input=b"0\n1\n")
+
+    process.kill()
+
+    regex = r"pid +user +elapsed +command\n"
+    regex += r"-+  -+  -+  -+  -+\n"
+    regex += r" 1 +([0-9]+) +(\S+) +[0-9:-]+ +(.*)\n"
+    regex += r" 2 +([0-9]+) +(\S+) +[0-9:-]+ +(.*)\n"
+    regex += r"which process to attach\?\(1-2\) "
+    regex += r"which process to attach\?\(1-2\) "
+    matches = re.search(regex, result).groups()
+    
+    expected = (
+        str(pid), getpass.getuser(), binary_path,
+        str(process.pid), getpass.getuser(),
+    )
+
+    assert matches[:-1] == expected
+    assert matches[-1].startswith(f"{binary_path} -i -i") and " ... " in matches[-1]
+
+    matches = re.search(r"Attaching to ([0-9]+)", result).groups()
+    assert matches == (str(pid),)
+
+    assert re.search(rf"Detaching from program: {binary_path}, process {pid}", result)
+
+
+@pytest.mark.skipif(can_attach is False, reason=REASON_CANNOT_ATTACH)
+def test_attachp_command_attaches_to_procname_resolve_first(launched_bash_binary):
+    pid, binary_path = launched_bash_binary
+
+    process = subprocess.Popen([binary_path] + ["-i"] * 1000, stdout=subprocess.PIPE, stdin=subprocess.PIPE)
+
+    binary_name = binary_path.split("/")[-1]
+    result = run_gdb_with_script(pyafter=["set attachp-resolve-method first", f"attachp {binary_name}"])
+
+    process.kill()
+
+    matches = re.search(r"Attaching to ([0-9]+)", result).groups()
+    assert matches == (str(pid),)
+
+    assert re.search(rf"Detaching from program: {binary_path}, process {pid}", result)
+
+
+@pytest.mark.skipif(can_attach is False, reason=REASON_CANNOT_ATTACH)
+def test_attachp_command_attaches_to_procname_resolve_last(launched_bash_binary):
+    pid, binary_path = launched_bash_binary
+
+    process = subprocess.Popen([binary_path] + ["-i"] * 1000, stdout=subprocess.PIPE, stdin=subprocess.PIPE)
+
+    binary_name = binary_path.split("/")[-1]
+    result = run_gdb_with_script(pyafter=["set attachp-resolve-method last", f"attachp {binary_name}"])
+
+    process.kill()
+
+    matches = re.search(r"Attaching to ([0-9]+)", result).groups()
+    assert matches == (str(process.pid),)
+
+    assert re.search(rf"Detaching from program: {binary_path}, process {process.pid}", result)
 
 
 @pytest.mark.skipif(can_attach is False, reason=REASON_CANNOT_ATTACH)

--- a/tests/gdb-tests/tests/test_attachp.py
+++ b/tests/gdb-tests/tests/test_attachp.py
@@ -132,7 +132,8 @@ def test_attachp_command_attaches_to_procname_resolve_ask(launched_bash_binary):
 
     binary_name = binary_path.split("/")[-1]
     result = run_gdb_with_script(
-        pyafter=["set attachp-resolution-method ask", f"attachp {binary_name}"], stdin_input=b"0\n1\n"
+        pyafter=["set attachp-resolution-method ask", f"attachp {binary_name}"],
+        stdin_input=b"0\n1\n",
     )
 
     process.kill()

--- a/tests/gdb-tests/tests/test_attachp.py
+++ b/tests/gdb-tests/tests/test_attachp.py
@@ -75,7 +75,7 @@ def test_attachp_command_attaches_to_procname_resolve_none(launched_bash_binary)
 
     binary_name = binary_path.split("/")[-1]
     result = run_gdb_with_script(
-        pyafter=["set attachp-resolve-method none", f"attachp {binary_name}"]
+        pyafter=["set attachp-resolution-method none", f"attachp {binary_name}"]
     )
 
     process.kill()
@@ -103,7 +103,7 @@ def test_attachp_command_attaches_to_procname_resolve_none_no_truncate(launched_
 
     binary_name = binary_path.split("/")[-1]
     result = run_gdb_with_script(
-        pyafter=["set attachp-resolve-method none", f"attachp --no-truncate {binary_name}"]
+        pyafter=["set attachp-resolution-method none", f"attachp --no-truncate {binary_name}"]
     )
 
     process.kill()
@@ -132,7 +132,7 @@ def test_attachp_command_attaches_to_procname_resolve_ask(launched_bash_binary):
 
     binary_name = binary_path.split("/")[-1]
     result = run_gdb_with_script(
-        pyafter=["set attachp-resolve-method ask", f"attachp {binary_name}"], stdin_input=b"0\n1\n"
+        pyafter=["set attachp-resolution-method ask", f"attachp {binary_name}"], stdin_input=b"0\n1\n"
     )
 
     process.kill()
@@ -163,7 +163,7 @@ def test_attachp_command_attaches_to_procname_resolve_ask(launched_bash_binary):
 
 
 @pytest.mark.skipif(can_attach is False, reason=REASON_CANNOT_ATTACH)
-def test_attachp_command_attaches_to_procname_resolve_first(launched_bash_binary):
+def test_attachp_command_attaches_to_procname_resolve_oldest(launched_bash_binary):
     pid, binary_path = launched_bash_binary
 
     process = subprocess.Popen(
@@ -172,7 +172,7 @@ def test_attachp_command_attaches_to_procname_resolve_first(launched_bash_binary
 
     binary_name = binary_path.split("/")[-1]
     result = run_gdb_with_script(
-        pyafter=["set attachp-resolve-method first", f"attachp {binary_name}"]
+        pyafter=["set attachp-resolution-method oldest", f"attachp {binary_name}"]
     )
 
     process.kill()
@@ -184,7 +184,7 @@ def test_attachp_command_attaches_to_procname_resolve_first(launched_bash_binary
 
 
 @pytest.mark.skipif(can_attach is False, reason=REASON_CANNOT_ATTACH)
-def test_attachp_command_attaches_to_procname_resolve_last(launched_bash_binary):
+def test_attachp_command_attaches_to_procname_resolve_newest(launched_bash_binary):
     pid, binary_path = launched_bash_binary
 
     process = subprocess.Popen(
@@ -193,7 +193,7 @@ def test_attachp_command_attaches_to_procname_resolve_last(launched_bash_binary)
 
     binary_name = binary_path.split("/")[-1]
     result = run_gdb_with_script(
-        pyafter=["set attachp-resolve-method last", f"attachp {binary_name}"]
+        pyafter=["set attachp-resolution-method newest", f"attachp {binary_name}"]
     )
 
     process.kill()

--- a/tests/gdb-tests/tests/utils.py
+++ b/tests/gdb-tests/tests/utils.py
@@ -5,7 +5,7 @@ import re
 import subprocess
 
 
-def run_gdb_with_script(binary="", core="", pybefore=None, pyafter=None, timeout=None):
+def run_gdb_with_script(binary="", core="", input=None, pybefore=None, pyafter=None, timeout=None):
     """
     Runs GDB with given commands launched before and after loading of gdbinit.py
     Returns GDB output.
@@ -32,7 +32,7 @@ def run_gdb_with_script(binary="", core="", pybefore=None, pyafter=None, timeout
     command += ["--eval-command", "quit"]
 
     print(f"Launching command: {command}")
-    output = subprocess.check_output(command, stderr=subprocess.STDOUT, timeout=timeout)
+    output = subprocess.check_output(command, stderr=subprocess.STDOUT, timeout=timeout, input=input)
 
     # Python 3 returns bytes-like object so lets have it consistent
     output = codecs.decode(output, "utf8")

--- a/tests/gdb-tests/tests/utils.py
+++ b/tests/gdb-tests/tests/utils.py
@@ -5,7 +5,9 @@ import re
 import subprocess
 
 
-def run_gdb_with_script(binary="", core="", input=None, pybefore=None, pyafter=None, timeout=None):
+def run_gdb_with_script(
+    binary="", core="", stdin_input=None, pybefore=None, pyafter=None, timeout=None
+):
     """
     Runs GDB with given commands launched before and after loading of gdbinit.py
     Returns GDB output.
@@ -32,7 +34,9 @@ def run_gdb_with_script(binary="", core="", input=None, pybefore=None, pyafter=N
     command += ["--eval-command", "quit"]
 
     print(f"Launching command: {command}")
-    output = subprocess.check_output(command, stderr=subprocess.STDOUT, timeout=timeout, input=input)
+    output = subprocess.check_output(
+        command, stderr=subprocess.STDOUT, timeout=timeout, input=stdin_input
+    )
 
     # Python 3 returns bytes-like object so lets have it consistent
     output = codecs.decode(output, "utf8")


### PR DESCRIPTION
Added new parameter `attachp-resolve-method`. This allows processes to be selected using the `first`(select oldest), `last`(select latest), or `ask`(decide interactively) method, rather than using `attach` again when a conflict occurs.
In addition to this, the details of the process will be displayed in a table when a conflict occurs.

![image](https://github.com/pwndbg/pwndbg/assets/32513370/666f7052-8623-4996-9ba8-6afd0d6e846e)
![image](https://github.com/pwndbg/pwndbg/assets/32513370/fc16b8d1-ebf7-4b85-820f-920a766e5989)

After creating most of the implementation of this pull request, I noticed that a similar pull request was created before(#1890 ). However, that pull request seemed to be inactive, so I decided to open the pull request anyway.
I will leave it up to the maintainer to decide how to handle this issue.
