### PR TITLE
Restore stack frame after display

### DIFF
--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -882,6 +882,10 @@ def context_threads(with_banner=True, target=sys.stdout, width=None):
         original_thread = gdb.selected_thread()
     except SystemError:
         original_thread = None
+    try:
+        original_frame = gdb.selected_frame()
+    except gdb.error:
+        original_frame = None
 
     all_threads = gdb.selected_inferior().threads()[::-1]
 
@@ -945,6 +949,8 @@ def context_threads(with_banner=True, target=sys.stdout, width=None):
 
     if original_thread is not None and original_thread.is_valid():
         original_thread.switch()
+    if original_frame is not None and original_frame.is_valid():
+        original_frame.select()
 
     return out
 

--- a/pwndbg/commands/tls.py
+++ b/pwndbg/commands/tls.py
@@ -88,6 +88,10 @@ def threads(num_threads, respect_config) -> None:
         original_thread = gdb.selected_thread()
     except SystemError:
         original_thread = None
+    try:
+        original_frame = gdb.selected_frame()
+    except gdb.error:
+        original_frame = None
 
     all_threads = gdb.selected_inferior().threads()[::-1]
 
@@ -143,6 +147,8 @@ def threads(num_threads, respect_config) -> None:
 
     if original_thread is not None and original_thread.is_valid():
         original_thread.switch()
+    if original_frame is not None and original_frame.is_valid():
+        original_frame.select()
 
     print(tabulate(table, headers))
     print(f"\nShowing {len(displayed_threads)} of {len(all_threads)} threads.")


### PR DESCRIPTION
The commands `context threads` and `threads` use `thread.switch()` to examine other threads, which resets the selected stack frame to `#0`. This commit restores the selected frame afterwards.
