### PR TITLE
feat : use "PIP_NO_CACHE_DIR" env with pip in dockerfiles to save space

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ FROM $image
 
 WORKDIR /pwndbg
 
+ENV PIP_NO_CACHE_DIR=true
 ENV LANG en_US.utf8
 ENV TZ=America/New_York
 ENV ZIGPATH=/opt/zig

--- a/Dockerfile.arch
+++ b/Dockerfile.arch
@@ -13,6 +13,7 @@ FROM $image
 
 WORKDIR /pwndbg
 
+ENV PIP_NO_CACHE_DIR=true
 ENV LANG en_US.utf8
 ENV TZ=America/New_York
 ENV ZIGPATH=/opt/zig


### PR DESCRIPTION
using the  "PIP_NO_CACHE_DIR" env with pip install, make sure downloaded packages by pip don't cache on the system. This is a best practice that makes sure to fetch from a repo instead of using a local cached one. Further, in the case of Docker Containers, by restricting caching, we can reduce image size. In terms of stats, it depends upon the number of python packages multiplied by their respective size. e.g for heavy packages with a lot of dependencies it reduces a lot by don't cache pip packages.

Further, more detailed information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6