### PR TITLE
Emulator Arm SP register fix

### DIFF
--- a/pwndbg/emu/emulator.py
+++ b/pwndbg/emu/emulator.py
@@ -222,9 +222,10 @@ class Emulator:
 
         # Initialize the register state
         for reg in (
-            list(self.regs.retaddr)
+            list(self.regs.flags)
+            + list(self.regs.retaddr)
             + list(self.regs.misc)
-            + list(self.regs.common)  # this includes the flags register
+            + list(self.regs.common_no_flag)  # this includes the flags register
         ):
             enum = self.get_reg_enum(reg)
 

--- a/pwndbg/emu/emulator.py
+++ b/pwndbg/emu/emulator.py
@@ -220,28 +220,9 @@ class Emulator:
         # (address_successfully_executed, size_of_instruction)
         self.last_single_step_result = InstructionExecutedResult(None, None)
 
-        # The specific order of this list is very important:
-        # Due to the behavior of Arm in the Unicorn engine,
-        # we must write the flags register after PC, and the stack pointer after the flags register.
-        # Otherwise, the values will be clobbered
-        # https://github.com/pwndbg/pwndbg/pull/2337
-        raw_list = (
-            [self.regs.pc]
-            + list(self.regs.flags)
-            + [self.regs.stack, self.regs.frame]
-            + list(self.regs.retaddr)
-            + list(self.regs.misc)
-            + list(self.regs.gpr)
-        )
-
-        # Get rid of duplicates and "None" values - some registers, like .frame are sometimes non-existent
-        reg_list = []
-        for x in raw_list:
-            if x and x not in reg_list:
-                reg_list.append(x)
 
         # Initialize the register state
-        for reg in reg_list:
+        for reg in self.regs.emulated_regs_order:
             enum = self.get_reg_enum(reg)
 
             if not reg:

--- a/pwndbg/emu/emulator.py
+++ b/pwndbg/emu/emulator.py
@@ -220,7 +220,6 @@ class Emulator:
         # (address_successfully_executed, size_of_instruction)
         self.last_single_step_result = InstructionExecutedResult(None, None)
 
-
         # Initialize the register state
         for reg in self.regs.emulated_regs_order:
             enum = self.get_reg_enum(reg)

--- a/pwndbg/emu/emulator.py
+++ b/pwndbg/emu/emulator.py
@@ -132,7 +132,7 @@ arch_to_reg_const_map = {
 ) = (0, 1, 2, 4, 8, 16, 32, 64, 128)
 
 DEBUG = NO_DEBUG
-# DEBUG = -1 # ALL
+DEBUG = -1 # ALL
 # DEBUG = DEBUG_EXECUTING | DEBUG_MEM_MAP | DEBUG_MEM_READ
 
 if DEBUG != NO_DEBUG:
@@ -225,7 +225,7 @@ class Emulator:
             list(self.regs.flags)
             + list(self.regs.retaddr)
             + list(self.regs.misc)
-            + list(self.regs.common_no_flag)  # this includes the flags register
+            + list(self.regs.common_no_flag)
         ):
             enum = self.get_reg_enum(reg)
 

--- a/pwndbg/emu/emulator.py
+++ b/pwndbg/emu/emulator.py
@@ -132,7 +132,7 @@ arch_to_reg_const_map = {
 ) = (0, 1, 2, 4, 8, 16, 32, 64, 128)
 
 DEBUG = NO_DEBUG
-# DEBUG = -1  # ALL
+# DEBUG = -1 # ALL
 # DEBUG = DEBUG_EXECUTING | DEBUG_MEM_MAP | DEBUG_MEM_READ
 
 if DEBUG != NO_DEBUG:
@@ -222,10 +222,9 @@ class Emulator:
 
         # Initialize the register state
         for reg in (
-            list(self.regs.flags)
-            + list(self.regs.retaddr)
+            list(self.regs.retaddr)
             + list(self.regs.misc)
-            + list(self.regs.common_no_flag)  # this includes the flags register
+            + list(self.regs.common)  # this includes the flags register
         ):
             enum = self.get_reg_enum(reg)
 

--- a/pwndbg/emu/emulator.py
+++ b/pwndbg/emu/emulator.py
@@ -224,6 +224,7 @@ class Emulator:
         # Due to the behavior of Arm in the Unicorn engine,
         # we must write the flags register after PC, and the stack pointer after the flags register.
         # Otherwise, the values will be clobbered
+        # https://github.com/pwndbg/pwndbg/pull/2337
         raw_list = (
             [self.regs.pc]
             + list(self.regs.flags)

--- a/pwndbg/emu/emulator.py
+++ b/pwndbg/emu/emulator.py
@@ -132,7 +132,7 @@ arch_to_reg_const_map = {
 ) = (0, 1, 2, 4, 8, 16, 32, 64, 128)
 
 DEBUG = NO_DEBUG
-DEBUG = -1 # ALL
+# DEBUG = -1  # ALL
 # DEBUG = DEBUG_EXECUTING | DEBUG_MEM_MAP | DEBUG_MEM_READ
 
 if DEBUG != NO_DEBUG:

--- a/pwndbg/emu/emulator.py
+++ b/pwndbg/emu/emulator.py
@@ -132,7 +132,7 @@ arch_to_reg_const_map = {
 ) = (0, 1, 2, 4, 8, 16, 32, 64, 128)
 
 DEBUG = NO_DEBUG
-# DEBUG = -1 # ALL
+DEBUG = -1 # ALL
 # DEBUG = DEBUG_EXECUTING | DEBUG_MEM_MAP | DEBUG_MEM_READ
 
 if DEBUG != NO_DEBUG:
@@ -222,9 +222,10 @@ class Emulator:
 
         # Initialize the register state
         for reg in (
-            list(self.regs.retaddr)
+            list(self.regs.flags)
+            + list(self.regs.retaddr)
             + list(self.regs.misc)
-            + list(self.regs.common)  # this includes the flags register
+            + list(self.regs.common_no_flag)  # this includes the flags register
         ):
             enum = self.get_reg_enum(reg)
 

--- a/pwndbg/emu/emulator.py
+++ b/pwndbg/emu/emulator.py
@@ -240,7 +240,6 @@ class Emulator:
             if x and x not in reg_list:
                 reg_list.append(x)
 
-        print(reg_list)
         # Initialize the register state
         for reg in reg_list:
             enum = self.get_reg_enum(reg)

--- a/pwndbg/emu/emulator.py
+++ b/pwndbg/emu/emulator.py
@@ -220,13 +220,28 @@ class Emulator:
         # (address_successfully_executed, size_of_instruction)
         self.last_single_step_result = InstructionExecutedResult(None, None)
 
-        # Initialize the register state
-        for reg in (
-            list(self.regs.flags)
+        # The specific order of this list is very important:
+        # Due to the behavior of Arm in the Unicorn engine,
+        # we must write the flags register after PC, and the stack pointer after the flags register.
+        # Otherwise, the values will be clobbered
+        raw_list = (
+            [self.regs.pc]
+            + list(self.regs.flags)
+            + [self.regs.stack, self.regs.frame]
             + list(self.regs.retaddr)
             + list(self.regs.misc)
-            + list(self.regs.common_no_flag)
-        ):
+            + list(self.regs.gpr)
+        )
+
+        # Get rid of duplicates and "None" values - some registers, like .frame are sometimes non-existent
+        reg_list = []
+        for x in raw_list:
+            if x and x not in reg_list:
+                reg_list.append(x)
+
+        print(reg_list)
+        # Initialize the register state
+        for reg in reg_list:
             enum = self.get_reg_enum(reg)
 
             if not reg:

--- a/pwndbg/emu/emulator.py
+++ b/pwndbg/emu/emulator.py
@@ -132,7 +132,7 @@ arch_to_reg_const_map = {
 ) = (0, 1, 2, 4, 8, 16, 32, 64, 128)
 
 DEBUG = NO_DEBUG
-DEBUG = -1 # ALL
+# DEBUG = -1 # ALL
 # DEBUG = DEBUG_EXECUTING | DEBUG_MEM_MAP | DEBUG_MEM_READ
 
 if DEBUG != NO_DEBUG:

--- a/pwndbg/lib/regs.py
+++ b/pwndbg/lib/regs.py
@@ -86,16 +86,10 @@ class RegisterSet:
         # Otherwise, the values will be clobbered
         # https://github.com/pwndbg/pwndbg/pull/2337
         self.emulated_regs_order: list[str] = []
-        
-        for reg in ([pc]
-            + list(flags)
-            + [stack, frame]
-            + list(retaddr)
-            + list(misc)
-            + list(gpr)):
+
+        for reg in [pc] + list(flags) + [stack, frame] + list(retaddr) + list(misc) + list(gpr):
             if reg and reg not in self.emulated_regs_order:
                 self.emulated_regs_order.append(reg)
-
 
         self.all = set(misc) | set(flags) | set(extra_flags) | set(self.retaddr) | set(self.common)
         self.all -= {None}

--- a/pwndbg/lib/regs.py
+++ b/pwndbg/lib/regs.py
@@ -80,6 +80,23 @@ class RegisterSet:
             if reg and reg not in self.common:
                 self.common.append(reg)
 
+        # The specific order of this list is very important:
+        # Due to the behavior of Arm in the Unicorn engine,
+        # we must write the flags register after PC, and the stack pointer after the flags register.
+        # Otherwise, the values will be clobbered
+        # https://github.com/pwndbg/pwndbg/pull/2337
+        self.emulated_regs_order: list[str] = []
+        
+        for reg in ([pc]
+            + list(flags)
+            + [stack, frame]
+            + list(retaddr)
+            + list(misc)
+            + list(gpr)):
+            if reg and reg not in self.emulated_regs_order:
+                self.emulated_regs_order.append(reg)
+
+
         self.all = set(misc) | set(flags) | set(extra_flags) | set(self.retaddr) | set(self.common)
         self.all -= {None}
 

--- a/pwndbg/lib/regs.py
+++ b/pwndbg/lib/regs.py
@@ -75,10 +75,12 @@ class RegisterSet:
         self.retval = retval
 
         # In 'common', we don't want to lose the ordering of:
-        self.common = []
+        self.common_no_flag = []
         for reg in gpr + (frame, stack, pc) + tuple(flags):
-            if reg and reg not in self.common:
-                self.common.append(reg)
+            if reg and reg not in self.common_no_flag:
+                self.common_no_flag.append(reg)
+
+        self.common = self.common_no_flag + list(flags)
 
         self.all = set(misc) | set(flags) | set(extra_flags) | set(self.retaddr) | set(self.common)
         self.all -= {None}

--- a/pwndbg/lib/regs.py
+++ b/pwndbg/lib/regs.py
@@ -85,7 +85,7 @@ class RegisterSet:
         # we must write the flags register after PC, and the stack pointer after the flags register.
         # Otherwise, the values will be clobbered
         # https://github.com/pwndbg/pwndbg/pull/2337
-        self.emulated_regs_order: list[str] = []
+        self.emulated_regs_order: List[str] = []
 
         for reg in [pc] + list(flags) + [stack, frame] + list(retaddr) + list(misc) + list(gpr):
             if reg and reg not in self.emulated_regs_order:

--- a/pwndbg/lib/regs.py
+++ b/pwndbg/lib/regs.py
@@ -75,12 +75,10 @@ class RegisterSet:
         self.retval = retval
 
         # In 'common', we don't want to lose the ordering of:
-        self.common_no_flag = []
-        for reg in gpr + (frame, stack, pc):
-            if reg and reg not in self.common_no_flag:
-                self.common_no_flag.append(reg)
-
-        self.common = self.common_no_flag + list(flags)
+        self.common = []
+        for reg in gpr + (frame, stack, pc) + tuple(flags):
+            if reg and reg not in self.common:
+                self.common.append(reg)
 
         self.all = set(misc) | set(flags) | set(extra_flags) | set(self.retaddr) | set(self.common)
         self.all -= {None}

--- a/pwndbg/lib/regs.py
+++ b/pwndbg/lib/regs.py
@@ -76,7 +76,7 @@ class RegisterSet:
 
         # In 'common', we don't want to lose the ordering of:
         self.common_no_flag = []
-        for reg in gpr + (frame, stack, pc) + tuple(flags):
+        for reg in gpr + (frame, stack, pc):
             if reg and reg not in self.common_no_flag:
                 self.common_no_flag.append(reg)
 


### PR DESCRIPTION
This PR makes a fix to emulation in Arm mode.

Previously, the stack pointer register - `SP` - would always mysteriously contain the value of the zero, despite us explicitly setting the value in the emulator. After some debugging, I found that the stack pointer value in the emulator resets to 0 when we copy the process flag `CPSR` register to the emulator.  I made an issue on the Unicorn Engine to track this: https://github.com/unicorn-engine/unicorn/issues/1984

This resulted in the emulator silently segfaulting very frequently (on all pushes, pops, and many load instructions which reference the stack pointer). 

The fix to this is to simply first write the value of the CPSR register to the emulator, and then our stack pointer. This involves reordering the initialization order. 


