### PR TITLE
add vmmap --gaps option

### DIFF
--- a/pwndbg/color/memory.py
+++ b/pwndbg/color/memory.py
@@ -21,6 +21,7 @@ c = ColorConfig(
         ColorParamSpec("data", "purple", "color for all other writable memory"),
         ColorParamSpec("rodata", "normal", "color for all read only memory"),
         ColorParamSpec("rwx", "underline", "color added to all RWX memory"),
+        ColorParamSpec("guard", "cyan", "color added to all guard pages (no perms)"),
     ],
 )
 
@@ -76,6 +77,8 @@ def get(address: int | gdb.Value, text: str | None = None, prefix: str | None = 
         color = c.code
     elif page.rw:
         color = c.data
+    elif page.is_guard:
+        color = c.guard
     else:
         color = c.rodata
 

--- a/pwndbg/commands/vmmap.py
+++ b/pwndbg/commands/vmmap.py
@@ -5,6 +5,7 @@ Command to print the virtual memory map a la /proc/self/maps.
 from __future__ import annotations
 
 import argparse
+from typing import Tuple
 
 import gdb
 from elftools.elf.constants import SH_FLAGS
@@ -14,8 +15,12 @@ import pwndbg.color.memory as M
 import pwndbg.commands
 import pwndbg.gdblib.elf
 import pwndbg.gdblib.vmmap
+from pwndbg.color import cyan
+from pwndbg.color import green
+from pwndbg.color import red
 from pwndbg.commands import CommandCategory
 from pwndbg.gdblib import gdb_version
+from pwndbg.lib.memory import Page
 
 integer_types = (int, gdb.Value)
 
@@ -42,6 +47,102 @@ def print_vmmap_table_header() -> None:
     print(
         f"{'Start':>{2 + 2 * pwndbg.gdblib.arch.ptrsize}} {'End':>{2 + 2 * pwndbg.gdblib.arch.ptrsize}} {'Perm'} {'Size':>8} {'Offset':>6} {'File'}"
     )
+
+
+def print_vmmap_gaps_table_header() -> None:
+    """
+    Prints the table header for the vmmap --gaps command.
+    """
+    header = (
+        f"{'Start':>{2 + 2 * pwndbg.gdblib.arch.ptrsize}} "
+        f"{'End':>{2 + 2 * pwndbg.gdblib.arch.ptrsize}} "
+        f"{'Perm':>4} "
+        f"{'Size':>8} "
+        f"{'Note':>9} "
+        f"{'Accumulated Size':>{2 + 2 * pwndbg.gdblib.arch.ptrsize}}"
+    )
+    print(header)
+
+
+def calculate_total_memory(pages: Tuple[Page, ...]) -> None:
+    total = 0
+    for page in pages:
+        total += page.memsz
+    if total > 1024 * 1024:
+        print(f"Total memory mapped: {total:#x} ({total//1024//1024} MB)")
+    else:
+        print(f"Total memory mapped: {total:#x} ({total//1024} KB)")
+
+
+def gap_text(page: Page) -> str:
+    # Strip out offset and objfile from stringified page
+    display_text = " ".join(str(page).split(" ")[:-2])
+    return display_text.rstrip()
+
+
+def print_map(page: Page) -> None:
+    print(green(gap_text(page)))
+
+
+def print_adjacent_map(map_start: Page, map_end: Page) -> None:
+    print(
+        green(
+            f"{gap_text(map_end)} {'ADJACENT':>9} {hex(map_end.end - map_start.start):>{2 + 2 * pwndbg.gdblib.arch.ptrsize}}"
+        )
+    )
+
+
+def print_guard(page: Page) -> None:
+    print(cyan(f"{gap_text(page)} {'GUARD':>9} "))
+
+
+def print_gap(current: Page, last_map: Page):
+    print(
+        red(
+            " - " * int(51 / 3)
+            + f" {'GAP':>9} {hex(current.start - last_map.end):>{2 + 2 * pwndbg.gdblib.arch.ptrsize}}"
+        )
+    )
+
+
+def print_vmmap_gaps(pages: Tuple[Page, ...]) -> None:
+    """
+    Indicates the size of adjacent memory regions and unmapped gaps between them in process memory
+    """
+    print(f"LEGEND: {green('MAPPED')} | {cyan('GUARD')} | {red('GAP')}")
+    print_vmmap_gaps_table_header()
+
+    last_map = None  # The last mapped region we looked at
+    last_start = None  # The last starting region of a series of mapped regions
+
+    for page in pages:
+        if last_map:
+            # If there was a gap print it, and also print the last adjacent map set length
+            if last_map.end != page.start:
+                if last_start and last_start != last_map:
+                    print_adjacent_map(last_start, last_map)
+                print_gap(page, last_map)
+
+            # If this is a guard page, print the last map and the guard page
+            elif page.is_guard:
+                if last_start and last_start != last_map:
+                    print_adjacent_map(last_start, last_map)
+                print_guard(page)
+                last_start = None
+                last_map = page
+                continue
+
+            # If we are tracking an adjacent set, don't print the current one yet
+            elif last_start:
+                if last_start != last_map:
+                    print_map(last_map)
+                last_map = page
+                continue
+
+        print_map(page)
+        last_start = page
+        last_map = page
+    calculate_total_memory(pages)
 
 
 parser = argparse.ArgumentParser(
@@ -78,6 +179,11 @@ parser.add_argument(
 parser.add_argument(
     "-B", "--lines-before", type=int, help="Number of pages to display before result", default=1
 )
+parser.add_argument(
+    "--gaps",
+    action="store_true",
+    help="Display unmapped memory gap information in the memory map.",
+)
 
 
 @pwndbg.commands.ArgparsedCommand(
@@ -85,7 +191,7 @@ parser.add_argument(
 )
 @pwndbg.commands.OnlyWhenRunning
 def vmmap(
-    gdbval_or_str=None, writable=False, executable=False, lines_after=1, lines_before=1
+    gdbval_or_str=None, writable=False, executable=False, lines_after=1, lines_before=1, gaps=False
 ) -> None:
     lookaround_lines_limit = 64
 
@@ -96,7 +202,7 @@ def vmmap(
     # All displayed pages, including lines after and lines before
     total_pages = pwndbg.gdblib.vmmap.get()
 
-    # Filtered memory pages, indicated by an backtrace arrow in results
+    # Filtered memory pages, indicated by a backtrace arrow in results
     filtered_pages = []
 
     # Only filter when -A and -B arguments are valid
@@ -131,6 +237,10 @@ def vmmap(
 
     if not total_pages:
         print("There are no mappings for specified address or module.")
+        return
+
+    if gaps:
+        print_vmmap_gaps(total_pages)
         return
 
     print(M.legend())

--- a/pwndbg/lib/memory.py
+++ b/pwndbg/lib/memory.py
@@ -119,6 +119,10 @@ class Page:
         return self.read and self.write and self.execute
 
     @property
+    def is_guard(self) -> bool:
+        return not (self.read or self.write or self.execute)
+
+    @property
     def permstr(self) -> str:
         flags = self.flags
         return "".join(

--- a/tests/gdb-tests/tests/binaries/mmap_gaps.c
+++ b/tests/gdb-tests/tests/binaries/mmap_gaps.c
@@ -1,0 +1,52 @@
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+void break_here(void) {}
+
+#define ADDR (void *)0xcafe0000
+#define PGSZ 0x1000
+
+void *xmmap(void *addr, size_t length, int prot, int flags, int fd,
+            off_t offset) {
+    void *p = mmap(addr, length, prot, flags, fd, offset);
+    if (MAP_FAILED == p) {
+        printf("Failed to map fixed address at %p\n", (void *)addr);
+        perror("mmap");
+        exit(EXIT_FAILURE);
+    }
+    return p;
+}
+
+int main(void) {
+    // We want to allocate multiple adjacent regions, too confirm that vmmap
+    // --gaps detects them properly. So iensure we have adjacent allocation,
+    // unmapped holes, as well as some guard page with no permissions.
+
+    uint64_t address = (uint64_t)ADDR;
+    void    *p;
+
+    // 2 adjacent pages
+    p = xmmap((void *)address, PGSZ, PROT_READ,
+              MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, -1, 0);
+    address += PGSZ;
+    p = xmmap((void *)address, PGSZ, PROT_READ | PROT_WRITE,
+              MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, -1, 0);
+    address += PGSZ;
+
+    // GUARD page
+    p = xmmap((void *)address, PGSZ, PROT_NONE,
+              MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, -1, 0);
+    mprotect(p, 0x1000, PROT_NONE);
+    address += PGSZ;
+
+    p = xmmap((void *)address, PGSZ, PROT_READ | PROT_WRITE | PROT_EXEC,
+              MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, -1, 0);
+    address += PGSZ;
+
+    break_here();
+}


### PR DESCRIPTION
The following adds a new `--gaps` option to `vmmap` command which can be used to figure out where there are holes in the process memory map.

The following is an example of what it looks like when run against the included test case:

![Screenshot from 2024-05-27 14-04-06](https://github.com/pwndbg/pwndbg/assets/13679876/4f282fa2-1e0b-4b7d-b8b1-65da9bdf4903)

This also adds a new color for guard pages into the memory module, but because actually adding that to the vmmap (not --gaps) legend would break most of the existing tests, it something that will have to wait to add another time.