### PR TITLE
CMP-like instruction annotations for AArch64, Arm

### DIFF
--- a/pwndbg/gdblib/disasm/aarch64.py
+++ b/pwndbg/gdblib/disasm/aarch64.py
@@ -108,36 +108,6 @@ class DisassemblyAssistant(pwndbg.gdblib.disasm.arch.DisassemblyAssistant):
             ARM64_INS_CCMN: self._common_cmp_annotator_builder("cpsr", ""),
         }
 
-    def generic_register_destination(self, instruction, emu: Emulator) -> None:
-        """
-        This function can be used to annotate instructions that have a register destination,
-        which in AArch64 is always the first register. Works only while we are using emulation.
-
-        In an ideal world, we have more specific code on a case-by-case basis to allow us to
-        annotate results even when not emulating (as is done in many x86 handlers)
-        """
-
-        left = instruction.operands[0]
-
-        # Emulating determined the value that was set in the destination register
-        if left.after_value is not None:
-            TELESCOPE_DEPTH = max(0, int(pwndbg.config.disasm_telescope_depth))
-
-            # Telescope the address
-            telescope_addresses = super()._telescope(
-                left.after_value,
-                TELESCOPE_DEPTH + 1,
-                instruction,
-                left,
-                emu,
-                read_size=pwndbg.gdblib.arch.ptrsize,
-            )
-
-            if not telescope_addresses:
-                return
-
-            instruction.annotation = f"{left.str} => {super()._telescope_format_list(telescope_addresses, TELESCOPE_DEPTH, emu)}"
-
     @override
     def _condition(
         self, instruction: PwndbgInstruction, emu: Emulator

--- a/pwndbg/gdblib/disasm/aarch64.py
+++ b/pwndbg/gdblib/disasm/aarch64.py
@@ -223,9 +223,9 @@ class DisassemblyAssistant(pwndbg.gdblib.disasm.arch.DisassemblyAssistant):
         if op.cs_op.shift.type != 0:
             target = AARCH64_BIT_SHIFT_MAP[op.cs_op.shift.type](
                 target, op.cs_op.shift.value, target_bit_width
-            )
+            ) & ((1 << target_bit_width) - 1)
 
-        return target & ((1 << target_bit_width) - 1)
+        return target 
 
     @override
     def _parse_register(
@@ -254,14 +254,14 @@ class DisassemblyAssistant(pwndbg.gdblib.disasm.arch.DisassemblyAssistant):
         )
 
         if op.cs_op.ext != 0:
-            target = AARCH64_EXTEND_MAP[op.cs_op.ext](target)
+            target = AARCH64_EXTEND_MAP[op.cs_op.ext](target) & ((1 << target_bit_width) - 1)
 
         if op.cs_op.shift.type != 0:
             target = AARCH64_BIT_SHIFT_MAP[op.cs_op.shift.type](
                 target, op.cs_op.shift.value, target_bit_width
-            )
+            ) & ((1 << target_bit_width) - 1)
 
-        return target & ((1 << target_bit_width) - 1)
+        return target
 
 
 assistant = DisassemblyAssistant("aarch64")

--- a/pwndbg/gdblib/disasm/aarch64.py
+++ b/pwndbg/gdblib/disasm/aarch64.py
@@ -169,7 +169,7 @@ class DisassemblyAssistant(pwndbg.gdblib.disasm.arch.DisassemblyAssistant):
         self.annotation_handlers.get(instruction.id, lambda *a: None)(instruction, emu)
 
     def _register_width(self, instruction: PwndbgInstruction, op: EnhancedOperand) -> int:
-        return 32 if instruction.cs_insn.reg_name(op.reg)[0] == 'w' else 64
+        return 32 if instruction.cs_insn.reg_name(op.reg)[0] == "w" else 64
 
     @override
     def _parse_immediate(self, instruction: PwndbgInstruction, op: EnhancedOperand, emu: Emulator):
@@ -218,7 +218,7 @@ class DisassemblyAssistant(pwndbg.gdblib.disasm.arch.DisassemblyAssistant):
             target = AARCH64_EXTEND_MAP[op.cs_op.ext](target) & ((1 << target_bit_width) - 1)
 
         if op.cs_op.shift.type != 0:
-            print(target,op.cs_op.shift.type,op.cs_op.shift.value)
+            print(target, op.cs_op.shift.type, op.cs_op.shift.value)
             target = AARCH64_BIT_SHIFT_MAP[op.cs_op.shift.type](
                 target, op.cs_op.shift.value, target_bit_width
             ) & ((1 << target_bit_width) - 1)

--- a/pwndbg/gdblib/disasm/aarch64.py
+++ b/pwndbg/gdblib/disasm/aarch64.py
@@ -225,7 +225,7 @@ class DisassemblyAssistant(pwndbg.gdblib.disasm.arch.DisassemblyAssistant):
                 target, op.cs_op.shift.value, target_bit_width
             ) & ((1 << target_bit_width) - 1)
 
-        return target 
+        return target
 
     @override
     def _parse_register(

--- a/pwndbg/gdblib/disasm/aarch64.py
+++ b/pwndbg/gdblib/disasm/aarch64.py
@@ -184,16 +184,8 @@ class DisassemblyAssistant(pwndbg.gdblib.disasm.arch.DisassemblyAssistant):
         if target is None:
             return None
 
-        target_bit_width = (
-            self._register_width(instruction, instruction.operands[0])
-            if instruction.operands[0].type == CS_OP_REG
-            else 64
-        )
-
         if op.cs_op.shift.type != 0:
-            target = AARCH64_BIT_SHIFT_MAP[op.cs_op.shift.type](
-                target, op.cs_op.shift.value, target_bit_width
-            ) & ((1 << target_bit_width) - 1)
+            target = AARCH64_BIT_SHIFT_MAP[op.cs_op.shift.type](target, op.cs_op.shift.value, 64)
 
         return target
 

--- a/pwndbg/gdblib/disasm/arch.py
+++ b/pwndbg/gdblib/disasm/arch.py
@@ -777,11 +777,11 @@ class DisassemblyAssistant:
                 left, right = instruction.operands
 
                 if (
-                    left.before_value_resolved is not None
-                    and right.before_value_resolved is not None
+                    (l_value := left.before_value_resolved) is not None
+                    and (r_value := right.before_value_resolved) is not None
                 ):
                     print_left, print_right = pwndbg.enhance.format_small_int_pair(
-                        left.before_value_resolved, right.before_value_resolved
+                        l_value, r_value
                     )
                     # Ex: "0x7f - 0x12" or "0xdffffdea + 0x8"
                     instruction.annotation = (

--- a/pwndbg/gdblib/disasm/arch.py
+++ b/pwndbg/gdblib/disasm/arch.py
@@ -771,7 +771,7 @@ class DisassemblyAssistant:
 
         def handler(instruction: PwndbgInstruction, emu: Emulator):
             # If there are just two operands, we can assume we are comparing them directly, and can display the values.
-            # Some architectures have variants with more operands that modify the values before comparison.
+            # Some architectures have variants with more operands.
             if len(instruction.operands) == 2:
                 left, right = instruction.operands
 

--- a/pwndbg/gdblib/disasm/arch.py
+++ b/pwndbg/gdblib/disasm/arch.py
@@ -776,13 +776,10 @@ class DisassemblyAssistant:
             if len(instruction.operands) == 2:
                 left, right = instruction.operands
 
-                if (
-                    (l_value := left.before_value_resolved) is not None
-                    and (r_value := right.before_value_resolved) is not None
-                ):
-                    print_left, print_right = pwndbg.enhance.format_small_int_pair(
-                        l_value, r_value
-                    )
+                if (l_value := left.before_value_resolved) is not None and (
+                    r_value := right.before_value_resolved
+                ) is not None:
+                    print_left, print_right = pwndbg.enhance.format_small_int_pair(l_value, r_value)
                     # Ex: "0x7f - 0x12" or "0xdffffdea + 0x8"
                     instruction.annotation = (
                         f"{print_left} {char_to_separate_operands} {print_right}"

--- a/pwndbg/gdblib/disasm/arch.py
+++ b/pwndbg/gdblib/disasm/arch.py
@@ -767,7 +767,6 @@ class DisassemblyAssistant:
 
         To reduce code duplication, subclasses can use this function to create an annotator for CMP-like instructions.
         """
-        SPACES = 5
         FLAG_REG_NAME_DISPLAY = flags_register_name.upper()
 
         def handler(instruction: PwndbgInstruction, emu: Emulator):
@@ -798,7 +797,7 @@ class DisassemblyAssistant:
                     # has more than two operands, then we don't have a way of showing them, so this avoids the "+="" below
                     instruction.annotation = display_result
                 else:
-                    instruction.annotation += " " * SPACES + display_result
+                    instruction.annotation += " " * 5 + display_result
 
         return handler
 

--- a/pwndbg/gdblib/disasm/arch.py
+++ b/pwndbg/gdblib/disasm/arch.py
@@ -11,6 +11,7 @@ import pwndbg.chain
 import pwndbg.color.context as C
 import pwndbg.color.memory as MemoryColor
 import pwndbg.color.syntax_highlight as H
+import pwndbg.enhance
 import pwndbg.gdblib.memory
 import pwndbg.gdblib.remote
 import pwndbg.gdblib.symbol
@@ -754,6 +755,55 @@ class DisassemblyAssistant:
                 return
 
             instruction.annotation = f"{left.str} => {self._telescope_format_list(telescope_addresses, TELESCOPE_DEPTH, emu)}"
+
+    def _common_cmp_annotator_builder(
+        self, flags_register_name: str, char_to_separate_operands: str = "-"
+    ) -> Callable[[PwndbgInstruction, Emulator], None]:
+        """
+        Many architectures implement near-identical `CMP`-like instructions.
+
+        It takes two values, either subtracts, adds, or does some bit operation
+        with them to set values in the flag register.
+
+        To reduce code duplication, subclasses can use this function to create an annotator for CMP-like instructions.
+        """
+        SPACES = 5
+        FLAG_REG_NAME_DISPLAY = flags_register_name.upper()
+
+        def handler(instruction: PwndbgInstruction, emu: Emulator):
+            # If there are just two operands, we can assume we are comparing them directly, and can display the values.
+            # Some architectures have variants with more operands that modify the values before comparison.
+            if len(instruction.operands) == 2:
+                left, right = instruction.operands
+
+                if (
+                    left.before_value_resolved is not None
+                    and right.before_value_resolved is not None
+                ):
+                    print_left, print_right = pwndbg.enhance.format_small_int_pair(
+                        left.before_value_resolved, right.before_value_resolved
+                    )
+                    # Ex: "0x7f - 0x12" or "0xdffffdea + 0x8"
+                    instruction.annotation = (
+                        f"{print_left} {char_to_separate_operands} {print_right}"
+                    )
+
+            # Using emulation, we can determine the resulting value put into the flag register
+            if emu:
+                eflags_bits = pwndbg.gdblib.regs.flags[flags_register_name]
+                emu_eflags = emu.read_register(flags_register_name)
+                eflags_formatted = C.format_flags(emu_eflags, eflags_bits)
+
+                display_result = f"{FLAG_REG_NAME_DISPLAY} => {eflags_formatted}"
+
+                if instruction.annotation is None:
+                    # First part of this function usually sets .annotation to a string. But if the instruction
+                    # has more than two operands, then we don't have a way of showing them, so this avoids the "+="" below
+                    instruction.annotation = display_result
+                else:
+                    instruction.annotation += " " * SPACES + display_result
+
+        return handler
 
 
 generic_assistant = DisassemblyAssistant(None)

--- a/pwndbg/gdblib/disasm/arm.py
+++ b/pwndbg/gdblib/disasm/arm.py
@@ -11,10 +11,19 @@ import pwndbg.gdblib.arch
 import pwndbg.gdblib.disasm.arch
 import pwndbg.gdblib.memory
 import pwndbg.gdblib.regs
+import pwndbg.lib.disasm.helpers as bit_math
 from pwndbg.emu.emulator import Emulator
 from pwndbg.gdblib.disasm.instruction import EnhancedOperand
 from pwndbg.gdblib.disasm.instruction import InstructionCondition
 from pwndbg.gdblib.disasm.instruction import PwndbgInstruction
+
+# Note: this map does not contain all the Arm32 shift types, just the ones relevent to register and memory modifier operations
+ARM_BIT_SHIFT_MAP: Dict[int, Callable[[int, int, int], int]] = {
+    ARM_SFT_ASR: bit_math.arithmetic_shift_right,
+    ARM_SFT_LSL: bit_math.logical_shift_left,
+    ARM_SFT_LSR: bit_math.logical_shift_right,
+    ARM_SFT_ROR: bit_math.rotate_right,
+}
 
 
 class DisassemblyAssistant(pwndbg.gdblib.disasm.arch.DisassemblyAssistant):
@@ -110,6 +119,25 @@ class DisassemblyAssistant(pwndbg.gdblib.disasm.arch.DisassemblyAssistant):
     @override
     def _immediate_string(self, instruction, operand):
         return "#" + super()._immediate_string(instruction, operand)
+
+    @override
+    def _parse_register(
+        self, instruction: PwndbgInstruction, op: EnhancedOperand, emu: Emulator
+    ) -> int | None:
+        """
+        Register operands can have optional shifts in Arm
+        """
+        target = super()._parse_register(instruction, op, emu)
+        if target is None:
+            return None
+
+        # Optionally apply shift to the index register
+        if op.cs_op.shift.type != 0:
+            target = ARM_BIT_SHIFT_MAP.get(op.cs_op.shift.type, lambda *a: None)(
+                target, op.cs_op.shift.value, 32
+            )
+
+        return target
 
 
 assistant = DisassemblyAssistant("arm")


### PR DESCRIPTION
This PR adds annotation to `CMP`-like instructions (instructions that mutate flags register, often seen before branches or conditional instructions) to AArch64 and Arm.

For AArch64 there are five such instructions: `CMP, CMN, TST, CCMP`, and `CCMN`
Arm has 4 - `CMP, CMN, TST`, and `TEQ`

For the instructions, it displays the resulting value of the flags register, as well as the operation that took place.

Image for AArch64:
![aarch64_cmp](https://github.com/user-attachments/assets/f0310557-a028-45ad-b46c-4bbb5c3229bb)

Currently, it displays all the bits of the CPSR register. Would it make more sense to only display the flags that can be mutated - `N,Z,C,V`?
