### PR TITLE
Arm Thumb Instruction Set support with Unicorn + Capstone

### DIFF
--- a/pwndbg/emu/emulator.py
+++ b/pwndbg/emu/emulator.py
@@ -688,7 +688,7 @@ class Emulator:
         ident = self.hook_add(U.UC_HOOK_CODE, hook)
 
         pc: int = self.pc
-        if (thumb_bit := self.read_thumb_bit()):
+        if thumb_bit := self.read_thumb_bit():
             # Unicorn disregards the UC_MODE_THUMB mode passed into the constructor, and instead
             # determines Thumb mode based on the PC that is passed to the `emu_start` function
             # https://github.com/unicorn-engine/unicorn/issues/391

--- a/pwndbg/emu/emulator.py
+++ b/pwndbg/emu/emulator.py
@@ -539,10 +539,10 @@ class Emulator:
 
         Mimics the `read_thumb_bit` function defined in gdblib/arch.py
         """
-        if pwndbg.gdblib.arch.current == "arm":
+        if self.arch == "arm":
             if (cpsr := self.cpsr) is not None:
                 return (cpsr >> 5) & 1
-        elif pwndbg.gdblib.arch.current == "armcm":
+        elif self.arch == "armcm":
             if (xpsr := self.xpsr) is not None:
                 return (xpsr >> 24) & 1
         return None

--- a/pwndbg/emu/emulator.py
+++ b/pwndbg/emu/emulator.py
@@ -528,6 +528,25 @@ class Emulator:
             pc = pwndbg.gdblib.regs.pc
         self.uc.reg_write(self.get_reg_enum(self.regs.pc), pc)
 
+    def read_thumb_bit(self) -> int | None:
+        """
+        Return 0 or 1, representing the status of the Thumb bit in the current Arm architecture
+
+        This reads from the emulator itself, meaning this can be read to determine a state
+        transitions between non-Thumb and Thumb mode
+
+        Return None if the Thumb bit is not relevent to the current architecture
+
+        Mimics the `read_thumb_bit` function defined in gdblib/arch.py
+        """
+        if pwndbg.gdblib.arch.current == "arm":
+            if (cpsr := self.cpsr) is not None:
+                return (cpsr >> 5) & 1
+        elif pwndbg.gdblib.arch.current == "armcm":
+            if (xpsr := self.xpsr) is not None:
+                return (xpsr >> 24) & 1
+        return None
+
     def get_uc_mode(self):
         """
         Retrieve the mode used by Unicorn for the current architecture.
@@ -667,8 +686,21 @@ class Emulator:
 
     def emulate_with_hook(self, hook, count=512) -> None:
         ident = self.hook_add(U.UC_HOOK_CODE, hook)
+
+        pc: int = self.pc
+        if (thumb_bit := self.read_thumb_bit()):
+            # Unicorn disregards the UC_MODE_THUMB mode passed into the constructor, and instead
+            # determines Thumb mode based on the PC that is passed to the `emu_start` function
+            # https://github.com/unicorn-engine/unicorn/issues/391
+            #
+            # Because we single-step the emulator, we always have to read the Thumb bit from the emulator
+            # and set the least significant bit of the PC to 1 if the bit is 1 in order to enable Thumb mode
+            # for the execution of the next instruction. If this `emulate_with_hook` executes multiple instructions
+            # which have Thumb mode transitions, Unicorn will internally handle them.
+            pc |= thumb_bit
+
         try:
-            self.emu_start(self.pc, 0, count=count)
+            self.emu_start(pc, 0, count=count)
         finally:
             self.hook_del(ident)
 

--- a/pwndbg/emu/emulator.py
+++ b/pwndbg/emu/emulator.py
@@ -689,7 +689,7 @@ class Emulator:
 
         pc: int = self.pc
         if thumb_bit := self.read_thumb_bit():
-            # Unicorn disregards the UC_MODE_THUMB mode passed into the constructor, and instead
+            # Unicorn appears to disregard the UC_MODE_THUMB mode passed into the constructor, and instead
             # determines Thumb mode based on the PC that is passed to the `emu_start` function
             # https://github.com/unicorn-engine/unicorn/issues/391
             #

--- a/pwndbg/gdblib/disasm/__init__.py
+++ b/pwndbg/gdblib/disasm/__init__.py
@@ -122,7 +122,7 @@ computed_instruction_cache: DefaultDict[int, PwndbgInstruction] = collections.de
 
 # Maps an address to integer 0/1, indicating the Thumb mode bit for the given address.
 # Value is None if Thumb bit irrelevent or unknown.
-emulated_arm_mode_cache: DefaultDict[int,int] = collections.defaultdict(collections.defaultdict(lambda: None))
+emulated_arm_mode_cache: DefaultDict[int,int] = collections.defaultdict(lambda: None)
 
 
 @pwndbg.lib.cache.cache_until("objfile")
@@ -420,6 +420,9 @@ def near(
             if not emu.last_step_succeeded or not emu.valid:
                 emu = None
             else:
+                # Upon execution the previous instruction, the Thumb mode bit may have changed.
+                # This means we know whether the next instruction executed will be Thumb or not.
+                # This returns None in the case the Thumb bit is not relevent.
                 emulated_arm_mode_cache[emu.pc] = emu.read_thumb_bit()
 
         # Handle visual splits in the disasm view

--- a/pwndbg/gdblib/disasm/__init__.py
+++ b/pwndbg/gdblib/disasm/__init__.py
@@ -155,16 +155,16 @@ def get_disassembler_cached(arch, ptrsize: int, endian, extra=None):
 
 def get_disassembler(address):
     if pwndbg.gdblib.arch.current == "armcm":
-        thumb_mode = bool(emulated_arm_mode_cache[address])
+        thumb_mode = emulated_arm_mode_cache[address]
         if thumb_mode is None:
-            thumb_mode = bool(pwndbg.gdblib.regs.xpsr & (1 << 24))
+            thumb_mode = pwndbg.gdblib.regs.xpsr & (1 << 24)
         # novermin
         extra = (CS_MODE_MCLASS | CS_MODE_THUMB) if thumb_mode else CS_MODE_MCLASS
 
     elif pwndbg.gdblib.arch.current in ("arm", "aarch64"):
-        thumb_mode = bool(emulated_arm_mode_cache[address])
+        thumb_mode = emulated_arm_mode_cache[address]
         if thumb_mode is None:
-            thumb_mode = bool(pwndbg.gdblib.regs.cpsr & (1 << 5))
+            thumb_mode = pwndbg.gdblib.regs.cpsr & (1 << 5)
         extra = CS_MODE_THUMB if thumb_mode else CS_MODE_ARM
 
     elif pwndbg.gdblib.arch.current == "sparc":

--- a/pwndbg/gdblib/disasm/__init__.py
+++ b/pwndbg/gdblib/disasm/__init__.py
@@ -122,7 +122,7 @@ computed_instruction_cache: DefaultDict[int, PwndbgInstruction] = collections.de
 
 # Maps an address to integer 0/1, indicating the Thumb mode bit for the given address.
 # Value is None if Thumb bit irrelevent or unknown.
-emulated_arm_mode_cache: DefaultDict[int,int] = collections.defaultdict(lambda: None)
+emulated_arm_mode_cache: DefaultDict[int, int] = collections.defaultdict(lambda: None)
 
 
 @pwndbg.lib.cache.cache_until("objfile")
@@ -159,11 +159,7 @@ def get_disassembler(address):
         if thumb_mode is None:
             thumb_mode = bool(pwndbg.gdblib.regs.xpsr & (1 << 24))
         # novermin
-        extra = (
-            (CS_MODE_MCLASS | CS_MODE_THUMB)
-            if thumb_mode
-            else CS_MODE_MCLASS
-        )
+        extra = (CS_MODE_MCLASS | CS_MODE_THUMB) if thumb_mode else CS_MODE_MCLASS
 
     elif pwndbg.gdblib.arch.current in ("arm", "aarch64"):
         thumb_mode = bool(emulated_arm_mode_cache[address])


### PR DESCRIPTION
This PR adds support for Thumb-mode in Arm in the disasm view, allowing the Unicorn emulator to execute Thumb instructions, and allowing the Capstone disassembler to switch between Arm/Thumb mode while disassembling for the disasm view.

The 32-bit Arm execution state supports two architectures - Arm (A32) and Thumb (T32). Programs can freely switch between these two architectures through `interworking`, which simply means to write to the least-significant-bit of the program counter to change between Thumb and non-Thumb mode. The bit is not actually written to the PC in the hardware, and instead is directed to a bit in the CPSR flags register.

A32 mode solely consists of 4-byte instructions. Thumb (T32) mode has a completely different instruction set, which has a mix of 2 and 4 byte instructions. The Armv8-M profile (which the ARM Cortex-M series of CPU's use) executes solely in Thumb mode.

Previously, our use of the Unicorn emulator wasn't able to execute Thumb instructions, and it instead interpreted all instructions as A32 instructions. In order to use Thumb mode in Unicorn, turns out you have to set the least-significant-bit of the PC to 1 every time you start the emulator and want it to be in Thumb mode: https://github.com/unicorn-engine/unicorn/issues/391. There's a comment in the code further explaining this. This is now corrected and Thumb mode instructions are executed correctly.

To make the context display Thumb instructions correctly, we have to line up the Capstone disassembler with the emulation, so that the disassembler is aware that the emulator switched the Thumb mode and starts disassembling future instructions in the correct architecture.

The following are screenshots of a 4 instructions Arm program. Halfway through, the program set itself to Thumb mode (starting at instruction 3, we are in Thumb mode)

## Old:
We start in A32 mode, and the emulator and disassembler incorrectly interprets all future instructions as A32
![old_arm_thumb_disasm_broken](https://github.com/pwndbg/pwndbg/assets/55004530/beddf159-2185-428f-9309-90d10fb16594)

The program is in Thumb mode, and the disassembler sees this, but the Unicorn emulator, unable to execute T32 instructions, still thinks we are in A32 mode, thus the instructions all being 4-bytes apart since we use the emulator PC to determine the `next instruction`. The disassembler and Unicorn are not synced.
![thumb_mode_old_unicorn](https://github.com/pwndbg/pwndbg/assets/55004530/db37bce6-fe38-45e3-bc88-6c4e21d90740)

## New:
We start in A32 mode, and Unicorn and Capstone are synced in the transition to T32 mode.
![thumb_support_unicorn_capstone](https://github.com/pwndbg/pwndbg/assets/55004530/f1865869-331f-4b1b-9417-54d85bb86913)

![new_thumb_mode_unicorn](https://github.com/pwndbg/pwndbg/assets/55004530/664d42cf-2252-47ed-b0e8-cb266f29fb70)




