### PR TITLE
Manually resolve AArch64 conditional branches

### DIFF
--- a/pwndbg/gdblib/disasm/aarch64.py
+++ b/pwndbg/gdblib/disasm/aarch64.py
@@ -12,7 +12,45 @@ import pwndbg.gdblib.disasm.arch
 import pwndbg.gdblib.memory
 import pwndbg.gdblib.regs
 from pwndbg.emu.emulator import Emulator
-from pwndbg.gdblib.disasm.instruction import PwndbgInstruction
+from pwndbg.gdblib.disasm.instruction import InstructionCondition, PwndbgInstruction, boolean_to_instruction_condition
+from pwndbg.lib.regs import BitFlags
+
+
+
+def resolve_condition(condition: int, cpsr: int) -> InstructionCondition:
+    """
+    Given a condition and the NZCV flag bits, determine when the condition is satisfied
+    
+    The condition is a Capstone constant
+    """
+
+    n = (cpsr >> 31) & 1
+    z = (cpsr >> 30) & 1
+    c = (cpsr >> 29) & 1
+    v = (cpsr >> 28) & 1
+
+    condition = {
+        ARM64_CC_INVALID: True, # Capstone uses this code for the 'B' instruction, the unconditional branch
+        ARM64_CC_EQ: z == 1,
+        ARM64_CC_NE: z == 0,
+        ARM64_CC_HS: c == 1,
+        ARM64_CC_LO: c == 0,
+        ARM64_CC_MI: n == 1,
+        ARM64_CC_PL: n == 0,
+        ARM64_CC_VS: v == 1,
+        ARM64_CC_VC: v == 0,
+        ARM64_CC_HI: c == 1 and z == 0,
+        ARM64_CC_LS: not (c == 1 and z == 0),
+        ARM64_CC_GE: n == v,
+        ARM64_CC_LT: n != v,
+        ARM64_CC_GT: z == 0 and n == v,
+        ARM64_CC_LE: not (z == 0 and n == v),
+        ARM64_CC_AL: True,
+        ARM64_CC_NV: True
+    }.get(condition, False)
+
+    return InstructionCondition.TRUE if condition else InstructionCondition.FALSE
+
 
 
 class DisassemblyAssistant(pwndbg.gdblib.disasm.arch.DisassemblyAssistant):
@@ -63,6 +101,43 @@ class DisassemblyAssistant(pwndbg.gdblib.disasm.arch.DisassemblyAssistant):
                 return
 
             instruction.annotation = f"{left.str} => {super()._telescope_format_list(telescope_addresses, TELESCOPE_DEPTH, emu)}"
+
+
+    @override
+    def _condition(self, instruction: PwndbgInstruction, emu: Emulator) -> pwndbg.gdblib.disasm.arch.InstructionCondition:
+        
+        # For the given instructions, determine
+
+        # In ARM64, only branches have the conditional code in the instruction,
+        # as opposed to ARM32 which allows most instructions to be conditional
+        if instruction.id == ARM64_INS_B:
+            print("resolving conditional")
+            return resolve_condition(instruction.cs_insn.cc,pwndbg.gdblib.regs.cpsr)
+        
+        elif instruction.id == ARM64_INS_CBNZ:
+            op_val = instruction.operands[0].before_value
+            return boolean_to_instruction_condition(op_val != None and op_val != 0)
+        
+        elif instruction.id == ARM64_INS_CBZ:
+            op_val = instruction.operands[0].before_value
+            return boolean_to_instruction_condition(op_val != None and op_val == 0)
+
+        elif instruction.id == ARM64_INS_TBNZ:
+            op_val, bit = instruction.operands[0].before_value, instruction.operands[1].before_value, 
+
+            if op_val is not None and bit is not None:
+                return boolean_to_instruction_condition(bool((op_val >> bit) & 1))
+            
+        elif instruction.id == ARM64_INS_TBZ:
+            op_val, bit = instruction.operands[0].before_value, instruction.operands[1].before_value, 
+
+            if op_val is not None and bit is not None:
+                return boolean_to_instruction_condition(not ((op_val >> bit) & 1))
+            
+
+        # Addtionally, the "conditional comparisons" and "conditional selects" support conditional execution
+
+        return super()._condition(instruction, emu)
 
     @override
     def _set_annotation_string(self, instruction: PwndbgInstruction, emu: Emulator) -> None:

--- a/pwndbg/gdblib/disasm/aarch64.py
+++ b/pwndbg/gdblib/disasm/aarch64.py
@@ -139,7 +139,7 @@ class DisassemblyAssistant(pwndbg.gdblib.disasm.arch.DisassemblyAssistant):
             if op_val is not None and bit is not None:
                 return boolean_to_instruction_condition(not ((op_val >> bit) & 1))
 
-        # Addtionally, the "conditional comparisons" and "conditional selects" support conditional execution
+        # TODO: Additionally, the "conditional comparisons" and "conditional selects" support conditional execution
 
         return super()._condition(instruction, emu)
 

--- a/pwndbg/gdblib/disasm/instruction.py
+++ b/pwndbg/gdblib/disasm/instruction.py
@@ -42,6 +42,7 @@ from capstone.sparc import SPARC_INS_JMP
 from capstone.sparc import SPARC_INS_JMPL
 from capstone.x86 import X86_INS_JMP
 from capstone.x86 import X86Op
+from capstone.arm64 import CsArm64
 
 # Architecture specific instructions that mutate the instruction pointer unconditionally
 # The Capstone RET and CALL groups are also used to filter CALL and RET types when we check for unconditional jumps,
@@ -80,6 +81,8 @@ class InstructionCondition(Enum):
     # Unconditional instructions (most instructions), or we cannot reason about the instruction
     UNDETERMINED = 3
 
+def boolean_to_instruction_condition(condition: bool) -> InstructionCondition:
+    return InstructionCondition.TRUE if condition else InstructionCondition.FALSE
 
 # Only use within the instruction.__repr__ to give a nice output
 CAPSTONE_ARCH_MAPPING_STRING = {
@@ -318,7 +321,7 @@ class PwndbgInstruction:
     def __repr__(self) -> str:
         operands_str = " ".join([repr(op) for op in self.operands])
 
-        return f"""{self.mnemonic} {self.op_str} at {self.address:#x} (size={self.size}) (arch: {CAPSTONE_ARCH_MAPPING_STRING.get(self.cs_insn._cs.arch,None)})
+        info = f"""{self.mnemonic} {self.op_str} at {self.address:#x} (size={self.size}) (arch: {CAPSTONE_ARCH_MAPPING_STRING.get(self.cs_insn._cs.arch,None)})
         ID: {self.id}, {self.cs_insn.insn_name()}
         Raw asm: {'%-06s %s' % (self.mnemonic, self.op_str)}
         New asm: {self.asm_string}
@@ -332,6 +335,12 @@ class PwndbgInstruction:
         Unconditional jump: {self.is_unconditional_jump}
         Can change PC: {self.can_change_instruction_pointer}
         Syscall: {self.syscall if self.syscall is not None else ""} {self.syscall_name if self.syscall_name is not None else "N/A"}"""
+
+        # Hacky, but this is just for debugging
+        if hasattr(self.cs_insn, 'cc'):
+            info += f"\n\tARM condition code: {self.cs_insn.cc}"
+
+        return info
 
 
 class EnhancedOperand:

--- a/pwndbg/gdblib/disasm/instruction.py
+++ b/pwndbg/gdblib/disasm/instruction.py
@@ -42,7 +42,6 @@ from capstone.sparc import SPARC_INS_JMP
 from capstone.sparc import SPARC_INS_JMPL
 from capstone.x86 import X86_INS_JMP
 from capstone.x86 import X86Op
-from capstone.arm64 import CsArm64
 
 # Architecture specific instructions that mutate the instruction pointer unconditionally
 # The Capstone RET and CALL groups are also used to filter CALL and RET types when we check for unconditional jumps,
@@ -81,8 +80,10 @@ class InstructionCondition(Enum):
     # Unconditional instructions (most instructions), or we cannot reason about the instruction
     UNDETERMINED = 3
 
+
 def boolean_to_instruction_condition(condition: bool) -> InstructionCondition:
     return InstructionCondition.TRUE if condition else InstructionCondition.FALSE
+
 
 # Only use within the instruction.__repr__ to give a nice output
 CAPSTONE_ARCH_MAPPING_STRING = {
@@ -337,7 +338,7 @@ class PwndbgInstruction:
         Syscall: {self.syscall if self.syscall is not None else ""} {self.syscall_name if self.syscall_name is not None else "N/A"}"""
 
         # Hacky, but this is just for debugging
-        if hasattr(self.cs_insn, 'cc'):
+        if hasattr(self.cs_insn, "cc"):
             info += f"\n\tARM condition code: {self.cs_insn.cc}"
 
         return info


### PR DESCRIPTION
This PR enhances the way we resolve conditional branches in AArch64 during instruction enhancement.

For all branch-type instructions in AArch64, we can now determine whether or not the branch is taken and resolve it's target without emulation.  

Note that all of these screenshots have emulation disabled


A `ret` instruction before.
![aarch64_ret_before](https://github.com/pwndbg/pwndbg/assets/55004530/bd2aae3b-b6cd-4ec4-b980-3c6699d8991c)

After:
![aarch64_ret_afterpng](https://github.com/pwndbg/pwndbg/assets/55004530/7f05fb27-b3bd-4ee7-ab3e-92cffc2e589b)

A conditional branch before 
![aarch64_b_before](https://github.com/pwndbg/pwndbg/assets/55004530/43db1271-2650-4e7f-b32d-9fc0ee8339d1)

After (note the green check mark indicating that we are taking the branch):
![aarch64_b_after](https://github.com/pwndbg/pwndbg/assets/55004530/1a392799-5922-401e-8bfc-df24d33a39b4)


