### PR TITLE
Add Ubuntu 24.04 to CI

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        images: [ubuntu20.04, ubuntu22.04, debian11, archlinux]
+        images: [ubuntu20.04, ubuntu22.04, ubuntu24.04, debian11, archlinux]
 
     runs-on: ubuntu-latest
     timeout-minutes: 30


### PR DESCRIPTION
As @gsingh93 pointed out, the GH CI runner now supports Ubuntu 24.04, we should build & test on it as well.