### PR TITLE
Make retaddr default shown in context by default

### DIFF
--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -549,7 +549,7 @@ def regs(regs=[]) -> None:
 
 
 pwndbg.config.add_param("show-flags", False, "whether to show flags registers")
-pwndbg.config.add_param("show-retaddr-reg", False, "whether to show return address register")
+pwndbg.config.add_param("show-retaddr-reg", True, "whether to show return address register")
 
 
 def get_regs(regs: List[str] = None):

--- a/pwndbg/lib/regs.py
+++ b/pwndbg/lib/regs.py
@@ -248,7 +248,6 @@ aarch64 = RegisterSet(
         "x27",
         "x28",
         "x29",
-        "x30",
     ),
     misc=(
         "w0",
@@ -576,7 +575,6 @@ riscv = RegisterSet(
     stack="sp",
     retaddr=("ra",),
     gpr=(
-        "ra",
         "gp",
         "tp",
         "t0",


### PR DESCRIPTION
This PR proposes setting the `show-retaddr-reg` config setting to `True` by default. 

Most non-x86 architectures that Pwndbg supports use a "branch-and-link" mechanism for calling functions, meaning instead of pushing the return address to the stack, it is put into a register (and the function that is called is responsible for pushing it onto the stack in the case that it is not a leaf function). Arm and PowerPC use the "BL" registers, MIPS and RISCV uses the "ra" register, and SPARC has one reserved as well.

Currently, Pwndbg opts not to display this register by default in the context or when using the `regs` command, and instead hides it behind a configuration setting. 

I found the absence of the register confusing when first jumping into these non-x86 architectures and trying to find how functions are returning. I would see the register mentioned in Architecture manuals, but not see them in Pwndbg. Especially in the context of pwn, knowing where the return address is important, and only when I dug into the code did I find that the register was hidden behind a configuration setting.

As we move to have first-class support for non-x86 architectures, I'd propose to turn this setting on by default.

