### PR TITLE
Add an error type to the Debugger-agnostic API and move uses of the API to it

### DIFF
--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -17,6 +17,7 @@ from typing import TypeVar
 from typing_extensions import ParamSpec
 
 import pwndbg.exception
+
 # These aren't available under LLDB, and we can't get rid of them until all of
 # this functionality has been ported to the Debugger API.
 #
@@ -62,8 +63,7 @@ class CommandCategory(str, Enum):
     DEV = "Developer"
 
 
-assert pwndbg.dbg.session(), "Tried to set up commands with no interactive session"
-GDB_BUILTIN_COMMANDS = pwndbg.dbg.session().commands()
+GDB_BUILTIN_COMMANDS = pwndbg.dbg.commands()
 
 # Set in `reload` command so that we can skip double checking for registration
 # of an already existing command when re-registering GDB CLI commands

--- a/pwndbg/dbg/__init__.py
+++ b/pwndbg/dbg/__init__.py
@@ -282,12 +282,6 @@ class Debugger:
         """
         raise NotImplementedError()
 
-    def commands(self) -> List[str]:
-        """
-        List the commands available in this session.
-        """
-        raise NotImplementedError()
-
     def add_command(
         self, name: str, handler: Callable[[Debugger, str, bool], None]
     ) -> CommandHandle:
@@ -303,14 +297,6 @@ class Debugger:
     # pwndbg under LLDB without breaking it under GDB. Expect most of them to be
     # removed or replaced as the porting work continues.
     #
-
-    # We'd like to be able to gate some imports off during porting. This aids in
-    # that.
-    def is_gdblib_available(self) -> bool:
-        """
-        Whether gdblib is available under this debugger.
-        """
-        raise NotImplementedError()
 
     def addrsz(self, address: Any) -> str:
         """

--- a/pwndbg/dbg/__init__.py
+++ b/pwndbg/dbg/__init__.py
@@ -13,6 +13,10 @@ from typing import Tuple
 dbg: Debugger = None
 
 
+class Error(Exception):
+    pass
+
+
 class Frame:
     def evaluate_expression(self, expression: str) -> Value:
         """
@@ -28,6 +32,7 @@ class Thread:
         Frame at the bottom of the call stack for this thread.
         """
         raise NotImplementedError()
+
 
 
 class Process:
@@ -278,6 +283,12 @@ class Debugger:
         """
         raise NotImplementedError()
 
+    def commands(self) -> list[str]:
+        """
+        List the commands available in this session.
+        """
+        raise NotImplementedError()
+
     def add_command(
         self, name: str, handler: Callable[[Debugger, str, bool], None]
     ) -> CommandHandle:
@@ -293,6 +304,14 @@ class Debugger:
     # pwndbg under LLDB without breaking it under GDB. Expect most of them to be
     # removed or replaced as the porting work continues.
     #
+
+    # We'd like to be able to gate some imports off during porting. This aids in
+    # that.
+    def is_gdblib_available(self) -> bool:
+        """
+        Whether gdblib is available under this debugger.
+        """
+        raise NotImplementedError()
 
     def addrsz(self, address: Any) -> str:
         """

--- a/pwndbg/dbg/__init__.py
+++ b/pwndbg/dbg/__init__.py
@@ -34,7 +34,6 @@ class Thread:
         raise NotImplementedError()
 
 
-
 class Process:
     def threads(self) -> List[Thread]:
         """
@@ -283,7 +282,7 @@ class Debugger:
         """
         raise NotImplementedError()
 
-    def commands(self) -> list[str]:
+    def commands(self) -> List[str]:
         """
         List the commands available in this session.
         """

--- a/pwndbg/dbg/gdb.py
+++ b/pwndbg/dbg/gdb.py
@@ -7,6 +7,7 @@ from typing import Tuple
 
 import gdb
 from typing_extensions import Callable
+from typing_extensions import Set
 from typing_extensions import override
 
 import pwndbg
@@ -28,7 +29,6 @@ def parse_and_eval(expression: str, global_context: bool) -> gdb.Value:
         return gdb.parse_and_eval(expression)
 
 
-
 class GDBFrame(pwndbg.dbg_mod.Frame):
     def __init__(self, inner: gdb.Frame):
         self.inner = inner
@@ -40,9 +40,6 @@ class GDBFrame(pwndbg.dbg_mod.Frame):
         if selected != self.inner:
             self.inner.select()
             restore = True
-
-        if restore:
-            selected.select()
 
         ex = None
         try:
@@ -418,7 +415,7 @@ class GDB(pwndbg.dbg_mod.Debugger):
         except gdb.error:
             pass
         return None
-    
+
     def commands(self):
         current_pagination = gdb.execute("show pagination", to_string=True)
         current_pagination = current_pagination.split()[-1].rstrip(

--- a/pwndbg/dbg/gdb.py
+++ b/pwndbg/dbg/gdb.py
@@ -9,7 +9,6 @@ from typing import TypeVar
 
 import gdb
 from typing_extensions import Callable
-from typing_extensions import Set
 from typing_extensions import override
 
 import pwndbg
@@ -434,36 +433,9 @@ class GDB(pwndbg.dbg_mod.Debugger):
             pass
         return None
 
-    def commands(self):
-        current_pagination = gdb.execute("show pagination", to_string=True)
-        current_pagination = current_pagination.split()[-1].rstrip(
-            "."
-        )  # Take last word and skip period
-
-        gdb.execute("set pagination off")
-        command_list = gdb.execute("help all", to_string=True).strip().split("\n")
-        existing_commands: Set[str] = set()
-        for line in command_list:
-            line = line.strip()
-            # Skip non-command entries
-            if (
-                not line
-                or line.startswith("Command class:")
-                or line.startswith("Unclassified commands")
-            ):
-                continue
-            command = line.split()[0]
-            existing_commands.add(command)
-        gdb.execute(f"set pagination {current_pagination}")  # Restore original setting
-        return existing_commands
-
     @override
     def selected_inferior(self) -> pwndbg.dbg_mod.Process | None:
         return GDBProcess(gdb.selected_inferior())
-
-    @override
-    def is_gdblib_available(self):
-        return True
 
     @override
     def addrsz(self, address: Any) -> str:

--- a/pwndbg/dbg/gdb.py
+++ b/pwndbg/dbg/gdb.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
+import contextlib
 import signal
 from typing import Any
-from typing import ContextManager
-from typing import Generic
 from typing import List
 from typing import Tuple
 from typing import TypeVar
@@ -35,51 +34,36 @@ def parse_and_eval(expression: str, global_context: bool) -> gdb.Value:
 T = TypeVar("T")
 
 
-class Selection(ContextManager[None], Generic[T]):
+@contextlib.contextmanager
+def selection(target: T, get_current: Callable[[], T], select: Callable[[T], None]):
     """
     GDB has a lot of global state. Many of our queries require that we select a
     given object globally before we make them. When doing that, we must always
     be careful to return selection to its previous state before exiting. This
     class automatically manages the selection of a single object type.
+
+    Upon entrace to the `with` block, the element given by `target` will be
+    compared to the object returned by calling `get_current`. If they
+    compare different, the value previously returned by `get_current` is
+    saved, and the element given by `target` will be selected by passing it
+    as an argument to `select`, and, after execution leaves the `with`
+    block, the previously saved element will be selected in the same fashion
+    as the first element.
+
+    If the elements don't compare different, this is a no-op.
     """
 
-    select: Callable[[T], None]
-    target: T
-    get_current: Callable[[], T]
+    current = get_current()
+    restore = False
+    if current != target:
+        select(target)
+        restore = True
 
-    current: T
-    restore: bool
-
-    def __init__(self, target: T, get_current: Callable[[], T], select: Callable[[T], None]):
-        """
-        Upon entrace to the `with` block, the element given by `target` will be
-        compared to the object returned by calling `get_current`. If they
-        compare different, the value previously returned by `get_current` is
-        saved, and the element given by `target` will be selected by passing it
-        as an argument to `select`, and, after execution leaves the `with`
-        block, the previously saved element will be selected in the same fashion
-        as the first element.
-
-        If the elements don't compare different, this is a no-op.
-        """
-
-        self.get_current = get_current
-        self.select = select
-        self.target = target
-        self.restore = False
-        self.current = None
-
-    @override
-    def __enter__(self) -> None:
-        self.current = self.get_current()
-        if self.current != self.target:
-            self.select(self.target)
-            self.restore = True
-
-    @override
-    def __exit__(self, _exc_type, _exc, _traceback, /) -> None:
-        if self.restore:
-            self.select(self.current)
+    try:
+        yield
+    finally:
+        if restore:
+            select(current)
 
 
 class GDBFrame(pwndbg.dbg_mod.Frame):
@@ -88,7 +72,7 @@ class GDBFrame(pwndbg.dbg_mod.Frame):
 
     @override
     def evaluate_expression(self, expression: str) -> pwndbg.dbg_mod.Value:
-        with Selection(self.inner, lambda: gdb.selected_frame(), lambda f: f.select()):
+        with selection(self.inner, lambda: gdb.selected_frame(), lambda f: f.select()):
             try:
                 value = parse_and_eval(expression, global_context=False)
             except gdb.error as e:
@@ -103,7 +87,7 @@ class GDBThread(pwndbg.dbg_mod.Thread):
 
     @override
     def bottom_frame(self) -> pwndbg.dbg_mod.Frame:
-        with Selection(self.inner, lambda: gdb.selected_thread(), lambda t: t.switch()):
+        with selection(self.inner, lambda: gdb.selected_thread(), lambda t: t.switch()):
             value = gdb.newest_frame()
         return GDBFrame(value)
 


### PR DESCRIPTION
This PR is part of the GSoC 2024 LLDB port.

This PR adds a new class `pwndbg.dbg_mod.Error`, for exceptions that happen within the debugger-agnostic, wraps instances of `gdb.error` encountered by the GDB implementation of the Debugger-agnostic API in the new error type, and moves consumers that were using both the new API and `gdb.error` to the new error type.