### PR TITLE
feat: enhance attachp command to support partial process name matching.

### DIFF
--- a/pwndbg/commands/attachp.py
+++ b/pwndbg/commands/attachp.py
@@ -83,6 +83,24 @@ def attachp(no_truncate, target) -> None:
                 pids = []
 
             if not pids:
+                try:
+                    command = "ps aux | awk '{print $2, $11}'"
+                    ps_output = check_output(command, shell=True, universal_newlines=True)
+                except FileNotFoundError:
+                    print(message.error("Error: did not find `ps` command"))
+                    return
+                except CalledProcessError:
+                    pids = []
+
+                target_list = target.split()
+                for line in ps_output.strip().split("\n")[1:]:
+                    process_info = line.split()
+                    pid = process_info[0]
+                    command = " ".join(process_info[1:])
+                    if any(part in command for part in target_list) and len(pid) > 1:
+                        pids.append(pid)
+
+            if not pids:
                 print(message.error(f"Process {target} not found"))
                 return
 

--- a/pwndbg/commands/attachp.py
+++ b/pwndbg/commands/attachp.py
@@ -84,20 +84,21 @@ def attachp(no_truncate, target) -> None:
 
             if not pids:
                 try:
-                    command = "ps aux | awk '{print $2, $11}'"
-                    ps_output = check_output(command, shell=True, universal_newlines=True)
+                    ps_output = check_output(["ps", "-eo", "pid,args"], universal_newlines=True)
                 except FileNotFoundError:
                     print(message.error("Error: did not find `ps` command"))
                     return
                 except CalledProcessError:
                     pids = []
 
-                target_list = target.split()
+                target_list = [part for part in target.split() if len(part) >= 2]
                 for line in ps_output.strip().split("\n")[1:]:
                     process_info = line.split()
+                    if len(process_info) <= 1:
+                        continue
                     pid = process_info[0]
-                    command = " ".join(process_info[1:])
-                    if any(part in command for part in target_list) and len(pid) > 1:
+                    command = process_info[1]
+                    if any(part in command for part in target_list):
                         pids.append(pid)
 
             if not pids:


### PR DESCRIPTION
The PR enhances the `attachp` command to support partial process name matching. 

With this enhancement, users can specify partial process names now, and the command will attempt to find matching processes based on those partial names.

## Changes
- Added functionality to check for partial process name matches using the output of the `ps aux` command.
- Updated the logic to filter processes based on partial matches from the provided target list.

## Issue
#2301

## Other
This is my first PR to an open source project. Please let me know if there are any other changes needed or if you have any questions.