### PR TITLE
Fix docker-compose error on CI

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -27,7 +27,7 @@ jobs:
         key: ${{ matrix.images }}-cache-images-{hash}
 
     - name: Docker Build ${{ matrix.images }}
-      run: docker-compose build ${{ matrix.images }}
+      run: docker compose build ${{ matrix.images }}
 
     - name: Test on ${{ matrix.images }}
-      run: docker-compose run ${{ matrix.images }} ./tests.sh
+      run: docker compose run ${{ matrix.images }} ./tests.sh


### PR DESCRIPTION
For quite a while it's been preferred to use `docker compose` over `docker-compose`, but it seems like using `docker-compose` is finally causing some CI build failures saying that the command isn't found.
