### PR TITLE
Annotations for Arithmetic Instructions in RISCV, Arm, AArch64, MIPS, and x86

### DIFF
--- a/pwndbg/enhance.py
+++ b/pwndbg/enhance.py
@@ -30,7 +30,7 @@ def format_small_int(value: int) -> str:
     if value < 10:
         return str(value)
     else:
-        return hex(value & pwndbg.gdblib.arch.ptrmask)
+        return hex(value)
 
 
 def format_small_int_pair(first: int, second: int) -> Tuple[str, str]:
@@ -38,8 +38,8 @@ def format_small_int_pair(first: int, second: int) -> Tuple[str, str]:
         return (str(first), str(second))
     else:
         return (
-            hex(first & pwndbg.gdblib.arch.ptrmask),
-            hex(second & pwndbg.gdblib.arch.ptrmask),
+            hex(first),
+            hex(second),
         )
 
 

--- a/pwndbg/gdblib/disasm/aarch64.py
+++ b/pwndbg/gdblib/disasm/aarch64.py
@@ -110,6 +110,8 @@ AARCH64_MATH_INSTRUCTIONS = {
     ARM64_INS_LSLV: "<<",
     ARM64_INS_LSR: ">>",
     ARM64_INS_LSRV: ">>",
+    ARM64_INS_UDIV: "/",
+    ARM64_INS_SDIV: "/",
 }
 
 

--- a/pwndbg/gdblib/disasm/aarch64.py
+++ b/pwndbg/gdblib/disasm/aarch64.py
@@ -206,7 +206,7 @@ class DisassemblyAssistant(pwndbg.gdblib.disasm.arch.DisassemblyAssistant):
                 instruction.operands[0],
                 instruction.operands[-2].before_value,
                 instruction.operands[-1].before_value,
-                AARCH64_MATH_INSTRUCTIONS[instruction.id]
+                AARCH64_MATH_INSTRUCTIONS[instruction.id],
             )
         else:
             self.annotation_handlers.get(instruction.id, lambda *a: None)(instruction, emu)

--- a/pwndbg/gdblib/disasm/aarch64.py
+++ b/pwndbg/gdblib/disasm/aarch64.py
@@ -112,6 +112,11 @@ AARCH64_MATH_INSTRUCTIONS = {
     ARM64_INS_LSRV: ">>",
     ARM64_INS_UDIV: "/",
     ARM64_INS_SDIV: "/",
+    ARM64_INS_SMULH: "*",
+    ARM64_INS_SMULL: "*",
+    ARM64_INS_UMULH: "*",
+    ARM64_INS_UMULL: "*",
+    ARM64_INS_MUL: "*",
 }
 
 

--- a/pwndbg/gdblib/disasm/aarch64.py
+++ b/pwndbg/gdblib/disasm/aarch64.py
@@ -98,6 +98,11 @@ AARCH64_EXTEND_MAP: Dict[int, Callable[[int], int]] = {
     ARM64_EXT_SXTX: lambda x: bit_math.to_signed(x, 64),
 }
 
+AARCH64_MATH_INSTRUCTIONS = {
+    ARM64_INS_ADD: "+",
+    ARM64_INS_SUB: "-"
+}
+
 
 def resolve_condition(condition: int, cpsr: int) -> InstructionCondition:
     """
@@ -186,6 +191,15 @@ class DisassemblyAssistant(pwndbg.gdblib.disasm.arch.DisassemblyAssistant):
                 instruction.operands[0].before_value,
                 AARCH64_SINGLE_STORE_INSTRUCTIONS[instruction.id],
                 instruction.operands[1].str,
+            )
+        elif instruction.id in AARCH64_MATH_INSTRUCTIONS:
+            self._common_binary_op_annotator(
+                instruction,
+                emu,
+                instruction.operands[0],
+                instruction.operands[-2].before_value,
+                instruction.operands[-1].before_value,
+                AARCH64_MATH_INSTRUCTIONS[instruction.id]
             )
         else:
             self.annotation_handlers.get(instruction.id, lambda *a: None)(instruction, emu)

--- a/pwndbg/gdblib/disasm/aarch64.py
+++ b/pwndbg/gdblib/disasm/aarch64.py
@@ -100,7 +100,16 @@ AARCH64_EXTEND_MAP: Dict[int, Callable[[int], int]] = {
 
 AARCH64_MATH_INSTRUCTIONS = {
     ARM64_INS_ADD: "+",
-    ARM64_INS_SUB: "-"
+    ARM64_INS_SUB: "-",
+    ARM64_INS_AND: "&",
+    ARM64_INS_ORR: "&",
+    ARM64_INS_ASR: ">>s",
+    ARM64_INS_ASRV: ">>s",
+    ARM64_INS_EOR: "^",
+    ARM64_INS_LSL: "<<",
+    ARM64_INS_LSLV: "<<",
+    ARM64_INS_LSR: ">>",
+    ARM64_INS_LSRV: ">>",
 }
 
 
@@ -145,15 +154,13 @@ class DisassemblyAssistant(pwndbg.gdblib.disasm.arch.DisassemblyAssistant):
 
         self.annotation_handlers: Dict[int, Callable[[PwndbgInstruction, Emulator], None]] = {
             # MOV
-            ARM64_INS_MOV: self._common_generic_register_destination,
+            ARM64_INS_MOV: self._common_move_annotator,
+            # MOV WITH KEEP
+            ARM64_INS_MOVK: self._common_generic_register_destination,
             # ADR
             ARM64_INS_ADR: self._common_generic_register_destination,
             # ADRP
             ARM64_INS_ADRP: self._common_generic_register_destination,
-            # ADD
-            ARM64_INS_ADD: self._common_generic_register_destination,
-            # SUB
-            ARM64_INS_SUB: self._common_generic_register_destination,
             # CMP
             ARM64_INS_CMP: self._common_cmp_annotator_builder("cpsr", "-"),
             # CMN

--- a/pwndbg/gdblib/disasm/arch.py
+++ b/pwndbg/gdblib/disasm/arch.py
@@ -980,7 +980,6 @@ class DisassemblyAssistant:
                 instruction.annotation += f" ({math_string})"
             else:
                 instruction.annotation = math_string
-            
 
 
 

--- a/pwndbg/gdblib/disasm/arch.py
+++ b/pwndbg/gdblib/disasm/arch.py
@@ -953,11 +953,7 @@ class DisassemblyAssistant:
 
             instruction.annotation = f"{address_str} => {self._telescope_format_list(telescope_addresses, TELESCOPE_DEPTH, emu)}"
 
-    def _common_move_annotator(
-            self,
-            instruction: PwndbgInstruction,
-            emu: Emulator
-    ):
+    def _common_move_annotator(self, instruction: PwndbgInstruction, emu: Emulator):
         """
         This function handles annotating `MOV` type instructions - where the value of one register is placed into another.
         """
@@ -967,7 +963,7 @@ class DisassemblyAssistant:
             result = left.after_value or right.before_value
             if result is not None:
                 TELESCOPE_DEPTH = max(0, int(pwndbg.config.disasm_telescope_depth))
-                
+
                 telescope_addresses = self._telescope(
                     result,
                     TELESCOPE_DEPTH + 1,
@@ -976,9 +972,8 @@ class DisassemblyAssistant:
                 )
                 if not telescope_addresses:
                     return
-                
-                instruction.annotation = f"{left.str} => {self._telescope_format_list(telescope_addresses, TELESCOPE_DEPTH, emu)}"
 
+                instruction.annotation = f"{left.str} => {self._telescope_format_list(telescope_addresses, TELESCOPE_DEPTH, emu)}"
 
     def _common_binary_op_annotator(
         self,
@@ -989,17 +984,13 @@ class DisassemblyAssistant:
         op_two: int | None,
         char_to_separate_operands: str,
     ) -> None:
-        
         # Ex: "0x198723 + 0x2b8"
         math_string = None
 
         if op_one is not None and op_two is not None:
-            print_left, print_right = pwndbg.enhance.format_small_int_pair(
-                op_one, op_two
-            )
+            print_left, print_right = pwndbg.enhance.format_small_int_pair(op_one, op_two)
 
             math_string = f"{print_left} {char_to_separate_operands} {print_right}"
-
 
         # Using emulation, we can determine the resulting value
         if target_operand.after_value_resolved is not None:
@@ -1008,8 +999,6 @@ class DisassemblyAssistant:
                 instruction.annotation += f" ({math_string})"
         elif math_string:
             instruction.annotation = f"{target_operand.str} => {math_string}"
-
-
 
 
 generic_assistant = DisassemblyAssistant(None)

--- a/pwndbg/gdblib/disasm/arch.py
+++ b/pwndbg/gdblib/disasm/arch.py
@@ -951,5 +951,38 @@ class DisassemblyAssistant:
 
             instruction.annotation = f"{address_str} => {self._telescope_format_list(telescope_addresses, TELESCOPE_DEPTH, emu)}"
 
+    def _common_binary_op_annotator(
+        self,
+        instruction: PwndbgInstruction,
+        emu: Emulator,
+        target_operand: EnhancedOperand,
+        op_one: int | None,
+        op_two: int | None,
+        char_to_separate_operands: str,
+    ) -> None:
+        
+        math_string = None
+
+        if op_one is not None and op_two is not None:
+            print_left, print_right = pwndbg.enhance.format_small_int_pair(
+                op_one, op_two
+            )
+
+            math_string = f"{print_left} {char_to_separate_operands} {print_right}"
+
+
+        # Using emulation, we can determine the resulting value
+        if target_operand.after_value_resolved is not None:
+            instruction.annotation = f"{target_operand.str} => {MemoryColor.get_address_and_symbol(target_operand.after_value_resolved)}"
+
+        if math_string:
+            if instruction.annotation is not None:
+                instruction.annotation += f" ({math_string})"
+            else:
+                instruction.annotation = math_string
+            
+
+
+
 
 generic_assistant = DisassemblyAssistant(None)

--- a/pwndbg/gdblib/disasm/arch.py
+++ b/pwndbg/gdblib/disasm/arch.py
@@ -961,6 +961,7 @@ class DisassemblyAssistant:
         char_to_separate_operands: str,
     ) -> None:
         
+        # Ex: "0x198723 + 0x2b8"
         math_string = None
 
         if op_one is not None and op_two is not None:
@@ -974,12 +975,10 @@ class DisassemblyAssistant:
         # Using emulation, we can determine the resulting value
         if target_operand.after_value_resolved is not None:
             instruction.annotation = f"{target_operand.str} => {MemoryColor.get_address_and_symbol(target_operand.after_value_resolved)}"
-
-        if math_string:
-            if instruction.annotation is not None:
+            if math_string:
                 instruction.annotation += f" ({math_string})"
-            else:
-                instruction.annotation = math_string
+        elif math_string:
+            instruction.annotation = f"{target_operand.str} => {math_string}"
 
 
 

--- a/pwndbg/gdblib/disasm/arm.py
+++ b/pwndbg/gdblib/disasm/arm.py
@@ -100,7 +100,9 @@ class DisassemblyAssistant(pwndbg.gdblib.disasm.arch.DisassemblyAssistant):
                 instruction.operands[1].str,
             )
         elif instruction.id in ARM_MATH_INSTRUCTIONS:
-
+            # In Arm assembly, if there are two operands, than the first source operand is also the destination
+            # Example: add    sl, r3
+            # Or, it can be a seperate register. We use -1 and -2 indexes here to access the source operands either way
             self._common_binary_op_annotator(
                 instruction,
                 emu,
@@ -185,13 +187,7 @@ class DisassemblyAssistant(pwndbg.gdblib.disasm.arch.DisassemblyAssistant):
         return f"[{(', '.join(parts))}]"
 
     def read_thumb_bit(self, instruction: PwndbgInstruction, emu: Emulator) -> int | None:
-        if emu:
-            return emu.read_thumb_bit()
-        elif self.can_reason_about_process_state(instruction):
-            # Read the Thumb bit directly from the process flag register if we can
-            return process_read_thumb_bit()
-        else:
-            return 0
+        return 1 if instruction.cs_insn._cs._mode & CS_MODE_THUMB else 0
 
     @override
     def _immediate_string(self, instruction, operand):

--- a/pwndbg/gdblib/disasm/arm.py
+++ b/pwndbg/gdblib/disasm/arm.py
@@ -59,6 +59,12 @@ ARM_MATH_INSTRUCTIONS = {
     ARM_INS_ADD:"+",
     ARM_INS_ADDW:"+",
     ARM_INS_SUB:"-",
+    ARM_INS_ORR:"|",
+    ARM_INS_AND:"&",
+    ARM_INS_EOR:"^",
+    ARM_INS_ASR:">>s",
+    ARM_INS_LSR:">>",
+    ARM_INS_LSL:"<<",
 }
 
 class DisassemblyAssistant(pwndbg.gdblib.disasm.arch.DisassemblyAssistant):
@@ -66,6 +72,10 @@ class DisassemblyAssistant(pwndbg.gdblib.disasm.arch.DisassemblyAssistant):
         super().__init__(architecture)
 
         self.annotation_handlers: Dict[int, Callable[[PwndbgInstruction, Emulator], None]] = {
+            # MOV
+            ARM_INS_MOV: self._common_move_annotator,
+            ARM_INS_MOVW: self._common_move_annotator,
+
             # CMP
             ARM_INS_CMP: self._common_cmp_annotator_builder("cpsr", "-"),
             # CMN

--- a/pwndbg/gdblib/disasm/arm.py
+++ b/pwndbg/gdblib/disasm/arm.py
@@ -80,6 +80,10 @@ class DisassemblyAssistant(pwndbg.gdblib.disasm.arch.DisassemblyAssistant):
             # MOV
             ARM_INS_MOV: self._common_move_annotator,
             ARM_INS_MOVW: self._common_move_annotator,
+            # MOVT
+            ARM_INS_MOVT: self._common_generic_register_destination,
+            # MOVN
+            ARM_INS_MVN: self._common_generic_register_destination,
             # CMP
             ARM_INS_CMP: self._common_cmp_annotator_builder("cpsr", "-"),
             # CMN

--- a/pwndbg/gdblib/disasm/arm.py
+++ b/pwndbg/gdblib/disasm/arm.py
@@ -66,6 +66,9 @@ ARM_MATH_INSTRUCTIONS = {
     ARM_INS_LSL: "<<",
     ARM_INS_UDIV: "/",
     ARM_INS_SDIV: "/",
+    ARM_INS_MUL: "*",
+    ARM_INS_UMULL: "*",
+    ARM_INS_SMULL: "*",
 }
 
 

--- a/pwndbg/gdblib/disasm/arm.py
+++ b/pwndbg/gdblib/disasm/arm.py
@@ -64,6 +64,8 @@ ARM_MATH_INSTRUCTIONS = {
     ARM_INS_ASR: ">>s",
     ARM_INS_LSR: ">>",
     ARM_INS_LSL: "<<",
+    ARM_INS_UDIV: "/",
+    ARM_INS_SDIV: "/",
 }
 
 

--- a/pwndbg/gdblib/disasm/arm.py
+++ b/pwndbg/gdblib/disasm/arm.py
@@ -55,6 +55,11 @@ ARM_SINGLE_STORE_INSTRUCTIONS = {
     ARM_INS_STREX: 4,
 }
 
+ARM_MATH_INSTRUCTIONS = {
+    ARM_INS_ADD:"+",
+    ARM_INS_ADDW:"+",
+    ARM_INS_SUB:"-",
+}
 
 class DisassemblyAssistant(pwndbg.gdblib.disasm.arch.DisassemblyAssistant):
     def __init__(self, architecture: str) -> None:
@@ -93,6 +98,16 @@ class DisassemblyAssistant(pwndbg.gdblib.disasm.arch.DisassemblyAssistant):
                 instruction.operands[0].before_value,
                 ARM_SINGLE_STORE_INSTRUCTIONS[instruction.id],
                 instruction.operands[1].str,
+            )
+        elif instruction.id in ARM_MATH_INSTRUCTIONS:
+
+            self._common_binary_op_annotator(
+                instruction,
+                emu,
+                instruction.operands[0],
+                instruction.operands[-2].before_value,
+                instruction.operands[-1].before_value,
+                ARM_MATH_INSTRUCTIONS[instruction.id]
             )
         else:
             self.annotation_handlers.get(instruction.id, lambda *a: None)(instruction, emu)

--- a/pwndbg/gdblib/disasm/arm.py
+++ b/pwndbg/gdblib/disasm/arm.py
@@ -14,7 +14,6 @@ import pwndbg.gdblib.memory
 import pwndbg.gdblib.regs
 import pwndbg.lib.disasm.helpers as bit_math
 from pwndbg.emu.emulator import Emulator
-from pwndbg.gdblib.arch import read_thumb_bit as process_read_thumb_bit
 from pwndbg.gdblib.disasm.instruction import EnhancedOperand
 from pwndbg.gdblib.disasm.instruction import InstructionCondition
 from pwndbg.gdblib.disasm.instruction import PwndbgInstruction
@@ -56,16 +55,17 @@ ARM_SINGLE_STORE_INSTRUCTIONS = {
 }
 
 ARM_MATH_INSTRUCTIONS = {
-    ARM_INS_ADD:"+",
-    ARM_INS_ADDW:"+",
-    ARM_INS_SUB:"-",
-    ARM_INS_ORR:"|",
-    ARM_INS_AND:"&",
-    ARM_INS_EOR:"^",
-    ARM_INS_ASR:">>s",
-    ARM_INS_LSR:">>",
-    ARM_INS_LSL:"<<",
+    ARM_INS_ADD: "+",
+    ARM_INS_ADDW: "+",
+    ARM_INS_SUB: "-",
+    ARM_INS_ORR: "|",
+    ARM_INS_AND: "&",
+    ARM_INS_EOR: "^",
+    ARM_INS_ASR: ">>s",
+    ARM_INS_LSR: ">>",
+    ARM_INS_LSL: "<<",
 }
+
 
 class DisassemblyAssistant(pwndbg.gdblib.disasm.arch.DisassemblyAssistant):
     def __init__(self, architecture: str) -> None:
@@ -75,7 +75,6 @@ class DisassemblyAssistant(pwndbg.gdblib.disasm.arch.DisassemblyAssistant):
             # MOV
             ARM_INS_MOV: self._common_move_annotator,
             ARM_INS_MOVW: self._common_move_annotator,
-
             # CMP
             ARM_INS_CMP: self._common_cmp_annotator_builder("cpsr", "-"),
             # CMN
@@ -119,7 +118,7 @@ class DisassemblyAssistant(pwndbg.gdblib.disasm.arch.DisassemblyAssistant):
                 instruction.operands[0],
                 instruction.operands[-2].before_value,
                 instruction.operands[-1].before_value,
-                ARM_MATH_INSTRUCTIONS[instruction.id]
+                ARM_MATH_INSTRUCTIONS[instruction.id],
             )
         else:
             self.annotation_handlers.get(instruction.id, lambda *a: None)(instruction, emu)

--- a/pwndbg/gdblib/disasm/mips.py
+++ b/pwndbg/gdblib/disasm/mips.py
@@ -129,14 +129,6 @@ MIPS_BINARY_OPERATIONS = {
     MIPS_INS_XORI: "^",
     MIPS_INS_SLL: "<<",
     MIPS_INS_SLLV: "<<",
-    MIPS_INS_DIV: "/",
-    MIPS_INS_DIVU: "/",
-    MIPS_INS_DDIV: "/",
-    MIPS_INS_DDIVU: "/",
-    MIPS_INS_MOD: "%",
-    MIPS_INS_MODU: "%",
-    MIPS_INS_DMOD: "%",
-    MIPS_INS_DMODU: "%",
 }
 
 

--- a/pwndbg/gdblib/disasm/mips.py
+++ b/pwndbg/gdblib/disasm/mips.py
@@ -79,7 +79,7 @@ MIPS_SIMPLE_DESTINATION_INSTRUCTIONS = {
     MIPS_INS_SLTI,
     MIPS_INS_SLTIU,
     MIPS_INS_SLTU,
-        # Rare - unaligned read - have complex loading logic
+    # Rare - unaligned read - have complex loading logic
     MIPS_INS_LDL,
     MIPS_INS_LDR,
     # Rare - partial load on portions of address
@@ -109,27 +109,28 @@ MIPS_STORE_INSTRUCTIONS = {
 }
 
 MIPS_BINARY_OPERATIONS = {
-    MIPS_INS_ADD:"+",
-    MIPS_INS_ADDI:"+",
-    MIPS_INS_ADDIU:"+",
-    MIPS_INS_ADDU:"+",
-    MIPS_INS_DADD:"+",
-    MIPS_INS_DADDI:"+",
-    MIPS_INS_DADDIU:"+",
-    MIPS_INS_DADDU:"+",
-    MIPS_INS_SUB:"-",
-    MIPS_INS_SUBU:"-",
-    MIPS_INS_DSUB:"-",
-    MIPS_INS_DSUBU:"-",
-    MIPS_INS_ANDI:"&",
-    MIPS_INS_AND:"&",
-    MIPS_INS_ORI:"|",
-    MIPS_INS_OR:"|",
-    MIPS_INS_XOR:"^",
-    MIPS_INS_XORI:"^",
-    MIPS_INS_SLL:"<<",
-    MIPS_INS_SLLV:"<<"
+    MIPS_INS_ADD: "+",
+    MIPS_INS_ADDI: "+",
+    MIPS_INS_ADDIU: "+",
+    MIPS_INS_ADDU: "+",
+    MIPS_INS_DADD: "+",
+    MIPS_INS_DADDI: "+",
+    MIPS_INS_DADDIU: "+",
+    MIPS_INS_DADDU: "+",
+    MIPS_INS_SUB: "-",
+    MIPS_INS_SUBU: "-",
+    MIPS_INS_DSUB: "-",
+    MIPS_INS_DSUBU: "-",
+    MIPS_INS_ANDI: "&",
+    MIPS_INS_AND: "&",
+    MIPS_INS_ORI: "|",
+    MIPS_INS_OR: "|",
+    MIPS_INS_XOR: "^",
+    MIPS_INS_XORI: "^",
+    MIPS_INS_SLL: "<<",
+    MIPS_INS_SLLV: "<<",
 }
+
 
 # This class enhances 32-bit, 64-bit, and micro MIPS
 class DisassemblyAssistant(pwndbg.gdblib.disasm.arch.DisassemblyAssistant):
@@ -167,8 +168,9 @@ class DisassemblyAssistant(pwndbg.gdblib.disasm.arch.DisassemblyAssistant):
                 instruction.operands[0],
                 instruction.operands[1].before_value,
                 instruction.operands[2].before_value,
-                MIPS_BINARY_OPERATIONS[instruction.id]
+                MIPS_BINARY_OPERATIONS[instruction.id],
             )
+
         elif instruction.id in MIPS_SIMPLE_DESTINATION_INSTRUCTIONS:
             self._common_generic_register_destination(instruction, emu)
 

--- a/pwndbg/gdblib/disasm/mips.py
+++ b/pwndbg/gdblib/disasm/mips.py
@@ -121,6 +121,14 @@ MIPS_BINARY_OPERATIONS = {
     MIPS_INS_SUBU:"-",
     MIPS_INS_DSUB:"-",
     MIPS_INS_DSUBU:"-",
+    MIPS_INS_ANDI:"&",
+    MIPS_INS_AND:"&",
+    MIPS_INS_ORI:"|",
+    MIPS_INS_OR:"|",
+    MIPS_INS_XOR:"^",
+    MIPS_INS_XORI:"^",
+    MIPS_INS_SLL:"<<",
+    MIPS_INS_SLLV:"<<"
 }
 
 # This class enhances 32-bit, 64-bit, and micro MIPS

--- a/pwndbg/gdblib/disasm/mips.py
+++ b/pwndbg/gdblib/disasm/mips.py
@@ -170,7 +170,6 @@ class DisassemblyAssistant(pwndbg.gdblib.disasm.arch.DisassemblyAssistant):
                 instruction.operands[2].before_value,
                 MIPS_BINARY_OPERATIONS[instruction.id],
             )
-
         elif instruction.id in MIPS_SIMPLE_DESTINATION_INSTRUCTIONS:
             self._common_generic_register_destination(instruction, emu)
 

--- a/pwndbg/gdblib/disasm/mips.py
+++ b/pwndbg/gdblib/disasm/mips.py
@@ -129,6 +129,14 @@ MIPS_BINARY_OPERATIONS = {
     MIPS_INS_XORI: "^",
     MIPS_INS_SLL: "<<",
     MIPS_INS_SLLV: "<<",
+    MIPS_INS_DIV: "/",
+    MIPS_INS_DIVU: "/",
+    MIPS_INS_DDIV: "/",
+    MIPS_INS_DDIVU: "/",
+    MIPS_INS_MOD: "%",
+    MIPS_INS_MODU: "%",
+    MIPS_INS_DMOD: "%",
+    MIPS_INS_DMODU: "%",
 }
 
 

--- a/pwndbg/gdblib/disasm/mips.py
+++ b/pwndbg/gdblib/disasm/mips.py
@@ -61,20 +61,10 @@ CONDITION_RESOLVERS: Dict[int, Callable[[List[int]], bool]] = {
 # They all do some computation and set the register to the result.
 # These were derived from "MIPS Architecture for Programmers Volume II: The MIPS64 Instruction Set Reference Manual"
 MIPS_SIMPLE_DESTINATION_INSTRUCTIONS = {
-    MIPS_INS_ADD,
-    MIPS_INS_ADDI,
-    MIPS_INS_ADDIU,
-    MIPS_INS_ADDU,
     MIPS_INS_CLO,
     MIPS_INS_CLZ,
-    MIPS_INS_DADD,
-    MIPS_INS_DADDI,
-    MIPS_INS_DADDIU,
-    MIPS_INS_DADDU,
     MIPS_INS_DCLO,
     MIPS_INS_DCLZ,
-    MIPS_INS_DSUB,
-    MIPS_INS_DSUBU,
     MIPS_INS_LSA,
     MIPS_INS_DLSA,
     MIPS_INS_LUI,
@@ -82,8 +72,6 @@ MIPS_SIMPLE_DESTINATION_INSTRUCTIONS = {
     MIPS_INS_MFLO,
     MIPS_INS_SEB,
     MIPS_INS_SEH,
-    MIPS_INS_SUB,
-    MIPS_INS_SUBU,
     MIPS_INS_WSBH,
     MIPS_INS_MOVE,
     MIPS_INS_LI,
@@ -91,7 +79,7 @@ MIPS_SIMPLE_DESTINATION_INSTRUCTIONS = {
     MIPS_INS_SLTI,
     MIPS_INS_SLTIU,
     MIPS_INS_SLTU,
-    # Rare - unaligned read - have complex loading logic
+        # Rare - unaligned read - have complex loading logic
     MIPS_INS_LDL,
     MIPS_INS_LDR,
     # Rare - partial load on portions of address
@@ -120,6 +108,20 @@ MIPS_STORE_INSTRUCTIONS = {
     MIPS_INS_SD: 8,
 }
 
+MIPS_BINARY_OPERATIONS = {
+    MIPS_INS_ADD:"+",
+    MIPS_INS_ADDI:"+",
+    MIPS_INS_ADDIU:"+",
+    MIPS_INS_ADDU:"+",
+    MIPS_INS_DADD:"+",
+    MIPS_INS_DADDI:"+",
+    MIPS_INS_DADDIU:"+",
+    MIPS_INS_DADDU:"+",
+    MIPS_INS_SUB:"-",
+    MIPS_INS_SUBU:"-",
+    MIPS_INS_DSUB:"-",
+    MIPS_INS_DSUBU:"-",
+}
 
 # This class enhances 32-bit, 64-bit, and micro MIPS
 class DisassemblyAssistant(pwndbg.gdblib.disasm.arch.DisassemblyAssistant):
@@ -149,6 +151,15 @@ class DisassemblyAssistant(pwndbg.gdblib.disasm.arch.DisassemblyAssistant):
                 instruction.operands[0].before_value,
                 MIPS_STORE_INSTRUCTIONS[instruction.id],
                 instruction.operands[1].str,
+            )
+        elif instruction.id in MIPS_BINARY_OPERATIONS:
+            self._common_binary_op_annotator(
+                instruction,
+                emu,
+                instruction.operands[0],
+                instruction.operands[1].before_value,
+                instruction.operands[2].before_value,
+                MIPS_BINARY_OPERATIONS[instruction.id]
             )
         elif instruction.id in MIPS_SIMPLE_DESTINATION_INSTRUCTIONS:
             self._common_generic_register_destination(instruction, emu)

--- a/pwndbg/gdblib/disasm/riscv.py
+++ b/pwndbg/gdblib/disasm/riscv.py
@@ -95,11 +95,11 @@ RISCV_MATH_INSTRUCTIONS = {
     RISCV_INS_SRAIW: ">>s",
     RISCV_INS_SRAW: ">>s",
     # RV64M unique instructions
-    RISCV_INS_MULW:"*",
-    RISCV_INS_DIVW:"/",
-    RISCV_INS_DIVUW:"/",
-    RISCV_INS_REMW:"%",
-    RISCV_INS_REMUW:"%",
+    RISCV_INS_MULW: "*",
+    RISCV_INS_DIVW: "/",
+    RISCV_INS_DIVUW: "/",
+    RISCV_INS_REMW: "%",
+    RISCV_INS_REMUW: "%",
     # RV64C unique instructions
     RISCV_INS_C_ADDIW: "+",
     RISCV_INS_C_SUBW: "-",
@@ -120,7 +120,7 @@ class DisassemblyAssistant(pwndbg.gdblib.disasm.arch.DisassemblyAssistant):
             # C.LI
             RISCV_INS_C_LI: self._common_move_annotator,
             # LUI
-            RISCV_INS_LUI: self._lui_annotator
+            RISCV_INS_LUI: self._lui_annotator,
         }
 
     @override

--- a/pwndbg/gdblib/disasm/riscv.py
+++ b/pwndbg/gdblib/disasm/riscv.py
@@ -102,8 +102,8 @@ RISCV_MATH_INSTRUCTIONS = {
     RISCV_INS_REMUW: "%",
     # RV64C unique instructions
     RISCV_INS_C_ADDIW: "+",
+    RISCV_INS_C_ADDW: "+",
     RISCV_INS_C_SUBW: "-",
-    RISCV_INS_C_ADDW: "-",
 }
 
 

--- a/pwndbg/gdblib/disasm/riscv.py
+++ b/pwndbg/gdblib/disasm/riscv.py
@@ -52,53 +52,46 @@ RISCV_COMPRESSED_STORE_INSTRUCTIONS = {
 
 
 RISCV_MATH_INSTRUCTIONS = {
-    RISCV_INS_ADDI:"+",
-    RISCV_INS_ADD:"+",
-
-    RISCV_INS_C_ADDI:"+",
-    RISCV_INS_C_ADD:"+",
-
-    RISCV_INS_SUB:"-",
-    RISCV_INS_C_SUB:"-",
-    RISCV_INS_XORI:"^",
-    RISCV_INS_XOR:"^",
-    RISCV_INS_C_XOR:"^",
-
-    RISCV_INS_ORI:"|",
-    RISCV_INS_OR:"|",
-    RISCV_INS_C_OR:"|",
-
-    RISCV_INS_ANDI:"&",
-    RISCV_INS_C_ANDI:"&",
-    RISCV_INS_AND:"&",
-    RISCV_INS_C_AND:"&",
-    RISCV_INS_SLLI:"<<",
-    RISCV_INS_C_SLLI:"<<",
-    RISCV_INS_SLL:"<<",
-    RISCV_INS_SRLI:">>",
-    RISCV_INS_C_SRLI:">>",
-
-    RISCV_INS_SRL:">>",
+    RISCV_INS_ADDI: "+",
+    RISCV_INS_ADD: "+",
+    RISCV_INS_C_ADDI: "+",
+    RISCV_INS_C_ADD: "+",
+    RISCV_INS_SUB: "-",
+    RISCV_INS_C_SUB: "-",
+    RISCV_INS_XORI: "^",
+    RISCV_INS_XOR: "^",
+    RISCV_INS_C_XOR: "^",
+    RISCV_INS_ORI: "|",
+    RISCV_INS_OR: "|",
+    RISCV_INS_C_OR: "|",
+    RISCV_INS_ANDI: "&",
+    RISCV_INS_C_ANDI: "&",
+    RISCV_INS_AND: "&",
+    RISCV_INS_C_AND: "&",
+    RISCV_INS_SLLI: "<<",
+    RISCV_INS_C_SLLI: "<<",
+    RISCV_INS_SLL: "<<",
+    RISCV_INS_SRLI: ">>",
+    RISCV_INS_C_SRLI: ">>",
+    RISCV_INS_SRL: ">>",
     # TODO: use s here for arithmetic? https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#srai does
-    RISCV_INS_SRAI:">>s",
-    RISCV_INS_C_SRAI:">>s",
-    RISCV_INS_SRA:">>s",
-
+    RISCV_INS_SRAI: ">>s",
+    RISCV_INS_C_SRAI: ">>s",
+    RISCV_INS_SRA: ">>s",
     # Signed multiplication: TODO
-    RISCV_INS_MUL:"*",
-    RISCV_INS_MULH:"*",
-    RISCV_INS_MULHSU:"*",
-    RISCV_INS_MULHU:"*",
+    RISCV_INS_MUL: "*",
+    RISCV_INS_MULH: "*",
+    RISCV_INS_MULHSU: "*",
+    RISCV_INS_MULHU: "*",
     # TODO: signed
-    RISCV_INS_DIV:"/",
-    RISCV_INS_DIVU:"/",
-    RISCV_INS_REM:"%",
-    RISCV_INS_REMU:"%",
-
-    RISCV_INS_C_ADDI4SPN:"+",
-    RISCV_INS_C_ADDI16SP:"+",
-
+    RISCV_INS_DIV: "/",
+    RISCV_INS_DIVU: "/",
+    RISCV_INS_REM: "%",
+    RISCV_INS_REMU: "%",
+    RISCV_INS_C_ADDI4SPN: "+",
+    RISCV_INS_C_ADDI16SP: "+",
 }
+
 
 class DisassemblyAssistant(pwndbg.gdblib.disasm.arch.DisassemblyAssistant):
     def __init__(self, architecture) -> None:
@@ -179,25 +172,21 @@ class DisassemblyAssistant(pwndbg.gdblib.disasm.arch.DisassemblyAssistant):
                 instruction.operands[0],
                 instruction.operands[-2].before_value,
                 instruction.operands[-1].before_value,
-                RISCV_MATH_INSTRUCTIONS[instruction.id]
+                RISCV_MATH_INSTRUCTIONS[instruction.id],
             )
         else:
             self.annotation_handlers.get(instruction.id, lambda *a: None)(instruction, emu)
 
-    def _auipc_annotator(
-        self, instruction: PwndbgInstruction, emu: Emulator
-    ) -> None:
-
+    def _auipc_annotator(self, instruction: PwndbgInstruction, emu: Emulator) -> None:
         result_operand, right = instruction.operands
         if result_operand.str and right.before_value is not None:
-
             if (address := result_operand.after_value) is None:
                 # Resolve it manually without emulation
                 address = instruction.address + (right.before_value << 12)
 
-            instruction.annotation = f"{result_operand.str} => {MemoryColor.get_address_and_symbol(address)}"
-
-
+            instruction.annotation = (
+                f"{result_operand.str} => {MemoryColor.get_address_and_symbol(address)}"
+            )
 
     def _resolve_compressed_target_addr(
         self, instruction: PwndbgInstruction, emu: Emulator

--- a/pwndbg/gdblib/disasm/riscv.py
+++ b/pwndbg/gdblib/disasm/riscv.py
@@ -47,9 +47,7 @@ RISCV_COMPRESSED_STORE_INSTRUCTIONS = {
     RISCV_INS_C_SDSP: 8,
 }
 
-# TODO: RV64I and RV64M instructions that operate on 32-bit
-# And RV64C
-
+# TODO: RV64I, RV64M, and RV64C instructions that operate on 32-bit
 
 RISCV_MATH_INSTRUCTIONS = {
     RISCV_INS_ADDI: "+",
@@ -74,16 +72,13 @@ RISCV_MATH_INSTRUCTIONS = {
     RISCV_INS_SRLI: ">>",
     RISCV_INS_C_SRLI: ">>",
     RISCV_INS_SRL: ">>",
-    # TODO: use s here for arithmetic? https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#srai does
     RISCV_INS_SRAI: ">>s",
     RISCV_INS_C_SRAI: ">>s",
     RISCV_INS_SRA: ">>s",
-    # Signed multiplication: TODO
     RISCV_INS_MUL: "*",
     RISCV_INS_MULH: "*",
     RISCV_INS_MULHSU: "*",
     RISCV_INS_MULHU: "*",
-    # TODO: signed
     RISCV_INS_DIV: "/",
     RISCV_INS_DIVU: "/",
     RISCV_INS_REM: "%",

--- a/pwndbg/gdblib/disasm/riscv.py
+++ b/pwndbg/gdblib/disasm/riscv.py
@@ -182,14 +182,17 @@ class DisassemblyAssistant(pwndbg.gdblib.disasm.arch.DisassemblyAssistant):
                     dest_str,
                 )
         elif instruction.id in RISCV_MATH_INSTRUCTIONS:
-            self._common_binary_op_annotator(
-                instruction,
-                emu,
-                instruction.operands[0],
-                instruction.operands[-2].before_value,
-                instruction.operands[-1].before_value,
-                RISCV_MATH_INSTRUCTIONS[instruction.id],
-            )
+            # We need this check, because some of these instructions can encoded as aliases
+            # Example: NOP is an alias of ADDI where target is x0. In Capstone, the ID will still be that of ADDI but with no operands
+            if len(instruction.operands) >= 2:
+                self._common_binary_op_annotator(
+                    instruction,
+                    emu,
+                    instruction.operands[0],
+                    instruction.operands[-2].before_value,
+                    instruction.operands[-1].before_value,
+                    RISCV_MATH_INSTRUCTIONS[instruction.id],
+                )
         else:
             self.annotation_handlers.get(instruction.id, lambda *a: None)(instruction, emu)
 

--- a/pwndbg/gdblib/disasm/x86.py
+++ b/pwndbg/gdblib/disasm/x86.py
@@ -28,10 +28,10 @@ regs = {v: k for k, v in globals().items() if k.startswith("X86_REG_")}
 access = {v: k for k, v in globals().items() if k.startswith("CS_AC_")}
 
 X86_MATH_INSTRUCTIONS = {
-    X86_INS_ADD:"+",
-    X86_INS_SUB:"-",
-    X86_INS_AND:"&",
-    X86_INS_OR:"|",
+    X86_INS_ADD: "+",
+    X86_INS_SUB: "-",
+    X86_INS_AND: "&",
+    X86_INS_OR: "|",
 }
 
 # Capstone operand type for x86 is capstone.x86.X86Op
@@ -85,7 +85,7 @@ class DisassemblyAssistant(pwndbg.gdblib.disasm.arch.DisassemblyAssistant):
                 instruction.operands[0],
                 instruction.operands[0].before_value_resolved,
                 instruction.operands[1].before_value_resolved,
-                X86_MATH_INSTRUCTIONS[instruction.id]
+                X86_MATH_INSTRUCTIONS[instruction.id],
             )
         else:
             self.annotation_handlers.get(instruction.id, lambda *a: None)(instruction, emu)
@@ -210,7 +210,7 @@ class DisassemblyAssistant(pwndbg.gdblib.disasm.arch.DisassemblyAssistant):
                 instruction.operands[0],
                 instruction.operands[0].before_value_resolved,
                 instruction.operands[1].before_value_resolved,
-                "^"
+                "^",
             )
 
     def handle_inc(self, instruction: PwndbgInstruction, emu: Emulator) -> None:

--- a/pwndbg/gdblib/disasm/x86.py
+++ b/pwndbg/gdblib/disasm/x86.py
@@ -27,6 +27,12 @@ ops = {v: k for k, v in globals().items() if k.startswith("X86_OP_")}
 regs = {v: k for k, v in globals().items() if k.startswith("X86_REG_")}
 access = {v: k for k, v in globals().items() if k.startswith("CS_AC_")}
 
+X86_MATH_INSTRUCTIONS = {
+    X86_INS_ADD:"+",
+    X86_INS_SUB:"-",
+    X86_INS_AND:"&",
+    X86_INS_OR:"|",
+}
 
 # Capstone operand type for x86 is capstone.x86.X86Op
 # This type has a .size field, which indicates the operand read/write size in bytes
@@ -59,22 +65,30 @@ class DisassemblyAssistant(pwndbg.gdblib.disasm.arch.DisassemblyAssistant):
             X86_INS_XCHG: self.handle_xchg,
             # POP
             X86_INS_POP: self.handle_pop,
-            # ADD
-            X86_INS_ADD: self.handle_add,
-            # SUB
-            X86_INS_SUB: self.handle_sub,
             # CMP
             X86_INS_CMP: self._common_cmp_annotator_builder("eflags", "-"),
             # TEST
             X86_INS_TEST: self._common_cmp_annotator_builder("eflags", "&"),
             # XOR
             X86_INS_XOR: self.handle_xor,
-            # AND
-            X86_INS_AND: self.handle_and,
             # INC and DEC
             X86_INS_INC: self.handle_inc,
             X86_INS_DEC: self.handle_dec,
         }
+
+    @override
+    def _set_annotation_string(self, instruction: PwndbgInstruction, emu: Emulator) -> None:
+        if instruction.id in X86_MATH_INSTRUCTIONS:
+            self._common_binary_op_annotator(
+                instruction,
+                emu,
+                instruction.operands[0],
+                instruction.operands[0].before_value_resolved,
+                instruction.operands[1].before_value_resolved,
+                X86_MATH_INSTRUCTIONS[instruction.id]
+            )
+        else:
+            self.annotation_handlers.get(instruction.id, lambda *a: None)(instruction, emu)
 
     def handle_mov(self, instruction: PwndbgInstruction, emu: Emulator) -> None:
         left, right = instruction.operands
@@ -183,37 +197,6 @@ class DisassemblyAssistant(pwndbg.gdblib.disasm.arch.DisassemblyAssistant):
                 except Exception:
                     pass
 
-    def handle_add_sub_handler(
-        self, instruction: PwndbgInstruction, emu: Emulator, char_to_separate_operands: str
-    ) -> None:
-        # char_to_separate_operands = "+" or "-"
-        left, right = instruction.operands
-
-        # "a + b" or "a - b"
-        plus_string = ""
-
-        # This path set plus_string to "op1_value + op2_value" (or with a minus sign)
-        if left.before_value_resolved is not None and right.before_value_resolved is not None:
-            print_left, print_right = pwndbg.enhance.format_small_int_pair(
-                left.before_value_resolved, right.before_value_resolved
-            )
-
-            plus_string = f"{print_left} {char_to_separate_operands} {print_right}"
-
-        if left.after_value_resolved is not None:
-            instruction.annotation = f"{left.str} => {MemoryColor.get_address_and_symbol(left.after_value_resolved)} ({plus_string})"
-        elif plus_string:
-            # We didn't use emulation to determine the result - still display the operands
-            instruction.annotation = f"{left.str} => {plus_string}"
-
-    def handle_add(self, instruction: PwndbgInstruction, emu: Emulator) -> None:
-        # Same output as addition, showing the result
-        self.handle_add_sub_handler(instruction, emu, "+")
-
-    def handle_sub(self, instruction: PwndbgInstruction, emu: Emulator) -> None:
-        # Same output as addition, showing the result
-        self.handle_add_sub_handler(instruction, emu, "-")
-
     def handle_xor(self, instruction: PwndbgInstruction, emu: Emulator) -> None:
         left, right = instruction.operands
 
@@ -221,14 +204,14 @@ class DisassemblyAssistant(pwndbg.gdblib.disasm.arch.DisassemblyAssistant):
         if left.type == CS_OP_REG and right.type == CS_OP_REG and left.reg == right.reg:
             instruction.annotation = f"{left.str} => 0"
         else:
-            if left.after_value_resolved is not None:
-                instruction.annotation = f"{left.str} => {left.after_value_resolved}"
-
-    def handle_and(self, instruction: PwndbgInstruction, emu: Emulator) -> None:
-        left, right = instruction.operands
-
-        if left.after_value_resolved is not None:
-            instruction.annotation = f"{left.str} => {MemoryColor.get(left.after_value_resolved)}"
+            self._common_binary_op_annotator(
+                instruction,
+                emu,
+                instruction.operands[0],
+                instruction.operands[0].before_value_resolved,
+                instruction.operands[1].before_value_resolved,
+                "^"
+            )
 
     def handle_inc(self, instruction: PwndbgInstruction, emu: Emulator) -> None:
         # INC operand can be REG or [MEMORY]
@@ -239,11 +222,6 @@ class DisassemblyAssistant(pwndbg.gdblib.disasm.arch.DisassemblyAssistant):
 
     def handle_dec(self, instruction: PwndbgInstruction, emu: Emulator) -> None:
         self.handle_inc(instruction, emu)
-
-    @override
-    def _set_annotation_string(self, instruction: PwndbgInstruction, emu: Emulator) -> None:
-        # Dispatch to the correct handler
-        self.annotation_handlers.get(instruction.id, lambda *a: None)(instruction, emu)
 
     @override
     def _resolve_used_value(


### PR DESCRIPTION
This PR introduces annotations for most arithmetic instructions in RISCV, ARM, AArch64, MIPS, and X86. This consists of additions, subtractions, and bitwise operations such as `AND`, `OR`, `XOR`, and shift operations, and even integer multiplication and division operations. This means that the large majority of general-purpose instructions encountered in most binaries are now annotated.

The values of the source operands for the given operation are displayed in addition to the operator, and the result is shown when emulation is enabled.

For example, the x86 instruction `and    eax, 0xfff` would get `EAX => 0xaa6 (0xf7f51aa6 & 0xfff)` as an annotation.

The following ISA manuals were used to determine the instructions and operand usage:
mips: https://s3-eu-west-1.amazonaws.com/downloads-mips/documents/MIPS_Architecture_MIPS64_InstructionSet_%20AFP_P_MD00087_06.05.pdf
RISCV: https://msyksphinz-self.github.io/riscv-isadoc/html/index.html
arm/aarch64: https://developer.arm.com/documentation/dui0802/b/A32-and-T32-Instructions/A32-and-T32-instruction-summary?lang=en

Examples:

# RISC-V
![riscv_math_operations](https://github.com/user-attachments/assets/2564698c-b041-4297-9253-16a7438364da)

# MIPS
![mips_math_more](https://github.com/user-attachments/assets/4bde3ddb-1f39-4390-a2c1-5cf9597d0e8d)
![mips_math](https://github.com/user-attachments/assets/1a8fa90f-3e95-46ab-8618-e24ba07e39d8)

# AArch64
![aarcH64_math](https://github.com/user-attachments/assets/61b33fcb-5014-4575-89a2-b5acf25bdf2f)

# Arm
![arm_math_emulate_on](https://github.com/user-attachments/assets/d9435782-d6a8-4a32-b0e4-8978dfab7546)
With emulation disabled:
![arm_math_emulate_off](https://github.com/user-attachments/assets/0e019d27-1f3f-4a09-9de4-c04ac24b69af)

