### PR TITLE
feat : use "PIP_NO_CACHE_DIR" env with pip in dockerfiles to save space

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -10,6 +10,8 @@ if ! hash sudo 2> /dev/null && whoami | grep root; then
     }
 fi
 
+PIP_NO_CACHE_DIR=true
+
 # Helper functions
 linux() {
     uname | grep -i Linux &> /dev/null


### PR DESCRIPTION
using the  "PIP_NO_CACHE_DIR" env with pip install, make sure downloaded packages by pip don't cache on the system. This is a best practice that makes sure to fetch from a repo instead of using a local cached one. Further, in the case of Docker Containers, by restricting caching, we can reduce image size. In terms of stats, it depends upon the number of python packages multiplied by their respective size. e.g for heavy packages with a lot of dependencies it reduces a lot by don't cache pip packages.

Further, more detailed information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>