### PR TITLE
Remove unused reference arch.mode

### DIFF
--- a/pwndbg/gdblib/arch.py
+++ b/pwndbg/gdblib/arch.py
@@ -109,6 +109,5 @@ def _get_arch(ptrsize: int):
 def update() -> None:
     arch_name, ptrsize, endian = _get_arch(typeinfo.ptrsize)
     arch.update(arch_name, ptrsize, endian)
-    arch.mode = get_thumb_mode_string()
     pwnlib.context.context.arch = pwnlib_archs_mapping[arch_name]
     pwnlib.context.context.bits = ptrsize * 8

--- a/pwndbg/lib/arch.py
+++ b/pwndbg/lib/arch.py
@@ -12,7 +12,6 @@ class Arch:
     def __init__(self, arch_name: str, ptrsize: int, endian: Literal["little", "big"]) -> None:
         self.update(arch_name, ptrsize, endian)
         self.native_endian = str(sys.byteorder)
-        self.mode: Literal["arm", "thumb"] | None = None
 
     def update(self, arch_name: str, ptrsize: int, endian: Literal["little", "big"]) -> None:
         self.name = arch_name


### PR DESCRIPTION
This PR removes an unused reference to `arch.mode` which was introduced in a recent PR.