### PR TITLE
Update types-gdb version

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -8,7 +8,7 @@ rich==13.7.1
 ruff==0.3.0
 testresources==2.0.1
 tomli==2.0.1
-types-gdb==12.1.4.20240113
+types-gdb==12.1.4.20240305
 types-psutil==5.9.5.20240205
 types-Pygments==2.17.0.20240106
 types-requests==2.31.0.20240218

--- a/pwndbg/gdblib/__init__.py
+++ b/pwndbg/gdblib/__init__.py
@@ -17,7 +17,7 @@ regs = None
 __all__ = ["ctypes", "memory", "typeinfo"]
 
 # Export parsed GDB version
-gdb_version = tuple(map(int, re.search(r"(\d+)[^\d]+(\d+)", gdb.VERSION).groups()))  # type: ignore[attr-defined]
+gdb_version = tuple(map(int, re.search(r"(\d+)[^\d]+(\d+)", gdb.VERSION).groups()))
 
 
 # TODO: should the imports above be moved here?


### PR DESCRIPTION
I added the `gdb.VERSION` type [upstream](https://github.com/python/typeshed/pull/11529), so updating the dev requirements and removing the type ignore comment that's no longer needed.