### PR TITLE
feat: Add a few new memory APIs and replace old APIs

### DIFF
--- a/pwndbg/arguments.py
+++ b/pwndbg/arguments.py
@@ -211,7 +211,7 @@ def argument(n: int, abi: pwndbg.lib.abi.ABI | None = None) -> int:
 
     sp = pwndbg.gdblib.regs.sp + (n * pwndbg.gdblib.arch.ptrsize)
 
-    return int(pwndbg.gdblib.memory.poi(pwndbg.gdblib.typeinfo.ppvoid, sp))
+    return int(pwndbg.gdblib.memory.get_typed_pointer_value(pwndbg.gdblib.typeinfo.ppvoid, sp))
 
 
 def arguments(abi: pwndbg.lib.abi.ABI | None = None):

--- a/pwndbg/chain.py
+++ b/pwndbg/chain.py
@@ -77,7 +77,9 @@ def get(
             if not pwndbg.gdblib.abi.linux and not pwndbg.gdblib.vmmap.find(address):
                 break
 
-            next_address = int(pwndbg.gdblib.memory.poi(pwndbg.gdblib.typeinfo.ppvoid, address))
+            next_address = int(
+                pwndbg.gdblib.memory.get_typed_pointer_value(pwndbg.gdblib.typeinfo.ppvoid, address)
+            )
             address = next_address ^ ((address >> 12) if safe_linking else 0)
             address &= pwndbg.gdblib.arch.ptrmask
             result.append(address)

--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -49,7 +49,7 @@ def read_chunk(addr: int) -> Dict[str, int]:
         "mchunk_prev_size": "prev_size",
     }
     if isinstance(pwndbg.heap.current, DebugSymsHeap):
-        val = pwndbg.gdblib.memory.poi(pwndbg.heap.current.malloc_chunk, addr)
+        val = pwndbg.gdblib.memory.get_typed_pointer_value(pwndbg.heap.current.malloc_chunk, addr)
     else:
         val = pwndbg.heap.current.malloc_chunk(addr)
     value_keys: List[str] = val.type.keys()

--- a/pwndbg/commands/plist.py
+++ b/pwndbg/commands/plist.py
@@ -368,7 +368,7 @@ def plist(path, next, sentinel, inner_name, field_name) -> None:
                 target_type = field_type
                 target_address = address + field_offset
 
-            value = pwndbg.gdblib.memory.poi(target_type, target_address)
+            value = pwndbg.gdblib.memory.get_typed_pointer_value(target_type, target_address)
 
             symbol = pwndbg.gdblib.symbol.get(target_address)
             symbol = f"<{symbol}>" if symbol else ""

--- a/pwndbg/disasm/arch.py
+++ b/pwndbg/disasm/arch.py
@@ -445,7 +445,9 @@ class DisassemblyAssistant:
 
                 size_type = pwndbg.gdblib.typeinfo.get_type(read_size)
                 try:
-                    read_value = int(pwndbg.gdblib.memory.poi(size_type, address))
+                    read_value = int(
+                        pwndbg.gdblib.memory.get_typed_pointer_value(size_type, address)
+                    )
                     result.append(read_value)
                 except gdb.MemoryError:
                     pass
@@ -468,7 +470,9 @@ class DisassemblyAssistant:
                 if page and not page.write:
                     try:
                         address = int(
-                            pwndbg.gdblib.memory.poi(pwndbg.gdblib.typeinfo.ppvoid, address)
+                            pwndbg.gdblib.memory.get_typed_pointer_value(
+                                pwndbg.gdblib.typeinfo.ppvoid, address
+                            )
                         )
                         address &= pwndbg.gdblib.arch.ptrmask
                         address_list.append(address)

--- a/pwndbg/disasm/x86.py
+++ b/pwndbg/disasm/x86.py
@@ -370,7 +370,9 @@ class DisassemblyAssistant(pwndbg.disasm.arch.DisassemblyAssistant):
         address = (pwndbg.gdblib.regs.sp) + (pwndbg.gdblib.arch.ptrsize * pop)
 
         if pwndbg.gdblib.memory.peek(address):
-            return int(pwndbg.gdblib.memory.poi(pwndbg.gdblib.typeinfo.ppvoid, address))
+            return int(
+                pwndbg.gdblib.memory.get_typed_pointer_value(pwndbg.gdblib.typeinfo.ppvoid, address)
+            )
 
     # Override
     def condition(self, instruction: PwndbgInstruction, emu: Emulator) -> InstructionCondition:

--- a/pwndbg/emu/emulator.py
+++ b/pwndbg/emu/emulator.py
@@ -428,7 +428,7 @@ class Emulator:
             return E.integer(pwndbg.enhance.int_str(value))
 
         # Read from emulator memory
-        # intval = int(pwndbg.gdblib.memory.poi(pwndbg.gdblib.typeinfo.pvoid, value))
+        # intval = int(pwndbg.gdblib.memory.get_typed_pointer_value(pwndbg.gdblib.typeinfo.pvoid, value))
         read_value = self.read_memory(value, pwndbg.gdblib.arch.ptrsize)
         if read_value is not None:
             # intval = pwndbg.gdblib.arch.unpack(read_value)

--- a/pwndbg/enhance.py
+++ b/pwndbg/enhance.py
@@ -132,7 +132,7 @@ def enhance(
     if value + pwndbg.gdblib.arch.ptrsize > page.end:
         return E.integer(int_str(value))
 
-    intval = int(pwndbg.gdblib.memory.poi(pwndbg.gdblib.typeinfo.pvoid, value))
+    intval = int(pwndbg.gdblib.memory.get_typed_pointer_value(pwndbg.gdblib.typeinfo.pvoid, value))
     if safe_linking:
         intval ^= value >> 12
     intval0 = intval

--- a/pwndbg/gdblib/dt.py
+++ b/pwndbg/gdblib/dt.py
@@ -102,7 +102,7 @@ def dt(name: str = "", addr: int | gdb.Value | None = None, obj: gdb.Value | Non
     # If an address was specified, create a Value of the
     # specified type at that address.
     if addr is not None:
-        obj = pwndbg.gdblib.memory.poi(t, addr)
+        obj = pwndbg.gdblib.memory.get_typed_pointer_value(t, addr)
 
     # Header, optionally include the name
     header = name

--- a/pwndbg/gdblib/dynamic.py
+++ b/pwndbg/gdblib/dynamic.py
@@ -796,7 +796,9 @@ class CStruct:
         Reads the field with the given name from the struct instance located at
         the given address.
         """
-        val = pwndbg.gdblib.memory.poi(self.types[name], address + self.offsets[name])
+        val = pwndbg.gdblib.memory.get_typed_pointer_value(
+            self.types[name], address + self.offsets[name]
+        )
         if self.converters[name] is not None:
             return self.converters[name](val)
         else:

--- a/pwndbg/gdblib/heap_tracking.py
+++ b/pwndbg/gdblib/heap_tracking.py
@@ -365,7 +365,7 @@ def get_chunk(address, requested_size):
     Reads a chunk from a given address.
     """
     ty = pwndbg.gdblib.typeinfo.ppvoid
-    size = int(pwndbg.gdblib.memory.poi(ty, address - ty.sizeof))
+    size = int(pwndbg.gdblib.memory.get_typed_pointer_value(ty, address - ty.sizeof))
 
     # GLibc bakes the chunk flags in the lowest 3 bits of the size value,
     # so, we separate them here.

--- a/pwndbg/gdblib/kernel/slab.py
+++ b/pwndbg/gdblib/kernel/slab.py
@@ -336,7 +336,7 @@ def find_containing_slab_cache(addr: int) -> SlabCache | None:
         return None
 
     page_type = gdb.lookup_type("struct page")
-    page = memory.poi(page_type, kernel.virt_to_page(addr))
+    page = memory.get_typed_pointer_value(page_type, kernel.virt_to_page(addr))
     head_page = compound_head(page)
 
     slab_type = gdb.lookup_type(f"struct {slab_struct_type()}")

--- a/pwndbg/gdblib/memory.py
+++ b/pwndbg/gdblib/memory.py
@@ -93,7 +93,7 @@ def readtype(gdb_type: gdb.Type, addr: int) -> int:
     Returns:
         :class:`int`
     """
-    return int(gdb.Value(addr).cast(gdb_type.pointer()).dereference())
+    return int(get_typed_pointer_value(gdb_type, addr))
 
 
 def write(addr: int, data: str | bytes | bytearray) -> None:
@@ -305,13 +305,29 @@ def s64(addr: int) -> int:
     return readtype(pwndbg.gdblib.typeinfo.int64, addr)
 
 
-# TODO: `readtype` is just `int(poi(type, addr))`
-def poi(type: gdb.Type, addr: int | gdb.Value) -> gdb.Value:
-    """poi(addr) -> gdb.Value
+def cast_pointer(type: gdb.Type, addr: int | gdb.Value) -> gdb.Value:
+    """Create a gdb.Value at given address and cast it to the pointer of specified type"""
+    if isinstance(addr, int):
+        addr = gdb.Value(addr)
+    return addr.cast(type.pointer())
 
-    Read one ``gdb.Type`` object at the specified address.
-    """
-    return gdb.Value(addr).cast(type.pointer()).dereference()
+
+def get_typed_pointer(type: str | gdb.Type, addr: int | gdb.Value) -> gdb.Value:
+    """Look up a type by name if necessary and return a gdb.Value of addr cast to that type"""
+    if isinstance(type, str):
+        gdb_type = pwndbg.gdblib.typeinfo.load(type)
+        if gdb_type is None:
+            raise ValueError(f"Type '{type}' not found")
+    elif isinstance(type, gdb.Type):
+        gdb_type = type
+    else:
+        raise ValueError(f"Invalid type: {type}")
+    return cast_pointer(gdb_type, addr)
+
+
+def get_typed_pointer_value(type_name: str | gdb.Type, addr: int | gdb.Value) -> gdb.Value:
+    """Read the pointer value of addr cast to type specified by type_name"""
+    return get_typed_pointer(type_name, addr).dereference()
 
 
 @pwndbg.lib.cache.cache_until("stop")
@@ -376,7 +392,7 @@ def fetch_struct_as_dictionary(
     exclude_fields: Set[str] = set(),
 ) -> GdbDict:
     struct_type = gdb.lookup_type("struct " + struct_name)
-    fetched_struct = poi(struct_type, struct_address)
+    fetched_struct = get_typed_pointer_value(struct_type, struct_address)
 
     return pack_struct_into_dictionary(fetched_struct, include_only_fields, exclude_fields)
 

--- a/pwndbg/gdblib/typeinfo.py
+++ b/pwndbg/gdblib/typeinfo.py
@@ -131,14 +131,6 @@ def load(name: str) -> Optional[gdb.Type]:
         return None
 
 
-def read_gdbvalue(type_name: str, addr: int) -> gdb.Value:
-    """Read the memory contents at addr and interpret them as a GDB value with the given type"""
-    gdb_type = load(type_name)
-    if gdb_type is None:
-        raise ValueError(f"Type {type_name} not found")
-    return gdb.Value(addr).cast(gdb_type.pointer()).dereference()
-
-
 def get_type(size: int) -> gdb.Type:
     return {
         1: pwndbg.gdblib.typeinfo.uint8,

--- a/pwndbg/heap/structs.py
+++ b/pwndbg/heap/structs.py
@@ -175,8 +175,12 @@ class CStruct2GDB:
         field_type = next(f for f in self._c_struct._fields_ if f[0] == field)[1]
         if hasattr(field_type, "_length_"):  # f is a ctypes Array
             t = C2GDB_MAPPING[field_type._type_]
-            return pwndbg.gdblib.memory.poi(t.array(field_type._length_ - 1), field_address)
-        return pwndbg.gdblib.memory.poi(C2GDB_MAPPING[field_type], field_address)
+            return pwndbg.gdblib.memory.get_typed_pointer_value(
+                t.array(field_type._length_ - 1), field_address
+            )
+        return pwndbg.gdblib.memory.get_typed_pointer_value(
+            C2GDB_MAPPING[field_type], field_address
+        )
 
     @property
     def type(self):

--- a/pwndbg/hexdump.py
+++ b/pwndbg/hexdump.py
@@ -166,7 +166,7 @@ def hexdump(
 
         for i in range(count):
             try:
-                gval = pwndbg.gdblib.memory.poi(size_type, address + i * size)
+                gval = pwndbg.gdblib.memory.get_typed_pointer_value(size_type, address + i * size)
                 values.append(int(gval))
             except gdb.MemoryError:
                 break

--- a/tests/gdb-tests/tests/heap/test_heap.py
+++ b/tests/gdb-tests/tests/heap/test_heap.py
@@ -142,7 +142,7 @@ def test_malloc_chunk_command(start_binary):
     results = {}
     chunk_types = ["allocated", "tcache", "fast", "small", "large", "unsorted"]
     for name in chunk_types:
-        chunks[name] = pwndbg.gdblib.memory.poi(
+        chunks[name] = pwndbg.gdblib.memory.get_typed_pointer_value(
             pwndbg.heap.current.malloc_chunk, gdb.lookup_symbol(f"{name}_chunk")[0].value()
         )
         results[name] = gdb.execute(f"malloc_chunk {name}_chunk", to_string=True).splitlines()
@@ -164,7 +164,7 @@ def test_malloc_chunk_command(start_binary):
 
     # Test some non-main-arena chunks
     for name in chunk_types:
-        chunks[name] = pwndbg.gdblib.memory.poi(
+        chunks[name] = pwndbg.gdblib.memory.get_typed_pointer_value(
             pwndbg.heap.current.malloc_chunk, gdb.lookup_symbol(f"{name}_chunk")[0].value()
         )
         results[name] = gdb.execute(f"malloc_chunk {name}_chunk", to_string=True).splitlines()
@@ -241,7 +241,7 @@ def test_malloc_chunk_dump_command(start_binary):
     gdb.execute("break break_here")
     gdb.execute("continue")
 
-    chunk = pwndbg.gdblib.memory.poi(
+    chunk = pwndbg.gdblib.memory.get_typed_pointer_value(
         pwndbg.heap.current.malloc_chunk, gdb.lookup_symbol("test_chunk")[0].value()
     )
     chunk_addr = chunk.address


### PR DESCRIPTION
These are some changes that I made while porting some musl mallocng functionality, but am breaking up PRs so that it's easier to manage. So this just exposes some new API that aren't yet being called anywhere. 

Hopefully are intuitively named. If people have better ideas, I'm happy to change them. If we settle on something, we can change the read_gdbvalue() calls in a separate PR later.