### PR TITLE
arch.py: fix arch detection for riscv

### DIFF
--- a/pwndbg/gdblib/arch.py
+++ b/pwndbg/gdblib/arch.py
@@ -9,7 +9,20 @@ from pwndbg.lib.arch import Arch
 
 # TODO: x86-64 needs to come before i386 in the current implementation, make
 # this order-independent
-ARCHS = ("x86-64", "i386", "aarch64", "mips", "powerpc", "sparc", "arm", "armcm", "rv32", "rv64")
+ARCHS = (
+    "x86-64",
+    "i386",
+    "aarch64",
+    "mips",
+    "powerpc",
+    "sparc",
+    "arm",
+    "armcm",
+    "riscv:rv32",
+    "riscv:rv64",
+    "riscv",
+)
+
 
 # mapping between gdb and pwntools arch names
 pwnlib_archs_mapping = {
@@ -21,8 +34,9 @@ pwnlib_archs_mapping = {
     "sparc": "sparc",
     "arm": "arm",
     "armcm": "thumb",
-    "rv32": "riscv32",
-    "rv64": "riscv64",
+    "riscv:rv32": "riscv32",
+    "riscv:rv64": "riscv64",
+    "riscv": "riscv64",
 }
 
 

--- a/pwndbg/gdblib/arch.py
+++ b/pwndbg/gdblib/arch.py
@@ -64,7 +64,7 @@ def _get_arch(ptrsize: int):
                 match = "armcm"
             elif match.startswith("riscv:"):
                 match = match[6:]
-            elif match = "riscv":
+            elif match == "riscv":
                 match = "rv64"
             return match, ptrsize, endian
 

--- a/pwndbg/gdblib/arch.py
+++ b/pwndbg/gdblib/arch.py
@@ -34,9 +34,8 @@ pwnlib_archs_mapping = {
     "sparc": "sparc",
     "arm": "arm",
     "armcm": "thumb",
-    "riscv:rv32": "riscv32",
-    "riscv:rv64": "riscv64",
-    "riscv": "riscv64",
+    "rv32": "riscv32",
+    "rv64": "riscv64",
 }
 
 
@@ -63,6 +62,10 @@ def _get_arch(ptrsize: int):
             # Distinguish between Cortex-M and other ARM
             if match == "arm" and "-m" in arch:
                 match = "armcm"
+            elif match.startswith("riscv:"):
+                match = match[6:]
+            elif match = "riscv":
+                match = "rv64"
             return match, ptrsize, endian
 
     if not_exactly_arch:


### PR DESCRIPTION
arch.py: fix arch detection for riscv. 

Info: https://github.com/bminor/binutils-gdb/blob/f6149394f9a46d03ff853a0e83aae61441182811/gdb/testsuite/gdb.arch/riscv-default-tdesc.exp#L35

Error:
![image](https://github.com/pwndbg/pwndbg/assets/3074260/e58aabfa-b4b7-4929-a878-04fc211fb6b7)
