### PR TITLE
Add cached symbol value lookup

### DIFF
--- a/pwndbg/gdblib/symbol.py
+++ b/pwndbg/gdblib/symbol.py
@@ -137,6 +137,21 @@ def get(address: int | gdb.Value, gdb_only: bool = False) -> str:
 
 
 @pwndbg.lib.cache.cache_until("objfile")
+def value(symbol):
+    """Get gdb.Value object for given symbol"""
+
+    try:
+        symbol_obj = gdb.lookup_symbol(symbol)[0]
+        if symbol_obj:
+            return symbol_obj.value()
+        else:
+            return None
+    except gdb.error as e:
+        if all(x not in str(e) for x in skipped_exceptions):
+            raise e
+
+
+@pwndbg.lib.cache.cache_until("objfile")
 def address(symbol: str) -> int | None:
     """
     Get the address for `symbol`


### PR DESCRIPTION
I'm not entirely sure this is that useful, but I had added it when porting stuff so figured I'd send a PR anyway. I realized after you can do the same with the existing `symbol.parse_and_eval`, which handles gdb expression evaluation. The handling for strictly `gdb.Value` lookup in `symbol.address` seemed slightly more robust, and I figured possibly having caching for when would be good, though I'm not familiar enough with how `@pwndbg.lib.cache` works to say how much of a difference it will make if used.