### PR TITLE
FIX: pwndbg.gdblib.regs.frame is None

### DIFF
--- a/pwndbg/commands/telescope.py
+++ b/pwndbg/commands/telescope.py
@@ -193,7 +193,7 @@ def telescope(address=None, count=telescope_lines, to_string=False, reverse=Fals
 
     bp = None
     if print_framepointer_offset and pwndbg.gdblib.regs.frame is not None:
-        # If pwndbg.gdblib.regs.frame is None, indexing regs will return None
+        # regs.frame can be None on aarch64
         bp = pwndbg.gdblib.regs[pwndbg.gdblib.regs.frame]
 
     for i, addr in enumerate(range(start, stop, step)):

--- a/pwndbg/commands/telescope.py
+++ b/pwndbg/commands/telescope.py
@@ -192,7 +192,7 @@ def telescope(address=None, count=telescope_lines, to_string=False, reverse=Fals
         collapse_buffer.clear()
 
     bp = None
-    if print_framepointer_offset:
+    if print_framepointer_offset and pwndbg.gdblib.regs.frame is not None:
         # If pwndbg.gdblib.regs.frame is None, indexing regs will return None
         bp = pwndbg.gdblib.regs[pwndbg.gdblib.regs.frame]
 


### PR DESCRIPTION
Revert c37030633afc2c8f4620c959e9c27168ce32e98e as pwndbg.gdblib.regs.frame can be None