### PR TITLE
Re-enable attr-defined type check error for some modules

### DIFF
--- a/pwndbg/auxv.py
+++ b/pwndbg/auxv.py
@@ -98,9 +98,7 @@ class AUXV(Dict[str, Union[int, str]]):
 
         if name in ["AT_EXECFN", "AT_PLATFORM"]:
             try:
-                value = gdb.Value(value)
-                value = value.cast(pwndbg.gdblib.typeinfo.pchar)
-                value = value.string()
+                value = gdb.Value(value).cast(pwndbg.gdblib.typeinfo.pchar).string()
             except Exception:
                 value = "couldnt read AUXV!"
 

--- a/pwndbg/disasm/__init__.py
+++ b/pwndbg/disasm/__init__.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import collections
 import re
+import typing
 from typing import DefaultDict
 from typing import List
 from typing import Union
@@ -141,7 +142,7 @@ class SimpleInstruction:
     def __init__(self, address) -> None:
         self.address = address
         ins = gdb.newest_frame().architecture().disassemble(address)[0]
-        asm = ins["asm"].split(maxsplit=1)
+        asm = typing.cast(str, ins["asm"]).split(maxsplit=1)
         self.mnemonic = asm[0].strip()
         self.op_str = asm[1].strip() if len(asm) > 1 else ""
         self.size = ins["length"]

--- a/pwndbg/gdblib/__init__.py
+++ b/pwndbg/gdblib/__init__.py
@@ -17,7 +17,7 @@ regs = None
 __all__ = ["ctypes", "memory", "typeinfo"]
 
 # Export parsed GDB version
-gdb_version = tuple(map(int, re.search(r"(\d+)[^\d]+(\d+)", gdb.VERSION).groups()))
+gdb_version = tuple(map(int, re.search(r"(\d+)[^\d]+(\d+)", gdb.VERSION).groups()))  # type: ignore[attr-defined]
 
 
 # TODO: should the imports above be moved here?

--- a/pwndbg/gdblib/bpoint.py
+++ b/pwndbg/gdblib/bpoint.py
@@ -51,7 +51,7 @@ class BreakpointEvent(gdb.Breakpoint):
         )
 
     def delete(self) -> None:
-        REGISTERED_BP_EVENTS.remove(id(self))
+        del REGISTERED_BP_EVENTS[id(self)]
         super().delete()
 
     def on_breakpoint_hit(self) -> None:

--- a/pwndbg/gdblib/kernel/__init__.py
+++ b/pwndbg/gdblib/kernel/__init__.py
@@ -232,7 +232,7 @@ class i386Ops(x86Ops):
     def __init__(self) -> None:
         # https://elixir.bootlin.com/linux/v6.2/source/arch/x86/include/asm/page_32_types.h#L18
         self._PAGE_OFFSET = int(kconfig()["CONFIG_PAGE_OFFSET"], 16)
-        self.START_KERNEL_map = self.PAGE_OFFSET
+        self.START_KERNEL_map = self._PAGE_OFFSET
 
     @property
     def ptr_size(self) -> int:

--- a/pwndbg/gdblib/memory.py
+++ b/pwndbg/gdblib/memory.py
@@ -43,15 +43,14 @@ def read(addr: int, count: int, partial: bool = False) -> bytearray:
         if not partial:
             raise
 
-        if not hasattr(e, "message"):
-            e.message = str(e)
+        message = str(e)
 
         stop_addr = addr
-        match = re.search(r"Memory at address (\w+) unavailable\.", e.message)
+        match = re.search(r"Memory at address (\w+) unavailable\.", message)
         if match:
             stop_addr = int(match.group(1), 0)
         else:
-            stop_addr = int(e.message.split()[-1], 0)
+            stop_addr = int(message.split()[-1], 0)
 
         if stop_addr != addr:
             return read(addr, stop_addr - addr)

--- a/pwndbg/gdblib/regs.py
+++ b/pwndbg/gdblib/regs.py
@@ -43,6 +43,7 @@ ARCH_GET_GS = 0x1004
 
 
 class module(ModuleType):
+    previous: dict[str, int] = {}
     last: dict[str, int] = {}
 
     @pwndbg.lib.cache.cache_until("stop", "prompt")

--- a/pwndbg/lib/abi.py
+++ b/pwndbg/lib/abi.py
@@ -40,7 +40,7 @@ class ABI:
         return DEFAULT_ABIS[(8 * pwndbg.gdblib.arch.ptrsize, pwndbg.gdblib.arch.current, "linux")]
 
     @staticmethod
-    def syscall() -> ABI:
+    def syscall() -> SyscallABI:
         return SYSCALL_ABIS[(8 * pwndbg.gdblib.arch.ptrsize, pwndbg.gdblib.arch.current, "linux")]
 
     @staticmethod
@@ -111,7 +111,7 @@ DEFAULT_ABIS: Dict[Tuple[int, str, str], ABI] = {
     (64, "rv64", "linux"): linux_riscv64,
 }
 
-SYSCALL_ABIS: Dict[Tuple[int, str, str], ABI] = {
+SYSCALL_ABIS: Dict[Tuple[int, str, str], SyscallABI] = {
     (32, "i386", "linux"): linux_i386_syscall,
     (64, "x86-64", "linux"): linux_amd64_syscall,
     (64, "aarch64", "linux"): linux_aarch64_syscall,

--- a/pwndbg/lib/cache.py
+++ b/pwndbg/lib/cache.py
@@ -153,7 +153,7 @@ def cache_until(*event_names: str) -> Callable[[Callable[..., T]], Callable[...,
 
         # Set the cache on the function so it can be cleared on demand
         # this may be useful for tests
-        decorator.cache = cache
+        decorator.cache = cache  # type: ignore[attr-defined]
 
         # Register the cache for the given event so it can be cleared
         for event_name in event_names:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,22 +73,48 @@ pretty = true
 show_error_codes = true
 incremental = false
 disable_error_code = [
-    # Lots of dynamic attribute access
-    "attr-defined",
     # https://github.com/python/mypy/issues/6232
     "assignment"
 ]
 
 [[tool.mypy.overrides]]
 module = [
-   # Capstone constants
-   "pwndbg.disasm.*",
-   "pwndbg.gdblib.nearpc",
-   # Module fields
-   "pwndbg.gdblib.typeinfo",
-   "pwndbg.gdblib.elf",
+    "pwndbg.disasm.*",
+    "pwndbg.gdblib.elf",
 ]
 disable_error_code = ["name-defined"]
+
+[[tool.mypy.overrides]]
+module = [
+    "pwndbg.color.*",
+    "pwndbg.commands.context",
+    "pwndbg.commands.cymbol",
+    "pwndbg.commands.hexdump",
+    "pwndbg.commands.procinfo",
+    "pwndbg.commands.reload",
+    "pwndbg.commands.telescope",
+    "pwndbg.commands.version",
+    "pwndbg.exception",
+    "pwndbg.disasm.jump",
+    "pwndbg.gdblib.dt",
+    "pwndbg.gdblib.dynamic",
+    "pwndbg.gdblib.events",
+    "pwndbg.gdblib.got",
+    "pwndbg.gdblib.heap_tracking",
+    "pwndbg.gdblib.stack",
+    "pwndbg.heap.*",
+    "pwndbg.hexdump",
+    "pwndbg.ui",
+    "pwndbg.wrappers.*",
+]
+disable_error_code = ["attr-defined"]
+
+[[tool.mypy.overrides]]
+module = [
+    "pwndbg.gdblib.nearpc",
+    "pwndbg.gdblib.typeinfo",
+]
+disable_error_code = ["name-defined", "attr-defined"]
 
 [[tool.mypy.overrides]]
 module = ["capstone.*", "unicorn.*", "pwnlib.*", "elftools.*", "ipdb.*", "r2pipe", "rzpipe", "rich.*", "pt"]


### PR DESCRIPTION
Ignoring globally `attr-defined` errors was hiding some bugs. This PR fixes a few of the easy issues, and then disables `attr-defined` per-module instead of globally. There are quite a few offending modules, but this is still better than ignoring these errors throughout the entire project.