### PR TITLE
Add ability to pause events

### DIFF
--- a/pwndbg/gdblib/memory.py
+++ b/pwndbg/gdblib/memory.py
@@ -162,9 +162,13 @@ def poke(address: int) -> bool:
     if c is None:
         return False
     try:
+        pwndbg.gdblib.events.pause(gdb.events.memory_changed)
         write(address, c)
     except Exception:
         return False
+    finally:
+        pwndbg.gdblib.events.unpause(gdb.events.memory_changed)
+
     return True
 
 


### PR DESCRIPTION
This PR adds the ability to temporarily pause GDB event handlers (#2327), and pauses events while Pwndbg is exploring memory for page permissions. 

This makes stepping through remote processes with Qemu much smoother, as an event handler listening for `mem_changed` clears the disasm instruction cache, and without pausing the event firing, the cache would seemingly randomly get cleared.