### PR TITLE
Add support for fs/gs register in Unicorn and annotations

### DIFF
--- a/pwndbg/emu/emulator.py
+++ b/pwndbg/emu/emulator.py
@@ -102,7 +102,10 @@ arch_to_UC_consts = {
 # Architecture specific maps: Map<reg_name, Unicorn constant>
 arch_to_reg_const_map = {
     "i386": create_reg_to_const_map(arch_to_UC_consts["i386"]),
-    "x86-64": create_reg_to_const_map(arch_to_UC_consts["x86-64"]),
+    "x86-64": create_reg_to_const_map(
+        arch_to_UC_consts["x86-64"],
+        {"FSBASE": U.x86_const.UC_X86_REG_FS_BASE, "GSBASE": U.x86_const.UC_X86_REG_GS_BASE},
+    ),
     "mips": create_reg_to_const_map(arch_to_UC_consts["mips"]),
     "sparc": create_reg_to_const_map(arch_to_UC_consts["sparc"]),
     "arm": create_reg_to_const_map(arch_to_UC_consts["arm"]),
@@ -168,7 +171,7 @@ arch_to_SYSCALL = {
 }
 
 # https://github.com/unicorn-engine/unicorn/issues/550
-blacklisted_regs = ["ip", "cs", "ds", "es", "fs", "gs", "ss", "fsbase", "gsbase"]
+blacklisted_regs = ["ip", "cs", "ds", "es", "fs", "gs", "ss"]
 
 """
 e = pwndbg.emu.emulator.Emulator()

--- a/pwndbg/gdblib/disasm/x86.py
+++ b/pwndbg/gdblib/disasm/x86.py
@@ -332,9 +332,11 @@ class DisassemblyAssistant(pwndbg.gdblib.disasm.arch.DisassemblyAssistant):
 
         if op.mem.segment != 0:
             if op.mem.segment == X86_REG_FS:
-                target = pwndbg.gdblib.regs.fsbase
+                if (target := pwndbg.gdblib.regs.fsbase) is None:
+                    return None
             elif op.mem.segment == X86_REG_GS:
-                target = pwndbg.gdblib.regs.gsbase
+                if (target := pwndbg.gdblib.regs.gsbase) is None:
+                    return None
             else:
                 return None
         # Both a segment and base cannot be in use


### PR DESCRIPTION
This PR adds support for `fs`/`gs` segment registers in Unicorn and in x86 annotations. In `x86-64`, Unicorn is now able to emulate instructions that reference fs/gs segments, and annotations display the results of these instructions. There is also support for annotations in 32-bit x86.

The fix is small: we have a property of our `regs` object which will fetch the value of `fsbase` (or `gsbase`). Unicorn, however, called the constant `FS_BASE`, so we need to just add an explicit mapping so our Pwndbg `FSBASE` is mapped to the Unicorn X86 `FS_BASE` constant (same with `gsbase`). 

In `x86-64`, the `fs` register, when seen in assembly, effectively uses the value of the `fsbase` register for any address computation. The Unicorn engine follows this, so by setting the `fsbase` register accordingly, all memory accesses work correctly.

In 32-bit mode, however, these `fsbase/gsbase` registers do not exist, and instead the segment address is stored in memory in the `GDT`. In order to make fs/gs use work Unicorn, we would need to setup the GDT correctly in Unicorn, which would be significantly more difficult in most cases (we could perhaps create a fake GDT - probably more effort than is worth and [creates other complications](https://github.com/unicorn-engine/unicorn/issues/877)). 32-bit access to `fs` and `gs` still creates full annotations for the current instruction without emulation since the actual process is able to access `fs` and `gs` - it's just Unicorn that cannot.

The most visible change this provides is making it easy to see stack cookies in annotations.


![fs_move](https://github.com/user-attachments/assets/ec2b3f36-6e1f-436a-836f-c9be69245155)

![sub_fs_base](https://github.com/user-attachments/assets/607e3cc8-e3fb-46f8-9908-d5c1cebf8fa3)

32-bit x86 instruction - works without emulation for the current instruction
![32_bit_x86_current-instruction](https://github.com/user-attachments/assets/70c512b4-c734-41b3-aeea-6ac47457469e)

Thanks to @lebr0nli for finding that Unicorn will now function with `fsbase/gsbase` and for [initial PoC code](https://github.com/pwndbg/pwndbg/pull/2001#discussion_r1509273898).

Related issue: #113