### PR TITLE
Fix caching for pwndbg.gdblib.elf functions

### DIFF
--- a/pwndbg/gdblib/elf.py
+++ b/pwndbg/gdblib/elf.py
@@ -240,7 +240,7 @@ def dump_relocations_by_section_name(
 
 
 @pwndbg.gdblib.proc.OnlyWhenRunning
-@pwndbg.lib.cache.cache_until("start")
+@pwndbg.lib.cache.cache_until("start", "objfile")
 def exe() -> Ehdr | None:
     """
     Return a loaded ELF header object pointing to the Ehdr of the
@@ -253,7 +253,7 @@ def exe() -> Ehdr | None:
 
 
 @pwndbg.gdblib.proc.OnlyWhenRunning
-@pwndbg.lib.cache.cache_until("start")
+@pwndbg.lib.cache.cache_until("start", "objfile")
 def entry() -> int:
     """
     Return the address of the entry point for the main executable.
@@ -293,7 +293,7 @@ def load(pointer: int) -> Ehdr | None:
 ehdr_type_loaded = 0
 
 
-@pwndbg.lib.cache.cache_until("start")
+@pwndbg.lib.cache.cache_until("start", "objfile")
 def reset_ehdr_type_loaded() -> None:
     global ehdr_type_loaded
     ehdr_type_loaded = 0

--- a/pwndbg/gdblib/events.py
+++ b/pwndbg/gdblib/events.py
@@ -62,10 +62,6 @@ class StartEvent:
         self.running = True
 
         for function in self.registered:
-            if debug:
-                sys.stdout.write(
-                    "{!r} {}.{}\n".format("start", function.__module__, function.__name__)
-                )
             function()
 
     def on_exited(self) -> None:

--- a/pwndbg/gdblib/events.py
+++ b/pwndbg/gdblib/events.py
@@ -7,7 +7,6 @@ by using a decorator.
 from __future__ import annotations
 
 import sys
-from functools import partial
 from functools import wraps
 from typing import Any
 from typing import Callable
@@ -133,14 +132,17 @@ def connect(
 
             pwndbg.exception.handle()
             raise e
+
     if priority:
         registered[event_handler].insert(0, caller)
     else:
         registered[event_handler].append(caller)
     if event_handler not in connected:
+
         def handle(*a: P.args, **kw: P.kwargs) -> None:
             for f in registered[event_handler]:
                 f(*a, **kw)
+
         event_handler.connect(handle)
         connected[event_handler] = handle
     return func

--- a/pwndbg/gdblib/hooks.py
+++ b/pwndbg/gdblib/hooks.py
@@ -72,7 +72,8 @@ pwndbg.lib.cache.connect_clear_caching_events(
         "thread": (pwndbg.gdblib.events.thread,),
         "prompt": (pwndbg.gdblib.events.before_prompt,),
         "forever": (),
-    }
+    },
+    priority=pwndbg.gdblib.events.HandlerPriority.CACHE_CLEAR,
 )
 
 

--- a/pwndbg/lib/cache.py
+++ b/pwndbg/lib/cache.py
@@ -18,8 +18,6 @@ from typing import Union
 
 from typing_extensions import ParamSpec
 
-import pwndbg.gdblib.events
-
 T = TypeVar("T")
 P = ParamSpec("P")
 
@@ -70,14 +68,14 @@ class _CacheUntilEvent:
     def __init__(self) -> None:
         self.caches: List[Cache] = []
 
-    def connect_event_hooks(self, event_hooks: Tuple[Any, ...]) -> None:
+    def connect_event_hooks(self, event_hooks: Tuple[Any, ...], **kwargs: Any) -> None:
         """
         A given _CacheUntilEvent object may require multiple debugger events
         to be handled properly. E.g. our `stop` cache needs to be handled
         by `stop`, `mem_changed` and `reg_changed` events.
         """
         for event_hook in event_hooks:
-            event_hook(self.clear, priority=pwndbg.gdblib.events.HandlerPriority.CACHE_CLEAR)
+            event_hook(self.clear, **kwargs)
 
     def clear(self) -> None:
         for cache in self.caches:
@@ -100,12 +98,12 @@ _ALL_CACHE_UNTIL_EVENTS: Dict[str, _CacheUntilEvent] = {
 _ALL_CACHE_EVENT_NAMES = tuple(_ALL_CACHE_UNTIL_EVENTS.keys())
 
 
-def connect_clear_caching_events(event_dicts: Dict[str, Tuple[Any, ...]]) -> None:
+def connect_clear_caching_events(event_dicts: Dict[str, Tuple[Any, ...]], **kwargs: Any) -> None:
     """
     Connect given debugger event hooks to correspoonding _CacheUntilEvent instances
     """
     for event_name, event_hooks in event_dicts.items():
-        _ALL_CACHE_UNTIL_EVENTS[event_name].connect_event_hooks(event_hooks)
+        _ALL_CACHE_UNTIL_EVENTS[event_name].connect_event_hooks(event_hooks, **kwargs)
 
 
 # A singleton used to mark a cache miss

--- a/pwndbg/lib/cache.py
+++ b/pwndbg/lib/cache.py
@@ -18,6 +18,8 @@ from typing import Union
 
 from typing_extensions import ParamSpec
 
+import pwndbg.gdblib.events
+
 T = TypeVar("T")
 P = ParamSpec("P")
 
@@ -75,7 +77,7 @@ class _CacheUntilEvent:
         by `stop`, `mem_changed` and `reg_changed` events.
         """
         for event_hook in event_hooks:
-            event_hook(self.clear, priority=True)
+            event_hook(self.clear, priority=pwndbg.gdblib.events.HandlerPriority.CACHE_CLEAR)
 
     def clear(self) -> None:
         for cache in self.caches:

--- a/pwndbg/lib/cache.py
+++ b/pwndbg/lib/cache.py
@@ -75,7 +75,7 @@ class _CacheUntilEvent:
         by `stop`, `mem_changed` and `reg_changed` events.
         """
         for event_hook in event_hooks:
-            event_hook(self.clear)
+            event_hook(self.clear, priority=True)
 
     def clear(self) -> None:
         for cache in self.caches:

--- a/tests/gdb-tests/tests/test_cache.py
+++ b/tests/gdb-tests/tests/test_cache.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import tests
+import pwndbg.gdblib.events
 from pwndbg.lib import cache
 
 BINARY = tests.binaries.get("reference-binary.out")
@@ -68,3 +69,28 @@ def test_cache_args_kwargs_properly(start_binary):
 
     assert foo("abc") == (5, "abc", (), {}) and x == 5
     assert foo(100, 200) == (6, 100, (200,), {}) and x == 6
+
+
+def test_cache_clear_has_priority(start_binary):
+    actions = []
+
+    @pwndbg.gdblib.events.stop
+    def on_stop():
+        actions.append("on_stop")
+        # test to make sure event handlers don't have a stale cache
+        foo()
+
+    @cache.cache_until("stop")
+    def foo():
+        actions.append("foo")
+
+    foo()
+    foo()
+    assert actions == ["foo"]
+
+    start_binary(BINARY)
+    assert actions == ["foo", "on_stop", "foo"]
+
+    foo()
+    foo()
+    assert actions == ["foo", "on_stop", "foo"]

--- a/tests/gdb-tests/tests/test_cache.py
+++ b/tests/gdb-tests/tests/test_cache.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import tests
 import pwndbg.gdblib.events
+import tests
 from pwndbg.lib import cache
 
 BINARY = tests.binaries.get("reference-binary.out")


### PR DESCRIPTION
Fixes #2237

Changes two things:
1. Functions in `pwndbg.gdblib.elf` that used to cache on only `start` now cache on both `start` and `objfile`, since changing object files should reload ELF information.
2. Implemented priority event handlers that run before other handlers, so that cache clears will happen before other handlers on that event.
