### PR TITLE
Cleaned up compatibility code for gdb < 9.2

### DIFF
--- a/pwndbg/gdblib/config.py
+++ b/pwndbg/gdblib/config.py
@@ -65,7 +65,7 @@ class Parameter(gdb.Parameter):
         )
 
     def get_set_string(self) -> str:
-        """Handles the GDB `set <param>` command for GDB >= 9"""
+        """Handles the GDB `set <param>`"""
         # GDB will set `self.value` to the user's input
         if self.value is None and self.param.param_class in (gdb.PARAM_UINTEGER, gdb.PARAM_INTEGER):
             # Note: This is really weird, according to GDB docs, 0 should mean "unlimited" for gdb.PARAM_UINTEGER and gdb.PARAM_INTEGER, but somehow GDB sets the value to `None` actually :/
@@ -87,7 +87,7 @@ class Parameter(gdb.Parameter):
         return f"Set {self.param.set_show_doc} to {self.native_value!r}."
 
     def get_show_string(self, svalue: str) -> str:
-        """Handles the GDB `show <param>` command for GDB >= 9"""
+        """Handles the GDB `show <param>`"""
         more_information_hint = f" See `help set {self.param.name}` for more information."
         return "{} is {!r}.{}".format(
             self.param.set_show_doc.capitalize(),

--- a/pwndbg/gdblib/config.py
+++ b/pwndbg/gdblib/config.py
@@ -26,13 +26,6 @@ import pwndbg.lib.config
 
 config = pwndbg.lib.config.Config()
 
-# GDB < 9 does not support PARAM_ZUINTEGER*, so we implement it by ourselves for consistency
-IS_GDB_GTE_9 = True
-if not hasattr(gdb, "PARAM_ZUINTEGER"):
-    gdb.PARAM_ZUINTEGER = "PARAM_ZUINTEGER"
-    gdb.PARAM_ZUINTEGER_UNLIMITED = "PARAM_ZUINTEGER_UNLIMITED"
-    IS_GDB_GTE_9 = False
-
 
 # See this for details about the API of `gdb.Parameter`:
 # https://sourceware.org/gdb/onlinedocs/gdb/Parameters-In-Python.html
@@ -49,7 +42,7 @@ class Parameter(gdb.Parameter):
         self.param = param
         self.value = param.value
 
-    def __init_super_gdb_gte_9(self, param: pwndbg.lib.config.Parameter) -> None:
+    def init_super(self, param: pwndbg.lib.config.Parameter) -> None:
         """Initializes the super class for GDB >= 9"""
         if param.param_class == gdb.PARAM_ENUM:
             super().__init__(
@@ -61,17 +54,6 @@ class Parameter(gdb.Parameter):
             return
         super().__init__(param.name, gdb.COMMAND_SUPPORT, param.param_class)
 
-    def __init_super_gdb_lt_9(self, param: pwndbg.lib.config.Parameter) -> None:
-        """Initializes the super class for GDB < 9"""
-        # GDB < 9 does not support PARAM_ZUINTEGER*, so we implement it by ourselves for consistency
-        if param.param_class in (gdb.PARAM_ZUINTEGER, gdb.PARAM_ZUINTEGER_UNLIMITED):
-            super().__init__(param.name, gdb.COMMAND_SUPPORT, pwndbg.lib.config.PARAM_CLASSES[int])
-            return
-        # the logic after this line is the same as GDB >= 9
-        self.__init_super_gdb_gte_9(param)
-
-    init_super = __init_super_gdb_gte_9 if IS_GDB_GTE_9 else __init_super_gdb_lt_9
-
     @property
     def native_value(self):
         return Parameter._value_to_gdb_native(self.param.value, param_class=self.param.param_class)
@@ -82,7 +64,7 @@ class Parameter(gdb.Parameter):
             self.param.default, param_class=self.param.param_class
         )
 
-    def __get_set_string_gdb_gte_9(self) -> str:
+    def get_set_string(self) -> str:
         """Handles the GDB `set <param>` command for GDB >= 9"""
         # GDB will set `self.value` to the user's input
         if self.value is None and self.param.param_class in (gdb.PARAM_UINTEGER, gdb.PARAM_INTEGER):
@@ -104,21 +86,7 @@ class Parameter(gdb.Parameter):
 
         return f"Set {self.param.set_show_doc} to {self.native_value!r}."
 
-    def __get_set_string_gdb_le_9(self) -> str:
-        """Handles the GDB `set <param>` command for GDB < 9"""
-        if (self.param.param_class == gdb.PARAM_ZUINTEGER and self.value < 0) or (  # type: ignore[operator]
-            self.param.param_class == gdb.PARAM_ZUINTEGER_UNLIMITED and self.value < -1  # type: ignore[operator]
-        ):
-            # Restore the old value
-            self.value = self.param.value
-            # GDB < 9 is too buggy, it won't handle `gdb.GdbError`..., so we return a string here
-            return "integer %d out of range" % self.value  # type: ignore[str-format]
-        # the logic after this line is the same as GDB >= 9
-        return self.__get_set_string_gdb_gte_9()
-
-    get_set_string = __get_set_string_gdb_gte_9 if IS_GDB_GTE_9 else __get_set_string_gdb_le_9
-
-    def __get_show_string_gdb_gte_9(self, svalue: str) -> str:
+    def get_show_string(self, svalue: str) -> str:
         """Handles the GDB `show <param>` command for GDB >= 9"""
         more_information_hint = f" See `help set {self.param.name}` for more information."
         return "{} is {!r}.{}".format(
@@ -126,15 +94,6 @@ class Parameter(gdb.Parameter):
             svalue,
             more_information_hint if self.__doc__ else "",
         )
-
-    def __get_show_string_gdb_le_9(self, svalue: str) -> str:
-        """Handles the GDB `show <param>` command for GDB < 9"""
-        if self.param.param_class == gdb.PARAM_ZUINTEGER_UNLIMITED and self.value == -1:
-            svalue = "unlimited"
-        # the logic after this line is the same as GDB >= 9
-        return self.__get_show_string_gdb_gte_9(svalue)
-
-    get_show_string = __get_show_string_gdb_gte_9 if IS_GDB_GTE_9 else __get_show_string_gdb_le_9
 
     @staticmethod
     def _value_to_gdb_native(value: Any, param_class: int | None = None) -> Any:


### PR DESCRIPTION
Fixes #2091

```
# grep -rEIi "gte_" .
./.venv/lib/python3.11/site-packages/_pytest/assertion/util.py:                explanation = _compare_gte_set(left, right, highlighter, verbose)
./.venv/lib/python3.11/site-packages/_pytest/assertion/util.py:    explanation = _compare_gte_set(left, right, highlighter)
./.venv/lib/python3.11/site-packages/_pytest/assertion/util.py:def _compare_gte_set(
                                                                  
```