### PR TITLE
Fix bug in get_elf_info_rebased that causes error

### DIFF
--- a/pwndbg/gdblib/elf.py
+++ b/pwndbg/gdblib/elf.py
@@ -164,7 +164,6 @@ def get_elf_info_rebased(filepath: str, vaddr: int) -> ELFInfo:
     for seg in raw_info.segments:
         s = dict(seg)
         for vaddr_attr in ["p_vaddr", "x_vaddr_mem_end", "x_vaddr_file_end"]:
-            assert isinstance(headers[vaddr_attr], int)
             s[vaddr_attr] += load  # type: ignore[operator]
         segments.append(s)
 


### PR DESCRIPTION
Closes #2266

`pwndbg.gdblib.elf.get_elf_info_rebased` has a line `assert isinstance(headers[vaddr_attr], int)`, which should actually be `s[vaddr_attr]` instead, causing a `KeyError`.

This PR deletes the assertion entirely, because the addition after will already fail if it's not an int (I'm not even sure how it could not be an int).
