### PR TITLE
Initial muslheap port

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -1,0 +1,4 @@
+# Credits
+
+- The musl mallocng functionality was originally ported from xf1le's [muslheap](https://github.com/xf1les/muslheap)
+  library

--- a/pwndbg/aglib/heap/mallocng.py
+++ b/pwndbg/aglib/heap/mallocng.py
@@ -228,31 +228,6 @@ class MuslMallocngMemoryAllocator(pwndbg.aglib.heap.heap.MemoryAllocator):
 
         return None
 
-    def get_group_type(self) -> pwndbg.dbg_mod.Value | None:
-        """Find the struct group indirectly using the meta group
-
-        There is another common `struct group` in grp.h that complicates pulling out the musl mallocng `struct group`,
-        because gdb will favour the first one it finds. And I'm also not sure that we want to rely on a specific context
-        block to pass to lookup_type. So since we know meta use is what we want, we just pull it from there.
-
-        FIXME: This should probably be abstracted to be a helper in pwndbg.aglib.typeinfo
-        """
-
-        meta_type = pwndbg.aglib.typeinfo.lookup_types("struct meta")
-        if meta_type is None:
-            print(message.error("Type 'struct meta' not found."))
-            return None
-        # Purposely fuzzy find the member in case meta ever changes
-        group_type = None
-        for field in meta_type.fields():
-            if str(field.type).startswith("struct group *"):
-                group_type = field.type.target()
-                break
-        if group_type is None:
-            print(message.error("Type 'struct group' not found in the 'meta' structure."))
-            return None
-        return group_type
-
     def get_stride(self, g: Dict) -> int | None:
         # http://git.musl-libc.org/cgit/musl/tree/src/malloc/mallocng/meta.h?h=v1.2.2#n175
 

--- a/pwndbg/aglib/heap/mallocng.py
+++ b/pwndbg/aglib/heap/mallocng.py
@@ -5,15 +5,14 @@ from pathlib import Path
 from typing import Dict
 from typing import List
 from typing import Tuple
-from typing import Any
+
 from pwnlib.term import text
 
 import pwndbg
-
-from pwndbg.lib.common import hex
-from pwndbg.lib.common import bin
 from pwndbg.color import message
 from pwndbg.constants import mallocng
+from pwndbg.lib.common import bin
+from pwndbg.lib.common import hex
 
 
 class Printer:

--- a/pwndbg/aglib/heap/mallocng.py
+++ b/pwndbg/aglib/heap/mallocng.py
@@ -1,0 +1,861 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Dict
+from typing import List
+from typing import Tuple
+from typing import Any
+from pwnlib.term import text
+
+import pwndbg
+
+from pwndbg.lib.common import hex
+from pwndbg.lib.common import bin
+from pwndbg.color import message
+from pwndbg.constants import mallocng
+
+
+class Printer:
+    """A helper class for pretty printing"""
+
+    def __init__(
+        self,
+        header_rjust: int | None = None,
+        header_ljust: int | None = None,
+        header_clr: int | None = None,
+        content_clr: int | None = None,
+    ) -> None:
+        self.HEADER_RJUST = header_rjust
+        self.HEADER_LJUST = header_ljust
+        self.HEADER_CLR = header_clr
+        self.CONTENT_CLR = content_clr
+
+    def set(
+        self,
+        header_rjust: int | None = None,
+        header_ljust: int | None = None,
+        header_clr: int | None = None,
+        content_clr: int | None = None,
+    ) -> None:
+        """Set Printer config for coloring and aligning"""
+
+        if header_rjust:
+            self.HEADER_RJUST = header_rjust
+        if header_ljust:
+            self.HEADER_LJUST = header_ljust
+        if header_clr:
+            self.HEADER_CLR = header_clr
+        if content_clr:
+            self.CONTENT_CLR = content_clr
+
+    def print(self, header: str, content: str, warning: str = "") -> None:
+        """Print out message with coloring and aligning"""
+
+        header, content, warning = map(str, (header, content, warning))
+
+        # Aligning (header)
+        if self.HEADER_RJUST:
+            header = header.rjust(self.HEADER_RJUST)
+        elif self.HEADER_LJUST:
+            header = header.ljust(self.HEADER_LJUST)
+        header += " :"
+
+        # Coloring (header)
+        if self.HEADER_CLR:
+            header = self.HEADER_CLR(header)
+        # Coloring (warning)
+        if warning:
+            warning = text.bold_yellow("[" + warning + "]")
+            # Coloring (content)
+            # Use red for content coloring if warning message is given
+            content = text.bold_red(content)
+        elif self.CONTENT_CLR:
+            content = self.CONTENT_CLR(content)
+
+        # Build and print out message
+        if warning:
+            ctx = "%s %s %s" % (header, content, warning)
+        else:
+            ctx = "%s %s" % (header, content)
+        print(ctx)
+
+
+def generate_mask_str(avail_mask: int, freed_mask: int) -> Tuple[str, str]:
+    """Generate pretty-print string for avail_mask and freed_mask
+
+    Example:
+       avail_mask : 0x7f80 (0b111111110000000)
+       freed_mask : 0x0    (0b000000000000000)
+    """
+
+    # Hex strings for avail_mask and freed_mask
+    ah = hex(avail_mask)
+    fh = hex(freed_mask)
+    maxlen = max(len(ah), len(fh))
+    ah = ah.ljust(maxlen)  # fills ' '
+    fh = fh.ljust(maxlen)
+
+    # Binary strings for avail_mask and freed_mask
+    ab = bin(avail_mask).replace("0b", "")
+    fb = bin(freed_mask).replace("0b", "")
+    maxlen = max(len(ab), len(fb))
+    ab = ab.zfill(maxlen)  # fills '0'
+    fb = fb.zfill(maxlen)
+
+    avail_str = ah + text.bold_white(" (0b%s)" % ab)
+    freed_str = fh + text.bold_white(" (0b%s)" % fb)
+    return (avail_str, freed_str)
+
+
+def generate_slot_map(meta: Dict, mask_index: int | None = None) -> str:
+    """Generate a map-like string to display the status of all slots in a group.
+
+    If mask_index is set, mask the specified slot in status map.
+
+    Example:
+       Slot status map: UUUAAAAFFUUUUUUU[U]UUUUUUUUUUUUU (from slot 29 to slot 0)
+        (U: Inuse / A: Available / F: Freed)
+    """
+
+    legend = " (%s: Inuse / %s: Available / %s: Freed)" % (
+        text.bold_white("U"),
+        text.bold_green("A"),
+        text.bold_red("F"),
+    )
+
+    avail_mask = int(meta["avail_mask"])
+    freed_mask = int(meta["freed_mask"])
+    slot_count = int(meta["last_idx"]) + 1
+
+    # Generate slot status map
+    mapstr = ""
+    for idx in range(slot_count):
+        avail = avail_mask & 1
+        freed = freed_mask & 1
+        if not freed and not avail:
+            # Inuse
+            s = text.bold_white("U")
+        elif not freed and avail:
+            # Available
+            s = text.bold_green("A")
+        elif freed and not avail:
+            # Freed
+            s = text.bold_red("F")
+        else:
+            s = "?"
+        # Mask the slot with index `mask_index` in the map
+        if idx == mask_index:
+            s = "[" + s + "]"
+        mapstr = s + mapstr
+
+        avail_mask >>= 1
+        freed_mask >>= 1
+
+    if slot_count > 1:
+        mapstr += " (from slot %s to slot %s)" % (
+            text.bold_blue(str(slot_count - 1)),
+            text.bold_blue("0"),
+        )
+
+    output = text.bold_magenta("\nSlot status map: ") + mapstr + "\n" + legend
+    return output
+
+
+class MuslMallocngMemoryAllocator(pwndbg.aglib.heap.heap.MemoryAllocator):
+    # fmt: off
+    size_classes = [
+        1, 2, 3, 4,
+        5, 6, 7, 8,
+        9, 10, 12, 15,
+        18, 20, 25, 31,
+        36, 42, 50, 63,
+        72, 84, 102, 127,
+        146, 170, 204, 255,
+        292, 340, 409, 511,
+        584, 682, 818, 1023,
+        1169, 1364, 1637, 2047,
+        2340, 2730, 3276, 4095,
+        4680, 5460, 6552, 8191,
+    ]
+    # fmt: on
+
+    def __init__(self) -> None:
+        # http://git.musl-libc.org/cgit/musl/tree/src/malloc/mallocng/malloc.c?h=v1.2.2#n40
+        # `ctx` (or `__malloc_context`) contains mallocng internal status (such as `active` and `free_meta_head`)
+        self.ctx = None
+
+    def check_mallocng(
+        self,
+    ) -> bool:
+        """Check if mallocng is availble on current environment
+
+        It simply checks if `__malloc_context` symbol is existed. If so, set the symbol value found as `self.ctx`.
+        """
+        sv = pwndbg.dbg.selected_inferior().symbol_address_from_name("__malloc_context")
+        if sv is None:
+            err_msg = """\
+    ERROR: can't find musl-libc debug symbols!
+
+    muslheap.py currently requires musl-libc 1.2.1+ with debug symbols installed.
+
+    Either debug symbols are not installed or broken, or a libc without mallocng support (e.g. musl-libc < 1.2.1 or glibc) is used."""
+            print(message.error(err_msg))
+            return False
+        else:
+            self.ctx = pwndbg.aglib.memory.get_typed_pointer_value("struct malloc_context", sv)
+        return True
+
+    def get_libcbase(self) -> int | None:
+        """Find and get musl libc.so base address from current memory mappings"""
+
+        # FIXME: check for any other alternative names for the musl-libc library?
+        soname_pattern = [
+            r"^ld-musl-.+\.so\.1$",
+            r"^libc\.so$",
+            r"^libc\.musl-.+\.so\.1$",
+        ]
+
+        for mapping in pwndbg.aglib.vmmap.get():
+            objfile = mapping.objfile
+            if not objfile or objfile.startswith("["):
+                continue
+            objfn = Path(objfile).name
+            for pattern in soname_pattern:
+                if re.match(pattern, objfn):
+                    return mapping.vaddr
+
+        print(message.warn("Warning: can't find musl-libc in memory mappings!\n"))
+
+        return None
+
+    def get_group_type(self) -> pwndbg.dbg_mod.Value | None:
+        """Find the struct group indirectly using the meta group
+
+        There is another common `struct group` in grp.h that complicates pulling out the musl mallocng `struct group`,
+        because gdb will favour the first one it finds. And I'm also not sure that we want to rely on a specific context
+        block to pass to lookup_type. So since we know meta use is what we want, we just pull it from there.
+
+        FIXME: This should probably be abstracted to be a helper in pwndbg.aglib.typeinfo
+        """
+
+        meta_type = pwndbg.aglib.typeinfo.lookup_types("struct meta")
+        if meta_type is None:
+            print(message.error("Type 'struct meta' not found."))
+            return None
+        # Purposely fuzzy find the member in case meta ever changes
+        group_type = None
+        for field in meta_type.fields():
+            if str(field.type).startswith("struct group *"):
+                group_type = field.type.target()
+                break
+        if group_type is None:
+            print(message.error("Type 'struct group' not found in the 'meta' structure."))
+            return None
+        return group_type
+
+    def get_stride(self, g: Dict) -> int | None:
+        # http://git.musl-libc.org/cgit/musl/tree/src/malloc/mallocng/meta.h?h=v1.2.2#n175
+
+        last_idx = int(g["last_idx"])
+        maplen = int(g["maplen"])
+        sizeclass = int(g["sizeclass"])
+
+        if not last_idx and maplen:
+            return maplen * 4096 - mallocng.UNIT
+        elif sizeclass < 48:
+            return self.size_classes[sizeclass] * mallocng.UNIT
+        else:
+            # Return None if we failed to get stride
+            return None
+
+    def is_bouncing(self, sc: int) -> bool:
+        # http://git.musl-libc.org/cgit/musl/tree/src/malloc/mallocng/meta.h?h=v1.2.2#n283
+
+        return (sc - 7 < 32) and int(self.ctx["bounces"][sc - 7]) >= 100
+
+    def okay_to_free(self, g: Dict) -> bool:
+        # http://git.musl-libc.org/cgit/musl/tree/src/malloc/mallocng/free.c?h=v1.2.2#n38
+
+        if not g["freeable"]:
+            return False
+
+        sc = int(g["sizeclass"])
+        cnt = int(g["last_idx"]) + 1
+        usage = int(self.ctx["usage_by_class"][sc])
+        stride = self.get_stride(g)
+
+        if (
+            sc >= 48
+            or stride < mallocng.UNIT * self.size_classes[sc]
+            or (not g["maplen"])
+            or g["next"] != g
+            or (not self.is_bouncing(sc))
+            or (9 * cnt <= usage and cnt < 20)
+        ):
+            return True
+
+        return False
+
+    def search_chain(self, p: pwndbg.dbg_mod.Value) -> List:
+        """Find slots where `p` is inside by traversing `ctx.meta_area_head` chain"""
+
+        p = int(p)
+
+        result = []
+        try:
+            # Traverse every meta object in `meta_area_head` chain
+            meta_area = self.ctx["meta_area_head"]
+            while int(meta_area):
+                for i in range(int(meta_area["nslots"])):
+                    meta = meta_area["slots"][i]
+                    if not meta["mem"]:
+                        # Skip unused
+                        continue
+                    stride = self.get_stride(meta)
+                    if not stride:
+                        # Skip invaild stride
+                        continue
+                    storage = int(meta["mem"]["storage"].address)
+                    slot_count = int(meta["last_idx"]) + 1
+                    group_start = int(meta["mem"])
+                    group_end = storage + slot_count * stride - mallocng.IB
+                    # Check if `p` is in the range of the group owned by this meta object
+                    if p >= group_start and p < group_end:
+                        if p >= (storage - mallocng.IB):
+                            # Calculate the index of the slot where `p` is inside
+                            slot_index = (p - (storage - mallocng.IB)) // stride
+                        else:
+                            # `p` is above the first slot, which means it's not inside of any slots in this group
+                            # However, we set the slot index to 0 (the first slot). It's acceptable in most cases.
+                            slot_index = 0
+                        # We need a pointer (struct meta*), not the object itself
+                        m = pwndbg.aglib.memory.get_typed_pointer("struct meta", meta.address)
+                        if not m:
+                            print(
+                                text.bold_red("ERROR:"), "Failed to get the pointer of struct meta"
+                            )
+                            return result
+                        result.append((m, slot_index))
+                meta_area = meta_area["next"]
+        except pwndbg.dbg_mod.Error as e:
+            print(text.bold_red("ERROR search_chain():"), str(e))
+            # raise
+        return result
+
+    # Called by mfindslot
+    def display_ob_slot(self, p: pwndbg.dbg_mod.Value, meta: Dict, index: int) -> None:
+        """Display slot out-of-band information
+
+        This allows you to find information about uninitialized slots.
+        """
+
+        print(text.bold_white("\n=========== SLOT OUT-OF-BAND ============= "))
+        printer = Printer(header_clr=text.bold_magenta, content_clr=text.bold_blue, header_rjust=10)
+        P = printer.print
+
+        stride = self.get_stride(meta)
+        slot_start = int(meta["mem"]["storage"][stride * index].address)
+
+        # Display the offset from slot to `p`
+        offset = int(p) - slot_start
+        if offset == 0:
+            offset_tips = text.bold_white("0")
+        elif offset > 0:
+            offset_tips = text.bold_green("+" + hex(offset))
+        else:
+            offset_tips = text.bold_red(hex(offset))
+        offset_tips = " (offset: %s)" % offset_tips
+
+        P("address", text.bold_blue(hex(slot_start)) + offset_tips)
+        P("index", index)
+        P("stride", hex(stride))
+        P("meta obj", text.magenta(hex(meta)))
+
+        # Check slot status
+        #
+        # In mallocng, a slot can be in one of the following status:
+        #  INUSE - slot is in use by user
+        #  AVAIL - slot is can be allocated to user
+        #  FREED - slot is freed
+        #
+        freed = (int(meta["freed_mask"]) >> index) & 1
+        avail = (int(meta["avail_mask"]) >> index) & 1
+        if not freed and not avail:
+            # Calculate the offset to `user_data` field
+            reserved_in_slot_head = (
+                int(pwndbg.aglib.memory.get_typed_pointer_value("uint8_t", slot_start - 3)) & 0xE0
+            ) >> 5
+            if reserved_in_slot_head == 7:
+                cycling_offset = int(
+                    pwndbg.aglib.memory.get_typed_pointer_value("uint16_t", slot_start - 2)
+                )
+                ud_offset = cycling_offset * mallocng.UNIT
+            else:
+                ud_offset = 0
+
+            userdata_ptr = slot_start + ud_offset
+            P(
+                "status",
+                "%s (userdata --> %s)"
+                % (text.bold_white("INUSE"), text.bold_blue(hex(userdata_ptr))),
+            )
+            print("(HINT: use `mslotinfo %s` to display in-band details)" % hex(userdata_ptr))
+        elif not freed and avail:
+            P("status", text.bold_green("AVAIL"))
+        elif freed and not avail:
+            P("status", text.bold_red("FREED"))
+        else:
+            P("status", text.bold_white("?"))
+
+    def parse_ib_meta(self, p: int) -> Dict:
+        """Parse 4-byte in-band meta and offset32"""
+        ib = {
+            "offset16": pwndbg.aglib.memory.get_typed_pointer_value("uint16_t", p - 2),
+            "index": int(pwndbg.aglib.memory.get_typed_pointer_value("uint8_t", p - 3)) & 0x1F,
+            "reserved_in_band": (
+                int(pwndbg.aglib.memory.get_typed_pointer_value("uint8_t", p - 3)) & 0xE0
+            )
+            >> 5,
+            "overflow_in_band": pwndbg.aglib.memory.get_typed_pointer_value("uint8_t", p - 4),
+            "offset32": int(pwndbg.aglib.memory.get_typed_pointer_value("uint32_t", p - 8)),
+        }
+        return ib
+
+    def display_ib_meta(self, p: int, ib: Dict) -> None:
+        """Display in-band meta"""
+
+        print(text.bold_white("============== IN-BAND META =============="))
+        printer = Printer(header_clr=text.bold_green, content_clr=text.bold_blue, header_rjust=13)
+        P = printer.print
+
+        # IB: Check index
+        index = ib["index"]
+        if index < 0x1F:
+            P("INDEX", index)
+        else:
+            P("INDEX", hex(index), "EXPECT: index < 0x1f")
+
+        # IB: Check reserved_in_band
+        reserved_in_band = ib["reserved_in_band"]
+        if reserved_in_band < 5:
+            P("RESERVED", reserved_in_band)
+        elif reserved_in_band == 5:
+            P("RESERVED", "5" + text.bold_magenta(" (Use reserved in slot end)"))
+        elif reserved_in_band == 6:
+            # This slot may be used as a group in mallocng internal.
+            # It can't be freed by free() since `reserved_in_band` is illegal.
+            # (See https://git.musl-libc.org/cgit/musl/tree/src/malloc/mallocng/malloc.c?h=v1.2.2#n269)
+            P(
+                "RESERVED",
+                "%s %s %s"
+                % (
+                    text.bold_red("6"),
+                    text.bold_yellow("[EXPECT: <= 5]"),
+                    text.bold_magenta("(This slot may internally used as a group)"),
+                ),
+            )
+        else:
+            P("RESERVED", hex(reserved_in_band), "EXPECT: <= 5")
+
+        # IB: Check overflow
+        offset16 = int(ib["offset16"])
+        overflow_in_band = int(ib["overflow_in_band"])
+        if not overflow_in_band:
+            group_ptr = p - (offset16 + 1) * mallocng.UNIT
+            P("OVERFLOW", 0)
+            P("OFFSET_16", "%s (group --> %s)" % (hex(offset16), hex(group_ptr)))
+        else:
+            # `offset32` can be used as the offset to group object
+            # instead of `offset16` in IB if `overflow_in_band` is not NULL.
+            # It is unlikely to happen in musl-libc for this feature
+            # is only used in aligned_alloc() and comes with restriction:
+            #   offset32  > 0xffff and offset16 == 0
+            offset32 = ib["offset32"]
+            group_ptr = p - (offset32 + 1) * mallocng.UNIT
+            P(
+                "OVERFLOW",
+                text.bold_white(hex(overflow_in_band)) + text.bold_magenta(" (Use 32-bit offset)"),
+            )
+            if offset32 > 0xFFFF:
+                P("OFFSET_32", "%s (group --> %s)" % (hex(offset32), hex(group_ptr)))
+            else:
+                P("OFFSET_32", hex(offset32), "EXPECT: > 0xffff")
+            if offset16:
+                P(
+                    "OFFSET_16",
+                    hex(offset16),
+                    "EXPECT: *(uint16_t*)(%s) == 0]" % hex(p - 2),
+                )
+
+    def display_group(self, group: Dict) -> None:
+        """Display group information"""
+
+        print(
+            text.bold_white("\n================= GROUP ================== ")
+            + "(at %s)" % hex(int(group.address))
+        )
+        printer = Printer(header_clr=text.bold_cyan, content_clr=text.bold_blue, header_rjust=13)
+        P = printer.print
+
+        meta = group["meta"]
+        P("meta", hex(meta))
+        P("active_idx", int(group["active_idx"]))
+        if meta == 0:
+            print(message.warn("WARNING: group.meta is NULL. Likely unintialized IB data."))
+
+    def display_meta(self, meta: Dict, ib: Dict | None = None, index: int | None = None):
+        """Display meta information
+
+        This gets called in two contexts, one where ib is known and one where index
+        is known.
+        """
+
+        # Careful here to avoid 'not index' test, as it can legitimately be 0
+        if not ib and index is None:
+            raise ValueError("display_meta() requires either ib or index")
+        if meta == 0:
+            print(message.warn("WARNING: display_meta() can't parse NULL meta object"))
+            return
+        group = meta["mem"].dereference()
+
+        if ib:
+            index = ib["index"]
+            if not int(ib["overflow_in_band"]):
+                offset = int(ib["offset16"])
+            else:
+                offset = int(ib["offset32"])
+
+        print(
+            text.bold_white("\n================== META ================== ") + "(at %s)" % hex(meta)
+        )
+        printer = Printer(header_clr=text.bold_magenta, content_clr=text.bold_blue, header_rjust=13)
+        P = printer.print
+
+        # META: Check prev, next (no validation)
+        P("prev", hex(meta["prev"]))
+        P("next", hex(meta["next"]))
+
+        # META: Check mem
+        mem = meta["mem"]
+        if int(group.address) == int(mem):
+            P("mem", hex(mem))
+        else:
+            P("mem", hex(mem), "EXPECT: 0x%lx" % int(group.address))
+
+        # META: Check last_idx
+        last_idx = int(meta["last_idx"])
+        if index <= last_idx:
+            P("last_idx", last_idx)
+        else:
+            P("last_idx", last_idx, "EXPECT: index <= last_idx")
+
+        avail_mask = int(meta["avail_mask"])
+        freed_mask = int(meta["freed_mask"])
+        avail_str, freed_str = generate_mask_str(avail_mask, freed_mask)
+
+        # META: Check avail_mask
+        if ib is None or not (avail_mask & (1 << index)):
+            P("avail_mask", avail_str)
+        else:
+            # If we have in-band data, assume we are looking at an in-use chunk,
+            # otherwise fetched IB data could be invalid
+            P("avail_mask", avail_str, "EXPECT: !(avail_mask & (1<<index))")
+
+        # META: Check freed_mask
+        if ib is None or not (freed_mask & (1 << index)):
+            P("freed_mask", freed_str)
+        else:
+            # If we have in-band data, assume we are looking at an in-use chunk,
+            # otherwise fetched IB data could be invalid
+            P("freed_mask", freed_str, "EXPECT: !(freed_mask & (1<<index))")
+
+        # META: Check area->check
+        area = pwndbg.aglib.memory.get_typed_pointer_value("struct meta_area", int(meta) & -4096)
+
+        secret = int(self.ctx["secret"])
+        if int(area["check"]) == secret:
+            P("area->check", hex(area["check"]))
+        else:
+            P(
+                "area->check",
+                hex(area["check"]),
+                "EXPECT: *(0x%lx) == 0x%lx" % (int(meta) & -4096, secret),
+            )
+
+        # META: Check sizeclass
+        sc = int(meta["sizeclass"])
+        if sc == 63:  # A special sizeclass for single slot group allocations
+            stride = self.get_stride(meta)
+            if stride:
+                P("sizeclass", "63 " + text.bold_white(" (stride: 0x%lx)" % stride))
+            else:
+                P("sizeclass", "63 " + text.bold_white(" (stride: ?)"))
+        elif sc < 48:
+            sc_stride = mallocng.UNIT * self.size_classes[sc]
+            real_stride = self.get_stride(meta)
+            if not real_stride:
+                stride_tips = text.bold_white("(stride: 0x%lx, real_stride: ?)" % sc_stride)
+            elif sc_stride != real_stride:
+                stride_tips = text.bold_white(
+                    "(stride: 0x%lx, real_stride: 0x%lx)" % (sc_stride, real_stride)
+                )
+            else:
+                stride_tips = text.bold_white("(stride: 0x%lx)" % sc_stride)
+            bad = 0
+            # Validation requires in-band data, which we won't have from mfindslot
+            if ib:
+                if not (int(offset) >= self.size_classes[sc] * index):
+                    P(
+                        "sizeclass",
+                        "%d %s" % (sc, stride_tips),
+                        "EXPECT: offset >= self.size_classes[sizeclass] * index",
+                    )
+                    bad = 1
+                if not (int(offset) < self.size_classes[sc] * (index + 1)):
+                    P(
+                        "sizeclass",
+                        "%d %s" % (sc, stride_tips),
+                        "EXPECT: offset < self.size_classes[sizeclass] * (index + 1)",
+                    )
+                    bad = 1
+            if not bad:
+                P("sizeclass", "%d %s" % (sc, stride_tips))
+        else:
+            P("sizeclass", sc, "EXPECT: sizeclass < 48 || sizeclass == 63")
+
+        # META: Check maplen
+        maplen = int(meta["maplen"])
+        if maplen:
+            if offset <= (maplen * (4096 // mallocng.UNIT)) - 1:
+                P("maplen", hex(maplen))
+            else:
+                P(
+                    "maplen",
+                    hex(maplen),
+                    "EXPECT: offset <= maplen * %d - 1" % (4096 // mallocng.UNIT),
+                )
+        else:
+            P("maplen", 0)
+
+        # META: Check freeable
+        P("freeable", int(meta["freeable"]))
+
+        # META: Check group allocation method
+        if not meta["freeable"]:
+            # This group is a donated memory.
+            # That is, it was placed in an unused RW memory area from a object file loaded by ld.so.
+            # (See http://git.musl-libc.org/cgit/musl/tree/src/malloc/mallocng/donate.c?h=v1.2.2#n10)
+
+            group_addr = int(group.address)
+
+            # Find out which object file in memory mappings donated this memory.
+            vmmap = pwndbg.aglib.vmmap.get()
+            for mapping in vmmap:
+                start = mapping.vaddr
+                end = mapping.vaddr + mapping.memsz
+                objfile = mapping.objfile
+                if not objfile or objfile.startswith("["):
+                    continue
+                if group_addr > start and group_addr < end:
+                    method = "donated from %s" % text.bold_white(objfile)
+                    break
+            else:
+                method = "donated from an unknown object file"
+        elif not meta["maplen"]:
+            # XXX: Find out which group is used.
+            method = text.bold_white("another group's slot")
+        else:
+            method = text.bold_white("individual mmap")
+        print(text.bold_magenta("\nGroup allocation method : ") + method)
+
+        # Display slot status map
+        print(generate_slot_map(meta, index))
+
+    def display_nontrivial_free(self, ib: Dict, group: Dict) -> None:
+        """Display the result of nontrivial_free()"""
+
+        printer = Printer(header_clr=text.bold_magenta, content_clr=text.bold_green)
+        P = printer.print
+        print()
+
+        print_dq = print_fg = print_fm = 0
+
+        meta = group["meta"]
+        sizeclass = int(meta["sizeclass"])
+        index = int(ib["index"])
+
+        mask = int(meta["freed_mask"]) | int(meta["avail_mask"])
+        slf = (1 << index) & mallocng.UINT32_MASK
+        if mask + slf == (2 << int(meta["last_idx"])) - 1 and self.okay_to_free(meta):
+            if meta["next"]:
+                if sizeclass < 48:
+                    P("Result of nontrivial_free()", "dequeue, free_group, free_meta")
+                else:
+                    P(
+                        "Result of nontrivial_free()",
+                        "dequeue, free_group, free_meta",
+                        "EXPECT: sizeclass < 48",
+                    )
+                print_dq = print_fg = print_fm = 1
+            else:
+                P("Result of nontrivial_free()", "free_group, free_meta")
+                print_fg = print_fm = 1
+        elif not mask and self.ctx["active"][sizeclass] != meta:
+            if sizeclass < 48:
+                P("Result of nontrivial_free()", "queue (active[%d])" % sizeclass)
+            else:
+                P(
+                    "Result of nontrivial_free()",
+                    "queue (active[%d])" % sizeclass,
+                    "EXPECT: sizeclass < 48",
+                )
+        else:
+            P("Result of nontrivial_free()", text.bold_white("Do nothing"))
+
+        # dequeue
+        if print_dq:
+            print(text.bold_green("  dequeue:"))
+            prev_next = text.magenta("*" + hex(meta["prev"]["next"].address))
+            prev_next = text.bold_blue("prev->next(") + prev_next + text.blue(")")
+            next_prev = text.magenta("*" + hex(meta["next"]["prev"].address))
+            next_prev = text.bold_blue("next->prev(") + next_prev + text.bold_blue(")")
+            next = text.bold_blue("next(") + text.magenta(hex(meta["next"])) + text.bold_blue(")")
+            prev = text.bold_blue("prev(") + text.magenta(hex(meta["prev"])) + text.bold_blue(")")
+            print("  \t%s = %s" % (prev_next, next))  # prev->next(XXX) = next(XXX)
+            print("  \t%s = %s" % (next_prev, prev))  # next->prev(XXX) = prev(XXX)
+        # free_group
+        if print_fg:
+            print(text.bold_green("  free_group:"))
+            if meta["maplen"]:
+                free_method = "munmap (len=0x%lx)" % (int(meta["maplen"]) * 4096)
+            else:
+                free_method = "nontrivial_free()"
+            print(
+                " \t%s%s%s%s"
+                % (
+                    text.bold_blue("group object at "),
+                    text.magenta(hex(int(meta["mem"]))),
+                    text.bold_blue(" will be freed by "),
+                    text.bold_cyan(free_method),
+                )
+            )
+        # free_meta
+        if print_fm:
+            print(text.bold_green("  free_meta:"))
+            print(
+                " \t%s%s%s"
+                % (
+                    text.bold_blue("meta object at "),
+                    text.magenta(hex(meta)),
+                    text.bold_blue(" will be freed and inserted into free_meta chain"),
+                )
+            )
+
+    # Called by mslotinfo.
+    def display_ib_slot(self, p: pwndbg.dbg_mod.Value, meta: Dict, ib: Dict) -> None:
+        """Display slot in-band information
+
+        This expects the slot to be in-use and tries to parse it's in-band data.
+
+        If the ib data isn't initialized yet, it will fail.
+        """
+
+        index = ib["index"]
+        stride = self.get_stride(meta)
+        slot_start = meta["mem"]["storage"][stride * index].address
+        slot_end = int(slot_start + stride - mallocng.IB)
+
+        print(
+            text.bold_white("\n============= SLOT IN-BAND =============== ")
+            + "(at %s)" % hex(slot_start)
+        )
+
+        printer = Printer(header_clr=text.bold_blue, content_clr=text.bold_white, header_rjust=20)
+        P = printer.print
+
+        # SLOT: Check cycling offset
+        reserved_in_slot_head = (
+            int(pwndbg.aglib.memory.get_typed_pointer_value("uint8_t", slot_start - 3)) & 0xE0
+        ) >> 5
+        if reserved_in_slot_head == 7:
+            # If `R` is 7, it indicates that slot header is used to store cycling offset (in `OFF` field)
+            # (See http://git.musl-libc.org/cgit/musl/tree/src/malloc/mallocng/meta.h?h=v1.2.2#n217)
+            cycling_offset = pwndbg.aglib.memory.get_typed_pointer_value(
+                "uint16_t", slot_start - 2
+            )  # `OFF`
+        else:
+            # Else, slot header is now occupied by in-band meta.
+            # In this case, `userdata` will be located at the beginning of slot.
+            cycling_offset = 0
+        userdata_ptr = slot_start + cycling_offset * mallocng.UNIT
+        P(
+            "cycling offset",
+            "%s (userdata --> %s)" % (hex(cycling_offset), hex(userdata_ptr)),
+        )
+
+        # SLOT: Check reserved
+        reserved_in_band = int(ib["reserved_in_band"])
+        if reserved_in_band < 5:
+            reserved = reserved_in_band
+        elif reserved_in_band == 5:
+            reserved_in_slot_end = int(
+                pwndbg.aglib.memory.get_typed_pointer_value("uint32_t", slot_end - 4)
+            )
+            if reserved_in_slot_end >= 5:
+                reserved = reserved_in_slot_end
+            else:
+                P("reserved (slot end)", hex(reserved_in_slot_end), "EXPECT: >= 5")
+                reserved = -1
+        else:
+            P("reserved (in-band)", hex(reserved_in_band), "EXPECT: <= 5")
+            reserved = -1
+
+        # SLOT: Check nominal size
+        if reserved != -1:
+            if reserved <= slot_end - int(p):
+                nominal_size = slot_end - reserved - int(p)
+                P("nominal size", hex(nominal_size))
+                P("reserved size", hex(reserved))
+            else:
+                P("nominal size", "N/A (reserved size is invaild)")
+                P("reserved size", hex(reserved), "EXPECT: <= %s" % hex(slot_end - int(p)))
+                reserved = -1
+        else:
+            P("nominal size", "N/A (reserved size is invaild)")
+
+        # SLOT: Check OVERFLOWs
+        if reserved != -1:
+            ud_overflow = int(
+                pwndbg.aglib.memory.get_typed_pointer_value("uint8_t", slot_end - reserved)
+            )
+            if not ud_overflow:
+                P("OVERFLOW (user data)", 0)
+            else:
+                P(
+                    "OVERFLOW (user data)",
+                    hex(ud_overflow),
+                    "EXPECT: *(uint8_t*)(%s) == 0" % hex(slot_end - reserved),
+                )
+            if reserved >= 5:
+                rs_overflow = pwndbg.aglib.memory.get_typed_pointer_value("uint8_t", slot_end - 5)
+                if not rs_overflow:
+                    P("OVERFLOW  (reserved)", 0)
+                else:
+                    P(
+                        "OVERFLOW  (reserved)",
+                        hex(rs_overflow),
+                        "EXPECT: *(uint8_t*)(%s) == 0" % hex(slot_end - 5),
+                    )
+        else:
+            P("OVERFLOW (user data)", "N/A (reserved size is invaild)")
+            P("OVERFLOW  (reserved)", "N/A (reserved size is invaild)")
+        ns_overflow = int(pwndbg.aglib.memory.get_typed_pointer_value("uint8_t", slot_end))
+        if not ns_overflow:
+            P("OVERFLOW (next slot)", 0)
+        else:
+            P(
+                "OVERFLOW (next slot)",
+                hex(ns_overflow),
+                "EXPECT: *(uint8_t*)(%s) == 0" % hex(slot_end),
+            )

--- a/pwndbg/aglib/vmmap.py
+++ b/pwndbg/aglib/vmmap.py
@@ -40,19 +40,3 @@ def find(address: int | pwndbg.dbg_mod.Value | None) -> pwndbg.lib.memory.Page |
     if pwndbg.dbg.is_gdblib_available():
         return pwndbg.gdblib.vmmap.explore(address)
     return None
-
-
-@pwndbg.lib.cache.cache_until("start", "stop")
-def find_base_address(pattern: str | list[str]) -> int | None:
-    if pwndbg.dbg.is_gdblib_available():
-        return pwndbg.gdblib.vmmap.find_base_address(pattern)
-
-    if isinstance(pattern, str):
-        pattern = [pattern]
-
-    for page in get():
-        for p in pattern:
-            if p in page.objfile:
-                return page.vaddr
-
-    return None

--- a/pwndbg/aglib/vmmap.py
+++ b/pwndbg/aglib/vmmap.py
@@ -40,3 +40,19 @@ def find(address: int | pwndbg.dbg_mod.Value | None) -> pwndbg.lib.memory.Page |
     if pwndbg.dbg.is_gdblib_available():
         return pwndbg.gdblib.vmmap.explore(address)
     return None
+
+
+@pwndbg.lib.cache.cache_until("start", "stop")
+def find_base_address(pattern: str | list[str]) -> int | None:
+    if pwndbg.dbg.is_gdblib_available():
+        return pwndbg.gdblib.vmmap.find_base_address(pattern)
+
+    if isinstance(pattern, str):
+        pattern = [pattern]
+
+    for page in get():
+        for p in pattern:
+            if p in page.objfile:
+                return page.vaddr
+
+    return None

--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -46,7 +46,8 @@ class CommandCategory(str, Enum):
     START = "Start"
     NEXT = "Step/Next/Continue"
     CONTEXT = "Context"
-    HEAP = "Heap"
+    HEAP = "GLibc ptmalloc2 Heap"
+    MUSLHEAP = "Musl mallocng Heap"
     BREAKPOINT = "Breakpoint"
     MEMORY = "Memory"
     STACK = "Stack"
@@ -745,6 +746,7 @@ def load_commands() -> None:
     import pwndbg.commands.misc
     import pwndbg.commands.mmap
     import pwndbg.commands.mprotect
+    import pwndbg.commands.muslheap
     import pwndbg.commands.nearpc
     import pwndbg.commands.next
     import pwndbg.commands.onegadget

--- a/pwndbg/commands/muslheap.py
+++ b/pwndbg/commands/muslheap.py
@@ -176,7 +176,7 @@ def mfindslot(addr: int | None = None) -> None:
     print(
         text.bold_green("Found:"),
         "slot index is %s, owned by meta object at %s."
-        % (text.bold_blue(str(index)), text.magenta(hex(meta))),
+        % (text.bold_blue(str(index)), text.magenta(hex(int(meta)))),
     )
 
     # Display slot and (out-of-band) meta information about the slot

--- a/pwndbg/commands/muslheap.py
+++ b/pwndbg/commands/muslheap.py
@@ -245,9 +245,10 @@ def mslotinfo(addr: int | None = None) -> None:
     else:
         offset = int(ib["offset32"])
     addr = p - (offset + 1) * mallocng.UNIT
-    group_type = mheap.get_group_type()
-    if not group_type:
-        print(message.error("Failed to get mallocng group type"))
+    try:
+        group_type = pwndbg.aglib.memory.find_struct_member_type("struct meta", "struct group *")
+    except ValueError as e:
+        print(message.error(f"Failed to get mallocng group type: {e}"))
         return
     group = pwndbg.aglib.memory.get_typed_pointer_value(group_type, addr)
     if not group:

--- a/pwndbg/commands/muslheap.py
+++ b/pwndbg/commands/muslheap.py
@@ -1,15 +1,16 @@
 from __future__ import annotations
 
 import argparse
+
 from pwnlib.term import text
 
 import pwndbg.color
 import pwndbg.commands
+from pwndbg.aglib.heap.mallocng import MuslMallocngMemoryAllocator
+from pwndbg.aglib.heap.mallocng import Printer
 from pwndbg.color import message
 from pwndbg.commands import CommandCategory
 from pwndbg.constants import mallocng
-from pwndbg.aglib.heap.mallocng import MuslMallocngMemoryAllocator
-from pwndbg.aglib.heap.mallocng import Printer
 from pwndbg.lib.common import hex
 
 mheap = MuslMallocngMemoryAllocator()

--- a/pwndbg/commands/muslheap.py
+++ b/pwndbg/commands/muslheap.py
@@ -1,0 +1,285 @@
+from __future__ import annotations
+
+import argparse
+from pwnlib.term import text
+
+import pwndbg.color
+import pwndbg.commands
+from pwndbg.color import message
+from pwndbg.commands import CommandCategory
+from pwndbg.constants import mallocng
+from pwndbg.aglib.heap.mallocng import MuslMallocngMemoryAllocator
+from pwndbg.aglib.heap.mallocng import Printer
+from pwndbg.lib.common import hex
+
+mheap = MuslMallocngMemoryAllocator()
+
+parser = argparse.ArgumentParser(
+    formatter_class=argparse.RawTextHelpFormatter,
+    description="""Dumps the musl mallocng heap state using malloc_context""",
+)
+
+
+@pwndbg.commands.ArgparsedCommand(parser, category=CommandCategory.MUSLHEAP)
+# @pwndbg.commands.OnlyWithResolvedHeapSyms
+# @pwndbg.commands.OnlyWhenHeapIsInitialized
+@pwndbg.commands.OnlyWhenUserspace
+def mheapinfo() -> None:
+    """Dumps the musl mallocng heap state using malloc_context"""
+    if not mheap.check_mallocng():
+        return
+    printer = Printer(header_clr=text.bold_magenta, content_clr=text.bold_white, header_rjust=16)
+    P = printer.print
+
+    # Print out useful fields in __malloc_context
+    P("secret", hex(mheap.ctx["secret"]))
+    P("mmap_counter", hex(mheap.ctx["mmap_counter"]))
+
+    # Print out available meta objects
+    P(
+        "avail_meta",
+        text.bold_green(hex(mheap.ctx["avail_meta"]))
+        + text.bold_white(" (count: %d)" % mheap.ctx["avail_meta_count"]),
+    )
+
+    # Walk and print out free_meta chain
+    m = head = mheap.ctx["free_meta_head"]
+    if head:
+        s = text.bold_blue(hex(head))
+        try:
+            while head != m["next"]:
+                m = m["next"]
+                s += text.bold_white(" -> ") + text.bold_blue(hex(m))
+        except pwndbg.dbg_mod.Error:
+            # Most recently accessed memory may be invaild
+            s += text.bold_red(" (Invaild memory)")
+        finally:
+            P("free_meta", s)
+    else:
+        P("free_meta", text.bold_white("0"))
+
+    # Print out available meta areas
+    P(
+        "avail_meta_area",
+        text.bold_blue(hex(mheap.ctx["avail_meta_areas"]))
+        + text.bold_white(" (count: %d)" % mheap.ctx["avail_meta_area_count"]),
+    )
+
+    # Walk and print out meta_area chain
+    ma = mheap.ctx["meta_area_head"]
+    if ma:
+        s = text.bold_blue(hex(ma))
+        try:
+            while ma["next"]:
+                ma = ma["next"]
+                s += text.bold_white(" -> ") + text.bold_blue(hex(ma))
+        except pwndbg.dbg_mod.Error:
+            # Most recently accessed memory may be invaild
+            s += text.bold_red(" (Invalid memory)")
+        finally:
+            P("meta_area_head", s)
+    else:
+        P("meta_area_head", text.bold_white("0"))
+    if mheap.ctx["meta_area_tail"]:
+        P("meta_area_tail", text.bold_blue(hex(mheap.ctx["meta_area_tail"])))
+    else:
+        P("meta_area_tail", text.bold_white("0"))
+
+    # Walk active bin
+    printer.set(header_clr=text.bold_green, content_clr=None)
+    for i in range(48):
+        m = head = mheap.ctx["active"][i]
+        if head:
+            s = text.bold_blue(hex(m))
+            try:
+                while True:
+                    s += (
+                        text.bold_blue(" (mem: ")
+                        + text.magenta(hex(m["mem"]))
+                        + text.bold_blue(")")
+                    )
+                    if hex(head) == hex(m["next"]):
+                        break
+                    m = m["next"]
+                    s += text.bold_white(" -> ") + text.bold_blue(hex(m))
+            except pwndbg.dbg_mod.Error:
+                # Most recently accessed memory may be invaild
+                s += text.bold_red(" (Invaild memory)")
+            finally:
+                stride_tips = " [0x%lx]" % (mheap.size_classes[i] * mallocng.UNIT)
+                P("active.[%d]" % i, s + stride_tips)
+
+
+parser = argparse.ArgumentParser(
+    formatter_class=argparse.RawTextHelpFormatter,
+    description="""Display useful variables and functions in musl-libc
+    """,
+)
+
+
+parser = argparse.ArgumentParser(
+    formatter_class=argparse.RawTextHelpFormatter,
+    description="""Find the musl mallocng slot index of the given address
+
+    Usage: mfindslot <address>
+    """,
+)
+
+# FIXME: It would be nice to be able to parse expressions like: (Table *)(0x124)->array
+parser.add_argument(
+    "addr",
+    type=int,
+    nargs="?",
+    default=None,
+    help="Slot (aka chunk) address",
+)
+
+
+@pwndbg.commands.ArgparsedCommand(parser, category=CommandCategory.MUSLHEAP)
+@pwndbg.commands.OnlyWhenUserspace
+def mfindslot(addr: int | None = None) -> None:
+    """Find the musl mallocng slot index of the given address
+
+    This works by traversing the `ctx.meta_area_head` chain of meta structures and checking if the given address
+    is within the associated group.
+    """
+    if not mheap.check_mallocng():
+        return
+
+    if addr is None:
+        print(message.error("Please provide a slot (aka chunk) address"))
+        return
+
+    # Find slots by traversing `ctx.meta_area_head` chain
+    result = mheap.search_chain(addr)
+    if len(result) == 0:
+        print(
+            message.warn(
+                "Not found. Address may not be managed by mallocng or the slot meta is corrupted."
+            )
+        )
+        return
+    elif len(result) == 1:
+        meta, index = result[0]
+    else:
+        # Multiple slots owning `p` is found.
+        # It's normal because mallocng may internally use a large slot to hold group with smaller slots.
+        # (See http://git.musl-libc.org/cgit/musl/tree/src/malloc/mallocng/malloc.c?h=v1.2.2#n260)
+
+        # Find slot which is actually managing `p` (the one with the smallest stride).
+        meta, index = result[0]
+        for x in result:
+            if int(x[0]["sizeclass"]) < int(meta["sizeclass"]):
+                meta, index = x
+
+    print(
+        text.bold_green("Found:"),
+        "slot index is %s, owned by meta object at %s."
+        % (text.bold_blue(str(index)), text.magenta(hex(meta))),
+    )
+
+    # Display slot and (out-of-band) meta information about the slot
+    try:
+        mheap.display_meta(meta, index=index)
+        if meta == 0:
+            return
+        mheap.display_ob_slot(addr, meta, index)
+    except pwndbg.dbg_mod.Error as e:
+        print(message.error("ERROR: " + str(e)))
+        return
+
+
+parser = argparse.ArgumentParser(
+    formatter_class=argparse.RawTextHelpFormatter,
+    description="""Display the musl mallocng slot (aka chunk) details
+
+    Usage: mslotinfo <addr>
+      * addr - A memory address that can be freed by `free()`, usually the one returned from `malloc()`.
+            In general, it should be a pointer to the `user_data` field of an *in-use* slot.
+            (Use `mfindslot` command to explore a memory address at arbitrary offset of a slot)
+    """,
+)
+
+# FIXME: It would be nice to be able to parse expressions like: (Table *)(0x124)->array
+
+parser.add_argument(
+    "addr",
+    type=int,
+    nargs="?",
+    default=None,
+    help="Slot (aka chunk) address",
+)
+
+
+@pwndbg.commands.ArgparsedCommand(parser, category=CommandCategory.MUSLHEAP)
+@pwndbg.commands.OnlyWhenUserspace
+def mslotinfo(addr: int | None = None) -> None:
+    """Display the musl mallocng slot (aka chunk) details"""
+
+    if not mheap.check_mallocng():
+        return
+
+    if addr is None:
+        print(message.error("Please provide a slot (aka chunk) address"))
+        return
+
+    p = pwndbg.dbg.selected_inferior().create_value(addr, pwndbg.aglib.typeinfo.pchar)
+    # type = pwndbg.aglib.typeinfo.lookup_types("uint8_t")
+    # p = val.cast(type.pointer())
+    # p = addr
+
+    # Parse in-band meta
+    try:
+        ib = mheap.parse_ib_meta(int(p))
+    except pwndbg.dbg_mod.Error as e:
+        print(message.error("ERROR:"), str(e))
+        return
+
+    # Display in-band meta information
+    mheap.display_ib_meta(int(p), ib)
+
+    # Get group struct object
+    if not int(ib["overflow_in_band"]):
+        offset = int(ib["offset16"])
+    else:
+        offset = int(ib["offset32"])
+    addr = p - (offset + 1) * mallocng.UNIT
+    group_type = mheap.get_group_type()
+    if not group_type:
+        print(message.error("Failed to get mallocng group type"))
+        return
+    group = pwndbg.aglib.memory.get_typed_pointer_value(group_type, addr)
+    if not group:
+        print(message.error("ERROR:"), "Failed to get group object")
+        return
+
+    # Display group and (out-band) meta information
+    try:
+        mheap.display_group(group)
+        meta = group["meta"]
+        if not int(meta):
+            print(message.error("Failed to find meta object"))
+            return
+        mheap.display_meta(meta, ib=ib)
+    except pwndbg.dbg_mod.Error as e:
+        print(message.error("ERROR:"), str(e))
+        return
+
+    # Check if we have vaild stride / sizeclass
+    stride = mheap.get_stride(group["meta"])
+    if stride:
+        # Display the result of nontrivial_free()
+        mheap.display_nontrivial_free(ib, group)
+
+        # Display slot information
+        try:
+            mheap.display_ib_slot(p, group["meta"], ib)
+        except pwndbg.dbg_mod.Error as e:
+            print(message.error("ERROR:"), str(e))
+            return
+    else:
+        print(
+            message.error(
+                "\nCan't get slot and nontrivial_free() information due to invaild sizeclass"
+            )
+        )

--- a/pwndbg/constants/mallocng.py
+++ b/pwndbg/constants/mallocng.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+# http://git.musl-libc.org/cgit/musl/tree/src/malloc/mallocng/meta.h?h=v1.2.2#n14
+IB = 4  # in-band metadata size
+UNIT = 16
+
+UINT32_MASK = (1 << 32) - 1
+UINT64_MASK = (1 << 64) - 1

--- a/pwndbg/dbg/gdb.py
+++ b/pwndbg/dbg/gdb.py
@@ -914,6 +914,10 @@ class GDBType(pwndbg.dbg_mod.Type):
 
         return self.inner == other.inner
 
+    @override
+    def __str__(self) -> str:
+        return str(self.inner)
+
     @property
     @override
     def name(self) -> str:

--- a/pwndbg/lib/common.py
+++ b/pwndbg/lib/common.py
@@ -1,4 +1,22 @@
 from __future__ import annotations
+import pwndbg
+import builtins
+
+
+def hex(x: int):
+    """Converts an integer to a hex string."""
+    try:
+        return builtins.hex(x)
+    except Exception:
+        return builtins.hex(int(x) & pwndbg.aglib.arch.ptrmask)
+
+
+def bin(x: int):
+    """Converts an integer to a binary string."""
+    try:
+        return builtins.bin(x)
+    except Exception:
+        return builtins.bin(int(x) & pwndbg.aglib.arch.ptrmask)
 
 
 # common functions

--- a/pwndbg/lib/common.py
+++ b/pwndbg/lib/common.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
-import pwndbg
+
 import builtins
+
+import pwndbg
 
 
 def hex(x: int):

--- a/tests/gdb-tests/tests/binaries/makefile
+++ b/tests/gdb-tests/tests/binaries/makefile
@@ -36,6 +36,8 @@ PWD=$(shell pwd)
 #GLIBC=/glibc_versions/2.29/tcache_x64
 GLIBC_2_33=$(PWD)/glibcs/2.33
 
+MUSL_1_2_4=$(PWD)/musls/1.2.4
+
 .PHONY : all clean
 
 CUSTOM_TARGETS = reference_bin_pie.out reference_bin_nopie.out reference_bin_nopie.i386.out symbol_1600_and_752.out initialized_heap_x64.out initialized_heap_i386_big.out linked_lists.out onegadget.x86-64.out onegadget.i386.out
@@ -109,6 +111,7 @@ heap_jemalloc_heap.out: heap_jemalloc_heap.c
 multiple_threads.out: multiple_threads.c
 	@echo "[+] Building multiple_threads.out"
 	${CC} -g -O0 -o multiple_threads.out multiple_threads.c -pthread -lpthread
+
 tls.x86-64.out: tls.x86-64.c
 	@echo "[+] Building tls.x86-64.c"
 	${ZIGCC} \
@@ -179,3 +182,16 @@ reference_bin_nopie.i386.out: reference-binary.c
 
 symbol_1600_and_752.out: symbol_1600_and_752.cpp
 	${CXX} -O0 -ggdb -Wno-pmf-conversions symbol_1600_and_752.cpp -o symbol_1600_and_752.out
+
+# musl tests
+# Building dynamic musl executables is a bit messy, so we can't use -target x86_64-linux-musl
+# https://github.com/ziglang/zig/issues/1190
+musl_mallocng_initialized.out: musl_mallocng_initialized.c
+	@echo "[+] Building musl_mallocng_initialized.out"
+	${ZIGCC} -v \
+		-L${MUSL_1_2_4}/usr/lib/ \
+		-L${MUSL_1_2_4}/lib/ \
+		-lc -dynamic \
+		-Wl,-rpath=${MUSL_1_2_4}/usr/lib/ \
+		-Wl,--dynamic-linker=${MUSL_1_2_4}/lib/ld-musl-x86_64.so.1 \
+		-o musl_mallocng_initialized.out musl_mallocng_initialized.c

--- a/tests/gdb-tests/tests/binaries/musl_mallocng_initialized.c
+++ b/tests/gdb-tests/tests/binaries/musl_mallocng_initialized.c
@@ -1,0 +1,9 @@
+#include <stdlib.h>
+
+void break_here(void) {}
+
+int main(void) {
+
+    char *p = malloc(10);
+    break_here();
+}

--- a/tests/gdb-tests/tests/binaries/musls/README.md
+++ b/tests/gdb-tests/tests/binaries/musls/README.md
@@ -1,0 +1,43 @@
+# musl libraries used by tests
+
+```bash
+❯ sha256sum tests/gdb-tests/tests/binaries/musls/1.2.4/lib/*
+a99a3b9349cccda16c787626594ca6fc1a1484eb8c5c49889f5345b6ee61840b  tests/gdb-tests/tests/binaries/musls/1.2.4/lib/ld-musl-124-x86_64.so.1
+a620bdc6789a0e984340b348095aac566f5351fbdbc5a767ef5a9d2db3bab2d2  tests/gdb-tests/tests/binaries/musls/1.2.4/lib/ld-musl-124-x86_64.so.1.debug
+a99a3b9349cccda16c787626594ca6fc1a1484eb8c5c49889f5345b6ee61840b  tests/gdb-tests/tests/binaries/musls/1.2.4/lib/ld-musl-x86_64.so.1
+a620bdc6789a0e984340b348095aac566f5351fbdbc5a767ef5a9d2db3bab2d2  tests/gdb-tests/tests/binaries/musls/1.2.4/lib/ld-musl-x86_64.so.1.debug
+❯ sha256sum tests/gdb-tests/tests/binaries/musls/1.2.4/usr/lib/*
+ffb51a69191a69fc34acaec1003fabe245d8841da7036d124d3445718415f9ea  tests/gdb-tests/tests/binaries/musls/1.2.4/usr/lib/crt1.o
+926a46168dbca60732de4b44734512d44dc40bd5886840fafe8ad5ccf80e6507  tests/gdb-tests/tests/binaries/musls/1.2.4/usr/lib/crti.o
+cc39e6fde3d1ed27fecec5ebe8ff0349b08cd493e08b8023d5da479c64e9a5a9  tests/gdb-tests/tests/binaries/musls/1.2.4/usr/lib/crtn.o
+46f1e3a2447a158922694da4b4bf473449dcd9187bb8eaaf58163f7c6d2179ee  tests/gdb-tests/tests/binaries/musls/1.2.4/usr/lib/rcrt1.o
+4c9e7de444013cf04513ef50d2c30c1a682f6c62fe9a5710f2af7d2c75396e94  tests/gdb-tests/tests/binaries/musls/1.2.4/usr/lib/Scrt1.o
+```
+
+## Obtaining binaries
+
+You can see which operating systems have what musl versions using [this query](https://pkgs.org/search/?q=musl).
+
+We use the alpine v.3.18 .apk as the base point for getting musl-1.2.4, so it can be manually extracted for verification
+if preferred.
+
+```bash
+wget https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/musl-1.2.4-r2.apk
+wget https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/musl-dev-1.2.4-r2.apk
+wget https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/musl-dbg-1.2.4-r2.apk
+sha256sum *.apk
+21c732ba7b1a7088a85d79a781076e3d5ec41b0bd52933ecb47bcc5804d6f501  musl-1.2.4-r2.apk
+7ef08becf7225f2515d045d25082aa9fe00282e1224bc3f816b5062741c958ec  musl-dev-1.2.4-r2.apk
+32b9837354e254e06b2f5429f0a9753580614bd0272ad8db0f5798544e20e9a7  musl-dbg-1.2.4-r2.apk
+tar -xvzf musl-1.2.4-r2.apk
+tar -xvzf musl-dev-1.2.4-r2.apk
+tar -xzvf musl-dbg-1.2.4-r2.apk
+```
+
+We are interested in the resulting files:
+
+* `lib/*`
+* `usr/lib/*`
+
+These are placed into `tests/gdb-tests/tests/binaries/musls/<version>` folders, and adjusted with symlinks of the form
+`ld-musl-124-x86_64.so.1` where 124 corresponds to version 1.2.4, so it's easier to find the exact versions.

--- a/tests/gdb-tests/tests/musl/mallocng/test_mallocng.py
+++ b/tests/gdb-tests/tests/musl/mallocng/test_mallocng.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import gdb
+
+import pwndbg
+import pwndbg.lib.strings
+import tests
+
+HEAP_BINARY = tests.binaries.get("musl_mallocng_initialized.out")
+
+
+def get_stride_0x10_slot_addr(mheapinfo_output):
+    slot_addr = None
+    for line in mheapinfo_output.splitlines():
+        if "active.[0]" in line:
+            # Expect line to be of form: active.[0] : 0x2040e0 (mem: 0x7ffff7ffecb0) [0x10]
+            # Get 0x7ffff7ffecb0) [0x10]
+            slot_addr = line.split("mem:")[-1]
+            if not slot_addr:
+                raise Exception("Could not find slot address. Expected (mem: ...) missing")
+            # Get 0x7ffff7ffecb0
+            slot_addr = slot_addr.split(")")[0]
+            if not slot_addr:
+                raise Exception("Could not find slot address. Expected (mem: ...) missing")
+            break
+    return slot_addr
+
+
+def check_meta_output(output):
+    # Check ================== META ================== fields
+    for expected in [
+        "prev",
+        "next",
+        "mem",
+        "last_idx",
+        "avail_mask",
+        "freed_mask",
+        "area->check",
+        "sizeclass",
+        "maplen",
+        "freeable",
+    ]:
+        assert f"{expected} :" in output
+
+
+def test_musl_mallocng(start_binary):
+    """Make sure we can execute any mallocng command"""
+    # TODO: Support other architectures or different libc versions
+    start_binary(HEAP_BINARY)
+    gdb.execute("break break_here")
+    gdb.execute("continue")
+
+    # print(gdb.execute("!pwd"))
+    # gdb.execute("add-symbol-file tests/binaries/musls/1.2.4/lib/ld-musl-x86_64.so.1.debug")
+    # gdb.execute("info sharedlibrary")
+    malloc_context = pwndbg.gdblib.symbol.address("__malloc_context")
+    assert malloc_context is not None
+
+    # Make sure at least one command works
+    mheapinfo_output = gdb.execute("mheapinfo", to_string=True)
+    assert "secret" in mheapinfo_output
+
+
+def test_musl_mallocng_mheapinfo(start_binary):
+    """Make sure all expected fields are output"""
+
+    start_binary(HEAP_BINARY)
+    gdb.execute("break break_here")
+    gdb.execute("continue")
+
+    # Make sure most expected fields are output
+    mheapinfo_output = gdb.execute("mheapinfo", to_string=True)
+    mheapinfo_output = pwndbg.lib.strings.strip_colors(mheapinfo_output)
+    for expected in [
+        "secret",
+        "mmap_counter",
+        "avail_meta",
+        "free_meta",
+        "avail_meta_area",
+        "meta_area_head",
+        "meta_area_tail",
+        "active.[0]",
+    ]:
+        assert f"{expected} :" in mheapinfo_output
+
+    # Make sure the base active group is stride 0x10
+    for line in mheapinfo_output.splitlines():
+        if "active.[0]" in line:
+            assert line.endswith("[0x10]")
+
+
+def test_musl_mallocng_mslotfind(start_binary):
+    """Test that mslotfind on a valid slot outputs expected values"""
+
+    # First use mheapinfo to find an active group to query for a slot to find
+    start_binary(HEAP_BINARY)
+    gdb.execute("break break_here")
+    gdb.execute("continue")
+
+    # FIXME: We could create a helper to combine these, as it will be common
+    mheapinfo_output = gdb.execute("mheapinfo", to_string=True)
+    mheapinfo_output = pwndbg.lib.strings.strip_colors(mheapinfo_output)
+    slot_addr = get_stride_0x10_slot_addr(mheapinfo_output)
+
+    mfindslot_output = gdb.execute(f"mfindslot {slot_addr}", to_string=True)
+    mfindslot_output = pwndbg.lib.strings.strip_colors(mfindslot_output)
+    assert "Found: slot index is" in mfindslot_output
+
+    # Check ================== SLOT OUT-OF-BAND ================== fields
+    for expected in ["address", "index", "stride", "meta obj", "status"]:
+        assert f"{expected} :" in mfindslot_output
+
+    check_meta_output(mfindslot_output)
+    assert (
+        "(stride: 0x10)" in mfindslot_output
+    )  # We grabbed a active.[0] slot above, so expect this to match
+
+
+def test_musl_mallocng_mslotinfo(start_binary):
+    start_binary(HEAP_BINARY)
+    gdb.execute("break break_here")
+    gdb.execute("continue")
+
+    mheapinfo_output = gdb.execute("mheapinfo", to_string=True)
+    mheapinfo_output = pwndbg.lib.strings.strip_colors(mheapinfo_output)
+    slot_addr = get_stride_0x10_slot_addr(mheapinfo_output)
+    mslotinfo_output = gdb.execute(f"mslotinfo {slot_addr}", to_string=True)
+    mslotinfo_output = pwndbg.lib.strings.strip_colors(mslotinfo_output)
+
+    # Check ============== IN-BAND META ==============
+    for expected in ["INDEX", "RESERVED", "OVERFLOW"]:
+        assert f"{expected} :" in mslotinfo_output
+    assert "OFFSET_16" in mslotinfo_output or "OFFSET_32" in mslotinfo_output
+
+    # Check ============== GROUP ==============
+    for expected in ["meta", "active_idx"]:
+        assert f"{expected} :" in mslotinfo_output
+
+    check_meta_output(mslotinfo_output)
+
+    assert "Group allocation method : " in mslotinfo_output
+
+    # Check ================== SLOT IN-BAND ============
+    for expected in [
+        "nominal size",
+        # "reserved size",
+        "OVERFLOW (user data)",
+        "OVERFLOW (next slot)",
+    ]:
+        assert f"{expected} :" in mslotinfo_output

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -116,7 +116,9 @@ def get_tests_list(
     tests_collect_output = result.stdout
 
     if result.returncode == 1:
+        print("Failed to collect tests")
         print(tests_collect_output)
+        print(result.stderr)
         exit(1)
     elif collect_only == 1:
         print(tests_collect_output)


### PR DESCRIPTION
This is my initial port of [muslheap](https://github.com/xf1les/muslheap) to work inside of pwndbg. All credit goes to xf1les, and I've put a note in CREDITS.md.

At the moment this PR branch won't be usable without applying some of the other pending PRs I've put up (namely #2185, #2157, and #2155), so it's mostly for initial review now. Once those get sorted, I'll rebase this and update so people know they can test it.

There are 2 commits in this PR. The first is the main commands being added, in a second is the tests:

## New heap commands

For now I've added a new category for musl mallocng, and changed the old heap category to glibc heap. Atm the command file is called muslheap.py but actually since this is mallocng-specific, it may be worth renaming, as perhaps support for the old musl heap allocator will get added eventually.

The functionality with the original ported is the mostly same (except I excluded the mmagic command as it's not really heap related), but the relevant parts that could be switched to use pwndbg APIs I've changed where I could figure out what to do. I've made minor changes to the names (use slot instead of chunk). I did some minor reorganization and reduce some duplication, which will make future refactoring easier. I also added more robust symbol look up handling for the group structure, since the original never worked for me.

The goal here is to just get some baseline version in that lets pwndbg users start playing with it and then we start adding more versions, static musl support, more commands, etc in future PR

There are some FIXME I added for things I'm not sure if there's better ways to do it in pwndbg, or just for things I want to add. Other XXX, etc are likely from the original author.

## Tests

I've added 1.2.4 dynamic musl test and functionality, to get the ball rolling. The ported library was originally designed for 1.2.2, so I suspect this will actually work well across most versions but I haven't tested.

For the tests I added aggressive asserts for almost all output to make sure nothing breaks initially while refactoring. 

### Test binary blobs

There's binary blobs that this includes in order to build the binary, namely the musl 1.2.4 shared library and .debug file, as well as .o files for crt linking. 

The .o files I included because zig is broken compiling musl targets, and will always compile the static version, so instead of specifying a target I manually point to the object files. Its likely that some of these can actually be removed, as for instance were not building a PIE test, etc. Also perhaps there's a better way to do this, as I haven't used zig before, so would be happy to drop the .o's if possible.

I put in the readme how I extracted those files and from where, with the sha256 hashes. Before this gets merged someone else should show that this is consistent with what they get and there are seeing the same hashes.

One other thing which I'm not sure if you folks have discussed before is that if we hypothetically add a bunch of versions of musl libraries (1.2.1 through 1.2.5 currently), and eventually also the libc.a (which is about 10M), this will get quite large to store in the repo, so it might be worth discussing if eventually some of this stuff should be in a separate repo and cloned by the developer scripts or whatever.