### PR TITLE
Allow using `regs` command for any valid register

### DIFF
--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -579,11 +579,10 @@ def get_regs(regs: List[str] = None):
         if reg is None:
             continue
 
-        if reg not in pwndbg.gdblib.regs:
+        value = pwndbg.gdblib.regs[reg]
+        if value is None:
             print(message.warn("Unknown register: %r" % reg))
             continue
-
-        value = pwndbg.gdblib.regs[reg]
 
         # Make the register stand out and give a color if changed
         regname = C.register(reg.ljust(4).upper())


### PR DESCRIPTION
Before the `regs` command wouldn't allow you to view the value of a register if it wasn't defined in the register set. This PR removes that restriction. We attempt to get the register value, and we only warn the user if the value is `None`. This allows you to see any register with `pwndbg.chain.format`, as well as use the lowercase name of a register and still see the value (which is not supported by GDB's `info register`).