### PR TITLE
Try repo-oss-debug if repo-debug is not present

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -47,7 +47,7 @@ install_swupd() {
 }
 
 install_zypper() {
-    sudo zypper mr -e repo-debug
+    sudo zypper mr -e repo-debug || sudo zypper mr -e repo-oss-debug
     sudo zypper refresh || true
     sudo zypper install -y gdb gdbserver python-devel python3-devel python2-pip python3-pip glib2-devel make glibc-debuginfo
 


### PR DESCRIPTION
On newer-installed openSUSE Tumbleweed systems, main openSUSE Tumbleweed repositories are managed by a service called `openSUSE`, which made some differences to default repository names:
```
xtex@xtex ~> zypper lr
Repository priorities are without effect. All enabled repositories share the same priority.

#  | Alias                      | Name                                   | Enabled | GPG Check | Refresh
---+----------------------------+----------------------------------------+---------+-----------+--------
 5 | openSUSE:repo-non-oss      | repo-non-oss                           | Yes     | (r ) Yes  | Yes
 6 | openSUSE:repo-openh264     | repo-openh264                          | Yes     | (r ) Yes  | Yes
 7 | openSUSE:repo-oss          | repo-oss                               | Yes     | (r ) Yes  | Yes
 8 | openSUSE:repo-oss-debug    | repo-oss-debug                         | Yes     | (r ) Yes  | Yes
 9 | openSUSE:repo-oss-source   | repo-oss-source                        | No      | ----      | ----
10 | openSUSE:update-tumbleweed | update-tumbleweed                      | Yes     | (r ) Yes  | Yes
```