### PR TITLE
Upgrade all dependencies

### DIFF
--- a/nix/pwndbg.nix
+++ b/nix/pwndbg.nix
@@ -26,6 +26,10 @@ let
         preferWheel = true;
       };
 
+      unix-ar = super.unix-ar.overridePythonAttrs (old: {
+        nativeBuildInputs = (old.nativeBuildInputs or []) ++ [self.setuptools];
+      });
+
       pt = super.pt.overridePythonAttrs (old: {
         buildInputs = (old.buildInputs or [ ]) ++ [ super.poetry-core ];
       });

--- a/poetry.lock
+++ b/poetry.lock
@@ -82,19 +82,19 @@ typecheck = ["mypy"]
 
 [[package]]
 name = "capstone"
-version = "5.0.0.post1"
+version = "5.0.1"
 description = "Capstone disassembly engine"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 files = [
-    {file = "capstone-5.0.0.post1-py3-none-macosx_10_9_universal2.whl", hash = "sha256:7993fee5e069dae052ea6392fcab5d06c68e14dab8a755c686bd2077fbc73982"},
-    {file = "capstone-5.0.0.post1-py3-none-manylinux1_i686.manylinux_2_5_i686.whl", hash = "sha256:64d9b93425ca4d5d2136ce8d421591ddf6c2af6ea37f542016530018d1fa7ada"},
-    {file = "capstone-5.0.0.post1-py3-none-manylinux1_i686.whl", hash = "sha256:9e7d0e910505efe7e12a80e5eba1bfe039e87f3b004d880515d62445c0d3d253"},
-    {file = "capstone-5.0.0.post1-py3-none-manylinux1_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4d477559219683200ea3abe4f5c2d5b3563f1f94f72f42292ad83feb0913cc29"},
-    {file = "capstone-5.0.0.post1-py3-none-manylinux1_x86_64.whl", hash = "sha256:94fdea8158a1066c5ba5bb284d1da0132227f10d3eb57de1784f4c64445c76d7"},
-    {file = "capstone-5.0.0.post1-py3-none-win32.whl", hash = "sha256:209e2f2f961c225d627714a351e8beb6266e6498653353d15ba9abc11f140553"},
-    {file = "capstone-5.0.0.post1-py3-none-win_amd64.whl", hash = "sha256:bb3cc7bc4dbacbdc4ff80c80a003b022424bcb98dcabe215bac2aaa7d3dbb0c3"},
-    {file = "capstone-5.0.0.post1.tar.gz", hash = "sha256:fe0affca395c09ce76a21c5f0fac026e74396839a220798ca5e57c54305bcf65"},
+    {file = "capstone-5.0.1-py3-none-macosx_10_9_universal2.whl", hash = "sha256:740a70624d3f258cf8503898dbfd968052c008ddd4fc4ab938c7046c8828c294"},
+    {file = "capstone-5.0.1-py3-none-manylinux1_i686.manylinux_2_5_i686.whl", hash = "sha256:3f34a949699c298e88d7c9a576a2fd7685dba658a9c432bce826eeb88676cf24"},
+    {file = "capstone-5.0.1-py3-none-manylinux1_i686.whl", hash = "sha256:08f16c2782e54d05c95f1d40e1ae0e58e4a57d6a6c3192f8c5ff61476f4130de"},
+    {file = "capstone-5.0.1-py3-none-manylinux1_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:ea8d0be06d2faa39545937fe88db239fd62227915f9744d8990439011c479f05"},
+    {file = "capstone-5.0.1-py3-none-manylinux1_x86_64.whl", hash = "sha256:04223a4e5c2374f21da59c5c5a5b90471bfcef5cb938e7b32de68579cf863b7a"},
+    {file = "capstone-5.0.1-py3-none-win32.whl", hash = "sha256:4356bdee55639c4448d025dc9d8a3b6c07f2b188c62b88df3d554a84e2cd89af"},
+    {file = "capstone-5.0.1-py3-none-win_amd64.whl", hash = "sha256:1bfa5c81e6880caf41a31946cd6d2d069c048bcc22edf121254b501a048de675"},
+    {file = "capstone-5.0.1.tar.gz", hash = "sha256:740afacc29861db591316beefe30df382c4da08dcb0345a0d10f0cac4f8b1ee2"},
 ]
 
 [[package]]
@@ -902,25 +902,27 @@ wcwidth = "*"
 
 [[package]]
 name = "psutil"
-version = "5.9.5"
+version = "5.9.8"
 description = "Cross-platform lib for process and system monitoring in Python."
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 files = [
-    {file = "psutil-5.9.5-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:be8929ce4313f9f8146caad4272f6abb8bf99fc6cf59344a3167ecd74f4f203f"},
-    {file = "psutil-5.9.5-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:ab8ed1a1d77c95453db1ae00a3f9c50227ebd955437bcf2a574ba8adbf6a74d5"},
-    {file = "psutil-5.9.5-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:4aef137f3345082a3d3232187aeb4ac4ef959ba3d7c10c33dd73763fbc063da4"},
-    {file = "psutil-5.9.5-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:ea8518d152174e1249c4f2a1c89e3e6065941df2fa13a1ab45327716a23c2b48"},
-    {file = "psutil-5.9.5-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:acf2aef9391710afded549ff602b5887d7a2349831ae4c26be7c807c0a39fac4"},
-    {file = "psutil-5.9.5-cp27-none-win32.whl", hash = "sha256:5b9b8cb93f507e8dbaf22af6a2fd0ccbe8244bf30b1baad6b3954e935157ae3f"},
-    {file = "psutil-5.9.5-cp27-none-win_amd64.whl", hash = "sha256:8c5f7c5a052d1d567db4ddd231a9d27a74e8e4a9c3f44b1032762bd7b9fdcd42"},
-    {file = "psutil-5.9.5-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:3c6f686f4225553615612f6d9bc21f1c0e305f75d7d8454f9b46e901778e7217"},
-    {file = "psutil-5.9.5-cp36-abi3-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7a7dd9997128a0d928ed4fb2c2d57e5102bb6089027939f3b722f3a210f9a8da"},
-    {file = "psutil-5.9.5-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:89518112647f1276b03ca97b65cc7f64ca587b1eb0278383017c2a0dcc26cbe4"},
-    {file = "psutil-5.9.5-cp36-abi3-win32.whl", hash = "sha256:104a5cc0e31baa2bcf67900be36acde157756b9c44017b86b2c049f11957887d"},
-    {file = "psutil-5.9.5-cp36-abi3-win_amd64.whl", hash = "sha256:b258c0c1c9d145a1d5ceffab1134441c4c5113b2417fafff7315a917a026c3c9"},
-    {file = "psutil-5.9.5-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:c607bb3b57dc779d55e1554846352b4e358c10fff3abf3514a7a6601beebdb30"},
-    {file = "psutil-5.9.5.tar.gz", hash = "sha256:5410638e4df39c54d957fc51ce03048acd8e6d60abc0f5107af51e5fb566eb3c"},
+    {file = "psutil-5.9.8-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:26bd09967ae00920df88e0352a91cff1a78f8d69b3ecabbfe733610c0af486c8"},
+    {file = "psutil-5.9.8-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:05806de88103b25903dff19bb6692bd2e714ccf9e668d050d144012055cbca73"},
+    {file = "psutil-5.9.8-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:611052c4bc70432ec770d5d54f64206aa7203a101ec273a0cd82418c86503bb7"},
+    {file = "psutil-5.9.8-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:50187900d73c1381ba1454cf40308c2bf6f34268518b3f36a9b663ca87e65e36"},
+    {file = "psutil-5.9.8-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:02615ed8c5ea222323408ceba16c60e99c3f91639b07da6373fb7e6539abc56d"},
+    {file = "psutil-5.9.8-cp27-none-win32.whl", hash = "sha256:36f435891adb138ed3c9e58c6af3e2e6ca9ac2f365efe1f9cfef2794e6c93b4e"},
+    {file = "psutil-5.9.8-cp27-none-win_amd64.whl", hash = "sha256:bd1184ceb3f87651a67b2708d4c3338e9b10c5df903f2e3776b62303b26cb631"},
+    {file = "psutil-5.9.8-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:aee678c8720623dc456fa20659af736241f575d79429a0e5e9cf88ae0605cc81"},
+    {file = "psutil-5.9.8-cp36-abi3-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8cb6403ce6d8e047495a701dc7c5bd788add903f8986d523e3e20b98b733e421"},
+    {file = "psutil-5.9.8-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d06016f7f8625a1825ba3732081d77c94589dca78b7a3fc072194851e88461a4"},
+    {file = "psutil-5.9.8-cp36-cp36m-win32.whl", hash = "sha256:7d79560ad97af658a0f6adfef8b834b53f64746d45b403f225b85c5c2c140eee"},
+    {file = "psutil-5.9.8-cp36-cp36m-win_amd64.whl", hash = "sha256:27cc40c3493bb10de1be4b3f07cae4c010ce715290a5be22b98493509c6299e2"},
+    {file = "psutil-5.9.8-cp37-abi3-win32.whl", hash = "sha256:bc56c2a1b0d15aa3eaa5a60c9f3f8e3e565303b465dbf57a1b730e7a2b9844e0"},
+    {file = "psutil-5.9.8-cp37-abi3-win_amd64.whl", hash = "sha256:8db4c1b57507eef143a15a6884ca10f7c73876cdf5d51e713151c1236a0e68cf"},
+    {file = "psutil-5.9.8-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:d16bbddf0693323b8c6123dd804100241da461e41d6e332fb0ba6058f630f8c8"},
+    {file = "psutil-5.9.8.tar.gz", hash = "sha256:6be126e3225486dff286a8fb9a06246a5253f4c7c53b475ea5f5ac934e64194c"},
 ]
 
 [package.extras]
@@ -968,13 +970,13 @@ tests = ["pytest"]
 
 [[package]]
 name = "pwntools"
-version = "4.11.0"
+version = "4.12.0"
 description = "Pwntools CTF framework and exploit development library."
 optional = false
 python-versions = ">=2.7"
 files = [
-    {file = "pwntools-4.11.0-py2.py3-none-any.whl", hash = "sha256:c16b3ee4479b87b87d7803085a04185bd4eeaaf3f5e2dd6196a6941c3b09aecd"},
-    {file = "pwntools-4.11.0.tar.gz", hash = "sha256:a85f1e777f343f91e221d175e1523d006eef1c8106c10fd2e338280bab273fa6"},
+    {file = "pwntools-4.12.0-py2.py3-none-any.whl", hash = "sha256:621a7545615a64f24c44ec7a45c0e504640ad0151d81a2e90205e66f76079c4c"},
+    {file = "pwntools-4.12.0.tar.gz", hash = "sha256:320285bd9266152fdba3b81de3a31e61a25076645507a38d85f34e1b15998eb1"},
 ]
 
 [package.dependencies]
@@ -997,16 +999,18 @@ rpyc = "*"
 six = ">=1.12.0"
 sortedcontainers = "*"
 unicorn = ">=1.0.2rc1"
+unix-ar = {version = "*", markers = "python_version >= \"3\""}
+zstandard = "*"
 
 [[package]]
 name = "pycparser"
-version = "2.21"
+version = "2.22"
 description = "C parser in Python"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+python-versions = ">=3.8"
 files = [
-    {file = "pycparser-2.21-py2.py3-none-any.whl", hash = "sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9"},
-    {file = "pycparser-2.21.tar.gz", hash = "sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206"},
+    {file = "pycparser-2.22-py3-none-any.whl", hash = "sha256:c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc"},
+    {file = "pycparser-2.22.tar.gz", hash = "sha256:491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6"},
 ]
 
 [[package]]
@@ -1022,17 +1026,18 @@ files = [
 
 [[package]]
 name = "pygments"
-version = "2.15.0"
+version = "2.17.2"
 description = "Pygments is a syntax highlighting package written in Python."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "Pygments-2.15.0-py3-none-any.whl", hash = "sha256:77a3299119af881904cd5ecd1ac6a66214b6e9bed1f2db16993b54adede64094"},
-    {file = "Pygments-2.15.0.tar.gz", hash = "sha256:f7e36cffc4c517fbc252861b9a6e4644ca0e5abadf9a113c72d1358ad09b9500"},
+    {file = "pygments-2.17.2-py3-none-any.whl", hash = "sha256:b27c2826c47d0f3219f29554824c30c5e8945175d888647acd804ddd04af846c"},
+    {file = "pygments-2.17.2.tar.gz", hash = "sha256:da46cec9fd2de5be3a8a784f434e4c4ab670b4ff54d605c4c2717e9d49c4c367"},
 ]
 
 [package.extras]
 plugins = ["importlib-metadata"]
+windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pynacl"
@@ -1205,18 +1210,18 @@ jupyter = ["ipywidgets (>=7.5.1,<9)"]
 
 [[package]]
 name = "ropgadget"
-version = "7.2"
+version = "7.4"
 description = "This tool lets you search your gadgets on your binaries to facilitate your ROP exploitation."
 optional = false
 python-versions = "*"
 files = [
-    {file = "ROPGadget-7.2-py2-none-any.whl", hash = "sha256:731dd866dce410e0f4a9e1052aac6e3b6376dc0294372a8b5e0bbf88f10a64a1"},
-    {file = "ROPGadget-7.2-py3-none-any.whl", hash = "sha256:a68bbbc05f2b9bd1ba9a0a01edebe9a661dea630ad2a78537747fade6b2eb482"},
-    {file = "ROPGadget-7.2.tar.gz", hash = "sha256:ec705810d37043b2aca32a164416c6198de7770bb5e45ca1bc219acb87ee2073"},
+    {file = "ROPGadget-7.4-py2-none-any.whl", hash = "sha256:5bc70eee0ffee45f683df57eaea3e0692bbea3f35200f3cf5a1cf28d7d61a774"},
+    {file = "ROPGadget-7.4-py3-none-any.whl", hash = "sha256:394ba571277a28a987116fa91c5336524f9a89e9b60a54ba97f2c34823bd0270"},
+    {file = "ROPGadget-7.4.tar.gz", hash = "sha256:a40626a32cf867d06192ef24e16221b2b7ba82e2ec84ab5bfdfb0b017559342f"},
 ]
 
 [package.dependencies]
-capstone = "*"
+capstone = ">=5.0.1"
 
 [[package]]
 name = "rpyc"
@@ -1260,19 +1265,19 @@ files = [
 
 [[package]]
 name = "setuptools"
-version = "69.0.3"
+version = "69.5.1"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "setuptools-69.0.3-py3-none-any.whl", hash = "sha256:385eb4edd9c9d5c17540511303e39a147ce2fc04bc55289c322b9e5904fe2c05"},
-    {file = "setuptools-69.0.3.tar.gz", hash = "sha256:be1af57fc409f93647f2e8e4573a142ed38724b8cdd389706a867bb4efcf1e78"},
+    {file = "setuptools-69.5.1-py3-none-any.whl", hash = "sha256:c636ac361bc47580504644275c9ad802c50415c7522212252c033bd15f301f32"},
+    {file = "setuptools-69.5.1.tar.gz", hash = "sha256:6c1fccdac05a97e598fb0ae3bbed5904ccb317337a51139dcd51453611bbb987"},
 ]
 
 [package.extras]
-docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (<7.2.5)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
-testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-ruff", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
-testing-integration = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "packaging (>=23.1)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
+docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
+testing = ["build[virtualenv]", "filelock (>=3.4.0)", "importlib-metadata", "ini2toml[lite] (>=0.9)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "mypy (==1.9)", "packaging (>=23.2)", "pip (>=19.1)", "pytest (>=6,!=8.1.1)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-home (>=0.5)", "pytest-mypy", "pytest-perf", "pytest-ruff (>=0.2.1)", "pytest-timeout", "pytest-xdist (>=3)", "tomli", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
+testing-integration = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "packaging (>=23.2)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
 
 [[package]]
 name = "six"
@@ -1458,13 +1463,13 @@ files = [
 
 [[package]]
 name = "typing-extensions"
-version = "4.6.1"
-description = "Backported and Experimental Type Hints for Python 3.7+"
+version = "4.11.0"
+description = "Backported and Experimental Type Hints for Python 3.8+"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "typing_extensions-4.6.1-py3-none-any.whl", hash = "sha256:6bac751f4789b135c43228e72de18637e9a6c29d12777023a703fd1a6858469f"},
-    {file = "typing_extensions-4.6.1.tar.gz", hash = "sha256:558bc0c4145f01e6405f4a5fdbd82050bd221b119f4bf72a961a1cfd471349d6"},
+    {file = "typing_extensions-4.11.0-py3-none-any.whl", hash = "sha256:c1f94d72897edaf4ce775bb7558d5b79d8126906a14ea5ed1635921406c0387a"},
+    {file = "typing_extensions-4.11.0.tar.gz", hash = "sha256:83f085bd5ca59c80295fc2a82ab5dac679cbe02b9f33f7d83af68e241bea51b0"},
 ]
 
 [[package]]
@@ -1483,6 +1488,17 @@ files = [
     {file = "unicorn-2.0.1.post1-py2.py3-none-win32.whl", hash = "sha256:9f0e3bbe207a6d2ddd3dff528bf3b2251c8e11d0fb4bab2338dff01475f6f41b"},
     {file = "unicorn-2.0.1.post1-py2.py3-none-win_amd64.whl", hash = "sha256:7145fe448d17b2377b18e08e0521749cf0f94b9d3fe8b67c032bb4c932a21c29"},
     {file = "unicorn-2.0.1.post1.tar.gz", hash = "sha256:7fc69523eb83b4c8abc7cb4410ca21875e066c34b7afe998f59481e830d28e56"},
+]
+
+[[package]]
+name = "unix-ar"
+version = "0.2.1"
+description = "AR file handling"
+optional = false
+python-versions = "~=3.6"
+files = [
+    {file = "unix_ar-0.2.1-py2.py3-none-any.whl", hash = "sha256:2acb718bc1308bf80e5b9da2614d8242cc2fe3be4cd8b2fd4719bce189aafcf1"},
+    {file = "unix_ar-0.2.1.tar.gz", hash = "sha256:bf9328ec70fa3a82f94dc26dc125264dbf62a2d8ffb1a3c8c8a8230175e72c4e"},
 ]
 
 [[package]]
@@ -1524,7 +1540,68 @@ files = [
     {file = "wcwidth-0.2.13.tar.gz", hash = "sha256:72ea0c06399eb286d978fdedb6923a9eb47e1c486ce63e9b4e64fc18303972b5"},
 ]
 
+[[package]]
+name = "zstandard"
+version = "0.22.0"
+description = "Zstandard bindings for Python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "zstandard-0.22.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:275df437ab03f8c033b8a2c181e51716c32d831082d93ce48002a5227ec93019"},
+    {file = "zstandard-0.22.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2ac9957bc6d2403c4772c890916bf181b2653640da98f32e04b96e4d6fb3252a"},
+    {file = "zstandard-0.22.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fe3390c538f12437b859d815040763abc728955a52ca6ff9c5d4ac707c4ad98e"},
+    {file = "zstandard-0.22.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1958100b8a1cc3f27fa21071a55cb2ed32e9e5df4c3c6e661c193437f171cba2"},
+    {file = "zstandard-0.22.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:93e1856c8313bc688d5df069e106a4bc962eef3d13372020cc6e3ebf5e045202"},
+    {file = "zstandard-0.22.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:1a90ba9a4c9c884bb876a14be2b1d216609385efb180393df40e5172e7ecf356"},
+    {file = "zstandard-0.22.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:3db41c5e49ef73641d5111554e1d1d3af106410a6c1fb52cf68912ba7a343a0d"},
+    {file = "zstandard-0.22.0-cp310-cp310-win32.whl", hash = "sha256:d8593f8464fb64d58e8cb0b905b272d40184eac9a18d83cf8c10749c3eafcd7e"},
+    {file = "zstandard-0.22.0-cp310-cp310-win_amd64.whl", hash = "sha256:f1a4b358947a65b94e2501ce3e078bbc929b039ede4679ddb0460829b12f7375"},
+    {file = "zstandard-0.22.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:589402548251056878d2e7c8859286eb91bd841af117dbe4ab000e6450987e08"},
+    {file = "zstandard-0.22.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a97079b955b00b732c6f280d5023e0eefe359045e8b83b08cf0333af9ec78f26"},
+    {file = "zstandard-0.22.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:445b47bc32de69d990ad0f34da0e20f535914623d1e506e74d6bc5c9dc40bb09"},
+    {file = "zstandard-0.22.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:33591d59f4956c9812f8063eff2e2c0065bc02050837f152574069f5f9f17775"},
+    {file = "zstandard-0.22.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:888196c9c8893a1e8ff5e89b8f894e7f4f0e64a5af4d8f3c410f0319128bb2f8"},
+    {file = "zstandard-0.22.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:53866a9d8ab363271c9e80c7c2e9441814961d47f88c9bc3b248142c32141d94"},
+    {file = "zstandard-0.22.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:4ac59d5d6910b220141c1737b79d4a5aa9e57466e7469a012ed42ce2d3995e88"},
+    {file = "zstandard-0.22.0-cp311-cp311-win32.whl", hash = "sha256:2b11ea433db22e720758cba584c9d661077121fcf60ab43351950ded20283440"},
+    {file = "zstandard-0.22.0-cp311-cp311-win_amd64.whl", hash = "sha256:11f0d1aab9516a497137b41e3d3ed4bbf7b2ee2abc79e5c8b010ad286d7464bd"},
+    {file = "zstandard-0.22.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:6c25b8eb733d4e741246151d895dd0308137532737f337411160ff69ca24f93a"},
+    {file = "zstandard-0.22.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f9b2cde1cd1b2a10246dbc143ba49d942d14fb3d2b4bccf4618d475c65464912"},
+    {file = "zstandard-0.22.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a88b7df61a292603e7cd662d92565d915796b094ffb3d206579aaebac6b85d5f"},
+    {file = "zstandard-0.22.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:466e6ad8caefb589ed281c076deb6f0cd330e8bc13c5035854ffb9c2014b118c"},
+    {file = "zstandard-0.22.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a1d67d0d53d2a138f9e29d8acdabe11310c185e36f0a848efa104d4e40b808e4"},
+    {file = "zstandard-0.22.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:39b2853efc9403927f9065cc48c9980649462acbdf81cd4f0cb773af2fd734bc"},
+    {file = "zstandard-0.22.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8a1b2effa96a5f019e72874969394edd393e2fbd6414a8208fea363a22803b45"},
+    {file = "zstandard-0.22.0-cp312-cp312-win32.whl", hash = "sha256:88c5b4b47a8a138338a07fc94e2ba3b1535f69247670abfe422de4e0b344aae2"},
+    {file = "zstandard-0.22.0-cp312-cp312-win_amd64.whl", hash = "sha256:de20a212ef3d00d609d0b22eb7cc798d5a69035e81839f549b538eff4105d01c"},
+    {file = "zstandard-0.22.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:d75f693bb4e92c335e0645e8845e553cd09dc91616412d1d4650da835b5449df"},
+    {file = "zstandard-0.22.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:36a47636c3de227cd765e25a21dc5dace00539b82ddd99ee36abae38178eff9e"},
+    {file = "zstandard-0.22.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:68953dc84b244b053c0d5f137a21ae8287ecf51b20872eccf8eaac0302d3e3b0"},
+    {file = "zstandard-0.22.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2612e9bb4977381184bb2463150336d0f7e014d6bb5d4a370f9a372d21916f69"},
+    {file = "zstandard-0.22.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:23d2b3c2b8e7e5a6cb7922f7c27d73a9a615f0a5ab5d0e03dd533c477de23004"},
+    {file = "zstandard-0.22.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:1d43501f5f31e22baf822720d82b5547f8a08f5386a883b32584a185675c8fbf"},
+    {file = "zstandard-0.22.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:a493d470183ee620a3df1e6e55b3e4de8143c0ba1b16f3ded83208ea8ddfd91d"},
+    {file = "zstandard-0.22.0-cp38-cp38-win32.whl", hash = "sha256:7034d381789f45576ec3f1fa0e15d741828146439228dc3f7c59856c5bcd3292"},
+    {file = "zstandard-0.22.0-cp38-cp38-win_amd64.whl", hash = "sha256:d8fff0f0c1d8bc5d866762ae95bd99d53282337af1be9dc0d88506b340e74b73"},
+    {file = "zstandard-0.22.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:2fdd53b806786bd6112d97c1f1e7841e5e4daa06810ab4b284026a1a0e484c0b"},
+    {file = "zstandard-0.22.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:73a1d6bd01961e9fd447162e137ed949c01bdb830dfca487c4a14e9742dccc93"},
+    {file = "zstandard-0.22.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9501f36fac6b875c124243a379267d879262480bf85b1dbda61f5ad4d01b75a3"},
+    {file = "zstandard-0.22.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:48f260e4c7294ef275744210a4010f116048e0c95857befb7462e033f09442fe"},
+    {file = "zstandard-0.22.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:959665072bd60f45c5b6b5d711f15bdefc9849dd5da9fb6c873e35f5d34d8cfb"},
+    {file = "zstandard-0.22.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:d22fdef58976457c65e2796e6730a3ea4a254f3ba83777ecfc8592ff8d77d303"},
+    {file = "zstandard-0.22.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:a7ccf5825fd71d4542c8ab28d4d482aace885f5ebe4b40faaa290eed8e095a4c"},
+    {file = "zstandard-0.22.0-cp39-cp39-win32.whl", hash = "sha256:f058a77ef0ece4e210bb0450e68408d4223f728b109764676e1a13537d056bb0"},
+    {file = "zstandard-0.22.0-cp39-cp39-win_amd64.whl", hash = "sha256:e9e9d4e2e336c529d4c435baad846a181e39a982f823f7e4495ec0b0ec8538d2"},
+    {file = "zstandard-0.22.0.tar.gz", hash = "sha256:8226a33c542bcb54cd6bd0a366067b610b41713b64c9abec1bc4533d69f51e70"},
+]
+
+[package.dependencies]
+cffi = {version = ">=1.11", markers = "platform_python_implementation == \"PyPy\""}
+
+[package.extras]
+cffi = ["cffi (>=1.11)"]
+
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "22ccc4a92b32fd22da3a27860e04ad24947b41180186be2a72003bf92d8972be"
+content-hash = "dc7d03b43ef7908a0f80773d02e7e9839b85f99b917c94e873745f63b40557f0"

--- a/poetry.lock
+++ b/poetry.lock
@@ -82,19 +82,19 @@ typecheck = ["mypy"]
 
 [[package]]
 name = "capstone"
-version = "5.0.1"
+version = "5.0.0.post1"
 description = "Capstone disassembly engine"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 files = [
-    {file = "capstone-5.0.1-py3-none-macosx_10_9_universal2.whl", hash = "sha256:740a70624d3f258cf8503898dbfd968052c008ddd4fc4ab938c7046c8828c294"},
-    {file = "capstone-5.0.1-py3-none-manylinux1_i686.manylinux_2_5_i686.whl", hash = "sha256:3f34a949699c298e88d7c9a576a2fd7685dba658a9c432bce826eeb88676cf24"},
-    {file = "capstone-5.0.1-py3-none-manylinux1_i686.whl", hash = "sha256:08f16c2782e54d05c95f1d40e1ae0e58e4a57d6a6c3192f8c5ff61476f4130de"},
-    {file = "capstone-5.0.1-py3-none-manylinux1_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:ea8d0be06d2faa39545937fe88db239fd62227915f9744d8990439011c479f05"},
-    {file = "capstone-5.0.1-py3-none-manylinux1_x86_64.whl", hash = "sha256:04223a4e5c2374f21da59c5c5a5b90471bfcef5cb938e7b32de68579cf863b7a"},
-    {file = "capstone-5.0.1-py3-none-win32.whl", hash = "sha256:4356bdee55639c4448d025dc9d8a3b6c07f2b188c62b88df3d554a84e2cd89af"},
-    {file = "capstone-5.0.1-py3-none-win_amd64.whl", hash = "sha256:1bfa5c81e6880caf41a31946cd6d2d069c048bcc22edf121254b501a048de675"},
-    {file = "capstone-5.0.1.tar.gz", hash = "sha256:740afacc29861db591316beefe30df382c4da08dcb0345a0d10f0cac4f8b1ee2"},
+    {file = "capstone-5.0.0.post1-py3-none-macosx_10_9_universal2.whl", hash = "sha256:7993fee5e069dae052ea6392fcab5d06c68e14dab8a755c686bd2077fbc73982"},
+    {file = "capstone-5.0.0.post1-py3-none-manylinux1_i686.manylinux_2_5_i686.whl", hash = "sha256:64d9b93425ca4d5d2136ce8d421591ddf6c2af6ea37f542016530018d1fa7ada"},
+    {file = "capstone-5.0.0.post1-py3-none-manylinux1_i686.whl", hash = "sha256:9e7d0e910505efe7e12a80e5eba1bfe039e87f3b004d880515d62445c0d3d253"},
+    {file = "capstone-5.0.0.post1-py3-none-manylinux1_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4d477559219683200ea3abe4f5c2d5b3563f1f94f72f42292ad83feb0913cc29"},
+    {file = "capstone-5.0.0.post1-py3-none-manylinux1_x86_64.whl", hash = "sha256:94fdea8158a1066c5ba5bb284d1da0132227f10d3eb57de1784f4c64445c76d7"},
+    {file = "capstone-5.0.0.post1-py3-none-win32.whl", hash = "sha256:209e2f2f961c225d627714a351e8beb6266e6498653353d15ba9abc11f140553"},
+    {file = "capstone-5.0.0.post1-py3-none-win_amd64.whl", hash = "sha256:bb3cc7bc4dbacbdc4ff80c80a003b022424bcb98dcabe215bac2aaa7d3dbb0c3"},
+    {file = "capstone-5.0.0.post1.tar.gz", hash = "sha256:fe0affca395c09ce76a21c5f0fac026e74396839a220798ca5e57c54305bcf65"},
 ]
 
 [[package]]
@@ -1210,18 +1210,18 @@ jupyter = ["ipywidgets (>=7.5.1,<9)"]
 
 [[package]]
 name = "ropgadget"
-version = "7.4"
+version = "7.3"
 description = "This tool lets you search your gadgets on your binaries to facilitate your ROP exploitation."
 optional = false
 python-versions = "*"
 files = [
-    {file = "ROPGadget-7.4-py2-none-any.whl", hash = "sha256:5bc70eee0ffee45f683df57eaea3e0692bbea3f35200f3cf5a1cf28d7d61a774"},
-    {file = "ROPGadget-7.4-py3-none-any.whl", hash = "sha256:394ba571277a28a987116fa91c5336524f9a89e9b60a54ba97f2c34823bd0270"},
-    {file = "ROPGadget-7.4.tar.gz", hash = "sha256:a40626a32cf867d06192ef24e16221b2b7ba82e2ec84ab5bfdfb0b017559342f"},
+    {file = "ROPGadget-7.3-py2-none-any.whl", hash = "sha256:67e904a0fada60b26c3cfcf3ce53970e8d92704ba895c1751ea4877923761582"},
+    {file = "ROPGadget-7.3-py3-none-any.whl", hash = "sha256:1e2cb62cc161bc235db09d2a017b5abaabe386e8919a2ee978725aa3382e967a"},
+    {file = "ROPGadget-7.3.tar.gz", hash = "sha256:4078e70601a2dc869123dfa352812dcc44767a4bbde482b7059d34b33bb67850"},
 ]
 
 [package.dependencies]
-capstone = ">=5.0.1"
+capstone = ">=5.0.0rc2"
 
 [[package]]
 name = "rpyc"
@@ -1604,4 +1604,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "dc7d03b43ef7908a0f80773d02e7e9839b85f99b917c94e873745f63b40557f0"
+content-hash = "bf5bd8c875870b335dc96f59665e66de27cc2f0fbc11ffae2f4fe1be443e03bb"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -296,7 +296,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "^3.8"
-capstone = "^5.0.1"
+capstone = "5.0.0.post1"
 ipython = "8.12.3"
 # Needed by Capstone due to https://github.com/pwndbg/pwndbg/pull/1946#issuecomment-1921603947
 setuptools = "^69.5.1"
@@ -305,7 +305,7 @@ pwntools = "^4.12.0"
 pycparser = "^2.22"
 pyelftools = "^0.29"
 pygments = "^2.17.2"
-ropgadget = "^7.4"
+ropgadget = "7.3"
 sortedcontainers = "^2.4.0"
 tabulate = "^0.9.0"
 typing-extensions = "^4.11.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -296,21 +296,21 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "^3.8"
-capstone = "5.0.0.post1"
+capstone = "^5.0.1"
 ipython = "8.12.3"
 # Needed by Capstone due to https://github.com/pwndbg/pwndbg/pull/1946#issuecomment-1921603947
-setuptools = "69.0.3"
-psutil = "5.9.5"
-pwntools = "4.11.0"
-pycparser = "2.21"
-pyelftools = "0.29"
-pygments = "2.15.0"
-ropgadget = "7.2"
-sortedcontainers = "2.4.0"
-tabulate = "0.9.0"
-typing-extensions = "4.6.1"
-unicorn = "2.0.1.post1"
-requests = "2.31.0"
+setuptools = "^69.5.1"
+psutil = "^5.9.8"
+pwntools = "^4.12.0"
+pycparser = "^2.22"
+pyelftools = "^0.29"
+pygments = "^2.17.2"
+ropgadget = "^7.4"
+sortedcontainers = "^2.4.0"
+tabulate = "^0.9.0"
+typing-extensions = "^4.11.0"
+unicorn = "^2.0.1.post1"
+requests = "^2.31.0"
 pt = {git = "https://github.com/martinradev/gdb-pt-dump", rev = "50227bda0b6332e94027f811a15879588de6d5cb"}
 
 [tool.poetry.group.dev]


### PR DESCRIPTION
1) Instead of pinning dependencies to an exact version in `pyproject.toml`, set the versions as minimums (with a preceding `^`). There's no need to pin exact dependency versions with `poetry` because they're already pinned in `poetry.lock`.
2) The pinned versions in `poetry.lock` can be upgraded with `poetry update`. This won't modify `pyproject.toml`
3) It is not necessary to bump versions in `pyproject.toml` if we follow the steps above, but it can be nice as it's easier to see what version we depend on without digging into `poetry.lock`. I used https://github.com/MousaZeidBaker/poetry-plugin-up to do this with `poetry up`

dev dependencies were left as is for now, and `capstone` and `ropgadget` were not upgraded, as they break some `nearpc` tests.