### PR TITLE
More gdbinit cleanup

### DIFF
--- a/gdbinit.py
+++ b/gdbinit.py
@@ -80,6 +80,10 @@ def update_deps(src_root: Path, venv_path: Path) -> None:
 
             # Only print the poetry output if anything was actually updated
             if "No dependencies to install or update" not in stdout:
+                # The output is usually long and ends up paginated. This
+                # normally gets disabled later during initialization, but in
+                # this case we disable it here to avoid pagination.
+                gdb.execute("set pagination off", to_string=True)
                 print(stdout)
         else:
             print(stderr, file=sys.stderr)

--- a/gdbinit.py
+++ b/gdbinit.py
@@ -149,7 +149,7 @@ def main() -> None:
     gdb.execute("set charset UTF-8", to_string=True)
     os.environ["PWNLIB_NOTERM"] = "1"
 
-    import pwndbg  # noqa: F401
+    import pwndbg  # noqa: F811
     import pwndbg.profiling
 
     pwndbg.profiling.init(profiler, start_time)
@@ -159,3 +159,7 @@ def main() -> None:
 
 
 main()
+
+# We've already imported this in `main`, but we reimport it here so that it's available
+# at the global scope when some starts a Python interpreter in GDB
+import pwndbg  # noqa: F401


### PR DESCRIPTION
- Move all global initialization into a function called `main`
- Disable pagination when we update poetry dependencies. Eventually we should just move all that initialization that happens in `pwndbg/__init__.py` here to avoid needing to do it again.