### PR TITLE
exception.py: fix bug when printing exceptions

### DIFF
--- a/pwndbg/exception.py
+++ b/pwndbg/exception.py
@@ -30,7 +30,7 @@ def print_exception(exception_msg):
         except ImportError:
             _rich_console = ...
 
-    if not isinstance(_rich_console, Ellipsis):  # type: ignore[arg-type]
+    if not isinstance(_rich_console, type(Ellipsis)):  # type: ignore[arg-type]
         _rich_console.print_exception()
     else:
         print(exception_msg)


### PR DESCRIPTION
TL;DR: isinstance(obj, Ellipsis) should be isinstance(obj, type(Ellipsis))

<!-- Please make sure to read the testing and linting instructions at https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md before creating a PR -->
