### PR TITLE
Move tests from lib/memory.py to separate unit test

### DIFF
--- a/pwndbg/lib/memory.py
+++ b/pwndbg/lib/memory.py
@@ -48,11 +48,6 @@ def page_offset(address: int) -> int:
     return address & (PAGE_SIZE - 1)
 
 
-# TODO: Move to a test
-assert round_down(0xDEADBEEF, 0x1000) == 0xDEADB000
-assert round_up(0xDEADBEEF, 0x1000) == 0xDEADC000
-
-
 class Page:
     """
     Represents the address space and page permissions of at least

--- a/tests/unit-tests/test_memory.py
+++ b/tests/unit-tests/test_memory.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock
+
+# Replace `pwndbg.commands` module with a mock to prevent import errors, as well
+# as the `load_commands` function
+module_name = "pwndbg.commands"
+module = MagicMock(__name__=module_name, load_commands=lambda: None)
+sys.modules[module_name] = module
+
+# Load the mocks for the `gdb` and `gdblib` modules
+import mocks.gdb
+import mocks.gdblib  # noqa: F401
+
+# We must import the function under test after all the mocks are imported
+from pwndbg.lib.memory import round_down, round_up
+
+
+def test_basic():
+    assert round_down(0xDEADBEEF, 0x1000) == 0xDEADB000
+    assert round_up(0xDEADBEEF, 0x1000) == 0xDEADC000
+
+
+def test_many():
+    for n in range(0x100):
+        for i in range(8):
+            alignment = 1 << i
+            down = round_down(n, alignment)
+            up = round_up(n, alignment)
+            assert down <= n and down + alignment > n and down % alignment == 0
+            assert up >= n and up - alignment < n and up % alignment == 0

--- a/tests/unit-tests/test_memory.py
+++ b/tests/unit-tests/test_memory.py
@@ -14,7 +14,8 @@ import mocks.gdb
 import mocks.gdblib  # noqa: F401
 
 # We must import the function under test after all the mocks are imported
-from pwndbg.lib.memory import round_down, round_up
+from pwndbg.lib.memory import round_down
+from pwndbg.lib.memory import round_up
 
 
 def test_basic_rounding():

--- a/tests/unit-tests/test_memory.py
+++ b/tests/unit-tests/test_memory.py
@@ -17,12 +17,12 @@ import mocks.gdblib  # noqa: F401
 from pwndbg.lib.memory import round_down, round_up
 
 
-def test_basic():
+def test_basic_rounding():
     assert round_down(0xDEADBEEF, 0x1000) == 0xDEADB000
     assert round_up(0xDEADBEEF, 0x1000) == 0xDEADC000
 
 
-def test_many():
+def test_many_rounding():
     for n in range(0x100):
         for i in range(8):
             alignment = 1 << i


### PR DESCRIPTION
Seems like a 2 year old TODO fell through the cracks

Also, the current bithack implementation only works for powers of 2 but is undocumented. Should the implementation be changed to be more general or should the documentation be updated?
