### PR TITLE
Modify python test scripts to work from nix

### DIFF
--- a/tests/gdb-tests/tests.py
+++ b/tests/gdb-tests/tests.py
@@ -5,6 +5,7 @@ import concurrent.futures
 import os
 import re
 import subprocess
+import sys
 import time
 from subprocess import CompletedProcess
 from typing import Tuple
@@ -159,6 +160,11 @@ def parse_args():
         "-s", "--serial", action="store_true", help="run tests one at a time instead of in parallel"
     )
     parser.add_argument(
+        "--nix",
+        action="store_true",
+        help="run tests using gdbinit.py built for nix environment",
+    )
+    parser.add_argument(
         "--collect-only",
         action="store_true",
         help="only show the output of test collection, don't run any tests",
@@ -176,6 +182,14 @@ if __name__ == "__main__":
     if args.pdb:
         print("Will run tests in serial and with Python debugger")
         args.serial = True
+    if args.nix:
+        gdbinit_path = os.path.join(ROOT_DIR, "result/share/pwndbg/gdbinit.py")
+        if not os.path.exists(gdbinit_path):
+            print("ERROR: No nix-compatible gdbinit.py found. Run nix build .#pwndbg-dev")
+            sys.exit(1)
+        GDB_INIT_PATH = os.path.join(ROOT_DIR, "result/share/pwndbg/gdbinit.py")
+        # This tells tests/utils.py where to find the gdbinit.py file when used by various tests
+        os.environ["GDB_INIT_PATH"] = GDB_INIT_PATH
     ensureZigPath()
     makeBinaries()
     tests: list[str] = getTestsList(args.collect_only, args.test_name_filter)

--- a/tests/gdb-tests/tests.py
+++ b/tests/gdb-tests/tests.py
@@ -187,9 +187,8 @@ if __name__ == "__main__":
         if not os.path.exists(gdbinit_path):
             print("ERROR: No nix-compatible gdbinit.py found. Run nix build .#pwndbg-dev")
             sys.exit(1)
-        GDB_INIT_PATH = os.path.join(ROOT_DIR, "result/share/pwndbg/gdbinit.py")
         # This tells tests/utils.py where to find the gdbinit.py file when used by various tests
-        os.environ["GDB_INIT_PATH"] = GDB_INIT_PATH
+        os.environ["GDB_INIT_PATH"] = gdbinit_path
     ensureZigPath()
     makeBinaries()
     tests: list[str] = getTestsList(args.collect_only, args.test_name_filter)

--- a/tests/gdb-tests/tests/utils.py
+++ b/tests/gdb-tests/tests/utils.py
@@ -5,10 +5,7 @@ import os
 import re
 import subprocess
 
-if os.environ.get("GDB_INIT_PATH"):
-    GDB_INIT_PATH = os.environ["GDB_INIT_PATH"]
-else:
-    GDB_INIT_PATH = "../../gdbinit.py"
+GDB_INIT_PATH = os.environ.get("GDB_INIT_PATH", "../../gdbinit.py")
 
 
 def run_gdb_with_script(

--- a/tests/gdb-tests/tests/utils.py
+++ b/tests/gdb-tests/tests/utils.py
@@ -5,7 +5,7 @@ import os
 import re
 import subprocess
 
-GDB_INIT_PATH = os.environ.get("GDB_INIT_PATH", "../../gdbinit.py")
+gdb_init_path = os.environ.get("GDB_INIT_PATH", "../../gdbinit.py")
 
 
 def run_gdb_with_script(
@@ -28,7 +28,7 @@ def run_gdb_with_script(
     for cmd in pybefore:
         command += ["--eval-command", cmd]
 
-    command += ["--command", GDB_INIT_PATH]
+    command += ["--command", gdb_init_path]
 
     if binary:
         command += [binary]

--- a/tests/gdb-tests/tests/utils.py
+++ b/tests/gdb-tests/tests/utils.py
@@ -1,12 +1,23 @@
 from __future__ import annotations
 
 import codecs
+import os
 import re
 import subprocess
 
+if os.environ.get("GDB_INIT_PATH"):
+    GDB_INIT_PATH = os.environ["GDB_INIT_PATH"]
+else:
+    GDB_INIT_PATH = "../../gdbinit.py"
+
 
 def run_gdb_with_script(
-    binary="", core="", stdin_input=None, pybefore=None, pyafter=None, timeout=None
+    binary="",
+    core="",
+    stdin_input=None,
+    pybefore=None,
+    pyafter=None,
+    timeout=None,
 ):
     """
     Runs GDB with given commands launched before and after loading of gdbinit.py
@@ -20,7 +31,7 @@ def run_gdb_with_script(
     for cmd in pybefore:
         command += ["--eval-command", cmd]
 
-    command += ["--command", "../../gdbinit.py"]
+    command += ["--command", GDB_INIT_PATH]
 
     if binary:
         command += [binary]


### PR DESCRIPTION
Minor tweaks to the testing scripts to be able to run in the nix dev shell and lazy load the gdbinit.py from utils.py. If someone has preference for how to pass the path to gdbinit.py instead of the environment let me know. Since it's just various tests importing that file directly, I chose that route. Don't have a lot of pytest experience though. 

This change allows someone to run `./tests.sh --nix` to test with the pwndbg copy built by nix.