### PR TITLE
fedora support for dev setup

### DIFF
--- a/setup-dev.sh
+++ b/setup-dev.sh
@@ -156,6 +156,28 @@ EOF
     download_zig_binary
 }
 
+install_dnf() {
+    set_zigpath "$(pwd)/.zig"
+
+    sudo dnf upgrade || true
+    sudo dnf install -y \
+        nasm \
+        gcc \
+        curl \
+        gdb \
+        parallel \
+        qemu-system-arm \
+        qemu-user
+
+    command -v go &> /dev/null || sudo dnf install -y go
+
+    if [[ "$1" != "" ]]; then
+        sudo dnf install shfmt
+    fi
+
+    download_zig_binary 
+}
+
 if linux; then
     distro=$(
         . /etc/os-release
@@ -172,6 +194,13 @@ if linux; then
             ;;
         "arch")
             install_pacman
+            ;;
+        "fedora")
+            fedora_version=$(
+                . /etc/os-release
+                echo ${VERSION_ID} version
+            )
+            install_dnf $fedora_verion
             ;;
         *) # we can add more install command for each distros.
             echo "\"$distro\" is not supported distro. Will search for 'apt' or 'pacman' package managers."

--- a/setup-dev.sh
+++ b/setup-dev.sh
@@ -175,7 +175,7 @@ install_dnf() {
         sudo dnf install shfmt
     fi
 
-    download_zig_binary 
+    download_zig_binary
 }
 
 if linux; then


### PR DESCRIPTION
Changes to  run ./setup-dev.sh on fedora(dnf)

Tested on fedora 37 and 39

![WhatsApp Image 2024-04-24 at 16 50 57 (1)](https://github.com/pwndbg/pwndbg/assets/72215253/2be31509-4207-4c76-a5d9-9238aa36e45d)
