### PR TITLE
fix: add a try catch around elftype reload so failure isn't fatal

### DIFF
--- a/pwndbg/gdblib/elf.py
+++ b/pwndbg/gdblib/elf.py
@@ -39,6 +39,7 @@ import pwndbg.gdblib.vmmap
 import pwndbg.lib.cache
 import pwndbg.lib.elftypes
 import pwndbg.lib.memory
+from pwndbg.color import message
 
 # ELF constants
 PF_X, PF_W, PF_R = 1, 2, 4
@@ -74,7 +75,12 @@ Phdr = Union[pwndbg.lib.elftypes.Elf32_Phdr, pwndbg.lib.elftypes.Elf64_Phdr]
 @pwndbg.gdblib.events.new_objfile
 def update() -> None:
     global Ehdr, Phdr
-    importlib.reload(pwndbg.lib.elftypes)
+    try:
+        importlib.reload(pwndbg.lib.elftypes)
+
+    except ImportError:
+        print(message.warn("Failed to reload pwndbg.lib.elftypes"))
+        pass
 
     if pwndbg.gdblib.arch.ptrsize == 4:
         Ehdr = pwndbg.lib.elftypes.Elf32_Ehdr


### PR DESCRIPTION
I haven't been able to reliably reproduce this, but I ran into an exception a couple times during development:

```
pwndbg> add-symbol-file ~/dev/pwndbg/tests/gdb-tests/tests/binaries/musls/1.2.4/lib/ld-musl-x86_64.so.
1.debug
add symbol table from file "/home/aa/dev/pwndbg/tests/gdb-tests/tests/binaries/musls/1.2.4/lib/ld-musl
-x86_64.so.1.debug"
Reading symbols from /home/aa/dev/pwndbg/tests/gdb-tests/tests/binaries/musls/1.2.4/lib/ld-musl-x86_64
.so.1.debug...
Expanding full symbols from /home/aa/dev/pwndbg/tests/gdb-tests/tests/binaries/musls/1.2.4/lib/ld-musl
-x86_64.so.1.debug...
Exception occurred: Error: module pwndbg.lib.elftypes not in sys.modules (<class 'ImportError'>)
For more info invoke `set exception-verbose on` and rerun the command
or debug it by yourself with `set exception-debugger on`
Traceback (most recent call last):
  File "/home/aa/source/pwndbg/result/share/pwndbg/pwndbg/gdblib/events.py", line 123, in caller
    raise e
  File "/home/aa/source/pwndbg/result/share/pwndbg/pwndbg/gdblib/events.py", line 118, in caller
    func()
  File "/home/aa/source/pwndbg/result/share/pwndbg/pwndbg/gdblib/elf.py", line 69, in update
    importlib.reload(pwndbg.lib.elftypes)
  File "/nix/store/glfr70gi7hfaj50mwj2431p8bg60fhqw-python3-3.11.9/lib/python3.11/importlib/__init__.p
y", line 148, in reload
    raise ImportError(msg.format(name), name=name)
ImportError: module pwndbg.lib.elftypes not in sys.modules
```

This just allows it to keep going if it's not able to reload, as I don't think it should be fatal.