### PR TITLE
cyclic: add argument to save output to file (fixes #2007)

### DIFF
--- a/pwndbg/commands/cyclic.py
+++ b/pwndbg/commands/cyclic.py
@@ -30,6 +30,7 @@ parser.add_argument(
     help="Size of the unique subsequences (defaults to the pointer size for the current arch)",
 )
 
+
 group = parser.add_mutually_exclusive_group(required=False)
 group.add_argument(
     "-l",
@@ -50,9 +51,17 @@ group.add_argument(
     help="Number of characters to print from the sequence (default: print the entire sequence)",
 )
 
+parser.add_argument(
+    "filename",
+    type=str,
+    help="Name (path) of the file to save the cyclic pattern to",
+    default="",
+    nargs="?",
+)
+
 
 @pwndbg.commands.ArgparsedCommand(parser, command_name="cyclic")
-def cyclic_cmd(alphabet, length, lookup, count=100) -> None:
+def cyclic_cmd(alphabet, length, lookup, count=100, filename="") -> None:
     if length:
         # Convert from gdb.Value
         length = int(length)
@@ -93,5 +102,12 @@ def cyclic_cmd(alphabet, length, lookup, count=100) -> None:
         else:
             print(message.success(f"Found at offset {offset}"))
     else:
-        sequence = cyclic(int(count), alphabet, length)
-        print(sequence.decode())
+        count = int(count)
+        sequence = cyclic(count, alphabet, length)
+
+        if not filename:
+            print(sequence.decode())
+        else:
+            with open(filename, "wb") as f:
+                f.write(sequence)
+                print(f"Written a cyclic sequence of length {count} to file {filename}")


### PR DESCRIPTION
This commit adds a `[filename]` argument to the `cyclic` command.

This makes it possible to do things like `cyclic 100 input` and `run < input` which was a feature Peda users used in the past.

Here is the full new help for cyclic command:

```
pwndbg> help cyclic
usage: cyclic [-h] [-a charset] [-n length] [-l lookup_value | count] [filename]

Cyclic pattern creator/finder.

positional arguments:
  count                 Number of characters to print from the sequence (default: print the
                        entire sequence) (default: 100)
  filename              Name (path) of the file to save the cyclic pattern to (default: )

options:
  -h, --help            show this help message and exit
  -a charset, --alphabet charset
                        The alphabet to use in the cyclic pattern (default:
                        abcdefghijklmnopqrstuvwxyz)
  -n length, --length length
                        Size of the unique subsequences (defaults to the pointer size for the
                        current arch)
  -l lookup_value, -o lookup_value, --offset lookup_value, --lookup lookup_value
                        Do a lookup instead of printing the sequence (accepts constant values
                        as well as expressions)
```

<!-- Please make sure to read the testing and linting instructions at https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md before creating a PR -->
