### PR TITLE
extend cymbol command to support struct loading from header files

### DIFF
--- a/pwndbg/commands/cymbol.py
+++ b/pwndbg/commands/cymbol.py
@@ -141,6 +141,42 @@ def add_custom_structure(custom_structure_name: str) -> None:
     load_custom_structure.__wrapped__(custom_structure_name, pwndbg_custom_structure_path)
 
 
+def add_custom_structure_from_file(header_file_path: str) -> None:
+    with open(header_file_path, "r") as file:
+        custom_structures_source = file.read().strip()
+
+    if not custom_structures_source:
+        print(message.notice("The header file is empty or does not contain valid structures."))
+        return
+
+    custom_structure_name = os.path.splitext(os.path.basename(header_file_path))[0]
+    pwndbg_custom_structure_path = os.path.join(pwndbg_cachedir, custom_structure_name) + ".c"
+
+    with open(pwndbg_custom_structure_path, "w") as f:
+        f.write(custom_structures_source)
+
+    print(message.success(f"Custom structure from {header_file_path} added."))
+    load_custom_structure(custom_structure_name)
+
+
+def add_custom_structure_from_file(header_file_path: str) -> None:
+    with open(header_file_path, "r") as file:
+        custom_structures_source = file.read().strip()
+
+    if not custom_structures_source:
+        print(message.notice("The header file is empty or does not contain valid structures."))
+        return
+
+    custom_structure_name = os.path.splitext(os.path.basename(header_file_path))[0]
+    pwndbg_custom_structure_path = os.path.join(pwndbg_cachedir, custom_structure_name) + ".c"
+
+    with open(pwndbg_custom_structure_path, "w") as f:
+        f.write(custom_structures_source)
+
+    print(message.success(f"Custom structure from {header_file_path} added."))
+    load_custom_structure(custom_structure_name)
+
+
 @OnlyWhenStructFileExists
 def edit_custom_structure(custom_structure_name: str, custom_structure_path: str) -> None:
     # Lookup an editor to use for editing the custom structure.
@@ -244,6 +280,14 @@ parser.add_argument(
     "--show",
     metavar="name",
     help="Show the source code of an existing custom structure",
+    default=None,
+    type=str,
+)
+parser.add_argument(
+    "-f",
+    "--file",
+    metavar="header_file",
+    help="Path to a C header file containing struct definitions",
     default=None,
     type=str,
 )

--- a/pwndbg/commands/cymbol.py
+++ b/pwndbg/commands/cymbol.py
@@ -276,7 +276,7 @@ parser.add_argument(
 
 
 @pwndbg.commands.ArgparsedCommand(parser)
-def cymbol(add, remove, edit, load, show) -> None:
+def cymbol(add, remove, edit, load, show, file) -> None:
     if add:
         add_custom_structure(add)
     elif remove:
@@ -287,5 +287,7 @@ def cymbol(add, remove, edit, load, show) -> None:
         load_custom_structure(load)
     elif show:
         show_custom_structure(show)
+    elif file:
+        add_custom_structure_from_file(file)
     else:
         parser.print_help()

--- a/pwndbg/commands/cymbol.py
+++ b/pwndbg/commands/cymbol.py
@@ -159,24 +159,6 @@ def add_custom_structure_from_file(header_file_path: str) -> None:
     load_custom_structure(custom_structure_name)
 
 
-def add_custom_structure_from_file(header_file_path: str) -> None:
-    with open(header_file_path, "r") as file:
-        custom_structures_source = file.read().strip()
-
-    if not custom_structures_source:
-        print(message.notice("The header file is empty or does not contain valid structures."))
-        return
-
-    custom_structure_name = os.path.splitext(os.path.basename(header_file_path))[0]
-    pwndbg_custom_structure_path = os.path.join(pwndbg_cachedir, custom_structure_name) + ".c"
-
-    with open(pwndbg_custom_structure_path, "w") as f:
-        f.write(custom_structures_source)
-
-    print(message.success(f"Custom structure from {header_file_path} added."))
-    load_custom_structure(custom_structure_name)
-
-
 @OnlyWhenStructFileExists
 def edit_custom_structure(custom_structure_name: str, custom_structure_path: str) -> None:
     # Lookup an editor to use for editing the custom structure.


### PR DESCRIPTION
This update should allow for (hopefully) easier debugging sessions by enhancing the cymbol command, incorporating external struct information directly into pwndbg, facilitating easier analysis of data structures without the need for source code modification.

- Parsing of C header files to extract struct definitions.
- Configuration options to specify custom header file paths.
