### PR TITLE
Use os._exit() to propagate return code in tests

### DIFF
--- a/gdbinit.py
+++ b/gdbinit.py
@@ -165,7 +165,8 @@ def main() -> None:
         venv_path = get_venv_path(src_root)
         if not venv_path.exists():
             print(f"Cannot find Pwndbg virtualenv directory: {venv_path}. Please re-run setup.sh")
-            sys.exit(1)
+            sys.stdout.flush()
+            os._exit(1)
 
         update_deps(src_root, venv_path)
         fixup_paths(src_root, venv_path)
@@ -203,4 +204,5 @@ try:
 
 except Exception:
     print(traceback.format_exc(), file=sys.stderr)
-    sys.exit(1)
+    sys.stdout.flush()
+    os._exit(1)

--- a/tests/gdb-tests/pytests_collect.py
+++ b/tests/gdb-tests/pytests_collect.py
@@ -24,7 +24,8 @@ rv = pytest.main(["--collect-only", TESTS_PATH], plugins=[collector])
 
 if rv == pytest.ExitCode.INTERRUPTED:
     print("Failed to collect all tests, perhaps there is a syntax error in one of test files?")
-    sys.exit(1)
+    sys.stdout.flush()
+    os._exit(1)
 
 
 print("Listing collected tests:")
@@ -32,4 +33,5 @@ for nodeid in collector.collected:
     print("Test:", nodeid)
 
 # easy way to exit GDB session
-sys.exit(0)
+sys.stdout.flush()
+os._exit(0)

--- a/tests/qemu-tests/pytests_collect.py
+++ b/tests/qemu-tests/pytests_collect.py
@@ -24,7 +24,8 @@ rv = pytest.main(["--collect-only", TESTS_PATH], plugins=[collector])
 
 if rv == pytest.ExitCode.INTERRUPTED:
     print("Failed to collect all tests, perhaps there is a syntax error in one of test files?")
-    sys.exit(1)
+    sys.stdout.flush()
+    os._exit(1)
 
 
 print("Listing collected tests:")


### PR DESCRIPTION
This PR fixes #2247 by replacing calls to `sys.exit` within the scope of our testing files to `os._exit`. To ensure that all print statements are flushed to `stdout`, a call to `sys.stdout.flush()` is placed before such calls.