### PR TITLE
[Docs] remove revision date from docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,13 +45,11 @@ plugins:
       separator: '[\s\u200b\-_,:!=\[\]()"`/]+|\.(?!\d)|&[lg]t;|(?!\b)(?=[A-Z][a-z])'
   - minify:
       minify_html: true
-  - git-revision-date-localized
   - git-committers:
       repository: pwndbg/pwndbg
       branch: dev
       exclude:
         - index.md
-        - docs/source/**
         - docs/commands/**
   - gen-files:
       scripts:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -59,7 +59,7 @@ plugins:
       default_handler: python
       handlers:
         python:
-          paths: [pwndbg]
+          paths: []
           # load_external_modules: true
           options:
             allow_inspection: true

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,12 +45,12 @@ plugins:
       separator: '[\s\u200b\-_,:!=\[\]()"`/]+|\.(?!\d)|&[lg]t;|(?!\b)(?=[A-Z][a-z])'
   - minify:
       minify_html: true
-  - git-committers:
-      repository: pwndbg/pwndbg
-      branch: dev
-      exclude:
-        - index.md
-        - docs/commands/**
+  # - git-committers:
+  #     repository: pwndbg/pwndbg
+  #     branch: dev
+  #     exclude:
+  #       - index.md
+  #       - docs/commands/**
   - gen-files:
       scripts:
         - scripts/gen_ref_pages.py

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,3 +1,4 @@
+site_url: https://pwndbg.re/pwndbg/
 site_name: Documentation
 site_description: >-
   pwndbg (/paʊnˈdiˌbʌɡ/) is a GDB plug-in that makes debugging with GDB suck less, with a focus on features needed by low-level software developers, hardware hackers, reverse-engineers and exploit developers.


### PR DESCRIPTION
git-revision-date-localized-plugin Running on GitHub Actions might lead to wrong
git-committers plugin may require a GitHub token if we exceed the API rate limit or for private repositories
