### PR TITLE
Small fix to annotations crash

### DIFF
--- a/pwndbg/color/disasm.py
+++ b/pwndbg/color/disasm.py
@@ -134,7 +134,8 @@ def instructions_and_padding(instructions: List[PwndbgInstruction]) -> List[str]
 
     # Final pass to apply final paddings to make alignment of blocks of instructions cleaner
     for i, (ins, asm, padding) in enumerate(zip(instructions, result, paddings)):
-        if ins.annotation:
+        # Padding being a valid number implies an annotation at this line
+        if padding is not None:
             asm = f"{ljust_colored(asm, padding)}{ins.annotation}"
 
         final_result.append(asm)

--- a/pwndbg/color/disasm.py
+++ b/pwndbg/color/disasm.py
@@ -134,8 +134,8 @@ def instructions_and_padding(instructions: List[PwndbgInstruction]) -> List[str]
 
     # Final pass to apply final paddings to make alignment of blocks of instructions cleaner
     for i, (ins, asm, padding) in enumerate(zip(instructions, result, paddings)):
-        # Padding being a valid number implies an annotation at this line
-        if padding is not None:
+        # Padding being None implies a jump target - this is already baked into "asm"
+        if ins.annotation and padding is not None:
             asm = f"{ljust_colored(asm, padding)}{ins.annotation}"
 
         final_result.append(asm)


### PR DESCRIPTION
This small PR fixes a crash in annotations in specific scenarios.

The control flow previously didn't account for a scenario where we generate an annotation for an instruction that also changes the program counter. Most instructions explicitly change the program counter (jump, ret), but in Arm, some instructions like `add` or `sub`, can have the PC as the target, and the codeflow didn't consider this, leading to a crash in these cases. If there's a jump target, it takes precedence. 

This would cause a crash once we have `sub` annotations on Arm.
```asm
.section .text
.global _start

_start:
ldr     R1, =_target
SUB PC, R1, #1

.THUMB
_target:
add r3,r4,r5
```