### PR TITLE
fix trailing whitespace everywhere

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -20,5 +20,5 @@ Some guides:
 
 ### Contact
 
-If you want to talk with other contributors and pwndbg users 
+If you want to talk with other contributors and pwndbg users
 join us at our [Discord server](https://discord.gg/x47DssnGwm)!

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -28,7 +28,7 @@ Briefly describe the problem you are having in a few paragraphs.
 
 <!--
 What do we have to do to reproduce the problem?
-If this is connected to particular C/asm code, 
+If this is connected to particular C/asm code,
 please provide the smallest C code that reproduces the issue.
 -->
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,5 +1,5 @@
 name: Docker build
-on: 
+on:
   pull_request:
     paths:
       - '**'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,5 @@
 name: Lint
-on: 
+on:
   pull_request:
     paths:
       - '**'
@@ -32,7 +32,7 @@ jobs:
       run: |
         git diff-index --quiet HEAD -- pwndbg tests
         ./lint.sh
-        
+
     - name: Run mypy
       uses: tsuyoshicho/action-mypy@v4
       with:

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -7,7 +7,7 @@ on:
     paths:
       - '**'
       - '!mkdocs.yml'
-      - '!docs/**'      
+      - '!docs/**'
     tags:
       - '*'
 

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -168,19 +168,19 @@ Feel free to update the list below!
 
 
 # Annotations
-Alongside the disassembled instructions in the dashboard, Pwndbg also has the ability to display annotations - text that contains relevent information regarding the execution of the instruction. For example, on the x86 `MOV` instruction, we can display the concrete value that gets placed into the destination register. Likewise, we can indicate the results of mathematical operations and memory accesses. The annotation in question is always dependent on the exact instruction being annotated - we handle it in a case-by-case basis. 
+Alongside the disassembled instructions in the dashboard, Pwndbg also has the ability to display annotations - text that contains relevent information regarding the execution of the instruction. For example, on the x86 `MOV` instruction, we can display the concrete value that gets placed into the destination register. Likewise, we can indicate the results of mathematical operations and memory accesses. The annotation in question is always dependent on the exact instruction being annotated - we handle it in a case-by-case basis.
 
 The main hurdle in providing annotations is determining what each instruction does, getting the relevent CPU registers and memory that are accessed, and then resolving concrete values of the operands. We call the process of determining this information "enhancement", as we enhance the information provided natively by GDB.
 
 The Capstone Engine disassembly framework is used to statically determine information about instructions and their operands. Take the x86 instruction `sub rax, rdx`. Given the raw bytes of the machine instructions, Capstone creates an object that provides an API that, among many things, exposes the names of the operands and the fact that they are both 8-byte wide registers. It provides all the information necessary to describe each operand. It also tells the general 'group' that a instruction belongs to, like if its a JUMP-like instruction, a RET, or a CALL. These groups are architecture agnostic.
 
-However, the Capstone Engine doesn't fill in concrete values that those registers take on. It has no way of knowing the value in `rdx`, nor can it actually read from memory. 
+However, the Capstone Engine doesn't fill in concrete values that those registers take on. It has no way of knowing the value in `rdx`, nor can it actually read from memory.
 
 To determine the actual values that the operands take on, and to determine the results of executing an instruction, we use the Unicorn Engine, a CPU emulator framework. The emulator has its own internal CPU register set and memory pages that mirror that of the host process, and it can execute instructions to mutate its internal state. Note that the Unicorn Engine cannot execute syscalls - it doesn't have knowledge of a kernel.
 
 We have the ability to single-step the emulator - tell it to execute the instruction at the program counter inside the emulator. After doing so, we can inspect the state of the emulator - read from its registers and memory. The Unicorn Engine itself doesn't expose information regarding what each instruction is doing - what is the instruction (is it an `add`, `mov`, `push`?) and what registers/memory locations is it reading to and writing from? - which is why we use the Capstone engine to statically determine this information.
 
-Using what we know about the instruction based on the Capstone engine - such as that it was a `sub` instruction and `rax` was written to - we query the emulator after stepping in to determine the results of the instruction. 
+Using what we know about the instruction based on the Capstone engine - such as that it was a `sub` instruction and `rax` was written to - we query the emulator after stepping in to determine the results of the instruction.
 
 We also read the program counter from the emulator to determine jumps and so we can display the instructions that will actually be executed, as opposed to displaying the instructions that follow consecutively in memory.
 
@@ -194,7 +194,7 @@ When the process stops, we instantiate the emulator from scratch. We copy all th
 
 The enhancement is broken into a couple stops:
 
-1. First, we resolve the values of all the operands of the instruction before stepping the emulator. This means we read values from registers and dereference memory depending on the operand type. This gives us the values of operands before the instruction executes. 
+1. First, we resolve the values of all the operands of the instruction before stepping the emulator. This means we read values from registers and dereference memory depending on the operand type. This gives us the values of operands before the instruction executes.
 2. Then, we step the emulator, executing a single instruction.
 3. We resolve the values of all operands again, giving us the `after_value` of each operand.
 4. Then, we enhance the "condition" field of PwndbgInstructions, where we determine if the instruction is conditional (conditional branch or conditional mov are common) and if the action is taken.
@@ -244,12 +244,12 @@ For example, say we have the following instructions with the first number being 
    0x555555556266 <main+566>    mov    rsi, rax
    0x555555556269 <main+569>    mov    qword ptr [rsp + 0x78], rax
    0x55555555626e <main+574>    call   qword ptr [rip + 0x6d6c]    <fstat64>
- 
+
  ► 0x555555556274 <main+580>    mov    edx, 5                  EDX => 5
    0x555555556279 <main+585>    lea    rsi, [rip + 0x3f30]     RSI => 0x55555555a1b0 ◂— 'standard output'
    0x555555556280 <main+592>    test   eax, eax
    0x555555556282 <main+594>    js     main+3784                   <main+3784>
- 
+
    0x555555556288 <main+600>    mov    rsi, qword ptr [rsp + 0xc8]
    0x555555556290 <main+608>    mov    edi, dword ptr [rsp + 0xa8]
 ```

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -6,12 +6,12 @@ Pwndbg has a great deal of useful features.  You can a list of all available com
 
 All function call sites are annotated with the arguments to those functions.  This works best with debugging symbols, but also works in the most common case where an imported function (e.g. libc function via GOT or PLT) is used.
 
-![](caps/arguments_getenv.png)  
-![](caps/arguments_memcpy.png)  
-![](caps/arguments_sigsetjmp.png)  
-![](caps/arguments_strcpy.png)  
-![](caps/arguments_syscall.png)  
-![](caps/arguments_xtrace_init.png)  
+![](caps/arguments_getenv.png)
+![](caps/arguments_memcpy.png)
+![](caps/arguments_sigsetjmp.png)
+![](caps/arguments_strcpy.png)
+![](caps/arguments_syscall.png)
+![](caps/arguments_xtrace_init.png)
 
 ## Context
 
@@ -19,7 +19,7 @@ A useful summary of the current execution context is printed every time GDB stop
 
 The output of the context may be redirected to a file (including other tty) by using `set context-output /path/to/file` while leaving other output in place.
 
-![](caps/context.png)  
+![](caps/context.png)
 
 ### Splitting / Layouting Context
 
@@ -123,13 +123,13 @@ Pwndbg uses Capstone Engine to display disassembled instructions, but also lever
 
 All absolute jumps are folded away, only displaying relevant instructions.
 
-![](caps/disasm_taken_folded.png)  
+![](caps/disasm_taken_folded.png)
 
 Additionally, if the current instruction is conditional, Pwndbg displays whether or not it is evaluated with a green check or a red X, and folds away instructions as necessary.
 
-![](caps/disasm_taken_after.png)  
-![](caps/disasm_taken_before.png)  
-![](caps/disasn_taken_false.png)  
+![](caps/disasm_taken_after.png)
+![](caps/disasm_taken_before.png)
+![](caps/disasn_taken_false.png)
 
 ## Emulation
 
@@ -137,27 +137,27 @@ Pwndbg leverages Unicorn Engine in order to only show instructions which will ac
 
 This is incredibly useful when stepping through jump tables, PLT entries, and even while ROPping!
 
-![](caps/emulate_vs_disasm.png)  
-![](caps/emulation_plt.png)  
-![](caps/emulation_rop.png)  
+![](caps/emulate_vs_disasm.png)
+![](caps/emulation_plt.png)
+![](caps/emulation_rop.png)
 
 ## Heap Inspection
 
 Pwndbg enables introspection of the glibc allocator, ptmalloc2, via a handful of introspection functions.
 
-![](caps/heap_arena.png)  
-![](caps/heap_mp.png)  
-![](caps/heap_bins.png)  
-![](caps/heap_fastbins.png)  
-![](caps/heap_unsorted.png)  
-![](caps/heap_smallbins.png)  
-![](caps/heap_largebins.png)  
-![](caps/heap_heap.png)  
-![](caps/heap_heap2.png)  
-![](caps/heap_mallocchunk.png)  
-![](caps/heap_topchunk.png)  
+![](caps/heap_arena.png)
+![](caps/heap_mp.png)
+![](caps/heap_bins.png)
+![](caps/heap_fastbins.png)
+![](caps/heap_unsorted.png)
+![](caps/heap_smallbins.png)
+![](caps/heap_largebins.png)
+![](caps/heap_heap.png)
+![](caps/heap_heap2.png)
+![](caps/heap_mallocchunk.png)
+![](caps/heap_topchunk.png)
 ![](caps/heap_fake_fast.png)
-![](caps/heap_try_free.png)  
+![](caps/heap_try_free.png)
 
 ## IDA Pro Integration
 
@@ -165,9 +165,9 @@ Pwndbg flips traditional IDA Pro integration on its head.  Rather than sticking 
 
 This allows extraction of comments, decompiled lines of source, breakpoints, and synchronized debugging (single-steps update the cursor in IDA).
 
-![](caps/ida_comments.png)  
-![](caps/ida_function.png)  
-![](caps/ida_integration.png)  
+![](caps/ida_comments.png)
+![](caps/ida_function.png)
+![](caps/ida_integration.png)
 
 Since the complete IDA API is exposed, new tools can be built on this functionality to further enhance Pwndbg's usefulness.
 
@@ -180,10 +180,10 @@ You can also connect to Ida Pro XMLRPC server hosted on different machine. In or
 There are two commands to set various options:
 
 * `theme` - to set particular output color/style
-![](caps/theme.png)  
+![](caps/theme.png)
 
 * `config` - to set parameters like whether to emulate code near current instruction, ida rpc connection info, hexdump bytes/width (and more)
-![](caps/config.png)  
+![](caps/config.png)
 
 Of course you can generate and put it in `.gdbinit` after pwndbg initialization to keep it persistent between pwngdb sessions.
 
@@ -197,27 +197,27 @@ Vanilla GDB, PEDA, and GEF all fail terribly in this scenario.
 
 #### GEF
 
-![](caps/qemu_gef.png)  
+![](caps/qemu_gef.png)
 
 #### PEDA
 
-![](caps/qemu_peda.png)  
+![](caps/qemu_peda.png)
 
 #### Vanilla GDB
 
-![](caps/qemu_vanilla.png)  
+![](caps/qemu_vanilla.png)
 
 #### Pwndbg
 
 However, Pwndbg works around the limitations of the GDB stub to give you the best debugger environment possible.
 
-![](caps/qemu_pwndbg.png)  
+![](caps/qemu_pwndbg.png)
 
 ## Process State Inspection
 
 Use the `procinfo` command in order to inspect the current process state, like UID, GID, Groups, SELinux context, and open file descriptors!  Pwndbg works particularly well with remote GDB debugging like with Android phones, which PEDA, GEF, and vanilla GDB choke on.
 
-![](caps/procinfo.png)  
+![](caps/procinfo.png)
 
 ## ROP Gadgets
 
@@ -225,13 +225,13 @@ Pwndbg makes using ROPGadget easy with the actual addresses in the process.
 
 Just use the `rop` command!
 
-![](caps/rop_grep.png)  
+![](caps/rop_grep.png)
 
 ## Search
 
 Pwndbg makes searching the target memory space easy, with a complete and easy-to-use interface.  Whether you're searching for bytes, strings, or various sizes of integer values or pointers, it's a simple command away.
 
-![](caps/search.png)  
+![](caps/search.png)
 
 ## Finding Leaks
 ![](caps/leakfind.png)
@@ -246,14 +246,14 @@ Inspecting memory dumps is easy with the `telescope` command.  It recursively de
 
 Pwndbg enhances the standard memory map listing, and allows easy searching.
 
-![](caps/vmmap.png)  
-![](caps/vmmap2.png)  
-![](caps/vmmap_pc.png)  
-![](caps/vmmap_register.png)  
-![](caps/vmmap_stack.png)  
+![](caps/vmmap.png)
+![](caps/vmmap2.png)
+![](caps/vmmap_pc.png)
+![](caps/vmmap_register.png)
+![](caps/vmmap_stack.png)
 
 ## Windbg Compatibility
 
 Pwndbg has a complete windbg compatibility layer.  You can `dd`, `dps`, `eq`, and even `eb eip 90` to your heart's content.
 
-![](caps/windbg.png)  
+![](caps/windbg.png)

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The portable version includes all necessary dependencies and should work without
 
 ### Download the Portable Version:
 
-Download the portable version from the [Pwndbg releases page](https://github.com/pwndbg/pwndbg/releases) by selecting the desired version. 
+Download the portable version from the [Pwndbg releases page](https://github.com/pwndbg/pwndbg/releases) by selecting the desired version.
 Choose the appropriate version for your system architecture (x86_64 or aarch64).
 
 ### Installation on RPM-based Systems (CentOS/Alma/Rocky/RHEL):
@@ -129,7 +129,7 @@ Want to help with development? Read [CONTRIBUTING](.github/CONTRIBUTING.md) or [
 ## How to develop?
 To run tests locally you can do this in docker image, after cloning repo run simply
 ```shell
-docker-compose run main ./tests.sh 
+docker-compose run main ./tests.sh
 ```
 Disclaimer - this won't work on apple silicon macs.
 

--- a/docs/blog/.authors.yml
+++ b/docs/blog/.authors.yml
@@ -5,7 +5,7 @@ authors:
     avatar: https://avatars.githubusercontent.com/u/10009354
     url: https://github.com/disconnect3d
   nikoshell:
-    name: Niko 
-    description: Creator 
+    name: Niko
+    description: Creator
     avatar: https://avatars.githubusercontent.com/u/150354584
     url: https://github.com/nikoshell

--- a/docs/blog/posts/pwndbg-coding-sprints-report.md
+++ b/docs/blog/posts/pwndbg-coding-sprints-report.md
@@ -104,8 +104,8 @@ I won't lie: most people that came were friends of mine, some of which I play [C
 On the EP sprint, since we were just a group of four, we focused on small improvements to the codebase. In total, we did the following:
 * [reviewed and merged the fs/gs_base fetching improvement PR](https://github.com/pwndbg/pwndbg/pull/1030),
 * [pinned the project's dependencies](https://github.com/pwndbg/pwndbg/pull/1033),
-* [updated the unicorn dependency version](https://github.com/pwndbg/pwndbg/pull/1034), 
-* [added a "tip of the day" feature](https://github.com/pwndbg/pwndbg/pull/1036), 
+* [updated the unicorn dependency version](https://github.com/pwndbg/pwndbg/pull/1034),
+* [added a "tip of the day" feature](https://github.com/pwndbg/pwndbg/pull/1036),
 * [improved the UX of using Pwndbg within a Python virtual environment](https://github.com/pwndbg/pwndbg/pull/1037),
 * and also [worked on enhancing the display of arguments when stopping on a call to the printf functions family](https://github.com/pwndbg/pwndbg/pull/1038).
 

--- a/docs/commands/dt/dt.md
+++ b/docs/commands/dt/dt.md
@@ -11,7 +11,7 @@
     Dump out information on a type (e.g. ucontext_t).
 
     Optionally overlay that information at an address.
-    
+
 ## Usage:
 
 

--- a/docs/commands/index.md
+++ b/docs/commands/index.md
@@ -7,9 +7,9 @@
 ## Start
 
 -  [attachp](attachp/attachp.md) Attaches to a given pid, process name or device file.
--  [entry](start/entry.md) 
+-  [entry](start/entry.md)
 -  [sstart](start/sstart.md) Alias for 'tbreak __libc_start_main; run'.
--  [start](start/start.md) 
+-  [start](start/start.md)
 
 ## Integrations
 
@@ -28,7 +28,7 @@
 -  [argc](argv/argc.md) Prints out the number of arguments.
 -  [argv](argv/argv.md) Prints out the contents of argv.
 -  [envp](argv/envp.md) Prints out the contents of the environment.
--  [aslr](aslr/aslr.md) 
+-  [aslr](aslr/aslr.md)
 -  [auxv](auxv/auxv.md) Print information from the Auxiliary ELF Vector.
 -  [elfsections](elf/elfsections.md) Prints the section mappings contained in the ELF header.
 -  [gotplt](elf/gotplt.md) Prints any symbols found in the .got.plt section if it exists.
@@ -50,7 +50,7 @@
 -  [comm](comments/comm.md) Put comments in assembly code.
 -  [cyclic](cyclic/cyclic_cmd.md) Cyclic pattern creator/finder.
 -  [cymbol](cymbol/cymbol.md) Add, show, load, edit, or delete custom structures in plain C.
--  [dt](dt/dt.md) 
+-  [dt](dt/dt.md)
 -  [dumpargs](dumpargs/dumpargs.md) Prints determined arguments for call instruction.
 -  [down](ida/down.md) Select and print stack frame called by this one.
 -  [up](ida/up.md) Select and print stack frame that called this one.
@@ -79,7 +79,7 @@
 -  [configfile](config/configfile.md) Generates a configuration file for the current pwndbg options.
 -  [theme](config/theme.md) Shows pwndbg-specific theme configuration.
 -  [themefile](config/themefile.md) Generates a configuration file for the current pwndbg theme options.
--  [memoize](memoize/memoize.md) 
+-  [memoize](memoize/memoize.md)
 -  [pwndbg](misc/pwndbg_.md) Prints out a list of all pwndbg commands.
 -  [reinit_pwndbg](reload/reinit_pwndbg.md) Makes pwndbg reinitialize all state.
 -  [reload](reload/reload.md) Reload pwndbg.
@@ -91,7 +91,7 @@
 -  [context](context/context.md) Print out the current register, instruction, and stack context.
 -  [contextoutput](context/contextoutput.md) Sets the output of a context section.
 -  [contextunwatch](context/contextunwatch.md) Removes an expression previously added to be watched.
--  [contextwatch](context/contextwatch.md) 
+-  [contextwatch](context/contextwatch.md)
 -  [regs](context/regs.md) Print out all registers and enhance the information.
 -  [xinfo](xinfo/xinfo.md) Shows offsets of the specified address from various useful locations.
 
@@ -106,13 +106,13 @@
 
 -  [distance](distance/distance.md) Print the distance between the two arguments, or print the offset to the address's page base.
 -  [hexdump](hexdump/hexdump.md) Hexdumps data at the specified address or module name.
--  [leakfind](leakfind/leakfind.md) 
--  [mmap](mmap/mmap.md) 
--  [mprotect](mprotect/mprotect.md) 
+-  [leakfind](leakfind/leakfind.md)
+-  [mmap](mmap/mmap.md)
+-  [mprotect](mprotect/mprotect.md)
 -  [p2p](p2p/p2p.md) Pointer to pointer chain search. Searches given mapping for all pointers that point to specified mapping.
 -  [telescope](p2p/ts.md) Recursively dereferences pointers starting at the specified address.
 -  [telescope](peda/xprint.md) Recursively dereferences pointers starting at the specified address.
--  [probeleak](probeleak/probeleak.md) 
+-  [probeleak](probeleak/probeleak.md)
 -  [search](search/search.md) Search memory for byte sequences, strings, pointers, and integer values.
 -  [telescope](telescope/telescope.md) Recursively dereferences pointers starting at the specified address.
 -  [vmmap](vmmap/vmmap.md) Print virtual memory map pages.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -41,7 +41,7 @@ The portable version includes all necessary dependencies and should work without
 
 ### Download the Portable Version:
 
-Download the portable version from the [Pwndbg releases page](https://github.com/pwndbg/pwndbg/releases) by selecting the desired version. 
+Download the portable version from the [Pwndbg releases page](https://github.com/pwndbg/pwndbg/releases) by selecting the desired version.
 Choose the appropriate version for your system architecture (x86_64 or aarch64).
 
 ### Installation on RPM-based Systems (CentOS/Alma/Rocky/RHEL):

--- a/tests/gdb-tests/tests/binaries/heap_bugs.c
+++ b/tests/gdb-tests/tests/binaries/heap_bugs.c
@@ -42,7 +42,7 @@ printf("a=%p\nb=%p\nc=%p\nd=%p\ne=%p\nf=%p\ng=%p\n", a, b, c, d, e, f, g);
 
 /*
 Every function MUST have two comments: "break1" and "break2"
-One after setup, second just before line triggering the bug 
+One after setup, second just before line triggering the bug
 */
 
 void invalid_pointer_overflow() {
@@ -241,7 +241,7 @@ int main(int argc, char const *argv[]) {
         case 14: corrupted_unsorted_chunks(); break;
         default: printf("Unknown\n");
     }
-    
+
     puts("END");
     return 0;
 }

--- a/tests/gdb-tests/tests/binaries/linked-lists.c
+++ b/tests/gdb-tests/tests/binaries/linked-lists.c
@@ -1,6 +1,6 @@
 #include <stddef.h> /* For NULL. */
 
-/* Linked list in which the pointer to the next element in inside the node 
+/* Linked list in which the pointer to the next element in inside the node
  * structure itself. */
 struct node {
     int value;
@@ -22,7 +22,7 @@ struct inner_a_node inner_a_node_c = { 2, { NULL } };
 struct inner_a_node inner_a_node_b = { 1, { &inner_a_node_c.inner } };
 struct inner_a_node inner_a_node_a = { 0, { &inner_a_node_b.inner } };
 
-/* Linked list in which the pointer to the next element is nested inside the 
+/* Linked list in which the pointer to the next element is nested inside the
  * structure. */
 struct inner_b_node;
 struct node_inner_b {

--- a/tests/gdb-tests/tests/binaries/multiple_threads.c
+++ b/tests/gdb-tests/tests/binaries/multiple_threads.c
@@ -46,6 +46,6 @@ int main()
 
     break_here();
     usleep(8000);
-    
+
     return 0;
 }

--- a/tests/gdb-tests/tests/binaries/search_memory.c
+++ b/tests/gdb-tests/tests/binaries/search_memory.c
@@ -24,7 +24,7 @@ int main(void)
         *(unsigned int *)(p + i) = 0xd00dbeef;
     }
 
-    // Pattern we want to avoid with -a 0x8 
+    // Pattern we want to avoid with -a 0x8
     for (int i = 0; i < 0x100000; i += 0x100) {
         *(unsigned int *)(p + i + 0x17) = 0xd00dbeef;
     }

--- a/tests/gdb-tests/tests/binaries/stepuntilasm_x64.asm
+++ b/tests/gdb-tests/tests/binaries/stepuntilasm_x64.asm
@@ -5,24 +5,24 @@ section .text
     global stop2
     global stop3
     global stop4
-_start: 
+_start:
 break_here:
     xor rax, rax
-stop1: 
+stop1:
     nop ; Stop point #1: No operands
-stop2: 
+stop2:
     xor rax, rax ; Stop point #2: Some simple operands
-    
+
     lea rax, [some_data]
-stop3: 
+stop3:
     ; Stop point #3: More complex operands.
-    mov qword [rax], 0x20 
-    
+    mov qword [rax], 0x20
+
     call loop
     lea rax, [some_data]
-stop4: 
+stop4:
     ; Stop point #4: Even more complex operands, after loop.
-    mov dword [rax+4], 0x20 
+    mov dword [rax+4], 0x20
 
 exit:
     ; Terminate the process by calling sys_exit(0) in Linux.
@@ -31,15 +31,15 @@ exit:
     syscall
 
 
-; Loop subroutine. Loops for a while so we can test whether stepuntilasm can get 
+; Loop subroutine. Loops for a while so we can test whether stepuntilasm can get
 ; to a directive that's sitting after a few iterations of a loop.
 loop:
     mov rax, 100
 loop_iter:
-    sub rax, 1    
+    sub rax, 1
     jnz loop_iter
 
-    ret 
+    ret
 
 section .bss
 some_data: resq 1


### PR DESCRIPTION
Remove all whitespace as requested in #2187  

Since it came up before while discussing lint.sh fwiw I usually use something like this (with more linters for other languages) in my pre-commit config on other projects:

```
cat .pre-commit-config.yaml
minimum_pre_commit_version: "2.9.0"
ci:
  autoupdate_schedule: monthly
repos:
  - repo: https://github.com/pre-commit/pre-commit-hooks
    rev: v4.6.0
    hooks:
      - id: check-added-large-files
      - id: check-case-conflict
      - id: check-executables-have-shebangs
      - id: check-merge-conflict
      - id: check-shebang-scripts-are-executable
      - id: destroyed-symlinks
      - id: detect-private-key
      - id: fix-byte-order-marker
      - id: forbid-submodules
      - id: mixed-line-ending
      - id: trailing-whitespace
```

and it automatically catches (and sometime is auto-corrects) stuff like this, but I also have my editor auto fix trailing whitespace as well. 

Probably something similar could be added to lint.sh to catch it if using pre-commit isn't wanted. For this PR I just used the above and ran `pre-commit run --all`, mind you it will barf on lots of other things like .py/.sh files with included shebangs that aren't executable or executable with no shebang. I will send a separate PR to fix those.