### PR TITLE
Optimize pwndbg.exception import time

### DIFF
--- a/pwndbg/exception.py
+++ b/pwndbg/exception.py
@@ -12,17 +12,30 @@ import pwndbg.lib.stdio
 from pwndbg.color import message
 from pwndbg.gdblib import config
 
-with pwndbg.lib.stdio.stdio:
-    try:
-        import ipdb as pdb
-    except ImportError:
-        import pdb
-    try:
-        from rich.console import Console
+try:
+    import ipdb as pdb
+except ImportError:
+    import pdb
 
-        _rich_console = Console()
-    except ImportError:
-        _rich_console = None
+_rich_console = None
+
+
+def print_exception(exception_msg):
+    global _rich_console
+
+    if _rich_console is None:
+        try:
+            from rich.console import Console
+
+            _rich_console = Console()
+        except ImportError:
+            _rich_console = ...
+
+    if not isinstance(_rich_console, Ellipsis):  # type: ignore[arg-type]
+        _rich_console.print_exception()
+    else:
+        print(exception_msg)
+
 
 verbose = config.add_param(
     "exception-verbose",
@@ -96,10 +109,7 @@ def handle(name="Error"):
     # Display the error
     if debug or verbose:
         exception_msg = traceback.format_exc()
-        if _rich_console:
-            _rich_console.print_exception()
-        else:
-            print(exception_msg)
+        print_exception(exception_msg)
         inform_report_issue(exception_msg)
 
     else:

--- a/pwndbg/exception.py
+++ b/pwndbg/exception.py
@@ -5,7 +5,6 @@ import sys
 import traceback
 
 import gdb
-import pkg_resources
 
 import pwndbg.lib.cache
 import pwndbg.lib.stdio
@@ -51,6 +50,8 @@ def inform_unmet_dependencies(errors) -> None:
     """
     Informs user about unmet dependencies
     """
+    import pkg_resources
+
     msg = message.error("You appear to have unmet Pwndbg dependencies.\n")
     for e in errors:
         if isinstance(e, pkg_resources.DistributionNotFound):


### PR DESCRIPTION
Timing legend:

```
import time: self [us] | cumulative | imported package
```

Before:
```
root@pwndbg:~/pwndbg# PYTHONPROFILEIMPORTTIME=1 gdb --batch 2>&1 | grep 'pwndbg\.exception'
import time:       557 |     127848 |     pwndbg.exception
root@pwndbg:~/pwndbg# PYTHONPROFILEIMPORTTIME=1 gdb --batch 2>&1 | grep 'pwndbg\.exception'
import time:       570 |     126656 |     pwndbg.exception
root@pwndbg:~/pwndbg# PYTHONPROFILEIMPORTTIME=1 gdb --batch 2>&1 | grep 'pwndbg\.exception'
import time:       506 |     120334 |     pwndbg.exception
root@pwndbg:~/pwndbg# PYTHONPROFILEIMPORTTIME=1 gdb --batch 2>&1 | grep 'pwndbg\.exception'
import time:       535 |     119497 |     pwndbg.exception
root@pwndbg:~/pwndbg# PYTHONPROFILEIMPORTTIME=1 gdb --batch 2>&1 | grep 'pwndbg\.exception'
import time:       504 |     119035 |     pwndbg.exception
root@pwndbg:~/pwndbg# PYTHONPROFILEIMPORTTIME=1 gdb --batch 2>&1 | grep 'pwndbg\.exception'
import time:       579 |     119783 |     pwndbg.exception
root@pwndbg:~/pwndbg# PYTHONPROFILEIMPORTTIME=1 gdb --batch 2>&1 | grep 'pwndbg\.exception'
import time:       499 |     123869 |     pwndbg.exception
```

After:

```
root@pwndbg:~/pwndbg# PYTHONPROFILEIMPORTTIME=1 gdb --batch 2>&1 | grep 'pwndbg\.exception'
import time:      1697 |      94657 |     pwndbg.exception
root@pwndbg:~/pwndbg# PYTHONPROFILEIMPORTTIME=1 gdb --batch 2>&1 | grep 'pwndbg\.exception'
import time:       430 |      83743 |     pwndbg.exception
root@pwndbg:~/pwndbg# PYTHONPROFILEIMPORTTIME=1 gdb --batch 2>&1 | grep 'pwndbg\.exception'
import time:       433 |      88847 |     pwndbg.exception
root@pwndbg:~/pwndbg# PYTHONPROFILEIMPORTTIME=1 gdb --batch 2>&1 | grep 'pwndbg\.exception'
import time:       474 |      93674 |     pwndbg.exception
root@pwndbg:~/pwndbg# PYTHONPROFILEIMPORTTIME=1 gdb --batch 2>&1 | grep 'pwndbg\.exception'
import time:       372 |      83209 |     pwndbg.exception
root@pwndbg:~/pwndbg# PYTHONPROFILEIMPORTTIME=1 gdb --batch 2>&1 | grep 'pwndbg\.exception'
import time:       529 |      83643 |     pwndbg.exception
root@pwndbg:~/pwndbg# PYTHONPROFILEIMPORTTIME=1 gdb --batch 2>&1 | grep 'pwndbg\.exception'
import time:       374 |      85408 |     pwndbg.exception
root@pwndbg:~/pwndbg# PYTHONPROFILEIMPORTTIME=1 gdb --batch 2>&1 | grep 'pwndbg\.exception'
import time:       374 |      83411 |     pwndbg.exception
```

This is of course not a huge benefit since its around 0.04s but its always something.