### PR TITLE
Start migrating to Python logging and add log_level command

### DIFF
--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -7,6 +7,7 @@ Pwndbg relies on several environment variables to customize its behavior. Below 
 - `HOME`, `XDG_CACHE_HOME`: Used by `lib.tempfile` to determine temporary file locations.
 - `PWNDBG_VENV_PATH`: Specifies the virtual environment path for Pwndbg.
 - `PWNDBG_DISABLE_COLORS`: Disables colored output in Pwndbg.
+- `PWNDBG_LOGLEVEL`: Initial log level to use for log messages.
 - `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`: Used by the `ai` command for accessing respective AI APIs.
 - `GITHUB_ACTIONS`, `RUN_FLAKY`: Used by `tests_commands.py` to determine the test environment.
 - `PWNDBG_PROFILE`: Enables profiling for benchmarking.

--- a/gdbinit.py
+++ b/gdbinit.py
@@ -30,9 +30,10 @@ def hash_file(file_path: str | Path) -> str:
 
 
 def run_poetry_install(poetry_path: os.PathLike[str], dev: bool = False) -> Tuple[str, str, int]:
-    command: List[str | os.PathLike[str]] = [poetry_path, "install"]
+    command: List[str] = [str(poetry_path), "install"]
     if dev:
         command.extend(("--with", "dev"))
+    logging.debug(f"Updating deps with command: {' '.join(command)}")
     result = subprocess.run(command, capture_output=True, text=True)
     return result.stdout.strip(), result.stderr.strip(), result.returncode
 
@@ -61,9 +62,14 @@ def update_deps(src_root: Path, venv_path: Path) -> None:
     poetry_lock_hash_path = venv_path / "poetry.lock.hash"
 
     current_hash = hash_file(src_root / "poetry.lock")
+    logging.debug(f"Current poetry.lock hash: {current_hash}")
+
     stored_hash = None
     if poetry_lock_hash_path.exists():
         stored_hash = poetry_lock_hash_path.read_text().strip()
+        logging.debug(f"Stored poetry.lock hash: {stored_hash}")
+    else:
+        logging.debug("No stored hash found")
 
     # If the hashes don't match, update the dependencies
     if current_hash != stored_hash:
@@ -129,6 +135,21 @@ def skip_venv(src_root) -> bool:
     )
 
 
+def init_logger():
+    log_level_env = os.environ.get("PWNDBG_LOGLEVEL", "WARNING")
+    log_level = getattr(logging, log_level_env.upper())
+
+    root_logger = logging.getLogger()
+    root_logger.setLevel(log_level)
+
+    # Add a custom StreamHandler we will use to customize log message formatting. We
+    # configure the handler later, after pwndbg has been imported.
+    handler = logging.StreamHandler()
+    root_logger.addHandler(handler)
+
+    return handler
+
+
 def main() -> None:
     profiler = cProfile.Profile()
 
@@ -137,15 +158,7 @@ def main() -> None:
         start_time = time.time()
         profiler.enable()
 
-    handler = logging.StreamHandler()
-
-    # Add the handler to the root logger
-    logging.getLogger().addHandler(handler)
-
-    log_level_env = os.environ.get("PWNDBG_LOGLEVEL", "WARNING")
-    log_level = getattr(logging, log_level_env.upper())
-
-    logging.basicConfig(level=log_level)
+    handler = init_logger()
 
     src_root = Path(__file__).parent.resolve()
     if not skip_venv(src_root):

--- a/pwndbg/color/message.py
+++ b/pwndbg/color/message.py
@@ -21,6 +21,8 @@ config_hint_color = theme.add_color_param(
 config_success_color = theme.add_color_param(
     "message-success-color", "green", "color of success messages"
 )
+config_debug_color = theme.add_color_param("message-debug-color", "blue", "color of debug messages")
+config_info_color = theme.add_color_param("message-info-color", "white", "color of info messages")
 config_warning_color = theme.add_color_param(
     "message-warning-color", "yellow", "color of warning messages"
 )
@@ -60,6 +62,14 @@ def hint(msg: object) -> str:
 
 def success(msg: object) -> str:
     return generateColorFunction(config.message_success_color)(msg)
+
+
+def debug(msg: object) -> str:
+    return generateColorFunction(config.message_warning_color)(msg)
+
+
+def info(msg: object) -> str:
+    return generateColorFunction(config.message_warning_color)(msg)
 
 
 def warn(msg: object) -> str:

--- a/pwndbg/commands/dev.py
+++ b/pwndbg/commands/dev.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import logging
 
 import pwndbg.color.message as MessageColor
 import pwndbg.commands
@@ -63,3 +64,20 @@ def dev_dump_instruction(address=None, force_emulate=False, no_emulate=False) ->
         if instructions:
             insn = instructions[0]
             print(repr(insn))
+
+
+parser = argparse.ArgumentParser(description="Set the log level.")
+parser.add_argument(
+    "level",
+    type=str,
+    nargs="?",
+    choices=["debug", "info", "warning", "error", "critical"],
+    default="warning",
+    help="The log level to set.",
+)
+
+
+@pwndbg.commands.ArgparsedCommand(parser, category=CommandCategory.DEV)
+def log_level(level: str) -> None:
+    logging.getLogger().setLevel(getattr(logging, level.upper()))
+    print(f"Log level set to {level}")

--- a/pwndbg/log.py
+++ b/pwndbg/log.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import logging
+
+import pwndbg.color
+
+
+class ColorFormatter(logging.Formatter):
+    log_funcs = {
+        logging.DEBUG: pwndbg.color.message.debug,
+        logging.INFO: pwndbg.color.message.info,
+        logging.WARNING: pwndbg.color.message.warn,
+        logging.ERROR: pwndbg.color.message.error,
+        logging.CRITICAL: pwndbg.color.message.error,
+    }
+
+    def format(self, record):
+        log_func = self.log_funcs.get(record.levelno)
+        formatter = logging.Formatter(log_func("%(message)s"))
+        return formatter.format(record)


### PR DESCRIPTION
(Note: don't merge this until #2242 is merged. I've included that commit in here so that we know that the tests are actually passing).

Starts implementing #245.

I got tired of having to add/remove print statements when I should have just been able to set a higher/lower log level.

- Adds the `PWNDBG_LOGLEVEL` environment variable to set the initial log level (defaults to `logging.WARNING`, I might change this to `logging.INFO`)
- Adds a custom `Formatter` to the root logger, so that log messages look exactly like they do now when you use `print(message.warn())` or `print(message.error())`.
- Convert some `print` statements to proper logging calls in `commands/__init__.py`
- Add the `log_level` developer command to change the log level

Here's an example where with the default log level, warning and error messages are shown, but I can change the log level and only have errors shown:
![image](https://github.com/pwndbg/pwndbg/assets/1012677/b1ad129e-a38a-40f3-94a5-2091b9004af2)
