### PR TITLE
Add Vim's `*.swp` files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,6 @@ gdb.txt
 
 # Nix build stuff
 result-*
+
+# Vim
+*.swp


### PR DESCRIPTION
This is part of the work being done for the GSoC 2024 LLDB Port, tracked by #2204.

This PR is a suggestion for a very small QoL improvement, really. Might make sense to just ignore all `*.swp` files, as git will every now and then try to add those those from open instances of the vim editor.