### PR TITLE
run nixfmt-rfc-style on all nix files

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -7,38 +7,56 @@
     inputs.nixpkgs.follows = "nixpkgs";
   };
 
-  outputs = { self, nixpkgs, poetry2nix }:
+  outputs =
+    {
+      self,
+      nixpkgs,
+      poetry2nix,
+    }:
     let
       # Self contained packages for: Debian, RHEL-like (yum, rpm), Alpine, Arch packages
       forAllSystems = nixpkgs.lib.genAttrs nixpkgs.lib.systems.flakeExposed;
-      forPortables = nixpkgs.lib.genAttrs [ "deb" "rpm" "apk" "archlinux" ];
+      forPortables = nixpkgs.lib.genAttrs [
+        "deb"
+        "rpm"
+        "apk"
+        "archlinux"
+      ];
 
-      pkgsBySystem = forAllSystems (system: import nixpkgs {
-        inherit system;
-        overlays = [ poetry2nix.overlays.default ];
-      });
-      pkgUtil = forAllSystems (system: import ./nix/bundle/pkg.nix {
-        pkgs = pkgsBySystem.${system};
-      });
+      pkgsBySystem = forAllSystems (
+        system:
+        import nixpkgs {
+          inherit system;
+          overlays = [ poetry2nix.overlays.default ];
+        }
+      );
+      pkgUtil = forAllSystems (system: import ./nix/bundle/pkg.nix { pkgs = pkgsBySystem.${system}; });
 
-      portableDrv = system: import ./nix/portable.nix {
-        pkgs = pkgsBySystem.${system};
-        pwndbg = self.packages.${system}.pwndbg;
-      };
-      portableDrvs = system: forPortables (packager: pkgUtil.${system}.buildPackagePFPM {
-        inherit packager;
-        drv = portableDrv system;
-        config = ./nix/bundle/nfpm.yaml;
-        preremove = ./nix/bundle/preremove.sh;
-      });
-      tarballDrv = system: {
-        tarball = pkgUtil.${system}.buildPackageTarball {
-          drv = portableDrv system;
+      portableDrv =
+        system:
+        import ./nix/portable.nix {
+          pkgs = pkgsBySystem.${system};
+          pwndbg = self.packages.${system}.pwndbg;
         };
+      portableDrvs =
+        system:
+        forPortables (
+          packager:
+          pkgUtil.${system}.buildPackagePFPM {
+            inherit packager;
+            drv = portableDrv system;
+            config = ./nix/bundle/nfpm.yaml;
+            preremove = ./nix/bundle/preremove.sh;
+          }
+        );
+      tarballDrv = system: {
+        tarball = pkgUtil.${system}.buildPackageTarball { drv = portableDrv system; };
       };
     in
-  {
-      packages = forAllSystems (system: {
+    {
+      packages = forAllSystems (
+        system:
+        {
           pwndbg = import ./nix/pwndbg.nix {
             pkgs = pkgsBySystem.${system};
             python3 = pkgsBySystem.${system}.python3;
@@ -50,5 +68,5 @@
         // (portableDrvs system)
         // (tarballDrv system)
       );
-  };
+    };
 }

--- a/nix/bundle/default.nix
+++ b/nix/bundle/default.nix
@@ -1,7 +1,8 @@
-{ pkgs
-, bin_dir ? "bin"
-, exe_dir ? "exe"
-, lib_dir ? if pkgs.stdenv.isDarwin then "Frameworks/Library.dylib" else "lib"
+{
+  pkgs,
+  bin_dir ? "bin",
+  exe_dir ? "exe",
+  lib_dir ? if pkgs.stdenv.isDarwin then "Frameworks/Library.dylib" else "lib",
 }:
 path:
 # Original file copied from https://github.com/3noch/nix-bundle-exe
@@ -11,23 +12,26 @@ path:
 #  2) a path to a directory containing bin/, or
 #  3) a path to an executable.
 let
-  print-needed-elf = pkgs.writeScriptBin
-    "print-needed-elf"
-    '''${pkgs.python3}'/bin/python ${./print_needed_elf.py} "$@"'';
+  print-needed-elf = pkgs.writeScriptBin "print-needed-elf" '''${pkgs.python3}'/bin/python ${./print_needed_elf.py} "$@"'';
 
-  relative-path = pkgs.writeScriptBin
-    "relative-path"
-    '''${pkgs.python3}'/bin/python ${./relative-path.py} "$@"'';
+  relative-path = pkgs.writeScriptBin "relative-path" '''${pkgs.python3}'/bin/python ${./relative-path.py} "$@"'';
 
   cfg =
     if pkgs.stdenv.isDarwin then
       {
-        deps = with pkgs; [ darwin.binutils darwin.sigtool ];
+        deps = with pkgs; [
+          darwin.binutils
+          darwin.sigtool
+        ];
         script = "bash ${./bundle-macos.sh}";
       }
     else if pkgs.stdenv.isLinux then
       {
-        deps = [ pkgs.glibc print-needed-elf relative-path ];
+        deps = [
+          pkgs.glibc
+          print-needed-elf
+          relative-path
+        ];
         script = "bash ${./bundle-linux.sh}";
       }
     else
@@ -36,19 +40,20 @@ let
   name = if pkgs.lib.isDerivation path then path.name else builtins.baseNameOf path;
   overrideEnv = name: value: if value == null then "" else "export ${name}='${value}'";
 in
-  pkgs.runCommand "bundle-${name}"
-  {
-    nativeBuildInputs = cfg.deps ++ [ pkgs.nukeReferences ];
+pkgs.runCommand "bundle-${name}" { nativeBuildInputs = cfg.deps ++ [ pkgs.nukeReferences ]; } ''
+  set -euo pipefail
+  export bin_dir='${bin_dir}'
+  export exe_dir='${exe_dir}'
+  export lib_dir='${lib_dir}'
+  ${
+    if builtins.pathExists "${path}/bin" then
+      ''
+        find '${path}/bin' -type f -executable -print0 | xargs -0 --max-args 1 ${cfg.script} "$out"
+      ''
+    else
+      ''
+        ${cfg.script} "$out" ${pkgs.lib.escapeShellArg path}
+      ''
   }
-  ''
-    set -euo pipefail
-    export bin_dir='${bin_dir}'
-    export exe_dir='${exe_dir}'
-    export lib_dir='${lib_dir}'
-    ${if builtins.pathExists "${path}/bin" then ''
-      find '${path}/bin' -type f -executable -print0 | xargs -0 --max-args 1 ${cfg.script} "$out"
-    '' else ''
-      ${cfg.script} "$out" ${pkgs.lib.escapeShellArg path}
-    ''}
-    find $out -empty -type d -delete
-  ''
+  find $out -empty -type d -delete
+''

--- a/nix/bundle/pkg.nix
+++ b/nix/bundle/pkg.nix
@@ -1,5 +1,5 @@
 {
-  pkgs ? import <nixpkgs> {}
+  pkgs ? import <nixpkgs> { },
 }:
 let
   pfpmArchs = {
@@ -12,64 +12,73 @@ let
     "riscv64-linux" = "riscv64";
   };
 
-  buildPackagePFPM = {
-    drv ? null
-    , config ? "nfpm.yaml"
-    , packager ? null  # apk|deb|rpm|archlinux
-    , preremove ? null
-    , ...
-   }@attrs: pkgs.stdenv.mkDerivation {
-    name = "nfpm-${packager}-${drv.name}";
-    buildInputs = [ pkgs.nfpm ];
+  buildPackagePFPM =
+    {
+      drv ? null,
+      config ? "nfpm.yaml",
+      packager ? null, # apk|deb|rpm|archlinux
+      preremove ? null,
+      ...
+    }@attrs:
+    pkgs.stdenv.mkDerivation {
+      name = "nfpm-${packager}-${drv.name}";
+      buildInputs = [ pkgs.nfpm ];
 
-    unpackPhase = "true";
+      unpackPhase = "true";
 
-    buildPhase = (pkgs.lib.optionalString (preremove != null) ''
-      cp ${preremove} preremove.sh
-    '') + ''
-      mkdir -p ./dist
-      ln -s ${drv} ./result
-      export VERSION=${drv.meta.version}
-      export ARCH=${pfpmArchs.${drv.meta.architecture}}
-      nfpm pkg --config ${config} --packager ${packager} --target ./dist
-    '';
+      buildPhase =
+        (pkgs.lib.optionalString (preremove != null) ''
+          cp ${preremove} preremove.sh
+        '')
+        + ''
+          mkdir -p ./dist
+          ln -s ${drv} ./result
+          export VERSION=${drv.meta.version}
+          export ARCH=${pfpmArchs.${drv.meta.architecture}}
+          nfpm pkg --config ${config} --packager ${packager} --target ./dist
+        '';
 
-    installPhase = ''
-      mkdir -p $out
-      cp -r ./dist/* $out
-    '';
-  };
+      installPhase = ''
+        mkdir -p $out
+        cp -r ./dist/* $out
+      '';
+    };
 
-  buildPackageTarball = {
-    drv ? null
-    , ...
-   }@attrs: pkgs.stdenv.mkDerivation {
-    name = "tarball-${drv.name}";
-    buildInputs = [ pkgs.gnutar ];
+  buildPackageTarball =
+    {
+      drv ? null,
+      ...
+    }@attrs:
+    pkgs.stdenv.mkDerivation {
+      name = "tarball-${drv.name}";
+      buildInputs = [ pkgs.gnutar ];
 
-    unpackPhase = "true";
+      unpackPhase = "true";
 
-    buildPhase = ''
-      mkdir -p ./dist
-      ln -s ${drv} ./result
-      export DIST_TAR=$PWD/dist/${drv.meta.name}_${drv.meta.version}_${pfpmArchs.${drv.meta.architecture}}.tar.gz
+      buildPhase = ''
+        mkdir -p ./dist
+        ln -s ${drv} ./result
+        export DIST_TAR=$PWD/dist/${drv.meta.name}_${drv.meta.version}_${
+          pfpmArchs.${drv.meta.architecture}
+        }.tar.gz
 
-      pushd ./result
-      chmod +x bin/* || true
-      chmod +x lib/ld-* || true
-      tar cvfJ $DIST_TAR \
-        --owner=0 --group=0 --mode=u+rw,uga+r \
-        --mtime='1970-01-01' \
-        .
-      popd
-    '';
+        pushd ./result
+        chmod +x bin/* || true
+        chmod +x lib/ld-* || true
+        tar cvfJ $DIST_TAR \
+          --owner=0 --group=0 --mode=u+rw,uga+r \
+          --mtime='1970-01-01' \
+          .
+        popd
+      '';
 
-    installPhase = ''
-      mkdir -p $out
-      cp -r ./dist/* $out
-    '';
-  };
-in {
+      installPhase = ''
+        mkdir -p $out
+        cp -r ./dist/* $out
+      '';
+    };
+in
+{
   buildPackagePFPM = buildPackagePFPM;
   buildPackageTarball = buildPackageTarball;
 }

--- a/nix/portable.nix
+++ b/nix/portable.nix
@@ -1,58 +1,62 @@
 {
-  pkgs ? import <nixpkgs> { }
-  , pwndbg ? import ./pwndbg.nix { }
+  pkgs ? import <nixpkgs> { },
+  pwndbg ? import ./pwndbg.nix { },
 }:
 let
   gdb = pwndbg.meta.gdb;
   python3 = pwndbg.meta.python3;
 
-  gdbBundledLib = pkgs.callPackage ./bundle {} "${gdb}/bin/gdb";
-  pyEnvBundledLib = pkgs.callPackage ./bundle {} "${pwndbg}/share/pwndbg/.venv/lib/";
+  gdbBundledLib = pkgs.callPackage ./bundle { } "${gdb}/bin/gdb";
+  pyEnvBundledLib = pkgs.callPackage ./bundle { } "${pwndbg}/share/pwndbg/.venv/lib/";
 
-  ldName = pkgs.lib.readFile (pkgs.runCommand "bundle" {
-    nativeBuildInputs = [ pkgs.patchelf ];
-  } ''
-    echo -n $(patchelf --print-interpreter "${gdbBundledLib}/exe/gdb") > $out
-  '');
+  ldName = pkgs.lib.readFile (
+    pkgs.runCommand "bundle" { nativeBuildInputs = [ pkgs.patchelf ]; } ''
+      echo -n $(patchelf --print-interpreter "${gdbBundledLib}/exe/gdb") > $out
+    ''
+  );
 
-  pwndbgBundleBin = pkgs.writeScript "pwndbg" ''#!/bin/sh
-dir="$(cd -- "$(dirname "$(dirname "$(realpath "$0")")")" >/dev/null 2>&1 ; pwd -P)"
-export PYTHONHOME="$dir"
-export PYTHONPYCACHEPREFIX="$dir/cache/"
-export PWNDBG_VENV_PATH="PWNDBG_PLEASE_SKIP_VENV"
-exec "$dir/lib/${ldName}" "$dir/exe/gdb" --quiet --early-init-eval-command="set charset UTF-8" --early-init-eval-command="set auto-load safe-path /" --command=$dir/exe/gdbinit.py "$@"
+  pwndbgBundleBin = pkgs.writeScript "pwndbg" ''
+    #!/bin/sh
+    dir="$(cd -- "$(dirname "$(dirname "$(realpath "$0")")")" >/dev/null 2>&1 ; pwd -P)"
+    export PYTHONHOME="$dir"
+    export PYTHONPYCACHEPREFIX="$dir/cache/"
+    export PWNDBG_VENV_PATH="PWNDBG_PLEASE_SKIP_VENV"
+    exec "$dir/lib/${ldName}" "$dir/exe/gdb" --quiet --early-init-eval-command="set charset UTF-8" --early-init-eval-command="set auto-load safe-path /" --command=$dir/exe/gdbinit.py "$@"
   '';
   # for cache: pwndbg --eval-command="py import compileall; compileall.compile_dir('/usr/lib/pwndbg/'); exit()"
 
-  portable = pkgs.runCommand "portable-${pwndbg.name}" {
-    meta = {
-      name = pwndbg.name;
-      version = pwndbg.version;
-      architecture = gdb.stdenv.targetPlatform.system;
-    };
-    nativeBuildInputs = [ pkgs.makeWrapper ];
-  } ''
-    mkdir -p $out/pwndbg/bin/
-    mkdir -p $out/pwndbg/lib/
-    mkdir -p $out/pwndbg/exe/
-    mkdir -p $out/pwndbg/share/gdb/
-    mkdir -p $out/pwndbg/cache/
+  portable =
+    pkgs.runCommand "portable-${pwndbg.name}"
+      {
+        meta = {
+          name = pwndbg.name;
+          version = pwndbg.version;
+          architecture = gdb.stdenv.targetPlatform.system;
+        };
+        nativeBuildInputs = [ pkgs.makeWrapper ];
+      }
+      ''
+        mkdir -p $out/pwndbg/bin/
+        mkdir -p $out/pwndbg/lib/
+        mkdir -p $out/pwndbg/exe/
+        mkdir -p $out/pwndbg/share/gdb/
+        mkdir -p $out/pwndbg/cache/
 
-    cp -rf ${gdbBundledLib}/exe/* $out/pwndbg/exe/
-    cp -rf ${gdbBundledLib}/lib/* $out/pwndbg/lib/
-    cp -rf ${pyEnvBundledLib}/lib/* $out/pwndbg/lib/
+        cp -rf ${gdbBundledLib}/exe/* $out/pwndbg/exe/
+        cp -rf ${gdbBundledLib}/lib/* $out/pwndbg/lib/
+        cp -rf ${pyEnvBundledLib}/lib/* $out/pwndbg/lib/
 
-    cp -rf ${pwndbg}/share/pwndbg/.venv/share/gdb/* $out/pwndbg/share/gdb/
-    cp -rf ${gdb}/share/gdb/* $out/pwndbg/share/gdb/
-    chmod -R +w $out
+        cp -rf ${pwndbg}/share/pwndbg/.venv/share/gdb/* $out/pwndbg/share/gdb/
+        cp -rf ${gdb}/share/gdb/* $out/pwndbg/share/gdb/
+        chmod -R +w $out
 
-    cp -rf ${pwndbg.src}/pwndbg $out/pwndbg/lib/${python3.libPrefix}/site-packages/
-    cp ${pwndbg.src}/gdbinit.py $out/pwndbg/exe/
+        cp -rf ${pwndbg.src}/pwndbg $out/pwndbg/lib/${python3.libPrefix}/site-packages/
+        cp ${pwndbg.src}/gdbinit.py $out/pwndbg/exe/
 
-    cp ${pwndbgBundleBin} $out/pwndbg/bin/pwndbg
+        cp ${pwndbgBundleBin} $out/pwndbg/bin/pwndbg
 
-    # fix python "subprocess.py" to use "/bin/sh" and not the nix'ed version, otherwise "gdb-pt-dump" is broken
-    substituteInPlace $out/pwndbg/lib/${python3.libPrefix}/subprocess.py --replace "'${pkgs.bash}/bin/sh'" "'/bin/sh'"
-  '';
+        # fix python "subprocess.py" to use "/bin/sh" and not the nix'ed version, otherwise "gdb-pt-dump" is broken
+        substituteInPlace $out/pwndbg/lib/${python3.libPrefix}/subprocess.py --replace "'${pkgs.bash}/bin/sh'" "'/bin/sh'"
+      '';
 in
-  portable
+portable

--- a/nix/pwndbg.nix
+++ b/nix/pwndbg.nix
@@ -1,59 +1,62 @@
 {
-  pkgs ? import <nixpkgs> { }
-  , python3 ? pkgs.python3
-  , gdb ? pkgs.gdb
-  , inputs ? null
+  pkgs ? import <nixpkgs> { },
+  python3 ? pkgs.python3,
+  gdb ? pkgs.gdb,
+  inputs ? null,
 }:
 let
-  binPath = pkgs.lib.makeBinPath ([
-    python3.pkgs.pwntools   # ref: https://github.com/pwndbg/pwndbg/blob/2023.07.17/pwndbg/wrappers/checksec.py#L8
-  ] ++ pkgs.lib.optionals pkgs.stdenv.isLinux [
-    python3.pkgs.ropper     # ref: https://github.com/pwndbg/pwndbg/blob/2023.07.17/pwndbg/commands/ropper.py#L30
-    python3.pkgs.ropgadget  # ref: https://github.com/pwndbg/pwndbg/blob/2023.07.17/pwndbg/commands/rop.py#L34
-  ]);
+  binPath = pkgs.lib.makeBinPath (
+    [
+      python3.pkgs.pwntools # ref: https://github.com/pwndbg/pwndbg/blob/2023.07.17/pwndbg/wrappers/checksec.py#L8
+    ]
+    ++ pkgs.lib.optionals pkgs.stdenv.isLinux [
+      python3.pkgs.ropper # ref: https://github.com/pwndbg/pwndbg/blob/2023.07.17/pwndbg/commands/ropper.py#L30
+      python3.pkgs.ropgadget # ref: https://github.com/pwndbg/pwndbg/blob/2023.07.17/pwndbg/commands/rop.py#L34
+    ]
+  );
 
   pyEnv = pkgs.poetry2nix.mkPoetryEnv {
-    groups = [];  # put [ "dev" ] to build "dev" dependencies
-    checkGroups = [];  # put [ "dev" ] to build "dev" dependencies
+    groups = [ ]; # put [ "dev" ] to build "dev" dependencies
+    checkGroups = [ ]; # put [ "dev" ] to build "dev" dependencies
     projectDir = inputs.pwndbg;
     python = python3;
-    overrides = pkgs.poetry2nix.overrides.withDefaults (self: super: {
-      pip = python3.pkgs.pip;  # fix infinite loop in nix, look here: https://github.com/nix-community/poetry2nix/issues/1184#issuecomment-1644878841
-      unicorn = python3.pkgs.unicorn;  # fix build for aarch64 (but it will use same version like in nixpkgs)
+    overrides = pkgs.poetry2nix.overrides.withDefaults (
+      self: super: {
+        pip = python3.pkgs.pip; # fix infinite loop in nix, look here: https://github.com/nix-community/poetry2nix/issues/1184#issuecomment-1644878841
+        unicorn = python3.pkgs.unicorn; # fix build for aarch64 (but it will use same version like in nixpkgs)
 
-      # disable build from source, because rust's hash had to be repaired many times, see: PR https://github.com/pwndbg/pwndbg/pull/2024
-      cryptography = super.cryptography.override {
-        preferWheel = true;
-      };
+        # disable build from source, because rust's hash had to be repaired many times, see: PR https://github.com/pwndbg/pwndbg/pull/2024
+        cryptography = super.cryptography.override { preferWheel = true; };
 
-      unix-ar = super.unix-ar.overridePythonAttrs (old: {
-        nativeBuildInputs = (old.nativeBuildInputs or []) ++ [self.setuptools];
-      });
+        unix-ar = super.unix-ar.overridePythonAttrs (old: {
+          nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [ self.setuptools ];
+        });
 
-      pt = super.pt.overridePythonAttrs (old: {
-        buildInputs = (old.buildInputs or [ ]) ++ [ super.poetry-core ];
-      });
-      capstone = super.capstone.overridePythonAttrs (old: {
-        # fix darwin
-        preBuild = pkgs.lib.optionalString pkgs.stdenv.isDarwin ''
-          sed -i 's/^IS_APPLE := .*$/IS_APPLE := 1/' ./src/Makefile
-        '';
-        # fix build for aarch64: https://github.com/capstone-engine/capstone/issues/2102
-        postPatch = pkgs.lib.optionalString pkgs.stdenv.isLinux ''
-          substituteInPlace setup.py --replace manylinux1 manylinux2014
-        '';
-      });
-    });
+        pt = super.pt.overridePythonAttrs (old: {
+          buildInputs = (old.buildInputs or [ ]) ++ [ super.poetry-core ];
+        });
+        capstone = super.capstone.overridePythonAttrs (old: {
+          # fix darwin
+          preBuild = pkgs.lib.optionalString pkgs.stdenv.isDarwin ''
+            sed -i 's/^IS_APPLE := .*$/IS_APPLE := 1/' ./src/Makefile
+          '';
+          # fix build for aarch64: https://github.com/capstone-engine/capstone/issues/2102
+          postPatch = pkgs.lib.optionalString pkgs.stdenv.isLinux ''
+            substituteInPlace setup.py --replace manylinux1 manylinux2014
+          '';
+        });
+      }
+    );
   };
 
-  pwndbgVersion = pkgs.lib.readFile (pkgs.runCommand "pwndbgVersion" {
-    nativeBuildInputs = [ pkgs.python3 ];
-  } ''
-    mkdir pkg
-    cd pkg
-    cp ${inputs.pwndbg + "/pwndbg/lib/version.py"} version.py
-    python3 -c 'import version; print(version.__version__, end="")' > $out
-  '');
+  pwndbgVersion = pkgs.lib.readFile (
+    pkgs.runCommand "pwndbgVersion" { nativeBuildInputs = [ pkgs.python3 ]; } ''
+      mkdir pkg
+      cd pkg
+      cp ${inputs.pwndbg + "/pwndbg/lib/version.py"} version.py
+      python3 -c 'import version; print(version.__version__, end="")' > $out
+    ''
+  );
 
   pwndbg = pkgs.stdenv.mkDerivation {
     name = "pwndbg";
@@ -86,4 +89,4 @@ let
     };
   };
 in
-  pwndbg
+pwndbg


### PR DESCRIPTION
This run of `nix run nixpkgs-unstable#nixfmt-rfc-style --` across all of the nix files so that upcoming nix PRs will be easier to read. May want to add this to `lint.sh` I suppose.

It is probably worth considering setting up https://github.com/cachix/git-hooks.nix at some point, but can do that later.