### PR TITLE
Disallow any-generics

### DIFF
--- a/pwndbg/auxv.py
+++ b/pwndbg/auxv.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import os
 import re
 import sys
+from typing import Dict
+from typing import Union
 
 import gdb
 
@@ -81,7 +83,7 @@ AT_CONSTANTS = {
 sys.modules[__name__].__dict__.update({v: k for k, v in AT_CONSTANTS.items()})
 
 
-class AUXV(dict):
+class AUXV(Dict[str, Union[int, str]]):
     def set(self, const: int, value) -> None:
         name = AT_CONSTANTS.get(const, "AT_UNKNOWN%i" % const)
 

--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -567,7 +567,7 @@ class ArgparsedCommand:
             if action.default is not None:
                 action.help += " (default: %(default)s)"
 
-    def __call__(self, function: Callable) -> _ArgparsedCommand:
+    def __call__(self, function: Callable[..., Any]) -> _ArgparsedCommand:
         for alias in self.aliases:
             _ArgparsedCommand(
                 self.parser, function, command_name=alias, is_alias=True, category=self.category

--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -5,6 +5,7 @@ import ast
 import os
 import sys
 from collections import defaultdict
+from typing import Any
 from typing import DefaultDict
 from typing import List
 from typing import Tuple
@@ -199,7 +200,7 @@ class CallOutput:
             return False
 
 
-def output(section):
+def output(section: str):
     """Creates a context manager corresponding to configured context output"""
     target = outputs.get(section, str(config_output))
     if not target or target == "stdout":
@@ -394,7 +395,7 @@ def context(subcontext=None) -> None:
     sections += [(arg, context_sections.get(arg[0], None)) for arg in args]
 
     result = defaultdict(list)
-    result_settings: DefaultDict[str, dict] = defaultdict(dict)
+    result_settings: DefaultDict[str, dict[Any, Any]] = defaultdict(dict)
     for section, func in sections:
         if func:
             target = output(section)

--- a/pwndbg/commands/killthreads.py
+++ b/pwndbg/commands/killthreads.py
@@ -20,7 +20,7 @@ Killing all other threads may be useful to use GDB checkpoints, e.g., to test gi
 """,
 )
 
-parser.add_argument("thread_ids", nargs="*", help="Thread IDs to kill.")
+parser.add_argument("thread_ids", type=int, nargs="*", help="Thread IDs to kill.")
 parser.add_argument(
     "-a",
     "--all",
@@ -31,7 +31,7 @@ parser.add_argument(
 
 @pwndbg.commands.ArgparsedCommand(parser, category=CommandCategory.PROCESS)
 @pwndbg.commands.OnlyWhenRunning
-def killthreads(thread_ids: list | None = None, all: bool = False) -> None:
+def killthreads(thread_ids: list[int] | None = None, all: bool = False) -> None:
     if len(thread_ids) == 0 and not all:
         print(message.error("No thread IDs or --all flag specified"))
         return

--- a/pwndbg/disasm/__init__.py
+++ b/pwndbg/disasm/__init__.py
@@ -65,7 +65,7 @@ VariableInstructionSizeMax = {
     "rv64": 22,
 }
 
-backward_cache: DefaultDict = collections.defaultdict(lambda: None)
+backward_cache: DefaultDict[int, int] = collections.defaultdict(lambda: None)
 
 
 @pwndbg.lib.cache.cache_until("objfile")

--- a/pwndbg/gdblib/onegadget.py
+++ b/pwndbg/gdblib/onegadget.py
@@ -6,6 +6,7 @@ import os
 import re
 import subprocess
 from enum import Enum
+from typing import Any
 
 import gdb
 from tabulate import tabulate
@@ -181,13 +182,13 @@ class Lambda:
         self.deref_count -= 1
         return self
 
-    def evaluate(self, context: dict) -> int | Lambda:
+    def evaluate(self, context: dict[Any, Any]) -> int | Lambda:
         if self.deref_count > 0 or (self.obj and self.obj not in context):
             raise ValueError(f"Can't eval {self}")
         return context[self.obj] + self.immi
 
     @staticmethod
-    def parse(argument: str, predefined: dict = {}) -> int | Lambda:
+    def parse(argument: str, predefined: dict[Any, Any] = {}) -> int | Lambda:
         if not argument or argument == "!":
             return 0
         try:

--- a/pwndbg/heap/structs.py
+++ b/pwndbg/heap/structs.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import ctypes
+from typing import Any
 
 import gdb
 
@@ -202,7 +203,7 @@ class CStruct2GDB:
         return fake_gdb_fields
 
     @classmethod
-    def keys(cls) -> list:
+    def keys(cls) -> list[str]:
         """
         Return a list of the names of the fields in the struct to make it compatible with the `gdb.Type` interface.
         """
@@ -221,7 +222,7 @@ class CStruct2GDB:
         """
         return getattr(cls._c_struct, field).offset
 
-    def items(self) -> tuple:
+    def items(self) -> tuple[tuple[Any, Any], ...]:
         """
         Returns a tuple of (field name, field value) pairs.
         """

--- a/pwndbg/ida.py
+++ b/pwndbg/ida.py
@@ -481,7 +481,7 @@ class IDC:
 
     def __init__(self) -> None:
         if available():
-            data: dict = _ida.eval(self.query)
+            data: dict[Any, Any] = _ida.eval(self.query)
             self.__dict__.update(data)
 
 

--- a/pwndbg/lib/cache.py
+++ b/pwndbg/lib/cache.py
@@ -25,7 +25,7 @@ debug = NO_DEBUG
 debug_name = "regs"
 
 
-class DebugCacheDict(UserDict):
+class DebugCacheDict(UserDict):  # type: ignore[type-arg]
     def __init__(self, func: Callable[..., Any], *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self.hits = 0

--- a/pwndbg/lib/kernel/kconfig.py
+++ b/pwndbg/lib/kernel/kconfig.py
@@ -24,7 +24,7 @@ def config_to_key(name: str) -> str:
     return "CONFIG_" + name.upper()
 
 
-class Kconfig(UserDict):
+class Kconfig(UserDict):  # type: ignore[type-arg]
     def __init__(self, compressed_config: bytes) -> None:
         super().__init__()
         self.data = parse_compresed_config(compressed_config)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ strict_optional = false
 check_untyped_defs = true
 allow_untyped_globals = true
 allow_redefinition = true
+allow_any_generics = false
 warn_redundant_casts = true
 warn_unused_ignores = true
 warn_no_return = true


### PR DESCRIPTION
Set the `mypy` option `allow_any_generics` to `false`, update as many type hints as accurately as possible, set the rest of the hints to `Any` for now. We aren't allowed to subscript `UserDict` until Python 3.9, so add `# type: ignore` there for now.