### PR TITLE
nix: cryptography: disable build from source, because rust hash had t…

### DIFF
--- a/nix/pwndbg.nix
+++ b/nix/pwndbg.nix
@@ -18,6 +18,12 @@ let
     overrides = pkgs.poetry2nix.overrides.withDefaults (self: super: {
       pip = python3.pkgs.pip;  # fix infinite loop in nix, look here: https://github.com/nix-community/poetry2nix/issues/1184#issuecomment-1644878841
       unicorn = python3.pkgs.unicorn;  # fix build for aarch64 (but it will use same version like in nixpkgs)
+
+      # disable build from source, because rust's hash had to be repaired many times, see: PR https://github.com/pwndbg/pwndbg/pull/2024
+      cryptography = super.cryptography.override {
+        preferWheel = true;
+      };
+
       pt = super.pt.overridePythonAttrs (old: {
         buildInputs = (old.buildInputs or [ ]) ++ [ super.poetry-core ];
       });


### PR DESCRIPTION
cryptography: disable build from source, because rust hash had to be repaired many times, see: eg. https://github.com/pwndbg/pwndbg/pull/2024