### PR TITLE
Fix race condition in test_loads.py

### DIFF
--- a/tests/gdb-tests/tests/test_loads.py
+++ b/tests/gdb-tests/tests/test_loads.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import os
 import re
-
 import threading
 
 import tests
@@ -39,6 +38,7 @@ def _helper_create_corefile():
             create_coredump = ["run", f"generate-core-file {CORE}"]
             run_gdb_with_script(binary=BINARY, pyafter=create_coredump)
             assert os.path.isfile(CORE)
+
 
 def test_loads_binary_with_core_without_crashing():
     _helper_create_corefile()


### PR DESCRIPTION
`test_loads_binary_with_core_without_crashing` and `test_loads_core_without_crashing` use the same corefile and may run in parallel, which can cause one of the tests to run with a partially written corefile and sporadically fail.

~~This PR adds a lock to the corefile generation so that can't happen.~~ This won't work because the tests are run in different processes. The PR now combines both tests into one so that they're run serially, which lowers the descriptiveness of the test names a bit, but [file locks suck for a variety of reasons](https://0pointer.de/blog/projects/locking.html), so I would rather not go that route.
