### PR TITLE
Mips64 arch

### DIFF
--- a/pwndbg/lib/abi.py
+++ b/pwndbg/lib/abi.py
@@ -84,6 +84,7 @@ linux_amd64_syscall = SyscallABI(["rax", "rdi", "rsi", "rdx", "r10", "r8", "r9"]
 linux_arm_syscall = SyscallABI(["r7", "r0", "r1", "r2", "r3", "r4", "r5", "r6"], 4, 0)
 linux_aarch64_syscall = SyscallABI(["x8", "x0", "x1", "x2", "x3", "x4", "x5"], 16, 0)
 linux_mips_syscall = SyscallABI(["$v0", "$a0", "$a1", "$a2", "$a3"], 4, 0)
+linux_mips64_syscall = SyscallABI(["$v0", "$a0", "$a1", "$a2", "$a3", "$a4", "$a5"], 4, 0)
 linux_ppc_syscall = SyscallABI(["r0", "r3", "r4", "r5", "r6", "r7", "r8", "r9"], 4, 0)
 linux_ppc64_syscall = SyscallABI(["r0", "r3", "r4", "r5", "r6", "r7", "r8"], 8, 0)
 linux_riscv32_syscall = SyscallABI(["a7", "a0", "a1", "a2", "a3", "a4", "a5", "a6"], 4, 0)

--- a/pwndbg/lib/abi.py
+++ b/pwndbg/lib/abi.py
@@ -74,6 +74,7 @@ linux_amd64 = ABI(["rdi", "rsi", "rdx", "rcx", "r8", "r9"], 8, 0)
 linux_arm = ABI(["r0", "r1", "r2", "r3"], 8, 0)
 linux_aarch64 = ABI(["x0", "x1", "x2", "x3"], 16, 0)
 linux_mips = ABI(["$a0", "$a1", "$a2", "$a3"], 4, 0)
+linux_mips64 = ABI(["$a0", "$a1", "$a2", "$a3", "$a4", "$a5", "$a6", "$a7"], 8, 0)
 linux_ppc = ABI(["r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10"], 4, 0)
 linux_ppc64 = ABI(["r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10"], 8, 0)
 linux_riscv32 = ABI(["a0", "a1", "a2", "a3", "a4", "a5", "a6", "a7"], 4, 0)
@@ -106,6 +107,7 @@ DEFAULT_ABIS: Dict[Tuple[int, str, str], ABI] = {
     (32, "arm", "linux"): linux_arm,
     (32, "thumb", "linux"): linux_arm,
     (32, "mips", "linux"): linux_mips,
+    (64, "mips", "linux"): linux_mips64,
     (32, "powerpc", "linux"): linux_ppc,
     (64, "powerpc", "linux"): linux_ppc64,
     (32, "rv32", "linux"): linux_riscv32,
@@ -119,6 +121,7 @@ SYSCALL_ABIS: Dict[Tuple[int, str, str], SyscallABI] = {
     (32, "arm", "linux"): linux_arm_syscall,
     (32, "thumb", "linux"): linux_arm_syscall,
     (32, "mips", "linux"): linux_mips_syscall,
+    (64, "mips", "linux"): linux_mips64_syscall,
     (32, "powerpc", "linux"): linux_ppc_syscall,
     (64, "powerpc", "linux"): linux_ppc64_syscall,
     (32, "rv32", "linux"): linux_riscv32_syscall,


### PR DESCRIPTION
This small PR adds an ABI/SyscallABI constant for 64-bit MIPS. 

I got the registers for the syscall ABI from https://man7.org/linux/man-pages/man2/syscall.2.html

And the function calling convention from https://math-atlas.sourceforge.net/devel/assembly/mipsabi64.pdf

For both, I used the `N64` ABI.

This fixes a KeyError crash in 64-bit MIPS when a dictionary with these values was indexed (occurred when encountering syscalls).