### PR TITLE
when gdb.execute throws an error in symbol.get return ""

### DIFF
--- a/pwndbg/gdblib/symbol.py
+++ b/pwndbg/gdblib/symbol.py
@@ -94,6 +94,7 @@ def get(address: int, gdb_only=False) -> str:
         return ""
 
     # This sucks, but there's not a GDB API for this.
+    # Workaround for a bug with Rust language, see #2094
     try:
         result = gdb.execute(f"info symbol 0x{address:x}", to_string=True, from_tty=False)
     except gdb.error:

--- a/pwndbg/gdblib/symbol.py
+++ b/pwndbg/gdblib/symbol.py
@@ -94,7 +94,10 @@ def get(address: int, gdb_only=False) -> str:
         return ""
 
     # This sucks, but there's not a GDB API for this.
-    result = gdb.execute("info symbol %#x" % int(address), to_string=True, from_tty=False)
+    try:
+        result = gdb.execute(f"info symbol 0x{address:x}", to_string=True, from_tty=False)
+    except gdb.error:
+        return ""
 
     if not gdb_only and result.startswith("No symbol"):
         address = int(address)


### PR DESCRIPTION
fixes: https://github.com/pwndbg/pwndbg/issues/2080
