### PR TITLE
Allow customizing qemu image download URL from command line

### DIFF
--- a/tests/qemu-tests/download_images.sh
+++ b/tests/qemu-tests/download_images.sh
@@ -4,7 +4,7 @@ set -o errexit
 
 CWD=$(dirname -- "$0")
 OUT_DIR="${CWD}/images"
-URL="https://github.com/pwndbg/linux-exploit-dev-env/releases/latest/download"
+URL=${URL:-"https://github.com/pwndbg/linux-exploit-dev-env/releases/latest/download"}
 
 mkdir -p "${OUT_DIR}"
 


### PR DESCRIPTION
This lets you run `URL=<my url> ./download_images.sh` to download the QEMU images from a different location. This makes it easier to test if the tests pass with the latest pre-release build of the images on GH before making that pre-release an official release.