### PR TITLE
Port the event system to the Debugger-agnostic API and move modules external to `gdblib` to it

### DIFF
--- a/pwndbg/auxv.py
+++ b/pwndbg/auxv.py
@@ -10,7 +10,6 @@ import gdb
 
 import pwndbg.gdblib.abi
 import pwndbg.gdblib.arch
-import pwndbg.gdblib.events
 import pwndbg.gdblib.info
 import pwndbg.gdblib.memory
 import pwndbg.gdblib.qemu

--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -23,7 +23,6 @@ import pwndbg.color.syntax_highlight as H
 import pwndbg.commands
 import pwndbg.commands.telescope
 import pwndbg.gdblib.disasm
-import pwndbg.gdblib.events
 import pwndbg.gdblib.heap_tracking
 import pwndbg.gdblib.nearpc
 import pwndbg.gdblib.regs
@@ -363,7 +362,7 @@ def context_ghidra(target=sys.stdout, with_banner=True, width=None):
         return banner + [message.error(e)]
 
 
-# @pwndbg.gdblib.events.stop
+# @pwndbg.dbg.event_handler(EventType.STOP)
 
 parser = argparse.ArgumentParser(
     description="Print out the current register, instruction, and stack context."

--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -362,7 +362,6 @@ def context_ghidra(target=sys.stdout, with_banner=True, width=None):
         return banner + [message.error(e)]
 
 
-
 parser = argparse.ArgumentParser(
     description="Print out the current register, instruction, and stack context."
 )

--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -362,7 +362,6 @@ def context_ghidra(target=sys.stdout, with_banner=True, width=None):
         return banner + [message.error(e)]
 
 
-# @pwndbg.dbg.event_handler(EventType.STOP)
 
 parser = argparse.ArgumentParser(
     description="Print out the current register, instruction, and stack context."

--- a/pwndbg/commands/ida.py
+++ b/pwndbg/commands/ida.py
@@ -7,11 +7,13 @@ import os
 
 import gdb
 
+import pwndbg
 import pwndbg.commands
 import pwndbg.commands.context
 import pwndbg.gdblib.regs
 import pwndbg.integration.ida
 from pwndbg.commands import CommandCategory
+from pwndbg.dbg import EventType
 from pwndbg.gdblib.functions import GdbFunction
 
 
@@ -19,7 +21,7 @@ from pwndbg.gdblib.functions import GdbFunction
     "Synchronize IDA's cursor with GDB.", category=CommandCategory.INTEGRATIONS
 )
 @pwndbg.commands.OnlyWhenRunning
-@pwndbg.gdblib.events.stop
+@pwndbg.dbg.event_handler(EventType.STOP)
 @pwndbg.integration.ida.withIDA
 def j(*args) -> None:
     """

--- a/pwndbg/commands/start.py
+++ b/pwndbg/commands/start.py
@@ -11,16 +11,17 @@ from shlex import quote
 
 import gdb
 
+import pwndbg
 import pwndbg.commands
 import pwndbg.gdblib.elf
-import pwndbg.gdblib.events
 import pwndbg.gdblib.symbol
 from pwndbg.commands import CommandCategory
+from pwndbg.dbg import EventType
 
 break_on_first_instruction = False
 
 
-@pwndbg.gdblib.events.start
+@pwndbg.dbg.event_handler(EventType.START)
 def on_start() -> None:
     global break_on_first_instruction
     if break_on_first_instruction:

--- a/pwndbg/dbg/__init__.py
+++ b/pwndbg/dbg/__init__.py
@@ -274,8 +274,8 @@ class EventType(Enum):
           process execution to continue after it had been previously suspended.
         - `NEW_MODULE`: This event is fired when a new application module has
           been encountered by the debugger. This usually happens when a new
-          application module is into the memory space of the process being
-          debugged.
+          application module is loaded into the memory space of the process being
+          debugged. In GDB terminology, these are called `objfile`s.
     """
 
     START = 0

--- a/pwndbg/dbg/__init__.py
+++ b/pwndbg/dbg/__init__.py
@@ -9,8 +9,11 @@ from typing import Any
 from typing import Callable
 from typing import List
 from typing import Tuple
+from typing import TypeVar
 
 dbg: Debugger = None
+
+T = TypeVar("T")
 
 
 class Error(Exception):
@@ -251,6 +254,39 @@ class CommandHandle:
         raise NotImplementedError()
 
 
+class EventType(Enum):
+    """
+    Events that can be listened for and reacted to in a debugger.
+
+    The events types listed here are defined as follows:
+        - `START`: This event is fired some time between the creation of or
+          attachment to the process to be debugged, and the start of its
+          execution.
+        - `STOP`: This event is fired after execution of the process has been
+          suspended, but before control is returned to the user for interactive
+          debugging.
+        - `EXIT`: This event is fired after the process being debugged has been
+          detached from or has finished executing.
+        - `MEMORY_CHANGED`: This event is fired when the user interactively makes
+          changes to the memory of the process being debugged.
+        - `REGISTER_CHANGED`: Like `MEMORY_CHANGED`, but for registers.
+        - `CONTINUE`: This event is fired after the user has requested for
+          process execution to continue after it had been previously suspended.
+        - `NEW_MODULE`: This event is fired when a new application module has
+          been encountered by the debugger. This usually happens when a new
+          application module is into the memory space of the process being
+          debugged.
+    """
+
+    START = 0
+    STOP = 1
+    EXIT = 2
+    MEMORY_CHANGED = 3
+    REGISTER_CHANGED = 4
+    CONTINUE = 5
+    NEW_MODULE = 6
+
+
 class Debugger:
     """
     The base class representing a debugger.
@@ -321,6 +357,21 @@ class Debugger:
         """
         Adds a command with the given name to the debugger, that invokes the
         given function every time it is called.
+        """
+        raise NotImplementedError()
+
+    def has_event_type(self, ty: EventType) -> bool:
+        """
+        Whether the given event type is supported by this debugger. Indicates
+        that a user either can or cannot register an event handler of this type.
+        """
+        raise NotImplementedError()
+
+    def event_handler(self, ty: EventType) -> Callable[[Callable[..., T]], Callable[..., T]]:
+        """
+        Sets up the given function to be called when an event of the given type
+        gets fired. Returns a callable that corresponds to the wrapped function.
+        This function my be used as a decorator.
         """
         raise NotImplementedError()
 

--- a/pwndbg/dbg/gdb.py
+++ b/pwndbg/dbg/gdb.py
@@ -61,9 +61,6 @@ def parse_and_eval(expression: str, global_context: bool) -> gdb.Value:
         return gdb.parse_and_eval(expression)
 
 
-T = TypeVar("T")
-
-
 @contextlib.contextmanager
 def selection(target: T, get_current: Callable[[], T], select: Callable[[T], None]):
     """

--- a/pwndbg/dbg/gdb.py
+++ b/pwndbg/dbg/gdb.py
@@ -21,18 +21,6 @@ from pwndbg.gdblib import load_gdblib
 T = TypeVar("T")
 
 
-# We pass the responsibility of event handling to gdblib.
-GDBLIB_EVENT_MAPPING = {
-    pwndbg.dbg_mod.EventType.EXIT: pwndbg.gdblib.events.exit,
-    pwndbg.dbg_mod.EventType.CONTINUE: pwndbg.gdblib.events.cont,
-    pwndbg.dbg_mod.EventType.START: pwndbg.gdblib.events.start,
-    pwndbg.dbg_mod.EventType.STOP: pwndbg.gdblib.events.stop,
-    pwndbg.dbg_mod.EventType.NEW_MODULE: pwndbg.gdblib.events.new_objfile,
-    pwndbg.dbg_mod.EventType.MEMORY_CHANGED: pwndbg.gdblib.events.mem_changed,
-    pwndbg.dbg_mod.EventType.REGISTER_CHANGED: pwndbg.gdblib.events.reg_changed,
-}
-
-
 class GDBRegisters(pwndbg.dbg_mod.Registers):
     def __init__(self, frame: GDBFrame):
         self.frame = frame
@@ -505,8 +493,21 @@ class GDB(pwndbg.dbg_mod.Debugger):
     def event_handler(
         self, ty: pwndbg.dbg_mod.EventType
     ) -> Callable[[Callable[..., T]], Callable[..., T]]:
-        # Just call into the gdblib handler.
-        return GDBLIB_EVENT_MAPPING[ty]
+        # Make use of the existing gdblib event handlers.
+        if ty == pwndbg.dbg_mod.EventType.EXIT:
+            return pwndbg.gdblib.events.exit
+        elif ty == pwndbg.dbg_mod.EventType.CONTINUE:
+            return pwndbg.gdblib.events.cont
+        elif ty == pwndbg.dbg_mod.EventType.START:
+            return pwndbg.gdblib.events.start
+        elif ty == pwndbg.dbg_mod.EventType.STOP:
+            return pwndbg.gdblib.events.stop
+        elif ty == pwndbg.dbg_mod.EventType.NEW_MODULE:
+            return pwndbg.gdblib.events.new_objfile
+        elif ty == pwndbg.dbg_mod.EventType.MEMORY_CHANGED:
+            return pwndbg.gdblib.events.mem_changed
+        elif ty == pwndbg.dbg_mod.EventType.REGISTER_CHANGED:
+            return pwndbg.gdblib.events.reg_changed
 
     @override
     def addrsz(self, address: Any) -> str:

--- a/pwndbg/gdblib/__init__.py
+++ b/pwndbg/gdblib/__init__.py
@@ -41,7 +41,6 @@ def load_gdblib() -> None:
     import pwndbg.gdblib.disasm.x86
     import pwndbg.gdblib.dynamic
     import pwndbg.gdblib.elf
-    import pwndbg.gdblib.events
     import pwndbg.gdblib.functions
     import pwndbg.gdblib.got
     import pwndbg.gdblib.hooks

--- a/pwndbg/gdblib/android.py
+++ b/pwndbg/gdblib/android.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 import gdb
 
-import pwndbg.gdblib.events
+import pwndbg
 import pwndbg.gdblib.file
 import pwndbg.gdblib.qemu
 import pwndbg.lib.cache
 from pwndbg.color import message
+from pwndbg.dbg import EventType
 
 
 @pwndbg.lib.cache.cache_until("start", "exit")
@@ -23,7 +24,7 @@ def is_android() -> bool:
     return False
 
 
-@pwndbg.gdblib.events.start
+@pwndbg.dbg.event_handler(EventType.START)
 def sysroot() -> None:
     cmd = "set sysroot remote:/"
     if is_android():

--- a/pwndbg/gdblib/arch.py
+++ b/pwndbg/gdblib/arch.py
@@ -5,7 +5,7 @@ from typing import Literal
 import gdb
 import pwnlib
 
-import pwndbg.gdblib.proc
+import pwndbg.gdblib
 from pwndbg.gdblib import typeinfo
 from pwndbg.lib.arch import Arch
 
@@ -81,6 +81,10 @@ def _get_arch(ptrsize: int):
         endian = "little"
     else:
         endian = "big"
+
+    # Importing requires that `pwndbg.dbg` already be set up, so we have to do
+    # it here, rather then on the top level.
+    import pwndbg.gdblib.proc
 
     if pwndbg.gdblib.proc.alive:
         arch = gdb.newest_frame().architecture().name()

--- a/pwndbg/gdblib/argv.py
+++ b/pwndbg/gdblib/argv.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 import gdb
 
+import pwndbg
 import pwndbg.gdblib.abi
 import pwndbg.gdblib.arch
-import pwndbg.gdblib.events
 import pwndbg.gdblib.memory
 import pwndbg.gdblib.regs
+from pwndbg.dbg import EventType
 
 #: Total number of arguments
 argc = None
@@ -21,7 +22,7 @@ envp = None
 envc = None
 
 
-@pwndbg.gdblib.events.start
+@pwndbg.dbg.event_handler(EventType.START)
 @pwndbg.gdblib.abi.LinuxOnly()
 def update() -> None:
     global argc

--- a/pwndbg/gdblib/ctypes.py
+++ b/pwndbg/gdblib/ctypes.py
@@ -13,15 +13,16 @@ from __future__ import annotations
 import ctypes
 import sys
 
+import pwndbg
 import pwndbg.gdblib.arch
-import pwndbg.gdblib.events
+from pwndbg.dbg import EventType
 
 module = sys.modules[__name__]
 Structure = ctypes.LittleEndianStructure  # default Structure type
 
 
-@pwndbg.gdblib.events.start
-@pwndbg.gdblib.events.new_objfile
+@pwndbg.dbg.event_handler(EventType.START)
+@pwndbg.dbg.event_handler(EventType.NEW_MODULE)
 def update() -> None:
     global Structure
     if pwndbg.gdblib.arch.endian == "little":

--- a/pwndbg/gdblib/disasm/__init__.py
+++ b/pwndbg/gdblib/disasm/__init__.py
@@ -17,13 +17,14 @@ import capstone
 import gdb
 from capstone import *  # noqa: F403
 
+import pwndbg
 import pwndbg.gdblib.arch
 import pwndbg.gdblib.disasm.arch
-import pwndbg.gdblib.events
 import pwndbg.gdblib.memory
 import pwndbg.gdblib.symbol
 import pwndbg.lib.cache
 from pwndbg.color import message
+from pwndbg.dbg import EventType
 from pwndbg.gdblib.disasm.arch import DEBUG_ENHANCEMENT
 from pwndbg.gdblib.disasm.instruction import ALL_JUMP_GROUPS
 from pwndbg.gdblib.disasm.instruction import PwndbgInstruction
@@ -87,7 +88,7 @@ next_addresses_cache: Set[int] = set()
 
 
 # Register GDB event listeners for all stop events
-@pwndbg.gdblib.events.stop
+@pwndbg.dbg.event_handler(EventType.STOP)
 def enhance_cache_listener() -> None:
     # Clear the register value cache to ensure we get the correct program counter value
     pwndbg.gdblib.regs.read_reg.cache.clear()  # type: ignore[attr-defined]
@@ -97,8 +98,8 @@ def enhance_cache_listener() -> None:
         computed_instruction_cache.clear()
 
 
-@pwndbg.gdblib.events.mem_changed
-@pwndbg.gdblib.events.reg_changed
+@pwndbg.dbg.event_handler(EventType.MEMORY_CHANGED)
+@pwndbg.dbg.event_handler(EventType.REGISTER_CHANGED)
 def clear_on_reg_mem_change() -> None:
     # We clear all the future computed instructions because when we manually change a register or memory, it's often a location
     # used by the instructions at or just after the current PC, and our previously emulated future instructions might be inaccurate

--- a/pwndbg/gdblib/elf.py
+++ b/pwndbg/gdblib/elf.py
@@ -24,11 +24,11 @@ from elftools.elf.elffile import ELFFile
 from elftools.elf.relocation import Relocation
 from elftools.elf.relocation import RelocationSection
 
+import pwndbg
 import pwndbg.auxv
 import pwndbg.gdblib.abi
 import pwndbg.gdblib.arch
 import pwndbg.gdblib.ctypes
-import pwndbg.gdblib.events
 import pwndbg.gdblib.file
 import pwndbg.gdblib.info
 import pwndbg.gdblib.memory
@@ -40,6 +40,7 @@ import pwndbg.lib.cache
 import pwndbg.lib.elftypes
 import pwndbg.lib.memory
 from pwndbg.color import message
+from pwndbg.dbg import EventType
 
 # ELF constants
 PF_X, PF_W, PF_R = 1, 2, 4
@@ -71,8 +72,8 @@ Ehdr = Union[pwndbg.lib.elftypes.Elf32_Ehdr, pwndbg.lib.elftypes.Elf64_Ehdr]
 Phdr = Union[pwndbg.lib.elftypes.Elf32_Phdr, pwndbg.lib.elftypes.Elf64_Phdr]
 
 
-@pwndbg.gdblib.events.start
-@pwndbg.gdblib.events.new_objfile
+@pwndbg.dbg.event_handler(EventType.START)
+@pwndbg.dbg.event_handler(EventType.NEW_MODULE)
 def update() -> None:
     global Ehdr, Phdr
     try:

--- a/pwndbg/gdblib/heap/__init__.py
+++ b/pwndbg/gdblib/heap/__init__.py
@@ -6,12 +6,12 @@ from typing import Sequence
 import gdb
 
 import pwndbg
-import pwndbg.gdblib.events
 import pwndbg.gdblib.heap.heap
 import pwndbg.gdblib.proc
 import pwndbg.gdblib.symbol
 import pwndbg.lib.config
 from pwndbg.color import message
+from pwndbg.dbg import EventType
 
 current: pwndbg.gdblib.heap.heap.MemoryAllocator | None = None
 
@@ -89,12 +89,12 @@ If you used setup.sh on Arch based distro you'll need to do a power cycle or set
 )
 
 
-@pwndbg.gdblib.events.start
+@pwndbg.dbg.event_handler(EventType.START)
 def update() -> None:
     resolve_heap(is_first_run=True)
 
 
-@pwndbg.gdblib.events.exit
+@pwndbg.dbg.event_handler(EventType.EXIT)
 def reset() -> None:
     global current
     # Re-initialize the heap

--- a/pwndbg/gdblib/heap/ptmalloc.py
+++ b/pwndbg/gdblib/heap/ptmalloc.py
@@ -28,7 +28,6 @@ import gdb
 
 import pwndbg
 import pwndbg.chain
-import pwndbg.gdblib.events
 import pwndbg.gdblib.heap
 import pwndbg.gdblib.heap.heap
 import pwndbg.gdblib.memory

--- a/pwndbg/gdblib/hooks.py
+++ b/pwndbg/gdblib/hooks.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import pwndbg
 import pwndbg.gdblib.abi
 import pwndbg.gdblib.events
 import pwndbg.gdblib.file
@@ -7,43 +8,44 @@ import pwndbg.gdblib.memory
 import pwndbg.gdblib.next
 import pwndbg.gdblib.tls
 import pwndbg.gdblib.typeinfo
+from pwndbg.dbg import EventType
 from pwndbg.gdblib import arch_mod
 
 # TODO: Combine these `update_*` hook callbacks into one method
 
 
-@pwndbg.gdblib.events.new_objfile
-@pwndbg.gdblib.events.start
-@pwndbg.gdblib.events.stop
+@pwndbg.dbg.event_handler(EventType.NEW_MODULE)
+@pwndbg.dbg.event_handler(EventType.START)
+@pwndbg.dbg.event_handler(EventType.STOP)
 def update_typeinfo() -> None:
     pwndbg.gdblib.typeinfo.update()
 
 
-@pwndbg.gdblib.events.start
-@pwndbg.gdblib.events.stop
-@pwndbg.gdblib.events.new_objfile
+@pwndbg.dbg.event_handler(EventType.START)
+@pwndbg.dbg.event_handler(EventType.STOP)
+@pwndbg.dbg.event_handler(EventType.NEW_MODULE)
 def update_arch() -> None:
     arch_mod.update()
 
 
-@pwndbg.gdblib.events.new_objfile
+@pwndbg.dbg.event_handler(EventType.NEW_MODULE)
 def reset_config() -> None:
     pwndbg.gdblib.kernel._kconfig = None
 
 
-@pwndbg.gdblib.events.start
+@pwndbg.dbg.event_handler(EventType.START)
 def on_start() -> None:
     pwndbg.gdblib.abi.update()
     pwndbg.gdblib.memory.update_min_addr()
 
 
-@pwndbg.gdblib.events.exit
+@pwndbg.dbg.event_handler(EventType.EXIT)
 def on_exit() -> None:
     pwndbg.gdblib.file.reset_remote_files()
     pwndbg.gdblib.next.clear_temp_breaks()
 
 
-@pwndbg.gdblib.events.stop
+@pwndbg.dbg.event_handler(EventType.STOP)
 def on_stop() -> None:
     pwndbg.gdblib.strings.update_length()
 

--- a/pwndbg/gdblib/kernel/rbtree.py
+++ b/pwndbg/gdblib/kernel/rbtree.py
@@ -2,14 +2,15 @@ from __future__ import annotations
 
 import gdb
 
-from pwndbg.gdblib.events import new_objfile
+import pwndbg
+from pwndbg.dbg import EventType
 from pwndbg.gdblib.kernel.macros import container_of
 
 rb_root_type = None
 rb_node_type = None
 
 
-@new_objfile
+@pwndbg.dbg.event_handler(EventType.NEW_MODULE)
 def init():
     global rb_root_type, rb_node_type
     try:

--- a/pwndbg/gdblib/memory.py
+++ b/pwndbg/gdblib/memory.py
@@ -12,7 +12,6 @@ from typing import Union
 import gdb
 
 import pwndbg.gdblib.arch
-import pwndbg.gdblib.events
 import pwndbg.gdblib.qemu
 import pwndbg.gdblib.typeinfo
 import pwndbg.gdblib.vmmap

--- a/pwndbg/gdblib/next.py
+++ b/pwndbg/gdblib/next.py
@@ -12,7 +12,6 @@ import capstone
 import gdb
 
 import pwndbg.gdblib.disasm
-import pwndbg.gdblib.events
 import pwndbg.gdblib.proc
 import pwndbg.gdblib.regs
 from pwndbg.color import message

--- a/pwndbg/gdblib/prompt.py
+++ b/pwndbg/gdblib/prompt.py
@@ -6,6 +6,7 @@ from typing import Tuple
 
 import gdb
 
+import pwndbg
 import pwndbg.commands
 import pwndbg.commands.context
 import pwndbg.decorators
@@ -16,6 +17,7 @@ import pwndbg.lib.cache
 import pwndbg.profiling
 from pwndbg.color import disable_colors
 from pwndbg.color import message
+from pwndbg.dbg import EventType
 from pwndbg.lib.tips import color_tip
 from pwndbg.lib.tips import get_tip_of_the_day
 
@@ -88,7 +90,7 @@ def prompt_hook(*a: Any) -> None:
         set_prompt()
 
 
-@pwndbg.gdblib.events.cont
+@pwndbg.dbg.event_handler(EventType.CONTINUE)
 def reset_context_shown(*a: Any) -> None:
     global context_shown
     context_shown = False

--- a/pwndbg/gdblib/qemu.py
+++ b/pwndbg/gdblib/qemu.py
@@ -9,11 +9,10 @@ import os
 import gdb
 import psutil
 
+import pwndbg
 import pwndbg.gdblib.remote
 import pwndbg.lib.cache
-
-# TODO: `import pwndbg.gdblib.events` leads to a circular import
-from pwndbg.gdblib.events import start
+from pwndbg.dbg import EventType
 
 
 @pwndbg.lib.cache.cache_until("stop")
@@ -68,7 +67,7 @@ def exec_file_supported() -> bool:
     return "exec-file" in response
 
 
-@start
+@pwndbg.dbg.event_handler(EventType.START)
 @pwndbg.lib.cache.cache_until("stop")
 def root() -> str | None:
     if not is_qemu_usermode():

--- a/pwndbg/gdblib/regs.py
+++ b/pwndbg/gdblib/regs.py
@@ -19,13 +19,14 @@ from typing import cast
 
 import gdb
 
+import pwndbg
 import pwndbg.gdblib.arch
-import pwndbg.gdblib.events
 import pwndbg.gdblib.proc
 import pwndbg.gdblib.qemu
 import pwndbg.gdblib.remote
 import pwndbg.gdblib.typeinfo
 import pwndbg.lib.cache
+from pwndbg.dbg import EventType
 from pwndbg.lib.regs import BitFlags
 from pwndbg.lib.regs import RegisterSet
 from pwndbg.lib.regs import reg_sets
@@ -278,8 +279,8 @@ tether = sys.modules[__name__]
 sys.modules[__name__] = module(__name__, "")
 
 
-@pwndbg.gdblib.events.cont
-@pwndbg.gdblib.events.stop
+@pwndbg.dbg.event_handler(EventType.CONTINUE)
+@pwndbg.dbg.event_handler(EventType.STOP)
 def update_last() -> None:
     M: module = cast(module, sys.modules[__name__])
     M.previous = M.last

--- a/pwndbg/gdblib/stack.py
+++ b/pwndbg/gdblib/stack.py
@@ -12,11 +12,12 @@ from typing import List
 
 import gdb
 
+import pwndbg
 import pwndbg.gdblib.abi
 import pwndbg.gdblib.elf
-import pwndbg.gdblib.events
 import pwndbg.gdblib.memory
 import pwndbg.lib.cache
+from pwndbg.dbg import EventType
 
 
 def find(address: int):
@@ -65,7 +66,7 @@ def current() -> pwndbg.lib.memory.Page | None:
     return find(pwndbg.gdblib.regs.sp)
 
 
-@pwndbg.gdblib.events.stop
+@pwndbg.dbg.event_handler(EventType.STOP)
 @pwndbg.lib.cache.cache_until("exit")
 def is_executable() -> bool:
     ehdr = pwndbg.gdblib.elf.exe()

--- a/pwndbg/gdblib/symbol.py
+++ b/pwndbg/gdblib/symbol.py
@@ -15,7 +15,6 @@ import gdb
 import pwndbg.gdblib.android
 import pwndbg.gdblib.arch
 import pwndbg.gdblib.elf
-import pwndbg.gdblib.events
 import pwndbg.gdblib.file
 import pwndbg.gdblib.memory
 import pwndbg.gdblib.qemu

--- a/pwndbg/gdblib/vmmap.py
+++ b/pwndbg/gdblib/vmmap.py
@@ -16,11 +16,11 @@ from typing import Tuple
 
 import gdb
 
+import pwndbg
 import pwndbg.auxv
 import pwndbg.color.message as M
 import pwndbg.gdblib.abi
 import pwndbg.gdblib.elf
-import pwndbg.gdblib.events
 import pwndbg.gdblib.file
 import pwndbg.gdblib.info
 import pwndbg.gdblib.kernel
@@ -273,13 +273,13 @@ def explore(address_maybe: int) -> pwndbg.lib.memory.Page | None:
 
 
 # Automatically ensure that all registers are explored on each stop
-# @pwndbg.gdblib.events.stop
+# @pwndbg.dbg.event_handler(EventType.STOP)
 def explore_registers() -> None:
     for regname in pwndbg.gdblib.regs.common:
         find(pwndbg.gdblib.regs[regname])
 
 
-# @pwndbg.gdblib.events.exit
+# @pwndbg.dbg.event_handler(EventType.EXIT)
 def clear_explored_pages() -> None:
     while explored_pages:
         explored_pages.pop()

--- a/pwndbg/integration/binja.py
+++ b/pwndbg/integration/binja.py
@@ -33,7 +33,6 @@ import pwndbg.color.context as context_color
 import pwndbg.decorators
 import pwndbg.gdblib.arch
 import pwndbg.gdblib.elf
-import pwndbg.gdblib.events
 import pwndbg.gdblib.memory
 import pwndbg.gdblib.nearpc
 import pwndbg.gdblib.regs
@@ -43,6 +42,7 @@ import pwndbg.lib.cache
 import pwndbg.lib.config
 from pwndbg.color import message
 from pwndbg.color import theme
+from pwndbg.dbg import EventType
 from pwndbg.gdblib.nearpc import c as nearpc_color
 from pwndbg.gdblib.nearpc import ljust_padding
 from pwndbg.lib.functions import Argument
@@ -198,7 +198,7 @@ def base():
     return _bn.get_base()
 
 
-@pwndbg.gdblib.events.stop
+@pwndbg.dbg.event_handler(EventType.STOP)
 @with_bn()
 def auto_update_pc() -> None:
     pc = pwndbg.gdblib.regs.pc
@@ -210,9 +210,9 @@ def auto_update_pc() -> None:
 _managed_bps: Dict[int, gdb.Breakpoint] = {}
 
 
-@pwndbg.gdblib.events.start
-@pwndbg.gdblib.events.stop
-@pwndbg.gdblib.events.cont
+@pwndbg.dbg.event_handler(EventType.START)
+@pwndbg.dbg.event_handler(EventType.STOP)
+@pwndbg.dbg.event_handler(EventType.CONTINUE)
 @with_bn()
 def auto_update_bp() -> None:
     bps: List[int] = _bn.get_bp_tags()
@@ -224,8 +224,8 @@ def auto_update_bp() -> None:
         _managed_bps[k] = bp
 
 
-@pwndbg.gdblib.events.cont
-@pwndbg.gdblib.events.exit
+@pwndbg.dbg.event_handler(EventType.CONTINUE)
+@pwndbg.dbg.event_handler(EventType.EXIT)
 @with_bn()
 def auto_clear_pc() -> None:
     _bn.clear_pc_tag()

--- a/pwndbg/integration/ida.py
+++ b/pwndbg/integration/ida.py
@@ -28,13 +28,13 @@ import pwndbg
 import pwndbg.decorators
 import pwndbg.gdblib.arch
 import pwndbg.gdblib.elf
-import pwndbg.gdblib.events
 import pwndbg.gdblib.memory
 import pwndbg.gdblib.regs
 import pwndbg.integration
 import pwndbg.lib.cache
 import pwndbg.lib.funcparser
 from pwndbg.color import message
+from pwndbg.dbg import EventType
 from pwndbg.lib.functions import Function
 
 ida_rpc_host = pwndbg.config.add_param("ida-rpc-host", "127.0.0.1", "ida xmlrpc server address")
@@ -285,8 +285,8 @@ def GetBptEA(i: int) -> int:
 _breakpoints: List[gdb.Breakpoint] = []
 
 
-@pwndbg.gdblib.events.cont
-@pwndbg.gdblib.events.stop
+@pwndbg.dbg.event_handler(EventType.CONTINUE)
+@pwndbg.dbg.event_handler(EventType.STOP)
 @withIDA
 def UpdateBreakpoints() -> None:
     # XXX: Remove breakpoints from IDA when the user removes them.
@@ -317,7 +317,7 @@ def SetColor(pc, color):
 colored_pc = None
 
 
-@pwndbg.gdblib.events.stop
+@pwndbg.dbg.event_handler(EventType.STOP)
 @withIDA
 def Auto_Color_PC() -> None:
     global colored_pc
@@ -325,7 +325,7 @@ def Auto_Color_PC() -> None:
     SetColor(colored_pc, 0x7F7FFF)
 
 
-@pwndbg.gdblib.events.cont
+@pwndbg.dbg.event_handler(EventType.CONTINUE)
 @withIDA
 def Auto_UnColor_PC() -> None:
     global colored_pc

--- a/tests/gdb-tests/tests/test_cache.py
+++ b/tests/gdb-tests/tests/test_cache.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-import pwndbg.gdblib.events
+import pwndbg
 import tests
+from pwndbg.dbg import EventType
 from pwndbg.lib import cache
 
 BINARY = tests.binaries.get("reference-binary.out")
@@ -74,7 +75,7 @@ def test_cache_args_kwargs_properly(start_binary):
 def test_cache_clear_has_priority(start_binary):
     actions = []
 
-    @pwndbg.gdblib.events.stop
+    @pwndbg.dbg.event_handler(EventType.STOP)
     def on_stop():
         actions.append("on_stop")
         # test to make sure event handlers don't have a stale cache


### PR DESCRIPTION
This PR is part of the GSoC 2024 LLDB port.

This PR adds an event interface, similar to the one currently exposed by `pwndbg.gdblib.events`, to the Debugger-agnostic API. This new event interface exposes the same event types as the `gdblib` interface - except for those that are not used outside `gdblib`, like `thread` and `before_prompt` - though one under a different name, better matching the terminology used in LLDB.

This PR also moves all uses of the `pwndbg.gdblib.events` interface in modules outside of `gdblib` to the new interface. To the best of my ability, I believe that behavior should be exactly the same between the two interfaces under GDB, and the tests seem to confirm that, but there might be something I'm missing, still.

Additionally, the LLDB implementation does not support this new interface and won't until the Pwndbg LLDB REPL gets merged. This is, to make a very long story short, due to the fact that LLDB does not have a robust way for us to listen to any events related to the lifetime of the process, unless we drive the lifetime and I/O of the process ourselves. I'll elaborate more on this issue when it comes time to submit the REPL PR.