### PR TITLE
Fix dependency installation on openSUSE Tumbleweed

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -49,7 +49,8 @@ install_swupd() {
 install_zypper() {
     sudo zypper mr -e repo-oss-debug || sudo zypper mr -e repo-debug
     sudo zypper refresh || true
-    sudo zypper install -y gdb gdbserver python-devel python3-devel python2-pip python3-pip glib2-devel make glibc-debuginfo
+    sudo zypper install -y gdb gdbserver python-devel python3-devel python3-pip glib2-devel make glibc-debuginfo
+    sudo zypper install -y python2-pip || true
 
     if uname -m | grep x86_64 > /dev/null; then
         sudo zypper install -y glibc-32bit-debuginfo || true

--- a/setup.sh
+++ b/setup.sh
@@ -50,7 +50,7 @@ install_zypper() {
     sudo zypper mr -e repo-oss-debug || sudo zypper mr -e repo-debug
     sudo zypper refresh || true
     sudo zypper install -y gdb gdbserver python-devel python3-devel python3-pip glib2-devel make glibc-debuginfo
-    sudo zypper install -y python2-pip || true
+    sudo zypper install -y python2-pip || true  # skip py2 installation if it doesn't exist
 
     if uname -m | grep x86_64 > /dev/null; then
         sudo zypper install -y glibc-32bit-debuginfo || true


### PR DESCRIPTION
openSUSE Tumbleweed no longer includes python2-pip

<!-- Please make sure to read the testing and linting instructions at https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md before creating a PR -->
