### PR TITLE
Fetch C struct as Python dictionary

### DIFF
--- a/pwndbg/gdblib/memory.py
+++ b/pwndbg/gdblib/memory.py
@@ -5,9 +5,7 @@ Reading, writing, and describing memory.
 from __future__ import annotations
 
 import re
-from typing import Callable
-from typing import Dict
-from typing import Union
+from typing import Callable, Dict, Union
 
 import gdb
 
@@ -17,8 +15,7 @@ import pwndbg.gdblib.qemu
 import pwndbg.gdblib.typeinfo
 import pwndbg.lib.cache
 import pwndbg.lib.memory
-from pwndbg.lib.memory import PAGE_MASK
-from pwndbg.lib.memory import PAGE_SIZE
+from pwndbg.lib.memory import PAGE_MASK, PAGE_SIZE
 
 GdbDict = Dict[str, Union["GdbDict", int]]
 
@@ -408,13 +405,13 @@ def pack_struct_into_dictionary(
 
 
 def convert_gdb_value_to_python_value(gdb_value: gdb.Value) -> int | GdbDict:
-    type_code_conversions: dict[int, Callable[[gdb.Value], int | GdbDict]] = {
-        gdb.TYPE_CODE_PTR: int,
-        gdb.TYPE_CODE_INT: int,
-        gdb.TYPE_CODE_STRUCT: pack_struct_into_dictionary,
-    }
-
     gdb_type = gdb_value.type.strip_typedefs()
-    conversion_function = type_code_conversions[gdb_type.code]
 
-    return conversion_function(gdb_value)
+    if gdb_type.code == gdb.TYPE_CODE_PTR:
+        return int(gdb_value)
+    elif gdb_type.code == gdb.TYPE_CODE_INT:
+        return int(gdb_value)
+    elif gdb_type.code == gdb.TYPE_CODE_STRUCT:
+        return pack_struct_into_dictionary(gdb_value)
+
+    raise NotImplementedError

--- a/pwndbg/gdblib/memory.py
+++ b/pwndbg/gdblib/memory.py
@@ -5,7 +5,8 @@ Reading, writing, and describing memory.
 from __future__ import annotations
 
 import re
-from typing import Callable, Dict, Union
+from typing import Dict
+from typing import Union
 
 import gdb
 
@@ -15,7 +16,8 @@ import pwndbg.gdblib.qemu
 import pwndbg.gdblib.typeinfo
 import pwndbg.lib.cache
 import pwndbg.lib.memory
-from pwndbg.lib.memory import PAGE_MASK, PAGE_SIZE
+from pwndbg.lib.memory import PAGE_MASK
+from pwndbg.lib.memory import PAGE_SIZE
 
 GdbDict = Dict[str, Union["GdbDict", int]]
 

--- a/pwndbg/gdblib/memory.py
+++ b/pwndbg/gdblib/memory.py
@@ -5,8 +5,8 @@ Reading, writing, and describing memory.
 from __future__ import annotations
 
 import re
-from typing import Any
 from typing import Callable
+from typing import Union
 
 import gdb
 
@@ -18,6 +18,9 @@ import pwndbg.lib.cache
 import pwndbg.lib.memory
 from pwndbg.lib.memory import PAGE_MASK
 from pwndbg.lib.memory import PAGE_SIZE
+
+GdbDict = dict[str, Union["GdbDict", int]]
+
 
 MMAP_MIN_ADDR = 0x8000
 
@@ -369,7 +372,7 @@ def fetch_struct_as_dictionary(
     struct_address: int,
     include_only_fields: set[str] = set(),
     exclude_fields: set[str] = set(),
-) -> dict[str, Any]:
+) -> GdbDict:
     struct_type = gdb.lookup_type("struct " + struct_name)
     fetched_struct = poi(struct_type, struct_address)
 
@@ -380,7 +383,7 @@ def pack_struct_into_dictionary(
     fetched_struct: gdb.Value,
     include_only_fields: set[str] = set(),
     exclude_fields: set[str] = set(),
-) -> dict[str, Any]:
+) -> GdbDict:
     struct_as_dictionary = {}
 
     if len(include_only_fields) != 0:
@@ -403,8 +406,8 @@ def pack_struct_into_dictionary(
     return struct_as_dictionary
 
 
-def convert_gdb_value_to_python_value(gdb_value: gdb.Value) -> int | dict[str, Any]:
-    type_code_conversions: dict[int, Callable[[gdb.Value], int | dict[str, Any]]] = {
+def convert_gdb_value_to_python_value(gdb_value: gdb.Value) -> int | GdbDict:
+    type_code_conversions: dict[int, Callable[[gdb.Value], int | GdbDict]] = {
         gdb.TYPE_CODE_PTR: int,
         gdb.TYPE_CODE_INT: int,
         gdb.TYPE_CODE_STRUCT: pack_struct_into_dictionary,

--- a/pwndbg/gdblib/memory.py
+++ b/pwndbg/gdblib/memory.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import re
 from typing import Callable
+from typing import Dict
 from typing import Union
 
 import gdb
@@ -19,7 +20,7 @@ import pwndbg.lib.memory
 from pwndbg.lib.memory import PAGE_MASK
 from pwndbg.lib.memory import PAGE_SIZE
 
-GdbDict = dict[str, Union["GdbDict", int]]
+GdbDict = Dict[str, Union["GdbDict", int]]
 
 
 MMAP_MIN_ADDR = 0x8000

--- a/pwndbg/gdblib/memory.py
+++ b/pwndbg/gdblib/memory.py
@@ -365,8 +365,8 @@ def update_min_addr() -> None:
 def fetch_struct_as_dictionary(
     struct_name: str,
     struct_address: int,
-    include_only_fields: list[str] | None = None,
-    exclude_fields: list[str] | None = None,
+    include_only_fields: set[str] = set(),
+    exclude_fields: set[str] = set(),
 ):
     struct_type = gdb.lookup_type("struct " + struct_name)
     fetched_struct = poi(struct_type, struct_address)
@@ -376,12 +376,12 @@ def fetch_struct_as_dictionary(
 
 def pack_struct_into_dictionary(
     fetched_struct: gdb.Value,
-    include_only_fields: list[str] | None = None,
-    exclude_fields: list[str] | None = None,
+    include_only_fields: set[str] = set(),
+    exclude_fields: set[str] = set(),
 ):
     struct_as_dictionary = {}
 
-    if include_only_fields is not None:
+    if len(include_only_fields) != 0:
         for field_name in include_only_fields:
             key = field_name
             value = convert_gdb_value_to_python_value(fetched_struct[field_name])
@@ -393,7 +393,7 @@ def pack_struct_into_dictionary(
                 struct_as_dictionary.update(
                     convert_gdb_value_to_python_value(fetched_struct[field])
                 )
-            elif exclude_fields is None or field.name not in exclude_fields:
+            elif field.name not in exclude_fields:
                 key = field.name
                 value = convert_gdb_value_to_python_value(fetched_struct[field])
                 struct_as_dictionary[key] = value

--- a/tests/gdb-tests/tests/binaries/nested_structs.c
+++ b/tests/gdb-tests/tests/binaries/nested_structs.c
@@ -1,0 +1,78 @@
+/* This program initializes some nested C structs.
+ * Useful for testing pwndbg commands that operate on structs.
+ */
+
+/* Can a command deal with nested typedefs?
+ * mydef_outer -> mydef_inner -> int
+ */
+typedef int mydef_inner;
+typedef mydef_inner mydef_outer;
+
+/* Can a command deal with anonymous structs?
+ * ISO C11 says anonymous_i & anonymous_j fields should be accessible like this:
+ * inner_struct.anonymous_i
+ */
+struct inner_struct
+{
+    int inner_a;
+    mydef_outer inner_b; // int
+
+    struct
+    {
+        int anonymous_i;
+        int anonymous_j;
+    };
+};
+
+/* Can a command deal with nested named structs and nested anonymous structs?
+ * The anonymous_nested field should be accessible like this:
+ * outer_struct.anonymous_nested
+ */
+struct outer_struct
+{
+    int outer_x;
+    mydef_outer outer_y; // int
+
+    struct inner_struct inner;
+
+    struct
+    {
+        int anonymous_k;
+        int anonymous_l;
+
+        struct
+        {
+            int anonymous_nested;
+        };
+    };
+
+    int outer_z;
+};
+
+// Set a breakpoint on this function to stop in the important places.
+void break_here(void) {}
+
+struct outer_struct outer;
+
+int main(void)
+{
+    // Initialize outer_struct fields with arbitrary values.
+    outer.outer_x = 1;
+    outer.outer_y = 2;
+    outer.outer_z = 5;
+
+    outer.inner.inner_a = 3;
+    outer.inner.inner_b = 4;
+
+    outer.inner.anonymous_i = 42;
+    outer.inner.anonymous_j = 44;
+
+    outer.anonymous_nested = 100;
+
+    outer.anonymous_k = 82;
+    outer.anonymous_l = 84;
+
+    break_here();
+
+    return 0;
+}

--- a/tests/gdb-tests/tests/test_memory.py
+++ b/tests/gdb-tests/tests/test_memory.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+import gdb
+
 import pwndbg.gdblib.memory
 import pwndbg.gdblib.stack
 import tests
 
 REFERENCE_BINARY = tests.binaries.get("reference-binary.out")
+NESTED_STRUCTS_BINARY = tests.binaries.get("nested_structs.out")
 
 
 def test_memory_read_write(start_binary):
@@ -30,3 +33,87 @@ def test_memory_read_write(start_binary):
     assert pwndbg.gdblib.memory.read(stack_addr, len(val) + 4) == bytearray(
         "Z" * 8 + "YYXX", "utf8"
     )
+
+
+def test_fetch_struct_as_dictionary(start_binary):
+    """
+    Test pwndbg.gdblib.memory.fetch_struct_as_dictionary()
+    Ensure it can handle nested structs, anonymous structs & nested typedefs.
+    """
+    start_binary(NESTED_STRUCTS_BINARY)
+    gdb.execute("break break_here")
+    gdb.execute("continue")
+
+    expected_result = {
+        "outer_x": 1,
+        "outer_y": 2,
+        "inner": {"inner_a": 3, "inner_b": 4, "anonymous_i": 42, "anonymous_j": 44},
+        "anonymous_k": 82,
+        "anonymous_l": 84,
+        "anonymous_nested": 100,
+        "outer_z": 5,
+    }
+
+    struct_address = pwndbg.gdblib.symbol.address("outer")
+    assert struct_address is not None
+
+    result = pwndbg.gdblib.memory.fetch_struct_as_dictionary("outer_struct", struct_address)
+
+    assert result == expected_result
+
+
+def test_fetch_struct_as_dictionary_include_filter(start_binary):
+    """
+    Test pwndbg.gdblib.memory.fetch_struct_as_dictionary()
+    Ensure its include_only_fields filter works.
+    """
+    start_binary(NESTED_STRUCTS_BINARY)
+    gdb.execute("break break_here")
+    gdb.execute("continue")
+
+    expected_result = {
+        "outer_x": 1,
+        "inner": {"inner_a": 3, "inner_b": 4, "anonymous_i": 42, "anonymous_j": 44},
+        "anonymous_k": 82,
+        "anonymous_nested": 100,
+    }
+
+    struct_address = pwndbg.gdblib.symbol.address("outer")
+    assert struct_address is not None
+
+    result = pwndbg.gdblib.memory.fetch_struct_as_dictionary(
+        "outer_struct",
+        struct_address,
+        include_only_fields=["outer_x", "inner", "anonymous_k", "anonymous_nested"],
+    )
+
+    assert result == expected_result
+
+
+def test_fetch_struct_as_dictionary_exclude_filter(start_binary):
+    """
+    Test pwndbg.gdblib.memory.fetch_struct_as_dictionary()
+    Ensure its exclude_fields filter works.
+    Note that the exclude filter cannot filter fields of anonymous structs.
+    """
+    start_binary(NESTED_STRUCTS_BINARY)
+    gdb.execute("break break_here")
+    gdb.execute("continue")
+
+    expected_result = {
+        "outer_y": 2,
+        "anonymous_k": 82,
+        "anonymous_l": 84,
+        "anonymous_nested": 100,
+    }
+
+    struct_address = pwndbg.gdblib.symbol.address("outer")
+    assert struct_address is not None
+
+    result = pwndbg.gdblib.memory.fetch_struct_as_dictionary(
+        "outer_struct",
+        struct_address,
+        exclude_fields=["outer_x", "inner", "outer_z"],
+    )
+
+    assert result == expected_result

--- a/tests/gdb-tests/tests/test_memory.py
+++ b/tests/gdb-tests/tests/test_memory.py
@@ -84,7 +84,7 @@ def test_fetch_struct_as_dictionary_include_filter(start_binary):
     result = pwndbg.gdblib.memory.fetch_struct_as_dictionary(
         "outer_struct",
         struct_address,
-        include_only_fields=["outer_x", "inner", "anonymous_k", "anonymous_nested"],
+        include_only_fields={"outer_x", "inner", "anonymous_k", "anonymous_nested"},
     )
 
     assert result == expected_result
@@ -113,7 +113,7 @@ def test_fetch_struct_as_dictionary_exclude_filter(start_binary):
     result = pwndbg.gdblib.memory.fetch_struct_as_dictionary(
         "outer_struct",
         struct_address,
-        exclude_fields=["outer_x", "inner", "outer_z"],
+        exclude_fields={"outer_x", "inner", "outer_z"},
     )
 
     assert result == expected_result


### PR DESCRIPTION
Add a function that fetches the contents of a C struct from memory in the form of a Python dictionary.
e.g. `fetch_struct ( <struct_name>, <struct_address> ) -> dict`

Struct fields can be filtered with include/exclude lists.

The purpose of this function is to make testing easier by providing some abstraction from the gdb library.
Eliminating the need to handle some `gdb.Value`s could relieve the burden of writing tests that need to run in gdb or mocking gdb classes.

I think this could be particularly helpful in the heap parsing code, which handles a few structs.
The downside is that you lose gdb's lazy fetching, but I believe this could be balanced somewhat by only requesting the fields your code needs, e.g. just the size field of a malloc_chunk struct.

I chose the dictionary format because you can access the fields of a `gdb.Value` in the same way, which hopefully reduces the changes required to integrate this function. Below is an example of what it's doing, starting with the C code representing the structs it's fetching, then the dictionary returned by the function in question with example uses of the filters.

<img width="259" alt="Screenshot 2024-03-22 at 11 35 33" src="https://github.com/pwndbg/pwndbg/assets/16000770/191f57ba-4286-4350-baa7-16511ba25b85">

<img width="922" alt="Screenshot 2024-03-29 at 10 15 58" src="https://github.com/pwndbg/pwndbg/assets/16000770/917ebee6-b749-46db-962b-4c78d8ce514a">

Note that anonymous structs/unions are flattened, as per ISO C11.
The exclude filter can't exclude fields from anonymous structs.

This work is similar to the `dt` command, but I found that code was very much tied up with its printing logic, so started from scratch here.