### PR TITLE
Exit with non-zero code from gdbinit.py if an exception occurs

### DIFF
--- a/gdbinit.py
+++ b/gdbinit.py
@@ -159,6 +159,8 @@ def main() -> None:
         pwndbg.profiling.profiler.start()
 
 
+# We wrap everything in try/except so that we can exit GDB with an error code
+# This is used by tests to check if gdbinit.py failed
 try:
     main()
 

--- a/gdbinit.py
+++ b/gdbinit.py
@@ -8,6 +8,7 @@ import site
 import subprocess
 import sys
 import time
+import traceback
 from glob import glob
 from pathlib import Path
 from typing import List
@@ -158,8 +159,13 @@ def main() -> None:
         pwndbg.profiling.profiler.start()
 
 
-main()
+try:
+    main()
 
-# We've already imported this in `main`, but we reimport it here so that it's available
-# at the global scope when some starts a Python interpreter in GDB
-import pwndbg  # noqa: F401
+    # We've already imported this in `main`, but we reimport it here so that it's
+    # available at the global scope when some starts a Python interpreter in GDB
+    import pwndbg  # noqa: F401
+
+except Exception:
+    print(traceback.format_exc(), file=sys.stderr)
+    sys.exit(1)


### PR DESCRIPTION
If an exception occurs when sourcing `gdbinit.py` with `source gdbinit.py` or with `--command` when running GDB, GDB does not exit. This is particularly a problem in our testing infrastructure, which relies on a non-zero exit code to determine if an error occurred.

In this PR I essentially wrapped all of `gdbinit.py` in a try/catch, and if an exception occurs we call `sys.exit(1)`, forcing the GDB return code to be non-zero. Note this doesn't apply to GDB 15 (which is used on Ubuntu 24.04), we'll need to find a separate solution for that.

Note that this should only affect exceptions that occur when sourcing `gdbinit.py`. Exceptions that happen later, like when running commands, don't get caught here and don't result in an exit (as expected).

Fixes #2218.