### PR TITLE
Hexdump: fixed computation of `hexdump.offset`

### DIFF
--- a/pwndbg/commands/hexdump.py
+++ b/pwndbg/commands/hexdump.py
@@ -86,7 +86,7 @@ def hexdump(address, count=pwndbg.config.hexdump_bytes) -> None:
 
     # TODO: What if arch endian is big, and use_big_endian is false?
     flip_group_endianness = (
-        bool(pwndbg.config.hexdump_group_use_big_endian) and pwndbg.gdblib.arch.endian == "little"
+        pwndbg.config.hexdump_group_use_big_endian and pwndbg.gdblib.arch.endian == "little"
     )
 
     # The user may have input the start and end range to dump instead of the

--- a/pwndbg/commands/hexdump.py
+++ b/pwndbg/commands/hexdump.py
@@ -65,7 +65,6 @@ parser.add_argument(
 def hexdump(address, count=pwndbg.config.hexdump_bytes) -> None:
     if hexdump.repeat:
         address = hexdump.last_address
-        hexdump.offset += 1
     else:
         hexdump.offset = 0
 
@@ -87,7 +86,7 @@ def hexdump(address, count=pwndbg.config.hexdump_bytes) -> None:
 
     # TODO: What if arch endian is big, and use_big_endian is false?
     flip_group_endianness = (
-        pwndbg.config.hexdump_group_use_big_endian and pwndbg.gdblib.arch.endian == "little"
+        bool(pwndbg.config.hexdump_group_use_big_endian) and pwndbg.gdblib.arch.endian == "little"
     )
 
     # The user may have input the start and end range to dump instead of the
@@ -112,12 +111,11 @@ def hexdump(address, count=pwndbg.config.hexdump_bytes) -> None:
         flip_group_endianness=flip_group_endianness,
         offset=hexdump.offset,
     )
-    for i, line in enumerate(result):
+
+    for line in result:
         print(line)
 
-    # If this command is entered again with no arguments, remember where we left off printing
-    # TODO: This is broken if the user inputs a count less than the width
-    hexdump.offset += i
+    hexdump.offset += count
 
 
 hexdump.last_address = 0

--- a/pwndbg/commands/hexdump.py
+++ b/pwndbg/commands/hexdump.py
@@ -86,7 +86,7 @@ def hexdump(address, count=pwndbg.config.hexdump_bytes) -> None:
 
     # TODO: What if arch endian is big, and use_big_endian is false?
     flip_group_endianness = (
-        pwndbg.config.hexdump_group_use_big_endian and pwndbg.gdblib.arch.endian == "little"
+        bool(pwndbg.config.hexdump_group_use_big_endian) and pwndbg.gdblib.arch.endian == "little"
     )
 
     # The user may have input the start and end range to dump instead of the

--- a/pwndbg/hexdump.py
+++ b/pwndbg/hexdump.py
@@ -70,17 +70,17 @@ def load_color_scheme() -> None:
 
 
 def hexdump(
-    data,
-    address=0,
-    width=16,
-    group_width=4,
-    flip_group_endianness=False,
-    skip=True,
-    offset=0,
-    size=0,
-    count=0,
-    repeat=False,
-    dX_call=False,
+    data: bytes,
+    address: int=0,
+    width: int=16,
+    group_width: int=4,
+    flip_group_endianness: bool=False,
+    skip: bool=True,
+    offset: int=0,
+    size: int=0,
+    count: int=0,
+    repeat: bool=False,
+    dX_call: bool=False,
 ):
     if not dX_call:
         if not color_scheme or not printable:

--- a/pwndbg/hexdump.py
+++ b/pwndbg/hexdump.py
@@ -71,16 +71,16 @@ def load_color_scheme() -> None:
 
 def hexdump(
     data: bytes,
-    address: int=0,
-    width: int=16,
-    group_width: int=4,
-    flip_group_endianness: bool=False,
-    skip: bool=True,
-    offset: int=0,
-    size: int=0,
-    count: int=0,
-    repeat: bool=False,
-    dX_call: bool=False,
+    address: int = 0,
+    width: int = 16,
+    group_width: int = 4,
+    flip_group_endianness: bool = False,
+    skip: bool = True,
+    offset: int = 0,
+    size: int = 0,
+    count: int = 0,
+    repeat: bool = False,
+    dX_call: bool = False,
 ):
     if not dX_call:
         if not color_scheme or not printable:

--- a/pwndbg/hexdump.py
+++ b/pwndbg/hexdump.py
@@ -128,9 +128,10 @@ def hexdump(
                     yield out
                     # Fallthrough (do not continue) so we yield the current line too
 
+            increment = i * width
             hexline = [
-                H.offset(f"+{(i + offset) * width:04x} "),
-                H.address(f"{address + (i * width):#08x}  "),
+                H.offset(f"+{offset + increment:04x} "),
+                H.address(f"{address + increment:#08x}  "),
             ]
 
             for group in groupby(group_width, line):

--- a/pwndbg/hexdump.py
+++ b/pwndbg/hexdump.py
@@ -88,7 +88,7 @@ def hexdump(
 
         # If there's nothing to print, just print the offset and address and return
         if not data:
-            yield H.offset("+%04x " % len(data)) + H.address("%#08x  " % (address + len(data)))
+            yield H.offset(f"+{offset:04x} ") + H.address(f"{address:#08x}  ")
 
             # Don't allow iterating over this generator again
             return
@@ -129,8 +129,8 @@ def hexdump(
                     # Fallthrough (do not continue) so we yield the current line too
 
             hexline = [
-                H.offset("+%04x " % ((i + offset) * width)),
-                H.address("%#08x  " % (address + (i * width))),
+                H.offset(f"+{(i + offset) * width:04x} "),
+                H.address(f"{address + (i * width):#08x}  "),
             ]
 
             for group in groupby(group_width, line):

--- a/tests/gdb-tests/tests/test_hexdump.py
+++ b/tests/gdb-tests/tests/test_hexdump.py
@@ -26,7 +26,7 @@ def run_tests(stack, use_big_endian, expected):
     # TODO: Repetition is not working in tests
     results.append(gdb.execute(f"hexdump {stack} 64", to_string=True))
     results.append(gdb.execute(f"hexdump {stack} 3", to_string=True))
-    
+
     assert len(results) == len(expected)
     for i, result in enumerate(results):
         expected_result = expected[i]
@@ -83,20 +83,21 @@ def test_hexdump_collapse_lines(start_binary):
     hexdump_lines(4)
     hexdump_lines(10)
 
+
 def test_hexdump_saved_address_and_offset(start_binary):
     # TODO There is no way to verify repetition: the last_address and offset are reset
     # before each command
     start_binary(BINARY)
     sp = pwndbg.gdblib.regs.rsp
-    
+
     SIZE = 21
-    
+
     pwndbg.gdblib.memory.write(sp, b"abcdefgh\x01\x02\x03\x04\x05\x06\x07\x08" * 16)
 
     out1 = gdb.execute(f"hexdump $rsp {SIZE}", to_string=True)
     out2 = (
-        '+0000 0x7fffffffdb40  61 62 63 64 65 66 67 68  01 02 03 04 05 06 07 08  │abcdefgh│........│\n'
-        '+0010 0x7fffffffdb50  61 62 63 64 65                                    │abcde   │        │\n'
+        "+0000 0x7fffffffdb40  61 62 63 64 65 66 67 68  01 02 03 04 05 06 07 08  │abcdefgh│........│\n"
+        "+0010 0x7fffffffdb50  61 62 63 64 65                                    │abcde   │        │\n"
     )
 
     assert out1 == out2

--- a/tests/gdb-tests/tests/test_hexdump.py
+++ b/tests/gdb-tests/tests/test_hexdump.py
@@ -26,7 +26,7 @@ def run_tests(stack, use_big_endian, expected):
     # TODO: Repetition is not working in tests
     results.append(gdb.execute(f"hexdump {stack} 64", to_string=True))
     results.append(gdb.execute(f"hexdump {stack} 3", to_string=True))
-
+    
     assert len(results) == len(expected)
     for i, result in enumerate(results):
         expected_result = expected[i]
@@ -82,3 +82,23 @@ def test_hexdump_collapse_lines(start_binary):
     hexdump_lines(3)
     hexdump_lines(4)
     hexdump_lines(10)
+
+def test_hexdump_saved_address_and_offset(start_binary):
+    # TODO There is no way to verify repetition: the last_address and offset are reset
+    # before each command
+    start_binary(BINARY)
+    sp = pwndbg.gdblib.regs.rsp
+    
+    SIZE = 21
+    
+    pwndbg.gdblib.memory.write(sp, b"abcdefgh\x01\x02\x03\x04\x05\x06\x07\x08" * 16)
+
+    out1 = gdb.execute(f"hexdump $rsp {SIZE}", to_string=True)
+    out2 = (
+        '+0000 0x7fffffffdb40  61 62 63 64 65 66 67 68  01 02 03 04 05 06 07 08  │abcdefgh│........│\n'
+        '+0010 0x7fffffffdb50  61 62 63 64 65                                    │abcde   │        │\n'
+    )
+
+    assert out1 == out2
+    assert pwndbg.commands.hexdump.hexdump.last_address == sp + SIZE
+    assert pwndbg.commands.hexdump.hexdump.offset == SIZE

--- a/tests/gdb-tests/tests/test_hexdump.py
+++ b/tests/gdb-tests/tests/test_hexdump.py
@@ -96,8 +96,8 @@ def test_hexdump_saved_address_and_offset(start_binary):
 
     out1 = gdb.execute(f"hexdump $rsp {SIZE}", to_string=True)
     out2 = (
-        "+0000 0x7fffffffdb40  61 62 63 64 65 66 67 68  01 02 03 04 05 06 07 08  │abcdefgh│........│\n"
-        "+0010 0x7fffffffdb50  61 62 63 64 65                                    │abcde   │        │\n"
+        f"+0000 0x{sp:x}  61 62 63 64 65 66 67 68  01 02 03 04 05 06 07 08  │abcdefgh│........│\n"
+        f"+0010 0x{sp+0x10:x}  61 62 63 64 65                                    │abcde   │        │\n"
     )
 
     assert out1 == out2


### PR DESCRIPTION
This fixes two bugs related to the offset that gets updated when one calls `hexdump` repeatedly, and adds typing to the definition of the `hexdump()` function.

## Bug 1

When the first hexdump skips a few lines, the repeat call to hexdump will display a wrong offset (+30 in the example).

![Screenshot from 2024-07-26 11-41-49](https://github.com/user-attachments/assets/13e38e69-ebf2-4222-8764-f3ab97e90f4e)

Now, it is fine:

![Screenshot from 2024-07-26 11-44-35](https://github.com/user-attachments/assets/76e7c430-ecab-4719-8e39-d21161ae0bbd)


## Bug 2

Before, when dumping an unaligned number of bytes, offset is off:

![Screenshot from 2024-07-26 11-40-35](https://github.com/user-attachments/assets/acbbf9e2-d4fb-4fa5-ae6e-e12944cdc3f3)

Now, it is fine:

![Screenshot from 2024-07-26 11-39-08](https://github.com/user-attachments/assets/8e16efab-df2c-4da7-83da-6aad13d9c975)


I included a make-do test (repetition does not seem to be handled properly by the test suite).

Thanks for the amazing tool.
Charles