### PR TITLE
Add ".." to the list of local path prefixes in `get_file()`

### DIFF
--- a/pwndbg/gdblib/file.py
+++ b/pwndbg/gdblib/file.py
@@ -57,7 +57,7 @@ def get_file(path: str, try_local_path: bool = False) -> str:
     Returns:
         The local path to the file
     """
-    assert path.startswith(("/", "./")) or path.startswith(
+    assert path.startswith(("/", "./", "../")) or path.startswith(
         "target:"
     ), "get_file called with incorrect path"
 


### PR DESCRIPTION
<!-- Please make sure to read the testing and linting instructions at https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md before creating a PR -->

This commit adds "../" to the list of local path prefixes.

Reproduce (assume that patchelf is in PATH)
```sh
ln -s /lib64/ld-linux-x86-64.so.2 ./ld-linux-x86-64.so.2
mkdir bin && cd bin
echo "int main() {}" > main.c && gcc -o main main.c
patchelf --set-interpreter ../ld-linux-x86-64.so.2 ./main
gdb -ex "set exception-debugger on" -ex "entry" -ex "got -a" ./main
```

Output:

```py
Reading symbols from ./main...
(No debugging symbols found in ./main)
Temporary breakpoint 1 at 0x555555555040
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".

Temporary breakpoint 1, 0x0000555555555040 in _start ()
Filtering out read-only entries (display them with -r or --show-readonly)

State of the GOT of ***/bin/main:
GOT protection: Partial RELRO | Found 0 GOT entries passing the filter

Traceback (most recent call last):
  File "***/pwndbg/pwndbg/commands/__init__.py", line 181, in __call__
    return self.function(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "***/pwndbg/pwndbg/commands/__init__.py", line 328, in _OnlyWhenRunning
    return function(*a, **kw)
           ^^^^^^^^^^^^^^^^^^
  File "***/pwndbg/pwndbg/commands/got.py", line 100, in got
    _got(path, accept_readonly, symbol_filter)
  File "***/pwndbg/pwndbg/commands/got.py", line 113, in _got
    local_path = pwndbg.gdblib.file.get_file(path, try_local_path=True)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "***/pwndbg/pwndbg/gdblib/file.py", line 60, in get_file
    assert path.startswith(("/", "./")) or path.startswith(
AssertionError: get_file called with incorrect path

If that is an issue, you can report it on https://github.com/pwndbg/pwndbg/issues
(Please don't forget to search if it hasn't been reported before)
To generate the report and open a browser, you may run `bugreport --run-browser`
PS: Pull requests are welcome
> ***/pwndbg/pwndbg/gdblib/file.py(60)get_file()
-> assert path.startswith(("/", "./")) or path.startswith(
(Pdb) p path
'../ld-linux-x86-64.so.2'
(Pdb) 
```