### PR TITLE
Unable to set param.value when encoding not UTF-8

### DIFF
--- a/gdbinit.py
+++ b/gdbinit.py
@@ -7,11 +7,13 @@ import os
 import site
 import sys
 import time
+import warnings
 from glob import glob
 from os import environ
 from os import path
 
 _profiler = cProfile.Profile()
+warnings.simplefilter("default", UnicodeWarning)
 
 _start_time = None
 if environ.get("PWNDBG_PROFILE") == "1":
@@ -60,14 +62,16 @@ else:
 encoding = locale.getpreferredencoding()
 
 if encoding != "UTF-8":
-    print("******")
-    print(f"Your encoding ({encoding}) is different than UTF-8. pwndbg might not work properly.")
-    print("You might try launching GDB with:")
-    print("    LC_CTYPE=C.UTF-8 gdb")
-    print(
-        "If that does not work, make sure that en_US.UTF-8 is uncommented in /etc/locale.gen and that you called `locale-gen` command"
-    )
-    print("******")
+    enc_warning_msg = """******
+    Your encoding ({}) is different than UTF-8. pwndbg might now work properly.
+    You might try launching GDB with:
+        LC_CTYPE=C.UTF-8 gdb
+
+    If that does not work, make sure that en_US.UTF-8 is uncommented in /etc/locale.gen and that you called `locale-gen` command.
+    ******
+    """.format(encoding)
+
+    warnings.warn(enc_warning_msg, UnicodeWarning)
 
 environ["PWNLIB_NOTERM"] = "1"
 

--- a/scripts/docs.py
+++ b/scripts/docs.py
@@ -7,12 +7,14 @@ import os
 import site
 import sys
 import time
+import warnings
 from glob import glob
 from os import environ
 from os import path
 import pdb, traceback, code
 
 _profiler = cProfile.Profile()
+warnings.simplefilter("module", UnicodeWarning)
 
 _start_time = None
 if environ.get("PWNDBG_PROFILE") == "1":
@@ -61,14 +63,16 @@ else:
 encoding = locale.getpreferredencoding()
 
 if encoding != "UTF-8":
-    print("******")
-    print(f"Your encoding ({encoding}) is different than UTF-8. pwndbg might not work properly.")
-    print("You might try launching GDB with:")
-    print("    LC_CTYPE=C.UTF-8 gdb")
-    print(
-        "If that does not work, make sure that en_US.UTF-8 is uncommented in /etc/locale.gen and that you called `locale-gen` command"
-    )
-    print("******")
+    enc_warning_msg = """******
+    Your encoding ({}) is different than UTF-8. pwndbg might not work properly.
+    You might try launching GDB with:
+        LC_CTYPE=C.UTF-8 gdb
+
+    If that does not work, make sure that en_US.UTF-8 is uncommented in /etc/locale.gen and that you called `locale-gen` command.
+    ******
+    """.format(encoding)
+
+    warnings.warn(enc_warning_msg, UnicodeWarning)
 
 environ["PWNLIB_NOTERM"] = "1"
 


### PR DESCRIPTION
Summary
-------
Prior to this change, when attempting to run `pwndbg` in Ubuntu 22.04.03 LTS docker container on Apple M3 MBP (without setting the code to UTF-8) the following pwn.lib.config.Parameter(s) were unable to be set:
- `chain-arrow-left`
- `chain-arrow-right`
- `banner-separator`
- `nearpc-branchmarker`
- `nearpc-prefix`
- `telescope-offset-separator`
- `telescope-repeating-marker`
- `backtrace-prefix`
- `code-prefix`
- `hexdump-ascii-block-separator`

All of these params correspond to the UI for `pwndbg`. By bypassing the set of param.value for each of these `pwndbg` is able to run on arm64 inside a docker container.

Altered the encoding warnings to warn using built-in `UnicodeWarning`.

<!-- Please make sure to read the testing and linting instructions at https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md before creating a PR -->
