### PR TITLE
Add addsymbol command

### DIFF
--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -653,6 +653,7 @@ def HexOrAddressExpr(s: str) -> int:
 
 def load_commands() -> None:
     # pylint: disable=import-outside-toplevel
+    import pwndbg.commands.addsymbol
     import pwndbg.commands.ai
     import pwndbg.commands.argv
     import pwndbg.commands.aslr

--- a/pwndbg/commands/addsymbol.py
+++ b/pwndbg/commands/addsymbol.py
@@ -1,19 +1,23 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
+import os
 
 import gdb
 
 import pwndbg.commands
 from pwndbg.commands import CommandCategory
-from pwndbg.gdblib.symbol import _create_symboled_elf
+from pwndbg.gdblib.symbol import create_symboled_elf
 
 parser = argparse.ArgumentParser(description="add custom symbols")
 parser.add_argument("name", type=str, help="name of the symbol")
 parser.add_argument("addr", type=int, help="addr of the symbol")
 
+SYMBOLS_CACHEDIR = pwndbg.lib.tempfile.cachedir("symbols")
 
-@pwndbg.commands.ArgparsedCommand(parser, category=CommandCategory.LINUX)
+
+@pwndbg.commands.ArgparsedCommand(parser, category=CommandCategory.MISC)
 @pwndbg.commands.OnlyWhenRunning
 def addsymbol(name, addr) -> None:
     module = pwndbg.gdblib.proc.exe
@@ -23,6 +27,20 @@ def addsymbol(name, addr) -> None:
         if module in p.objfile:
             vaddr = p.vaddr
 
-    path = _create_symboled_elf({name: addr}, base_addr=vaddr)
+    path = create_symboled_elf(
+        {name: addr},
+        base_addr=vaddr,
+        filename=os.path.join(SYMBOLS_CACHEDIR, compute_file_hash(module)),
+    )
 
     gdb.execute(f"add-symbol-file {path} {vaddr}")
+
+
+def compute_file_hash(filename: str) -> str:
+    """
+    Compute the MD5 hash of the file, return the hash
+    """
+    h = hashlib.md5()
+    with open(filename, "rb") as f:
+        h.update(f.read())
+    return h.hexdigest()

--- a/pwndbg/commands/addsymbol.py
+++ b/pwndbg/commands/addsymbol.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import argparse
+
+import gdb
+
+import pwndbg.commands
+from pwndbg.commands import CommandCategory
+from pwndbg.gdblib.symbol import _create_symboled_elf
+
+parser = argparse.ArgumentParser(description="add custom symbols")
+parser.add_argument("name", type=str, help="name of the symbol")
+parser.add_argument("addr", type=int, help="addr of the symbol")
+
+
+@pwndbg.commands.ArgparsedCommand(parser, category=CommandCategory.LINUX)
+@pwndbg.commands.OnlyWhenRunning
+def addsymbol(name, addr) -> None:
+    module = pwndbg.gdblib.proc.exe
+    vaddr = 0x0
+
+    for p in pwndbg.gdblib.vmmap.get():
+        if module in p.objfile:
+            vaddr = p.vaddr
+
+    path = _create_symboled_elf({name: addr}, base_addr=vaddr)
+
+    gdb.execute(f"add-symbol-file {path} {vaddr}")


### PR DESCRIPTION
- add command for adding temporary symbols

TODO:
- add some form of caching to avoid re-adding all symbols after restarting gdb. store symbols in `/tmp/symbols-<hash(binary_name)>.debug` instead of recreating symbol files repeatedly.
- we should build the elf in memory instead of using `objcopy` and `gcc`