### PR TITLE
Improve unsorted,small,large bins corruption check

### DIFF
--- a/pwndbg/gdblib/heap/__init__.py
+++ b/pwndbg/gdblib/heap/__init__.py
@@ -52,8 +52,8 @@ heap_chain_limit = add_heap_param(
     "heap-dereference-limit", 8, "number of chunks to dereference in each bin"
 )
 
-heap_corruption_check_limit = add_heap_param("heap-corruption-check-limit", 64, "lenght limit for bins which are fully checked for corruption")
-heap_corruption_check_limit += 1 # Make sure bins that are of default length are checked
+heap_corruption_check_limit = add_heap_param("heap-corruption-check-limit", 64, "amount of chunks to traverse (forwards and backwards) for the bin corruption check")
+heap_corruption_check_limit += 1 # Make sure that bins that have the default amount of chunks (64) are fully traversed
 
 resolve_heap_via_heuristic = add_heap_param(
     "resolve-heap-via-heuristic",

--- a/pwndbg/gdblib/heap/__init__.py
+++ b/pwndbg/gdblib/heap/__init__.py
@@ -52,6 +52,9 @@ heap_chain_limit = add_heap_param(
     "heap-dereference-limit", 8, "number of chunks to dereference in each bin"
 )
 
+heap_corruption_check_limit = add_heap_param("heap-corruption-check-limit", 64, "lenght limit for bins which are fully checked for corruption")
+heap_corruption_check_limit += 1 # Make sure bins that are of default length are checked
+
 resolve_heap_via_heuristic = add_heap_param(
     "resolve-heap-via-heuristic",
     "auto",

--- a/pwndbg/gdblib/heap/__init__.py
+++ b/pwndbg/gdblib/heap/__init__.py
@@ -52,8 +52,13 @@ heap_chain_limit = add_heap_param(
     "heap-dereference-limit", 8, "number of chunks to dereference in each bin"
 )
 
-heap_corruption_check_limit = add_heap_param("heap-corruption-check-limit", 64, "amount of chunks to traverse (forwards and backwards) for the bin corruption check")
-heap_corruption_check_limit += 1 # Make sure that bins that have the default amount of chunks (64) are fully traversed
+heap_corruption_check_limit = add_heap_param(
+    "heap-corruption-check-limit",
+    64,
+    "amount of chunks to traverse (forwards and backwards) for the bin corruption check",
+)
+# Make sure that bins that have the default amount of chunks (64) are fully traversed
+heap_corruption_check_limit += 1
 
 resolve_heap_via_heuristic = add_heap_param(
     "resolve-heap-via-heuristic",

--- a/pwndbg/gdblib/heap/__init__.py
+++ b/pwndbg/gdblib/heap/__init__.py
@@ -57,8 +57,6 @@ heap_corruption_check_limit = add_heap_param(
     64,
     "amount of chunks to traverse (forwards and backwards) for the bin corruption check",
 )
-# Make sure that bins that have the default amount of chunks (64) are fully traversed
-heap_corruption_check_limit += 1
 
 resolve_heap_via_heuristic = add_heap_param(
     "resolve-heap-via-heuristic",

--- a/pwndbg/gdblib/heap/ptmalloc.py
+++ b/pwndbg/gdblib/heap/ptmalloc.py
@@ -1282,7 +1282,7 @@ class GlibcMemoryAllocator(pwndbg.gdblib.heap.heap.MemoryAllocator, Generic[TheT
                 return True
             else:
                 bin_chk = Chunk(chain_fd[0])
-                if not(bin_chk.fd == bin_chk.bk == chain_fd[0]):
+                if not (bin_chk.fd == bin_chk.bk == chain_fd[0]):
                     return True
 
         else:
@@ -1341,9 +1341,6 @@ class GlibcMemoryAllocator(pwndbg.gdblib.heap.heap.MemoryAllocator, Generic[TheT
         if arena is None:
             return None
 
-        if index != 0:
-            return None
-
         normal_bins = arena._gdbValue["bins"]  # Breaks encapsulation, find a better way.
 
         bins_base = int(normal_bins.address) - (pwndbg.gdblib.arch.ptrsize * 2)
@@ -1366,10 +1363,10 @@ class GlibcMemoryAllocator(pwndbg.gdblib.heap.heap.MemoryAllocator, Generic[TheT
 
         full_chain_fd = get_chain(front, fd_offset)
         full_chain_bk = get_chain(back, bk_offset)
-        chain_fd = full_chain_fd[:(chain_size + 1)]
-        chain_bk = full_chain_bk[:(chain_size + 1)]
-        corrupt_chain_fd = full_chain_fd[:(corrupt_chain_size + 1)]
-        corrupt_chain_bk = full_chain_bk[:(corrupt_chain_size + 1)]
+        chain_fd = full_chain_fd[: (chain_size + 1)]
+        chain_bk = full_chain_bk[: (chain_size + 1)]
+        corrupt_chain_fd = full_chain_fd[: (corrupt_chain_size + 1)]
+        corrupt_chain_bk = full_chain_bk[: (corrupt_chain_size + 1)]
 
         is_chain_corrupted = self.check_chain_corrupted(corrupt_chain_fd, corrupt_chain_bk)
 

--- a/pwndbg/gdblib/heap/ptmalloc.py
+++ b/pwndbg/gdblib/heap/ptmalloc.py
@@ -1304,7 +1304,7 @@ class GlibcMemoryAllocator(pwndbg.gdblib.heap.heap.MemoryAllocator, Generic[TheT
             is_chain_corrupted = True
         elif len(chain_fd) < 2 or len(chain_bk) < 2:
             # Chains containing less than two entries are corrupted, as the smallest
-            # chain (an empty bin) would look like something like `[main_arena+88, 0]`.
+            # chain (an empty bin) would look something like `[main_arena+88, 0]`.
             is_chain_corrupted = True
         elif len(chain_fd) == len(chain_bk) == 2 and chain_fd == chain_bk and chain_fd[-1] == 0:
             # Check if bin[index] points to itself (is empty)

--- a/pwndbg/gdblib/heap/ptmalloc.py
+++ b/pwndbg/gdblib/heap/ptmalloc.py
@@ -1354,8 +1354,8 @@ class GlibcMemoryAllocator(pwndbg.gdblib.heap.heap.MemoryAllocator, Generic[TheT
         fd_offset = self.chunk_key_offset("fd")
         bk_offset = self.chunk_key_offset("bk")
 
-        chain_size = pwndbg.gdblib.heap.heap_chain_limit
-        corrupt_chain_size = pwndbg.gdblib.heap.heap_corruption_check_limit
+        chain_size = int(pwndbg.gdblib.heap.heap_chain_limit)
+        corrupt_chain_size = int(pwndbg.gdblib.heap.heap_corruption_check_limit)
 
         get_chain = lambda bin, offset: pwndbg.chain.get(
             int(bin),

--- a/pwndbg/gdblib/heap/ptmalloc.py
+++ b/pwndbg/gdblib/heap/ptmalloc.py
@@ -1265,9 +1265,6 @@ class GlibcMemoryAllocator(pwndbg.gdblib.heap.heap.MemoryAllocator, Generic[TheT
         Returns True if corruption is provable, otherwise False.
         """
 
-        print(f"chain_fd({len(chain_fd)}): {chain_fd}")
-        print(f"chain_bk({len(chain_bk)}): {chain_bk}")
-
         if len(chain_fd) != len(chain_bk):
             # If the chain lengths aren't equal, the chain is corrupted
             # The vast majority of corruptions will be caught here
@@ -1318,7 +1315,6 @@ class GlibcMemoryAllocator(pwndbg.gdblib.heap.heap.MemoryAllocator, Generic[TheT
                     return True
 
         return False
-
 
     def bin_at(
         self, index: int, arena_addr: int | None = None
@@ -1376,6 +1372,10 @@ class GlibcMemoryAllocator(pwndbg.gdblib.heap.heap.MemoryAllocator, Generic[TheT
         corrupt_chain_bk = full_chain_bk[:(corrupt_chain_size + 1)]
 
         is_chain_corrupted = self.check_chain_corrupted(corrupt_chain_fd, corrupt_chain_bk)
+
+        if not is_chain_corrupted and len(chain_fd) == len(chain_bk) == 2:
+            chain_fd = [0]
+            chain_bk = [0]
 
         return (chain_fd, chain_bk, is_chain_corrupted)
 

--- a/tests/gdb-tests/tests/heap/test_heap_bins.py
+++ b/tests/gdb-tests/tests/heap/test_heap_bins.py
@@ -486,3 +486,26 @@ def test_smallbins_sizes_32bit_big(start_binary):
 
     for bin_index, bin_size in enumerate(command_output):
         assert bin_size.split(":")[0] == expected[bin_index]
+
+def test_heap_corruption_low_dereference(start_binary):
+    """
+    Tests that the bins corruption check doesn't report
+    corrupted bins when heap-dereference-limit is less
+    than the number of chunks in a bin.
+    """
+
+    start_binary(BINARY)
+    gdb.execute("set context-output /dev/null")
+    gdb.execute("b breakpoint", to_string=True)
+
+    gdb.execute("continue")
+    gdb.execute("continue")
+    gdb.execute("continue")
+    gdb.execute("continue")
+
+    # unsorted bin now has 3 chunks
+
+    gdb.execute("set heap-dereference-limit 1")
+
+    bins_output = gdb.execute("bins", to_string=True)
+    assert("corrupted" not in bins_output)

--- a/tests/gdb-tests/tests/heap/test_heap_bins.py
+++ b/tests/gdb-tests/tests/heap/test_heap_bins.py
@@ -487,6 +487,7 @@ def test_smallbins_sizes_32bit_big(start_binary):
     for bin_index, bin_size in enumerate(command_output):
         assert bin_size.split(":")[0] == expected[bin_index]
 
+
 def test_heap_corruption_low_dereference(start_binary):
     """
     Tests that the bins corruption check doesn't report
@@ -508,4 +509,4 @@ def test_heap_corruption_low_dereference(start_binary):
     gdb.execute("set heap-dereference-limit 1")
 
     bins_output = gdb.execute("bins", to_string=True)
-    assert("corrupted" not in bins_output)
+    assert "corrupted" not in bins_output


### PR DESCRIPTION
Closes https://github.com/pwndbg/pwndbg/issues/1196 and Closes https://github.com/pwndbg/pwndbg/issues/2287.
This PR is based off of https://github.com/pwndbg/pwndbg/pull/1564.
+ Added a new heap parameter: `heap_corruption_check_limit` which states for how many chunks the corruption check is done
+ As opposed to the previous PR, every chunk has its fd/bk pointers checked instead of comparing the two lists. This results in more thorough checking when the forward and backward lists do not overlap fully.
+ `heap_corruption_check_limit` is allowed to have both a lower and a higher value than `heap-dereference-limit` which means the name "heap-dereference-limit" isn't really fitting anymore, but okay

Note:
`heap-dereference-limit` isn't really properly handled when its negative (pwndbg crashes) or zero, gdb defaults to this message when its set to zero:
```bash
pwndbg> set heap-dereference-limit 0
Set number of chunks to dereference in each bin to 'unlimited'.
``` 
but thats not actually what happens, as one chunk is printed. I set it so that `heap_corruption_check_limit` acts similarly i.e. no corruption check is done when it's set to zero. This has the unfortunate consequence that when `heap_corruption_check_limit` is set to zero, and the bin arena pointers are 0x0 (corrupted), the bin reads as "empty". I'd say this is moreso a logic error in the function that calls bin_at but whatever.

I generally tried to make it so that both parameters don't freak out when they have weird values.