### PR TITLE
cymbol: fix cymbol show and remove run and arch restrictions

### DIFF
--- a/pwndbg/commands/cymbol.py
+++ b/pwndbg/commands/cymbol.py
@@ -196,7 +196,7 @@ def load_custom_structure(custom_structure_name, custom_structure_path) -> None:
 @OnlyWhenStructFileExists
 def show_custom_structure(custom_structure_name, custom_structure_path) -> None:
     # Call wrapper .func() to avoid memoization.
-    highlighted_source = pwndbg.pwndbg.commands.context.get_highlight_source.func(
+    highlighted_source = pwndbg.pwndbg.commands.context.get_highlight_source.__wrapped__(
         custom_structure_path
     )
     print("\n".join(highlighted_source))
@@ -248,8 +248,6 @@ parser.add_argument(
 
 
 @pwndbg.commands.ArgparsedCommand(parser)
-@pwndbg.commands.OnlyWithArch(["x86-64"])
-@pwndbg.commands.OnlyWhenRunning
 def cymbol(add, remove, edit, load, show) -> None:
     if add:
         add_custom_structure(add)

--- a/pwndbg/commands/cymbol.py
+++ b/pwndbg/commands/cymbol.py
@@ -195,7 +195,7 @@ def load_custom_structure(custom_structure_name, custom_structure_path) -> None:
 
 @OnlyWhenStructFileExists
 def show_custom_structure(custom_structure_name, custom_structure_path) -> None:
-    # Call wrapper .func() to avoid memoization.
+    # Call non-caching version of the function (thus .__wrapped__)
     highlighted_source = pwndbg.pwndbg.commands.context.get_highlight_source.__wrapped__(
         custom_structure_path
     )


### PR DESCRIPTION
Before this PR the `cymbol show` (`cymbol -s ...`) command was crashingh due to some recent changes to caching.

Here is the exception stacktrace from that crash:
```
pwndbg> cymbol -s Point
╭─────────────────────── Traceback (most recent call last) ────────────────────────╮
│ /root/pwndbg/pwndbg/commands/__init__.py:190 in __call__                         │
│                                                                                  │
│   187 │                                                                          │
│   188 │   def __call__(self, *args: Any, **kwargs: Any) -> str | None:           │
│   189 │   │   try:                                                               │
│ ❱ 190 │   │   │   return self.function(*args, **kwargs)                          │
│   191 │   │   except TypeError as te:                                            │
│   192 │   │   │   print(f"{self.function.__name__.strip()!r}: {self.function.__d │
│   193 │   │   │   pwndbg.exception.handle(self.function.__name__)                │
│                                                                                  │
│ /root/pwndbg/pwndbg/commands/__init__.py:302 in _OnlyWithArch                    │
│                                                                                  │
│   299 │   │   @functools.wraps(function)                                         │
│   300 │   │   def _OnlyWithArch(*a: Any, **kw: Any) -> Optional[T]:              │
│   301 │   │   │   if pwndbg.gdblib.arch.name in arch_names:                      │
│ ❱ 302 │   │   │   │   return function(*a, **kw)                                  │
│   303 │   │   │   else:                                                          │
│   304 │   │   │   │   arches_str = ", ".join(arch_names)                         │
│   305 │   │   │   │   print(                                                     │
│                                                                                  │
│ /root/pwndbg/pwndbg/commands/__init__.py:346 in _OnlyWhenRunning                 │
│                                                                                  │
│   343 │   @functools.wraps(function)                                             │
│   344 │   def _OnlyWhenRunning(*a: Any, **kw: Any) -> Optional[T]:               │
│   345 │   │   if pwndbg.gdblib.proc.alive:                                       │
│ ❱ 346 │   │   │   return function(*a, **kw)                                      │
│   347 │   │   else:                                                              │
│   348 │   │   │   print(f"{function.__name__}: The program is not being run.")   │
│   349 │   │   │   return None                                                    │
│                                                                                  │
│ /root/pwndbg/pwndbg/commands/cymbol.py:265 in cymbol                             │
│                                                                                  │
│   262 │   elif load:                                                             │
│   263 │   │   load_custom_structure(load)                                        │
│   264 │   elif show:                                                             │
│ ❱ 265 │   │   show_custom_structure(show)                                        │
│   266 │   else:                                                                  │
│   267 │   │   parser.print_help()                                                │
│   268                                                                            │
│                                                                                  │
│ /root/pwndbg/pwndbg/commands/cymbol.py:70 in wrapper                             │
│                                                                                  │
│    67 │   │   if not os.path.exists(pwndbg_custom_structure_path):               │
│    68 │   │   │   print(message.error("No custom structure was found with the gi │
│    69 │   │   │   return                                                         │
│ ❱  70 │   │   return func(custom_structure_name, pwndbg_custom_structure_path)   │
│    71 │                                                                          │
│    72 │   return wrapper                                                         │
│    73                                                                            │
│                                                                                  │
│ /root/pwndbg/pwndbg/commands/cymbol.py:201 in show_custom_structure              │
│                                                                                  │
│   198 @OnlyWhenStructFileExists                                                  │
│   199 def show_custom_structure(custom_structure_name: str, custom_structure_pat │
│   200 │   # Call wrapper .func() to avoid memoization.                           │
│ ❱ 201 │   highlighted_source = pwndbg.pwndbg.commands.context.get_highlight_sour │
│   202 │   │   custom_structure_path                                              │
│   203 │   )                                                                      │
│   204 │   print("\n".join(highlighted_source))                                   │
╰──────────────────────────────────────────────────────────────────────────────────╯
AttributeError: 'function' object has no attribute 'func'
```

<!-- Please make sure to read the testing and linting instructions at https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md before creating a PR -->
