### PR TITLE
MIPS Annotations for Arithmetic and Load Instructions

### DIFF
--- a/pwndbg/gdblib/disasm/aarch64.py
+++ b/pwndbg/gdblib/disasm/aarch64.py
@@ -59,48 +59,18 @@ class DisassemblyAssistant(pwndbg.gdblib.disasm.arch.DisassemblyAssistant):
 
         self.annotation_handlers: Dict[int, Callable[[PwndbgInstruction, Emulator], None]] = {
             # MOV
-            ARM64_INS_MOV: self.generic_register_destination,
+            ARM64_INS_MOV: self._common_generic_register_destination,
             # ADR
-            ARM64_INS_ADR: self.generic_register_destination,
+            ARM64_INS_ADR: self._common_generic_register_destination,
             # ADRP
-            ARM64_INS_ADRP: self.generic_register_destination,
+            ARM64_INS_ADRP: self._common_generic_register_destination,
             # LDR
-            ARM64_INS_LDR: self.generic_register_destination,
+            ARM64_INS_LDR: self._common_generic_register_destination,
             # ADD
-            ARM64_INS_ADD: self.generic_register_destination,
+            ARM64_INS_ADD: self._common_generic_register_destination,
             # SUB
-            ARM64_INS_SUB: self.generic_register_destination,
+            ARM64_INS_SUB: self._common_generic_register_destination,
         }
-
-    def generic_register_destination(self, instruction, emu: Emulator) -> None:
-        """
-        This function can be used to annotate instructions that have a register destination,
-        which in AArch64 is always the first register. Works only while we are using emulation.
-
-        In an ideal world, we have more specific code on a case-by-case basis to allow us to
-        annotate results even when not emulating (as is done in many x86 handlers)
-        """
-
-        left = instruction.operands[0]
-
-        # Emulating determined the value that was set in the destination register
-        if left.after_value is not None:
-            TELESCOPE_DEPTH = max(0, int(pwndbg.config.disasm_telescope_depth))
-
-            # Telescope the address
-            telescope_addresses = super()._telescope(
-                left.after_value,
-                TELESCOPE_DEPTH + 1,
-                instruction,
-                left,
-                emu,
-                read_size=pwndbg.gdblib.arch.ptrsize,
-            )
-
-            if not telescope_addresses:
-                return
-
-            instruction.annotation = f"{left.str} => {super()._telescope_format_list(telescope_addresses, TELESCOPE_DEPTH, emu)}"
 
     @override
     def _condition(

--- a/pwndbg/gdblib/disasm/arch.py
+++ b/pwndbg/gdblib/disasm/arch.py
@@ -721,5 +721,36 @@ class DisassemblyAssistant:
         else:
             return None
 
+    def _common_generic_register_destination(
+        self, instruction: PwndbgInstruction, emu: Emulator
+    ) -> None:
+        """
+        This function can be used to annotate instructions that have a register destination.
+        In the vast majority of instructions in most architectures, the destination register is the first operand.
+
+        Using emulation, it will determine the value placed into the register, and create an annotation string based on the result.
+        """
+
+        left = instruction.operands[0]
+
+        # Emulating determined the value that was set in the destination register
+        if left.after_value is not None:
+            TELESCOPE_DEPTH = max(0, int(pwndbg.config.disasm_telescope_depth))
+
+            # Telescope the address
+            telescope_addresses = self._telescope(
+                left.after_value,
+                TELESCOPE_DEPTH + 1,
+                instruction,
+                left,
+                emu,
+                read_size=pwndbg.gdblib.arch.ptrsize,
+            )
+
+            if not telescope_addresses:
+                return
+
+            instruction.annotation = f"{left.str} => {self._telescope_format_list(telescope_addresses, TELESCOPE_DEPTH, emu)}"
+
 
 generic_assistant = DisassemblyAssistant(None)

--- a/pwndbg/gdblib/disasm/mips.py
+++ b/pwndbg/gdblib/disasm/mips.py
@@ -63,10 +63,66 @@ CONDITION_RESOLVERS: Dict[int, Callable[[List[int]], bool]] = {
     MIPS_INS_BLTZ: lambda ops: to_signed(ops[0]) < 0,
 }
 
+# These are instructions that have the first operand as the destination register.
+# They all do some computation and set the register to the result.
+# These were derived from "MIPS Architecture for Programmers Volume II: The MIPS64 Instruction Set Reference Manual"
+MIPS_SIMPLE_DESTINATION_INSTRUCTIONS = {
+    MIPS_INS_ADD,
+    MIPS_INS_ADDI,
+    MIPS_INS_ADDIU,
+    MIPS_INS_ADDU,
+    MIPS_INS_CLO,
+    MIPS_INS_CLZ,
+    MIPS_INS_DADD,
+    MIPS_INS_DADDI,
+    MIPS_INS_DADDIU,
+    MIPS_INS_DADDU,
+    MIPS_INS_DCLO,
+    MIPS_INS_DCLZ,
+    MIPS_INS_DSUB,
+    MIPS_INS_DSUBU,
+    MIPS_INS_LB,
+    MIPS_INS_LBU,
+    MIPS_INS_LD,
+    MIPS_INS_LDL,
+    MIPS_INS_LDPC,
+    MIPS_INS_LDR,
+    MIPS_INS_LH,
+    MIPS_INS_LHU,
+    MIPS_INS_LSA,
+    MIPS_INS_DLSA,
+    MIPS_INS_LUI,
+    MIPS_INS_LW,
+    MIPS_INS_LWL,
+    MIPS_INS_LWPC,
+    MIPS_INS_LWR,
+    MIPS_INS_LWU,
+    MIPS_INS_LWUPC,
+    MIPS_INS_MFHI,
+    MIPS_INS_MFLO,
+    MIPS_INS_SEB,
+    MIPS_INS_SEH,
+    MIPS_INS_SUB,
+    MIPS_INS_SUBU,
+    MIPS_INS_WSBH,
+    MIPS_INS_MOVE,
+    MIPS_INS_LI,
+    MIPS_INS_SLT,
+    MIPS_INS_SLTI,
+    MIPS_INS_SLTIU,
+    MIPS_INS_SLTU,
+}
 
+
+# This class enhances 32-bit, 64-bit, and micro MIPS
 class DisassemblyAssistant(pwndbg.gdblib.disasm.arch.DisassemblyAssistant):
     def __init__(self, architecture: str) -> None:
         super().__init__(architecture)
+
+    @override
+    def _set_annotation_string(self, instruction: PwndbgInstruction, emu: Emulator) -> None:
+        if instruction.id in MIPS_SIMPLE_DESTINATION_INSTRUCTIONS:
+            self._common_generic_register_destination(instruction, emu)
 
     @override
     def _condition(self, instruction: PwndbgInstruction, emu: Emulator) -> InstructionCondition:


### PR DESCRIPTION
This PR adds disasm annotations to the vast majority of instructions in MIPS that relate to arithmetic and load operations which make up the bulk of instructions encountered while stepping through a binary.

![mips_annotations](https://github.com/user-attachments/assets/2a459e5c-8e62-4908-82f0-6dba9a6e7dd6)


The instructions were chosen by reading the full list of instructions in the MIPS ISA - "MIPS Architecture for Programmers Volume II: The MIPS64 Instruction Set Reference Manual" (https://s3-eu-west-1.amazonaws.com/downloads-mips/documents/MIPS_Architecture_MIPS64_InstructionSet_%20AFP_P_MD00087_06.05.pdf)

Compared to x86, MIPS has a relatively simple instruction set architecture. All of the annotated instructions have an explicit register destination (always the first operand), and operate solely on registers (only store operations touch memory). This allows us to group the instructions together and annotate them in the same way.

Some MIPS instructions were skipped, namely those involving MIPS "coprocessors", floating point operations, and bitwise operations. Future PR's may incorporate supporting floating point and bit representations in our telescope and printing functions, because displaying them as raw integers is not ideal.

Additionally, "store" operations (that write to memory) will come in a future PR.
