### PR TITLE
asm command: fix default arch

### DIFF
--- a/pwndbg/commands/asm.py
+++ b/pwndbg/commands/asm.py
@@ -16,7 +16,6 @@ parser.add_argument(
 
 parser.add_argument(
     "--arch",
-    default=pwnlib.context.context.arch,
     choices=pwnlib.context.context.architectures.keys(),
     type=str,
     help="Target architecture",
@@ -62,6 +61,9 @@ def asm(shellcode, format, arch, avoid, infile) -> None:
         print(message.warn("Going to read from file: " + infile))
         with open(infile) as file:
             shellcode = [file.read()]
+
+    if not arch:
+        arch = pwnlib.context.context.arch
 
     bits_for_arch = pwnlib.context.context.architectures.get(arch, {}).get("bits")
     assembly = pwnlib.asm.asm(" ".join(shellcode), arch=arch, bits=bits_for_arch)


### PR DESCRIPTION
Before this commit, running `asm mov rax, 0xdeadbeef` would not work on amd64 targets because the default arch was set in the argparse default argument value and it was populated once.

Now, this `default=...` kwarg is not set and instead we fetch current arch inside the `asm` command directly when the user did not pass any architecture value.

<!-- Please make sure to read the testing and linting instructions at https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md before creating a PR -->
