### PR TITLE
Add comment to nearpc about pc being interpreted as lines

### DIFF
--- a/docs/commands/nearpc/nearpc.md
+++ b/docs/commands/nearpc/nearpc.md
@@ -19,7 +19,7 @@ usage: nearpc [-h] [-e] [pc] [lines]
 
 |Positional Argument|Help|
 | :--- | :--- |
-|`pc`|Address to disassemble near.|
+|`pc`|Address to disassemble near. If this is the only argument and the value provided is small enough, it is interpreted as lines instead.|
 |`lines`|Number of lines to show on either side of the address.|
 
 ## Optional Arguments

--- a/pwndbg/commands/nearpc.py
+++ b/pwndbg/commands/nearpc.py
@@ -6,7 +6,13 @@ import pwndbg.gdblib.nearpc
 from pwndbg.commands import CommandCategory
 
 parser = argparse.ArgumentParser(description="Disassemble near a specified address.")
-parser.add_argument("pc", type=int, nargs="?", default=None, help="Address to disassemble near.")
+parser.add_argument(
+    "pc",
+    type=int,
+    nargs="?",
+    default=None,
+    help="Address to disassemble near. If this is the only argument and the value provided is small enough, it is interpreted as lines instead.",
+)
 parser.add_argument(
     "lines",
     type=int,


### PR DESCRIPTION
In reference to https://github.com/pwndbg/pwndbg/issues/2332#issuecomment-2267093433.
It happens here in the code:
https://github.com/pwndbg/pwndbg/blob/dev/pwndbg/gdblib/nearpc.py#L105