### PR TITLE
Small fix to remote qemu branch target detection

### DIFF
--- a/pwndbg/gdblib/disasm/arch.py
+++ b/pwndbg/gdblib/disasm/arch.py
@@ -16,6 +16,7 @@ import pwndbg.gdblib.symbol
 import pwndbg.gdblib.typeinfo
 import pwndbg.gdblib.vmmap
 import pwndbg.lib.config
+import pwndbg.gdblib.remote
 from pwndbg.emu.emulator import Emulator
 from pwndbg.gdblib.disasm.instruction import FORWARD_JUMP_GROUP
 from pwndbg.gdblib.disasm.instruction import EnhancedOperand
@@ -668,7 +669,9 @@ class DisassemblyAssistant:
                         addr = resolved_addr
                     else:
                         page = pwndbg.gdblib.vmmap.find(resolved_addr)
-                        if page and page.execute:
+                        # When debugging a remote QEMU target, the page permissions are not accurate.
+                        # In this case, if the candidate address is mapped at all, just go with it.
+                        if page and (pwndbg.gdblib.remote.is_remote() or page.execute):
                             addr = resolved_addr
 
                 if addr is not None:

--- a/pwndbg/gdblib/disasm/arch.py
+++ b/pwndbg/gdblib/disasm/arch.py
@@ -12,11 +12,11 @@ import pwndbg.color.context as C
 import pwndbg.color.memory as MemoryColor
 import pwndbg.color.syntax_highlight as H
 import pwndbg.gdblib.memory
+import pwndbg.gdblib.remote
 import pwndbg.gdblib.symbol
 import pwndbg.gdblib.typeinfo
 import pwndbg.gdblib.vmmap
 import pwndbg.lib.config
-import pwndbg.gdblib.remote
 from pwndbg.emu.emulator import Emulator
 from pwndbg.gdblib.disasm.instruction import FORWARD_JUMP_GROUP
 from pwndbg.gdblib.disasm.instruction import EnhancedOperand

--- a/pwndbg/gdblib/disasm/arch.py
+++ b/pwndbg/gdblib/disasm/arch.py
@@ -671,7 +671,7 @@ class DisassemblyAssistant:
                         page = pwndbg.gdblib.vmmap.find(resolved_addr)
                         # When debugging a remote QEMU target, the page permissions are not accurate.
                         # In this case, if the candidate address is mapped at all, just go with it.
-                        if page and (pwndbg.gdblib.remote.is_remote() or page.execute):
+                        if page and (page.execute or pwndbg.gdblib.remote.is_remote()):
                             addr = resolved_addr
 
                 if addr is not None:


### PR DESCRIPTION
This PR makes a small fix to our default detection of branch targets in our enhancement code, making it work with remote QEMU targets more accurately.

When debugging a remote QEMU target, the memory permissions are not always accurate - the "execute" bit, for example, is not set for the pages that are executed. In the default logic to determine branch targets, it used to check for this execute bit when detecting a target. This breaks the automatic resolution of targets with QEMU.

![image](https://github.com/user-attachments/assets/fc792001-a389-4de8-acdf-c29d7164e032)

It will now bypass this check on remote targets.