### PR TITLE
Return `int` in `fix_int_reraise`

### DIFF
--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -504,7 +504,7 @@ class _ArgparsedCommand(Command):
         self,
         parser: argparse.ArgumentParser,
         function,
-        command_name: Optional[str] = None,
+        command_name=None,
         *a,
         **kw,
     ) -> None:

--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -245,9 +245,8 @@ def fix_int(*a, **kw) -> int:
     return int(fix(*a, **kw))
 
 
-def fix_int_reraise(*a, **kw):
-    # Type error likely due to https://github.com/python/mypy/issues/6799
-    return fix(*a, reraise=True, **kw)  # type: ignore[misc]
+def fix_int_reraise(*a, **kw) -> int:
+    return fix_int(*a, reraise=True, **kw)
 
 
 def OnlyWithFile(function: Callable[..., T]) -> Callable[..., Optional[T]]:
@@ -505,7 +504,7 @@ class _ArgparsedCommand(Command):
         self,
         parser: argparse.ArgumentParser,
         function,
-        command_name=None,
+        command_name: Optional[str] = None,
         *a,
         **kw,
     ) -> None:

--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -241,6 +241,11 @@ def fix(
     return None
 
 
+def fix_reraise(*a, **kw) -> str | gdb.Value | None:
+    # Type error likely due to https://github.com/python/mypy/issues/6799
+    return fix(*a, reraise=True, **kw)  # type: ignore[misc]
+
+
 def fix_int(*a, **kw) -> int:
     return int(fix(*a, **kw))
 
@@ -561,8 +566,10 @@ class ArgparsedCommand:
                 action.type = str
             if action.dest == "help":
                 continue
-            if action.type in (int, None):
+            if action.type == int:
                 action.type = fix_int_reraise
+            if action.type is None:
+                action.type = fix_reraise
             if action.default is not None:
                 action.help += " (default: %(default)s)"
 

--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -236,13 +236,12 @@ parser.add_argument(
 
 
 @pwndbg.commands.ArgparsedCommand(parser, aliases=["ctx-out"], category=CommandCategory.CONTEXT)
-def contextoutput(section, path, clearing, banner="both", width=None):
+def contextoutput(section, path, clearing, banner="both", width: int = None):
     if not banner:  # synonym for splitmind backwards compatibility
         banner = "none"
     if banner not in ("both", "top", "bottom", "none"):
         raise argparse.ArgumentError(banner_arg, f"banner can not be '{banner}'")
-    if width is not None:
-        width = int(width)
+
     outputs[section] = path
     output_settings[section] = {
         "clearing": clearing,

--- a/pwndbg/commands/cyclic.py
+++ b/pwndbg/commands/cyclic.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import string
+from typing import Optional
 
 import gdb
 from pwnlib.util.cyclic import cyclic
@@ -61,11 +62,8 @@ parser.add_argument(
 
 
 @pwndbg.commands.ArgparsedCommand(parser, command_name="cyclic")
-def cyclic_cmd(alphabet, length, lookup, count=100, filename="") -> None:
-    if length:
-        # Convert from gdb.Value
-        length = int(length)
-    else:
+def cyclic_cmd(alphabet, length: Optional[int], lookup, count=100, filename="") -> None:
+    if length is None:
         length = pwndbg.gdblib.arch.ptrsize
 
     if lookup:

--- a/pwndbg/commands/flags.py
+++ b/pwndbg/commands/flags.py
@@ -35,8 +35,6 @@ parser.add_argument(
 
 @pwndbg.commands.ArgparsedCommand(parser, aliases=["flag"], category=CommandCategory.REGISTER)
 def setflag(flag: str, value: int) -> None:
-    value = int(value)
-
     register_set = pwndbg.gdblib.regs.current
 
     flag = flag.upper()

--- a/pwndbg/commands/leakfind.py
+++ b/pwndbg/commands/leakfind.py
@@ -78,23 +78,31 @@ parser.add_argument(
 parser.add_argument(
     "-o",
     "--max_offset",
+    type=int,
     default=0x48,
     nargs="?",
     help="Max offset to add to addresses when looking for leak",
 )
 parser.add_argument(
-    "-d", "--max_depth", default=0x4, nargs="?", help="Maximum depth to follow pointers to"
+    "-d",
+    "--max_depth",
+    type=int,
+    default=0x4,
+    nargs="?",
+    help="Maximum depth to follow pointers to",
 )
 parser.add_argument(
     "-s",
     "--step",
     nargs="?",
+    type=int,
     default=0x1,
     help="Step to add between pointers so they are considered. For example, if this is 4 it would only consider pointers at an offset divisible by 4 from the starting pointer",
 )
 parser.add_argument(
     "--negative_offset",
     nargs="?",
+    type=int,
     default=0x0,
     help="Max negative offset to search before an address when looking for a leak",
 )
@@ -103,7 +111,12 @@ parser.add_argument(
 @pwndbg.commands.ArgparsedCommand(parser, category=CommandCategory.MEMORY)
 @pwndbg.commands.OnlyWhenRunning
 def leakfind(
-    address=None, page_name=None, max_offset=0x40, max_depth=0x4, step=0x1, negative_offset=0x0
+    address=None,
+    page_name=None,
+    max_offset: int = 0x40,
+    max_depth: int = 0x4,
+    step: int = 0x1,
+    negative_offset: int = 0x0,
 ):
     if address is None:
         raise argparse.ArgumentTypeError("No starting address provided.")
@@ -115,16 +128,13 @@ def leakfind(
     if not pwndbg.gdblib.memory.peek(address):
         raise argparse.ArgumentTypeError("Unable to read from starting address.")
 
-    max_depth = int(max_depth)
     # Just warn the user that a large depth might be slow.
     # Probably worth checking offset^depth < threshold. Do this when more benchmarking is established.
     if max_depth > 8:
         print(message.warn("leakfind may take a while to run on larger depths."))
 
-    stride = int(step)
+    stride = step
     address = int(address)
-    max_offset = int(max_offset)
-    negative_offset = int(negative_offset)
 
     # The below map stores a map of child address->(parent_address,parent_start_address)
     # In the above tuple, parent_address is the exact address with a pointer to the child address.

--- a/pwndbg/commands/patch.py
+++ b/pwndbg/commands/patch.py
@@ -5,7 +5,6 @@ import argparse
 from typing import Dict
 from typing import Tuple
 
-import gdb
 from pwnlib.asm import asm
 from pwnlib.asm import disasm
 
@@ -29,10 +28,7 @@ parser.add_argument("-q", "--quiet", action="store_true", help="don't print anyt
 
 @pwndbg.commands.ArgparsedCommand(parser)
 @pwndbg.commands.OnlyWhenRunning
-def patch(address: gdb.Value | int, ins: str, quiet: bool) -> None:
-    # Make sure that any gdb.Value object is converted to int
-    address = int(address)
-
+def patch(address: int, ins: str, quiet: bool) -> None:
     new_mem = asm(ins)
 
     old_mem = pwndbg.gdblib.memory.read(address, len(new_mem))
@@ -54,10 +50,7 @@ parser2.add_argument("address", type=int, help="Address to revert patch on")
 
 @pwndbg.commands.ArgparsedCommand(parser2)
 @pwndbg.commands.OnlyWhenRunning
-def patch_revert(address: gdb.Value | int) -> None:
-    # Make sure that any gdb.Value object is converted to int
-    address = int(address)
-
+def patch_revert(address: int) -> None:
     if not patches:
         print(message.notice("No patches to revert"))
         return

--- a/pwndbg/commands/valist.py
+++ b/pwndbg/commands/valist.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 import argparse
 
-import gdb
-
 import pwndbg.chain
 import pwndbg.color as C
 import pwndbg.commands
@@ -15,7 +13,7 @@ parser.add_argument("count", type=int, nargs="?", default=8, help="Number of arg
 
 @pwndbg.commands.ArgparsedCommand(parser)
 @pwndbg.commands.OnlyWhenRunning
-def valist(addr: gdb.Value, count: int) -> None:
+def valist(addr: int, count: int) -> None:
     # The `va_list` struct looks like this:
     #
     # ```
@@ -27,7 +25,6 @@ def valist(addr: gdb.Value, count: int) -> None:
     # } va_list[1];
     # ```
 
-    addr = int(addr)
     gp_offset = pwndbg.gdblib.memory.u32(addr)
     gp_index = gp_offset / 8
 

--- a/pwndbg/commands/windbg.py
+++ b/pwndbg/commands/windbg.py
@@ -442,13 +442,13 @@ parser.add_argument(
 
 @pwndbg.commands.ArgparsedCommand(parser, category=CommandCategory.WINDBG)
 @pwndbg.commands.OnlyWhenRunning
-def ln(value=None) -> None:
+def ln(value: int = None) -> None:
     """
     List the symbols nearest to the provided value.
     """
     if value is None:
         value = pwndbg.gdblib.regs.pc
-    value = int(value)
+
     x = pwndbg.gdblib.symbol.get(value)
     if x:
         result = f"({value:#x})   {x}"


### PR DESCRIPTION
`fix_int_reraise` seems to indicate it should return an `int` from its name, but it seems we forgot to cast the result from `fix` to an int. This fixes that, and now all commands that have an argument of `type=int` will actually get an `int` instead of a `gdb.Value`. If the argument type is unspecified, `fix_reraise` will get called, which keeps the old behavior.

I removed some casts that are no longer necessary.