### PR TITLE
Add -i flag to stack command.

### DIFF
--- a/pwndbg/commands/telescope.py
+++ b/pwndbg/commands/telescope.py
@@ -84,7 +84,9 @@ parser.add_argument(
 
 @pwndbg.commands.ArgparsedCommand(parser, category=CommandCategory.MEMORY)
 @pwndbg.commands.OnlyWhenRunning
-def telescope(address=None, count=telescope_lines, to_string=False, reverse=False, frame=False, inverse=False):
+def telescope(
+    address=None, count=telescope_lines, to_string=False, reverse=False, frame=False, inverse=False
+):
     """
     Recursively dereferences pointers starting at the specified address
     ($sp by default)
@@ -148,7 +150,7 @@ def telescope(address=None, count=telescope_lines, to_string=False, reverse=Fals
         inverse_set = 1
     else:
         start = address + ((count - 1) * ptrsize)
-        stop = address  - ptrsize
+        stop = address - ptrsize
         step = -1 * ptrsize
         inverse_set = -1
 
@@ -291,7 +293,9 @@ parser.add_argument(
 def stack(count, offset, frame, inverse) -> None:
     ptrsize = pwndbg.gdblib.typeinfo.ptrsize
     telescope.repeat = stack.repeat
-    telescope(address=pwndbg.gdblib.regs.sp + offset * ptrsize, count=count, frame=frame, inverse=inverse)
+    telescope(
+        address=pwndbg.gdblib.regs.sp + offset * ptrsize, count=count, frame=frame, inverse=inverse
+    )
 
 
 parser = argparse.ArgumentParser(

--- a/pwndbg/commands/telescope.py
+++ b/pwndbg/commands/telescope.py
@@ -220,12 +220,14 @@ def telescope(
             break
         if inverse:
             line_offset = addr - (stop + ptrsize) + (telescope.offset * ptrsize)
+            idx_offset = int((start - stop - ptrsize) / ptrsize) - (i + telescope.offset)
         else:
             line_offset = addr - start + (telescope.offset * ptrsize)
+            idx_offset = i + telescope.offset
         line = T.offset(
             "%02x%s%04x%s"
             % (
-                i + telescope.offset,
+                idx_offset,
                 delimiter,
                 line_offset,
                 separator,

--- a/pwndbg/commands/telescope.py
+++ b/pwndbg/commands/telescope.py
@@ -74,6 +74,16 @@ parser.add_argument(
 )
 
 parser.add_argument(
+    "-i",
+    "--inverse",
+    dest="inverse",
+    action="store_true",
+    default=False,
+    help="Show the stack reverse growth",
+)
+
+
+parser.add_argument(
     "address", nargs="?", default="$sp", type=int, help="The address to telescope at."
 )
 
@@ -147,12 +157,10 @@ def telescope(
         start = address
         stop = address + (count * ptrsize)
         step = ptrsize
-        inverse_set = 1
     else:
         start = address + ((count - 1) * ptrsize)
         stop = address - ptrsize
         step = -1 * ptrsize
-        inverse_set = -1
 
     # Find all registers which show up in the trace, map address to regs
     regs: dict[int, str] = {}
@@ -210,13 +218,16 @@ def telescope(
             collapse_repeating_values()
             result.append("<Could not read memory at %#x>" % addr)
             break
-
+        if inverse:
+            line_offset = addr - (stop + ptrsize) + (telescope.offset * ptrsize)
+        else:
+            line_offset = addr - start + (telescope.offset * ptrsize)
         line = T.offset(
             "%02x%s%04x%s"
             % (
                 i + telescope.offset,
                 delimiter,
-                (addr - start + (telescope.offset * ptrsize)) * inverse_set,
+                line_offset,
                 separator,
             )
         ) + " ".join(


### PR DESCRIPTION
Add support for reverse stack growth
Fixes #1939 

Example:
```
pwndbg> stack
00:0000│ rsp 0x7fffffffdff8 —▸ 0x7ffff7629d90 (__libc_start_call_main+128) ◂— mov edi, eax
01:0008│     0x7fffffffe000 ◂— 0x0
02:0010│     0x7fffffffe008 —▸ 0x55555557ad70 (main) ◂— endbr64 
03:0018│     0x7fffffffe010 ◂— 0x1ffffe0f0
04:0020│     0x7fffffffe018 —▸ 0x7fffffffe108 —▸ 0x7fffffffe41b ◂— '/home/suhas/opensource/h2o/build/h2o'
05:0028│     0x7fffffffe020 ◂— 0x0
06:0030│     0x7fffffffe028 ◂— 0xc10b22a59101465d
07:0038│     0x7fffffffe030 —▸ 0x7fffffffe108 —▸ 0x7fffffffe41b ◂— '/home/suhas/opensource/h2o/build/h2o'
pwndbg> stack -i
00:0000│     0x7fffffffe030 —▸ 0x7fffffffe108 —▸ 0x7fffffffe41b ◂— '/home/suhas/opensource/h2o/build/h2o'
01:0008│     0x7fffffffe028 ◂— 0xc10b22a59101465d
02:0010│     0x7fffffffe020 ◂— 0x0
03:0018│     0x7fffffffe018 —▸ 0x7fffffffe108 —▸ 0x7fffffffe41b ◂— '/home/suhas/opensource/h2o/build/h2o'
04:0020│     0x7fffffffe010 ◂— 0x1ffffe0f0
05:0028│     0x7fffffffe008 —▸ 0x55555557ad70 (main) ◂— endbr64 
06:0030│     0x7fffffffe000 ◂— 0x0
07:0038│ rsp 0x7fffffffdff8 —▸ 0x7ffff7629d90 (__libc_start_call_main+128) ◂— mov edi, eax
```