### PR TITLE
Fix Pwndbg on Py3.12 and Fedora: add setuptools as dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -257,6 +257,8 @@ packages = [
 [tool.poetry.dependencies]
 python = "^3.8"
 capstone = "5.0.0.post1"
+# Needed by Capstone due to https://github.com/pwndbg/pwndbg/pull/1946#issuecomment-1921603947
+setuptools = "69.0.3"
 psutil = "5.9.5"
 pwntools = "4.11.0"
 pycparser = "2.21"


### PR DESCRIPTION
It turned out that in some cases - e.g. when installing Pwndbg on Fedora 39 which uses Python 3.12, Pwndbg does not work failing with:

```
Traceback (most recent call last):
  File "/home/hhlp/.pwndbg/gdbinit.py", line 74, in <module>
    import pwndbg  # noqa: F401
    ^^^^^^^^^^^^^
  File "/home/hhlp/.pwndbg/pwndbg/__init__.py", line 9, in <module>
    import pwndbg.commands
  File "/home/hhlp/.pwndbg/pwndbg/commands/__init__.py", line 24, in <module>
    from pwndbg.heap.ptmalloc import DebugSymsHeap
  File "/home/hhlp/.pwndbg/pwndbg/heap/ptmalloc.py", line 18, in <module>
    import pwndbg.disasm
  File "/home/hhlp/.pwndbg/pwndbg/disasm/__init__.py", line 14, in <module>
    import capstone
  File "/home/hhlp/.pwndbg/.venv/lib/python3.12/site-packages/capstone/__init__.py", line 326, in <module>
    import distutils.sysconfig
ModuleNotFoundError: No module named 'distutils'
(gdb) 
```

It turns out that `distutils` package was removed in Python 3.12 and it is now provided by the `setuptools` module.

This commit fixes this issue by adding `setuptools` as a direct Pwndbg dependency.

<!-- Please make sure to read the testing and linting instructions at https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md before creating a PR -->
