### PR TITLE
refactor: Switch to use `pwnlib.term.text` for bold coloring

### DIFF
--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -15,6 +15,7 @@ from typing import List
 from typing import Optional
 from typing import Tuple
 
+from pwnlib.term import text
 from typing_extensions import ParamSpec
 
 import pwndbg
@@ -1178,7 +1179,7 @@ def context_threads(with_banner=True, target=sys.stdout, width=None):
 
             line += f"{pc_colored}"
             if symbol:
-                line += f" <{pwndbg.color.bold(pwndbg.color.green(symbol))}> "
+                line += f" <{text.bold_green(str(symbol))}> "
 
         out.append(line)
 

--- a/pwndbg/commands/misc.py
+++ b/pwndbg/commands/misc.py
@@ -4,6 +4,8 @@ import argparse
 import errno
 from collections import defaultdict
 
+from pwnlib.term import text
+
 import pwndbg.aglib.memory
 import pwndbg.aglib.regs
 import pwndbg.aglib.vmmap
@@ -101,7 +103,7 @@ parser.add_argument(
 def pwndbg_(filter_pattern, shell, all_, category_, list_categories) -> None:
     if list_categories:
         for category in CommandCategory:
-            print(C.bold(C.green(f"{category.value}")))
+            print(text.bold_green(category.value))
         return
 
     if all_:
@@ -133,11 +135,11 @@ def pwndbg_(filter_pattern, shell, all_, category_, list_categories) -> None:
             continue
         data = table_data[category]
 
-        category_header = C.bold(C.green(category + " Commands"))
-        alias_header = C.bold(C.blue("Aliases"))
+        category_header = text.bold_green(category + " Commands")
+        alias_header = text.bold_blue("Aliases")
         print(
             tabulate(
-                data, headers=[f"{category_header} [{alias_header}]", f"{C.bold('Description')}"]
+                data, headers=[f"{category_header} [{alias_header}]", f"{text.bold('Description')}"]
             )
         )
         print()

--- a/pwndbg/commands/tls.py
+++ b/pwndbg/commands/tls.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import argparse
 
+from pwnlib.term.text import bold_green
 from tabulate import tabulate
 
 import pwndbg.aglib.memory
@@ -85,7 +86,6 @@ group.add_argument(
 def threads(num_threads, respect_config) -> None:
     table = []
     headers = ["global_num", "name", "status", "pc", "symbol"]
-    bold_green = lambda text: pwndbg.color.bold(pwndbg.color.green(text))
 
     import gdb
 
@@ -122,7 +122,7 @@ def threads(num_threads, respect_config) -> None:
 
         if thread is original_thread:
             row = [
-                bold_green(thread.global_num),
+                bold_green(str(thread.global_num)),
                 bold_green(name),
             ]
         else:
@@ -144,7 +144,7 @@ def threads(num_threads, respect_config) -> None:
 
             if symbol:
                 if thread is original_thread:
-                    row.append(bold_green(symbol))
+                    row.append(bold_green(str(symbol)))
                 else:
                     row.append(symbol)
 


### PR DESCRIPTION
Previously if you wanted to use bold colors people would use a lambda or manually use 2 functions, for example:

```
pwndbg/commands/context.py
934:                line += f" <{pwndbg.color.bold(pwndbg.color.green(symbol))}> "
pwndbg/commands/tls.py
85:    bold_green = lambda text: pwndbg.color.bold(pwndbg.color.green(text))
```

These would let you just use `pwndbg.color.bold_green()` in the first case or `from pwndbg.color import bold_green` for the second case.

A tool I'm porting uses bolded colors for lots of stuff, which I'm keeping the same for now, so am using a bunch of these new functions.