### PR TITLE
Fix Register Read Bug

### DIFF
--- a/pwndbg/dbg/gdb.py
+++ b/pwndbg/dbg/gdb.py
@@ -29,7 +29,7 @@ class GDBRegisters(pwndbg.dbg_mod.Registers):
     def by_name(self, name: str) -> pwndbg.dbg_mod.Value | None:
         try:
             return GDBValue(self.frame.inner.read_register(name))
-        except gdb.error:
+        except (gdb.error, ValueError):
             # GDB throws an exception if the name is unknown, we just return
             # None when that is the case.
             pass


### PR DESCRIPTION
This PR fixes a bug in the reading of registers in GDB as used in `pwndbg.commands.fix` that causes a crash in `cyclic`, `dt`, and `bp` on certain inputs.

When reading a register from a frame in GDB, it can raise a "gdb.error", and through testing, a "ValueError" as well when the input is a random string. This PR simply adds the ValueError to the list of exceptions to catch.

Fix is currently used by 3 functions - `cyclic`, `dt`, and `bp`. 

Note that there is one other place in the codebase where `frame.read_register` is called: 

https://github.com/pwndbg/pwndbg/blob/707db877f3b27b099d1794cc55278d422832aee5/pwndbg/gdblib/regs.py#L35-L42

This case doesn't catch `gdb.error` - should this be added here as well? cc @Aplet123 