### PR TITLE
Add register value retrieval to Debugger-agnostic API and extra register check to Pwndbg command handler

### DIFF
--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -239,6 +239,13 @@ def fix(
         pass
 
     try:
+        # This will fail if gdblib is not available. While the next check
+        # alleviates the need for this call, it's not really equivalent, and
+        # we'll need a debugger-agnostic version of regs.fix() if we want to
+        # completely get rid of this call. We can't do that now because there's
+        # no debugger-agnostic architecture functions. Those will come later.
+        #
+        # TODO: Port architecutre functions and `pwndbg.gdblib.regs.fix` to debugger-agnostic API and remove this.
         arg = pwndbg.gdblib.regs.fix(arg)
         return target.evaluate_expression(arg)
     except Exception as e:
@@ -248,6 +255,7 @@ def fix(
     # see if that yields anything.
     if frame:
         regs = frame.regs()
+        arg = arg.strip()
         if arg.startswith("$"):
             arg = arg[1:]
         reg = regs.by_name(arg)

--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -232,12 +232,12 @@ def fix(
 
     # Try to evaluate the expression in the local, or, failing that, global
     # context.
-    ex = None
     try:
         return target.evaluate_expression(arg)
     except Exception:
         pass
 
+    ex = None
     try:
         # This will fail if gdblib is not available. While the next check
         # alleviates the need for this call, it's not really equivalent, and

--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -258,9 +258,9 @@ def fix(
     # might've gotten from `evaluate_expression`.
     if ex:
         if not quiet:
-            print(e)
+            print(ex)
         if reraise:
-            raise e
+            raise ex
 
     if sloppy:
         return arg

--- a/pwndbg/dbg/__init__.py
+++ b/pwndbg/dbg/__init__.py
@@ -12,15 +12,18 @@ from typing import Tuple
 
 dbg: Debugger = None
 
+
 class Registers:
     """
     A handle to the register values in a frame.
     """
+
     def by_name(self, name: str) -> Value | None:
         """
         Gets the value of a register if it exists, None otherwise.
         """
         raise NotImplementedError()
+
 
 class Frame:
     def evaluate_expression(self, expression: str) -> Value:
@@ -36,12 +39,14 @@ class Frame:
         """
         raise NotImplementedError()
 
+
 class Thread:
     def bottom_frame(self) -> Frame:
         """
         Frame at the bottom of the call stack for this thread.
         """
         raise NotImplementedError()
+
 
 class Process:
     def threads(self) -> List[Thread]:

--- a/pwndbg/dbg/__init__.py
+++ b/pwndbg/dbg/__init__.py
@@ -12,6 +12,15 @@ from typing import Tuple
 
 dbg: Debugger = None
 
+class Registers:
+    """
+    A handle to the register values in a frame.
+    """
+    def by_name(self, name: str) -> Value | None:
+        """
+        Gets the value of a register if it exists, None otherwise.
+        """
+        raise NotImplementedError()
 
 class Frame:
     def evaluate_expression(self, expression: str) -> Value:
@@ -21,6 +30,11 @@ class Frame:
         """
         raise NotImplementedError()
 
+    def regs(self) -> Registers:
+        """
+        Access the values of the registers in this frame.
+        """
+        raise NotImplementedError()
 
 class Thread:
     def bottom_frame(self) -> Frame:
@@ -28,7 +42,6 @@ class Thread:
         Frame at the bottom of the call stack for this thread.
         """
         raise NotImplementedError()
-
 
 class Process:
     def threads(self) -> List[Thread]:

--- a/pwndbg/dbg/gdb.py
+++ b/pwndbg/dbg/gdb.py
@@ -16,6 +16,18 @@ from pwndbg.commands import load_commands
 from pwndbg.gdblib import gdb_version
 from pwndbg.gdblib import load_gdblib
 
+class GDBRegisters(pwndbg.dbg_mod.Registers):
+    def __init__(self, frame: GDBFrame):
+        self.frame = frame
+
+    @override
+    def by_name(self, name: str):
+        try:
+            return GDBValue(self.frame.inner.read_register(name))
+        except gdb.error:
+            # GDB throws an exception if the name is unknown, we just return
+            # None when that is the case.
+            pass
 
 def parse_and_eval(expression: str, global_context: bool) -> gdb.Value:
     """
@@ -49,6 +61,9 @@ class GDBFrame(pwndbg.dbg_mod.Frame):
 
         return GDBValue(value)
 
+    @override
+    def regs(self):
+        return GDBRegisters(self)
 
 class GDBThread(pwndbg.dbg_mod.Thread):
     def __init__(self, inner: gdb.InferiorThread):

--- a/pwndbg/dbg/gdb.py
+++ b/pwndbg/dbg/gdb.py
@@ -31,6 +31,7 @@ class GDBRegisters(pwndbg.dbg_mod.Registers):
             pass
         return None
 
+
 def parse_and_eval(expression: str, global_context: bool) -> gdb.Value:
     """
     Same as `gdb.parse_and_eval`, but only uses `global_context` if it is

--- a/pwndbg/dbg/gdb.py
+++ b/pwndbg/dbg/gdb.py
@@ -16,6 +16,7 @@ from pwndbg.commands import load_commands
 from pwndbg.gdblib import gdb_version
 from pwndbg.gdblib import load_gdblib
 
+
 class GDBRegisters(pwndbg.dbg_mod.Registers):
     def __init__(self, frame: GDBFrame):
         self.frame = frame
@@ -64,6 +65,7 @@ class GDBFrame(pwndbg.dbg_mod.Frame):
     @override
     def regs(self):
         return GDBRegisters(self)
+
 
 class GDBThread(pwndbg.dbg_mod.Thread):
     def __init__(self, inner: gdb.InferiorThread):

--- a/pwndbg/dbg/gdb.py
+++ b/pwndbg/dbg/gdb.py
@@ -22,13 +22,14 @@ class GDBRegisters(pwndbg.dbg_mod.Registers):
         self.frame = frame
 
     @override
-    def by_name(self, name: str):
+    def by_name(self, name: str) -> pwndbg.dbg_mod.Value | None:
         try:
             return GDBValue(self.frame.inner.read_register(name))
         except gdb.error:
             # GDB throws an exception if the name is unknown, we just return
             # None when that is the case.
             pass
+        return None
 
 def parse_and_eval(expression: str, global_context: bool) -> gdb.Value:
     """
@@ -63,7 +64,7 @@ class GDBFrame(pwndbg.dbg_mod.Frame):
         return GDBValue(value)
 
     @override
-    def regs(self):
+    def regs(self) -> pwndbg.dbg_mod.Registers:
         return GDBRegisters(self)
 
 


### PR DESCRIPTION
This PR is part of the GSoC 2024 LLDB port.

This PR adds a new class `pwndbg.dbg_mod.Registers`, which wraps the values of the set of registers for a given frame, after a given call to the newly-added `pwndbg.dbg_mod.Frame.regs()` function. This new class contains a function that allows one to query for the value of a register, given its name.

That new class is used as part of the argument parsing logic for targets that don't support `pwndbg.gdblib.regs.fix()`, and is intended for use in later providing equivalent functionality to the `pwndbg.gdblib.regs` in a debugger-agnostic form.

To choice to have it as a separate class from `pwndbg.dbg_mod.Frame` stems from the fact that LLDB's `SBFrame.GetRegisters()` function returns all registers in the frame as a bundle. So, in order to save on calls to `GetRegisters` and avoid having to delve into internal caching - which requires events, and we don't have events in LLDB yet -, we follow the design of the LLDB API. 

This choice fits GDB pretty well, too, though it does involve an extra level of indirection if all you're doing is pulling a single register directly from the debugger-agnostic API, but that can be mitigated later by using caching in our future equivalent of `pwndbg.gdblib.regs`.