### PR TITLE
Fix lint.sh

### DIFF
--- a/lint.sh
+++ b/lint.sh
@@ -26,24 +26,14 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-set -o xtrace
-
 # Use Python virtual env for all programs used here
 if [[ -z "${PWNDBG_VENV_PATH}" ]]; then
     PWNDBG_VENV_PATH="./.venv"
 fi
 
-# shfmt is not a Python program but a system binary
-# so let's hack it into the virtualenv
-# This is not great, but we can't add a single binary to $PATH
-SHFMT_PATH=$(which shfmt)
-if [[ ! -z "${SHFMT_PATH}" ]]; then
-    ln -s ${SHFMT_PATH} ${PWNDBG_VENV_PATH}/bin/shfmt 2> /dev/null || true
-fi
-
-# Override PATH because we don't want any system-level binaries to be used
-PATH="${PWNDBG_VENV_PATH}/bin/"
 source "${PWNDBG_VENV_PATH}/bin/activate"
+
+set -o xtrace
 
 LINT_FILES="pwndbg tests *.py"
 LINT_TOOLS="isort black ruff vermin mypy"
@@ -62,7 +52,7 @@ call_shfmt() {
         local SHFMT_FILES=$(find . -name "*.sh" -not -path "./.venv/*")
         # Indents are four spaces, binary ops can start a line, indent switch cases,
         # and allow spaces following a redirect
-        shfmt ${FLAGS} -i 4 -bn -ci -sr -d .
+        shfmt ${FLAGS} -i 4 -bn -ci -sr -d ${SHFMT_FILES}
     else
         echo "shfmt not installed, skipping"
     fi


### PR DESCRIPTION
I don't think setting the PATH to the .venv bin directory is a good idea. We should just source the .venv, which puts its bin directory at the front of the path so those utilities will be found first. This way we don't have to rely on symlinks every time we want to use a system binary (i.e. the previous PR added a call to `find` and I didn't realize I needed to symlink it, and `errexit` doesn't work for subshells so I didn't notice).

Also, I forgot to actually use `${SHFMT_FILES}` in my previous PR, so this fixes that too.