### PR TITLE
Arm mode in banner

### DIFF
--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -22,6 +22,7 @@ import pwndbg.color.memory as M
 import pwndbg.color.syntax_highlight as H
 import pwndbg.commands
 import pwndbg.commands.telescope
+from pwndbg.gdblib.arch import get_thumb_mode_string
 import pwndbg.gdblib.disasm
 import pwndbg.gdblib.events
 import pwndbg.gdblib.heap_tracking
@@ -640,7 +641,11 @@ def context_disasm(target=sys.stdout, with_banner=True, width=None):
     # Note: we must fetch emulate value again after disasm since
     # we check if we can actually use emulation in `can_run_first_emulate`
     # and this call may disable it
-    info = " / {} / set emulate {}".format(pwndbg.gdblib.arch.current, pwndbg.config.emulate)
+    thumb_mode_str = get_thumb_mode_string()
+    if thumb_mode_str is not None:
+        info = " / {} / {} mode / set emulate {}".format(pwndbg.gdblib.arch.current, thumb_mode_str, pwndbg.config.emulate)
+    else:
+        info = " / {} / set emulate {}".format(pwndbg.gdblib.arch.current, pwndbg.config.emulate)
     banner = [pwndbg.ui.banner("disasm", target=target, width=width, extra=info)]
 
     # If we didn't disassemble backward, try to make sure

--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -22,7 +22,6 @@ import pwndbg.color.memory as M
 import pwndbg.color.syntax_highlight as H
 import pwndbg.commands
 import pwndbg.commands.telescope
-from pwndbg.gdblib.arch import get_thumb_mode_string
 import pwndbg.gdblib.disasm
 import pwndbg.gdblib.events
 import pwndbg.gdblib.heap_tracking
@@ -38,6 +37,7 @@ from pwndbg.color import ColorParamSpec
 from pwndbg.color import message
 from pwndbg.color import theme
 from pwndbg.commands import CommandCategory
+from pwndbg.gdblib.arch import get_thumb_mode_string
 
 theme.add_param("backtrace-prefix", "►", "prefix for current backtrace label")
 
@@ -643,7 +643,9 @@ def context_disasm(target=sys.stdout, with_banner=True, width=None):
     # and this call may disable it
     thumb_mode_str = get_thumb_mode_string()
     if thumb_mode_str is not None:
-        info = " / {} / {} mode / set emulate {}".format(pwndbg.gdblib.arch.current, thumb_mode_str, pwndbg.config.emulate)
+        info = " / {} / {} mode / set emulate {}".format(
+            pwndbg.gdblib.arch.current, thumb_mode_str, pwndbg.config.emulate
+        )
     else:
         info = " / {} / set emulate {}".format(pwndbg.gdblib.arch.current, pwndbg.config.emulate)
     banner = [pwndbg.ui.banner("disasm", target=target, width=width, extra=info)]

--- a/pwndbg/gdblib/arch.py
+++ b/pwndbg/gdblib/arch.py
@@ -41,6 +41,29 @@ pwnlib_archs_mapping = {
     "rv64": "riscv64",
 }
 
+def read_thumb_bit() -> int | None:
+    """
+    Return 0 or 1, representing the status of the Thumb bit in the current Arm architecture
+    
+    Return None if the Thumb bit is not relevent to the current architecture
+    """
+    if pwndbg.gdblib.arch.current == "arm":
+        # When program initially starts, cpsr may not be readable
+        cpsr = pwndbg.gdblib.regs.cpsr
+        if cpsr is not None:
+            return (cpsr >> 5) & 1
+    elif pwndbg.gdblib.arch.current == "armcm":
+        # ARM Cortex-M procesors only suport Thumb mode. However, there is still a bit
+        # that represents the Thumb mode (which is currently architecturally defined to be 1)
+        xpsr = pwndbg.gdblib.regs.xpsr
+        if xpsr is not None:
+            return (xpsr >> 24) & 1
+    # AArch64 does not have a Thumb bit
+    return None
+
+def get_thumb_mode_string() -> Literal["arm","thumb"] | None:
+    thumb_bit = read_thumb_bit()
+    return None if thumb_bit == None else "thumb" if thumb_bit == 1 else "arm"
 
 arch = Arch("i386", typeinfo.ptrsize, "little")
 
@@ -85,5 +108,6 @@ def _get_arch(ptrsize: int):
 def update() -> None:
     arch_name, ptrsize, endian = _get_arch(typeinfo.ptrsize)
     arch.update(arch_name, ptrsize, endian)
+    arch.mode = get_thumb_mode_string()
     pwnlib.context.context.arch = pwnlib_archs_mapping[arch_name]
     pwnlib.context.context.bits = ptrsize * 8

--- a/pwndbg/gdblib/arch.py
+++ b/pwndbg/gdblib/arch.py
@@ -50,7 +50,6 @@ def read_thumb_bit() -> int | None:
     """
     if pwndbg.gdblib.arch.current == "arm":
         # When program initially starts, cpsr may not be readable
-        cpsr = pwndbg.gdblib.regs.cpsr
         if (cpsr := pwndbg.gdblib.regs.cpsr) is not None:
             return (cpsr >> 5) & 1
     elif pwndbg.gdblib.arch.current == "armcm":

--- a/pwndbg/gdblib/arch.py
+++ b/pwndbg/gdblib/arch.py
@@ -56,8 +56,7 @@ def read_thumb_bit() -> int | None:
     elif pwndbg.gdblib.arch.current == "armcm":
         # ARM Cortex-M procesors only suport Thumb mode. However, there is still a bit
         # that represents the Thumb mode (which is currently architecturally defined to be 1)
-        xpsr = pwndbg.gdblib.regs.xpsr
-        if xpsr is not None:
+        if (xpsr := pwndbg.gdblib.regs.xpsr) is not None:
             return (xpsr >> 24) & 1
     # AArch64 does not have a Thumb bit
     return None

--- a/pwndbg/gdblib/arch.py
+++ b/pwndbg/gdblib/arch.py
@@ -51,7 +51,7 @@ def read_thumb_bit() -> int | None:
     if pwndbg.gdblib.arch.current == "arm":
         # When program initially starts, cpsr may not be readable
         cpsr = pwndbg.gdblib.regs.cpsr
-        if cpsr is not None:
+        if (cpsr := pwndbg.gdblib.regs.cpsr) is not None:
             return (cpsr >> 5) & 1
     elif pwndbg.gdblib.arch.current == "armcm":
         # ARM Cortex-M procesors only suport Thumb mode. However, there is still a bit

--- a/pwndbg/gdblib/arch.py
+++ b/pwndbg/gdblib/arch.py
@@ -41,10 +41,11 @@ pwnlib_archs_mapping = {
     "rv64": "riscv64",
 }
 
+
 def read_thumb_bit() -> int | None:
     """
     Return 0 or 1, representing the status of the Thumb bit in the current Arm architecture
-    
+
     Return None if the Thumb bit is not relevent to the current architecture
     """
     if pwndbg.gdblib.arch.current == "arm":
@@ -61,9 +62,11 @@ def read_thumb_bit() -> int | None:
     # AArch64 does not have a Thumb bit
     return None
 
-def get_thumb_mode_string() -> Literal["arm","thumb"] | None:
+
+def get_thumb_mode_string() -> Literal["arm", "thumb"] | None:
     thumb_bit = read_thumb_bit()
-    return None if thumb_bit == None else "thumb" if thumb_bit == 1 else "arm"
+    return None if thumb_bit is None else "thumb" if thumb_bit == 1 else "arm"
+
 
 arch = Arch("i386", typeinfo.ptrsize, "little")
 

--- a/pwndbg/gdblib/disasm/arm.py
+++ b/pwndbg/gdblib/disasm/arm.py
@@ -30,10 +30,10 @@ class DisassemblyAssistant(pwndbg.gdblib.disasm.arch.DisassemblyAssistant):
             else pwndbg.gdblib.regs.xpsr
         )
 
-        N = value & (1 << 31)
-        Z = value & (1 << 30)
-        C = value & (1 << 29)
-        V = value & (1 << 28)
+        N = (value >> 31) & 1
+        Z = (value >> 30) & 1
+        C = (value >> 29) & 1
+        V = (value >> 28) & 1
 
         cc = {
             ARM_CC_EQ: Z,
@@ -56,6 +56,17 @@ class DisassemblyAssistant(pwndbg.gdblib.disasm.arch.DisassemblyAssistant):
             return InstructionCondition.UNDETERMINED
 
         return InstructionCondition.TRUE if bool(cc) else InstructionCondition.FALSE
+
+    @override
+    def _resolve_target(self, instruction: PwndbgInstruction, emu: Emulator | None, call=False):
+        target = super()._resolve_target(instruction, emu, call)
+        if target is not None:
+            # On interworking branches - branches that can enable Thumb mode - the target of a jump
+            # has the least significant bit set to 1. This is not actually written to the PC
+            # and instead the CPU puts it into the Thumb mode register bit.
+            # This means we can clear the least significant bit of the target.
+            target = target & ~1
+        return target
 
     @override
     def _memory_string(self, instruction: PwndbgInstruction, op: EnhancedOperand) -> str:

--- a/pwndbg/gdblib/disasm/arm.py
+++ b/pwndbg/gdblib/disasm/arm.py
@@ -64,7 +64,7 @@ class DisassemblyAssistant(pwndbg.gdblib.disasm.arch.DisassemblyAssistant):
             # On interworking branches - branches that can enable Thumb mode - the target of a jump
             # has the least significant bit set to 1. This is not actually written to the PC
             # and instead the CPU puts it into the Thumb mode register bit.
-            # This means we can clear the least significant bit of the target.
+            # This means we have to clear the least significant bit of the target.
             target = target & ~1
         return target
 

--- a/pwndbg/lib/arch.py
+++ b/pwndbg/lib/arch.py
@@ -11,8 +11,8 @@ FMT_BIG_ENDIAN = {1: "B", 2: ">H", 4: ">I", 8: ">Q"}
 class Arch:
     def __init__(self, arch_name: str, ptrsize: int, endian: Literal["little", "big"]) -> None:
         self.update(arch_name, ptrsize, endian)
-
         self.native_endian = str(sys.byteorder)
+        self.mode: Literal["arm","thumb"] | None = None
 
     def update(self, arch_name: str, ptrsize: int, endian: Literal["little", "big"]) -> None:
         self.name = arch_name

--- a/pwndbg/lib/arch.py
+++ b/pwndbg/lib/arch.py
@@ -12,7 +12,7 @@ class Arch:
     def __init__(self, arch_name: str, ptrsize: int, endian: Literal["little", "big"]) -> None:
         self.update(arch_name, ptrsize, endian)
         self.native_endian = str(sys.byteorder)
-        self.mode: Literal["arm","thumb"] | None = None
+        self.mode: Literal["arm", "thumb"] | None = None
 
     def update(self, arch_name: str, ptrsize: int, endian: Literal["little", "big"]) -> None:
         self.name = arch_name


### PR DESCRIPTION
This PR adds text to the context banner in Arm32 indicating whether it is currently in Arm or Thumb mode

Arm mode:
![arm_mode](https://github.com/pwndbg/pwndbg/assets/55004530/6c11897b-fa99-4dcf-bdca-a2ced7a6616e)

Thumb mode:
![arm_mode_thumb](https://github.com/pwndbg/pwndbg/assets/55004530/ec38c868-0776-4a0f-82ac-ddf575f22539)

The double `arm` in arm mode is a little strange - so if there are suggestions on other ways to display this, please let me know.

Related issue: #292