### PR TITLE
Add test for prompt recolor on process state change

### DIFF
--- a/tests/gdb-tests/tests/test_prompt_recolor.py
+++ b/tests/gdb-tests/tests/test_prompt_recolor.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import gdb
+
+import pwndbg
+import pwndbg.color.message
+import pwndbg.gdblib.proc
+import tests
+
+BINARY = tests.binaries.get("reference-binary.out")
+
+
+def prepare_prompt(is_proc_alive):
+    prompt = "pwndbg> "
+
+    prompt = "\x02" + prompt + "\x01"  # STX + prompt + SOH
+    if is_proc_alive:
+        prompt = pwndbg.color.message.alive_prompt(prompt)
+    else:
+        prompt = pwndbg.color.message.prompt(prompt)
+    prompt = "\x01" + prompt + "\x02"  # SOH + prompt + STX
+
+    return prompt
+
+
+# check if expected and actual prompts correspond
+def run_prompt_check(is_proc_alive):
+    expected = prepare_prompt(is_proc_alive=is_proc_alive)
+    result = gdb.execute("show prompt", to_string=True)
+    result = result.replace("\\001", "\x01")
+    result = result.replace("\\002", "\x02")
+    result = result.replace(r"\e", "\x1b")
+    result = result.split('"')[1].encode("latin1")
+    expected = expected.encode("latin1")
+    print(f"Expected ---> {expected}")
+    print(f"Result   ---> {result}")
+
+    assert result == expected
+
+
+def test_prompt_recolor(start_binary):
+    gdb.execute("set disable-colors off")
+
+    # Check normal prompt
+    run_prompt_check(is_proc_alive=False)
+
+    # Check prompt when process is alive
+    start_binary(BINARY)
+    gdb.prompt_hook(*[])  # run prompt hook to update prompt
+    run_prompt_check(is_proc_alive=True)
+
+    gdb.execute("continue")
+    # Check prompt after process died
+    gdb.prompt_hook(*[])  # run prompt hook to update prompt
+    run_prompt_check(is_proc_alive=False)
+
+    gdb.execute("set disable-colors off")


### PR DESCRIPTION
@disconnect3d I'm back with the test for prompt color changes. The ``set disable-colors off`` command worked great, thanks for that!

I have a few issues with the way I wrote the test, however. I want your opinions on them:
1. I copy the ``set_prompt`` function and rewrite it to return the expected prompt as a string in ``prepare_prompt``. This is a problem, because if the ``set_prompt`` function changes, this might go out of sync and the test will have to change (extra work). Solving this problem will mean changing the underlying ``set_prompt`` function and then reusing it here. At least that's what I am thinking of.
2. After starting the binary, I have to manually call the ``prompt_hook`` that runs the ``set_prompt`` on process state change. I am not exactly sure why the prompt hook doesn't run in normal tests after each command? Is there a better way to make this happen?