### PR TITLE
Improved unmapped memory handling in vis_heap_chunk

### DIFF
--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -985,6 +985,10 @@ def vis_heap_chunks(
     allocator = pwndbg.gdblib.heap.current
     assert isinstance(allocator, GlibcMemoryAllocator)
 
+    if addr is not None and not pwndbg.gdblib.memory.is_readable_address(int(addr)):
+        print(message.error("The provided address is not readable."))
+        return
+
     if addr is not None:
         cursor = int(addr)
         heap_region = Heap(cursor)
@@ -1006,6 +1010,7 @@ def vis_heap_chunks(
     chunk = Chunk(cursor)
 
     chunk_id = 0
+    reached_mapping_end = False
     while True:
         if not all_chunks and chunk_id == count + 1:
             break
@@ -1013,6 +1018,7 @@ def vis_heap_chunks(
         # Don't read beyond the heap mapping if --beyond_top or corrupted heap.
         if cursor not in heap_region:
             chunk_delims.append(heap_region.end)
+            reached_mapping_end = True
             break
 
         # Don't repeatedly operate on the same address (e.g. chunk size of 0).
@@ -1024,8 +1030,13 @@ def vis_heap_chunks(
         else:
             chunk_delims.append(cursor)
 
-        if (chunk.is_top_chunk and not beyond_top) or (cursor == heap_region.end - ptr_size * 2):
+        if chunk.is_top_chunk and not beyond_top:
             chunk_delims.append(cursor + ptr_size * 2)
+            break
+
+        if cursor == heap_region.end - ptr_size * 2:
+            chunk_delims.append(cursor + ptr_size * 2)
+            reached_mapping_end = True
             break
 
         cursor += chunk.real_size
@@ -1042,12 +1053,15 @@ def vis_heap_chunks(
         generateColorFunction("blue"),
     ]
 
-    bin_collections = [
-        allocator.fastbins(arena.address),
-        allocator.unsortedbin(arena.address),
-        allocator.smallbins(arena.address),
-        allocator.largebins(arena.address),
-    ]
+    bin_collections = []
+    if arena is not None:
+        # Heap() Case 4; fake/mmapped chunk
+        bin_collections = [
+            allocator.fastbins(arena.address),
+            allocator.unsortedbin(arena.address),
+            allocator.smallbins(arena.address),
+            allocator.largebins(arena.address),
+        ]
     if allocator.has_tcache():
         # Only check for tcache entries belonging to the current thread,
         # it's difficult (impossible?) to find all the thread caches for a
@@ -1104,7 +1118,7 @@ def vis_heap_chunks(
             printed += 1
 
             labels.extend(bin_labels_map.get(cursor, []))
-            if cursor == arena.top:
+            if arena is not None and cursor == arena.top:
                 labels.append("Top chunk")
 
             asc += bin_ascii(data)
@@ -1116,6 +1130,9 @@ def vis_heap_chunks(
             cursor += ptr_size
 
     print(out)
+
+    if reached_mapping_end:
+        print(f"Reached end of memory mapping ({hex(heap_region.end)}).")
 
     if has_huge_chunk and pwndbg.config.max_visualize_chunk_size == 0:
         print(

--- a/pwndbg/gdblib/heap/ptmalloc.py
+++ b/pwndbg/gdblib/heap/ptmalloc.py
@@ -489,6 +489,9 @@ class Heap:
             self._gdbValue = None
         else:
             heap_region = allocator.get_region(addr)
+            if heap_region is None:
+                raise ValueError(f"Cannot build heap object on an unmapped address ({hex(addr)})")
+
             heap_info = allocator.get_heap(addr)
             try:
                 ar_ptr = int(heap_info["ar_ptr"])


### PR DESCRIPTION
Closes https://github.com/pwndbg/pwndbg/issues/2304
+ An error message when an unmapped address is provided
+ An informational message when the output is cut off because of reaching the end of a mapping
+ A new exception in `Heap()` to make debugging future errors easier 