### PR TITLE
Add pending-author-response workflow

### DIFF
--- a/.github/workflows/pending-author-response.yml
+++ b/.github/workflows/pending-author-response.yml
@@ -1,0 +1,14 @@
+name: Pending Author Response Label
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  issue_commented:
+    if: ${{ !github.event.issue.pull_request && contains(github.event.issue.labels.*.name, 'pending-response') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: siegerts/pending-author-response@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          pending-response-label: pending-response


### PR DESCRIPTION
According to https://github.com/siegerts/pending-author-response, we can tag an issue with a label (currently set to "pending-response"), and if the issue author responds the label is automatically removed.

I don't think there's a good way for me to test if this actually works without committing it, or setting up github secrets in my own repo...