### PR TITLE
Store Instruction Annotations for RISCV, Arm, AArch64, and MIPS

### DIFF
--- a/pwndbg/gdblib/disasm/aarch64.py
+++ b/pwndbg/gdblib/disasm/aarch64.py
@@ -49,6 +49,7 @@ AARCH64_SINGLE_LOAD_INSTRUCTIONS: Dict[int, int | None] = {
     ARM64_INS_LDAR: None,
 }
 
+# None indicates that the write size depends on the source register
 AARCH64_SINGLE_STORE_INSTRUCTIONS: Dict[int, int | None] = {
     ARM64_INS_STRB: 1,
     ARM64_INS_STURB: 1,
@@ -176,6 +177,15 @@ class DisassemblyAssistant(pwndbg.gdblib.disasm.arch.DisassemblyAssistant):
                 target_reg_size,
                 instruction.operands[0].str,
                 instruction.operands[1].str,
+            )
+        elif instruction.id in AARCH64_SINGLE_STORE_INSTRUCTIONS:
+            self._common_store_annotator(
+                instruction,
+                emu,
+                instruction.operands[1].before_value,
+                instruction.operands[0].before_value,
+                AARCH64_SINGLE_STORE_INSTRUCTIONS[instruction.id],
+                instruction.operands[1].str
             )
         else:
             self.annotation_handlers.get(instruction.id, lambda *a: None)(instruction, emu)

--- a/pwndbg/gdblib/disasm/aarch64.py
+++ b/pwndbg/gdblib/disasm/aarch64.py
@@ -185,7 +185,7 @@ class DisassemblyAssistant(pwndbg.gdblib.disasm.arch.DisassemblyAssistant):
                 instruction.operands[1].before_value,
                 instruction.operands[0].before_value,
                 AARCH64_SINGLE_STORE_INSTRUCTIONS[instruction.id],
-                instruction.operands[1].str
+                instruction.operands[1].str,
             )
         else:
             self.annotation_handlers.get(instruction.id, lambda *a: None)(instruction, emu)

--- a/pwndbg/gdblib/disasm/arch.py
+++ b/pwndbg/gdblib/disasm/arch.py
@@ -908,6 +908,7 @@ class DisassemblyAssistant:
 
             if telescope_print is not None:
                 instruction.annotation += f" => {telescope_print}"
+
     def _common_store_annotator(
         self,
         instruction: PwndbgInstruction,
@@ -919,9 +920,9 @@ class DisassemblyAssistant:
     ) -> None:
         """
         This function annotates store functions - moving data from a register to memory.
-        
+
         The `value` is truncated to match the `write_size`, if `write_size` is not None.
-        
+
         The annotation will indicate if the instruction will segfault.
 
         `write_size`: number of bytes of `value` that will be written
@@ -929,7 +930,7 @@ class DisassemblyAssistant:
 
         if address is None:
             return
-        
+
         if not pwndbg.gdblib.memory.peek(address):
             instruction.annotation = MessageColor.error(
                 f"<Cannot dereference [{MemoryColor.get(address)}]>"
@@ -940,8 +941,8 @@ class DisassemblyAssistant:
             TELESCOPE_DEPTH = max(0, int(pwndbg.config.disasm_telescope_depth))
 
             if write_size is not None:
-                value &= ((1 << (write_size * 8)) - 1)
-                
+                value &= (1 << (write_size * 8)) - 1
+
             telescope_addresses = self._telescope(
                 value,
                 TELESCOPE_DEPTH,
@@ -950,8 +951,6 @@ class DisassemblyAssistant:
             )
 
             instruction.annotation = f"{address_str} => {self._telescope_format_list(telescope_addresses, TELESCOPE_DEPTH, emu)}"
-
-
 
 
 generic_assistant = DisassemblyAssistant(None)

--- a/pwndbg/gdblib/disasm/arm.py
+++ b/pwndbg/gdblib/disasm/arm.py
@@ -92,7 +92,7 @@ class DisassemblyAssistant(pwndbg.gdblib.disasm.arch.DisassemblyAssistant):
                 instruction.operands[1].before_value,
                 instruction.operands[0].before_value,
                 ARM_SINGLE_STORE_INSTRUCTIONS[instruction.id],
-                instruction.operands[1].str
+                instruction.operands[1].str,
             )
         else:
             self.annotation_handlers.get(instruction.id, lambda *a: None)(instruction, emu)

--- a/pwndbg/gdblib/disasm/arm.py
+++ b/pwndbg/gdblib/disasm/arm.py
@@ -85,6 +85,15 @@ class DisassemblyAssistant(pwndbg.gdblib.disasm.arch.DisassemblyAssistant):
                 instruction.operands[0].str,
                 instruction.operands[1].str,
             )
+        elif instruction.id in ARM_SINGLE_STORE_INSTRUCTIONS:
+            self._common_store_annotator(
+                instruction,
+                emu,
+                instruction.operands[1].before_value,
+                instruction.operands[0].before_value,
+                ARM_SINGLE_STORE_INSTRUCTIONS[instruction.id],
+                instruction.operands[1].str
+            )
         else:
             self.annotation_handlers.get(instruction.id, lambda *a: None)(instruction, emu)
 

--- a/pwndbg/gdblib/disasm/mips.py
+++ b/pwndbg/gdblib/disasm/mips.py
@@ -113,6 +113,12 @@ MIPS_LOAD_INSTRUCTIONS = {
     MIPS_INS_LDPC: 8,
 }
 
+MIPS_STORE_INSTRUCTIONS = {
+    MIPS_INS_SB:1,
+    MIPS_INS_SH:2,
+    MIPS_INS_SW:4,
+    MIPS_INS_SD:8,
+}
 
 # This class enhances 32-bit, 64-bit, and micro MIPS
 class DisassemblyAssistant(pwndbg.gdblib.disasm.arch.DisassemblyAssistant):
@@ -133,6 +139,15 @@ class DisassemblyAssistant(pwndbg.gdblib.disasm.arch.DisassemblyAssistant):
                 pwndbg.gdblib.arch.ptrsize,
                 instruction.operands[0].str,
                 instruction.operands[1].str,
+            )
+        elif instruction.id in MIPS_STORE_INSTRUCTIONS:
+            self._common_store_annotator(
+                instruction,
+                emu,
+                instruction.operands[1].before_value,
+                instruction.operands[0].before_value,
+                MIPS_STORE_INSTRUCTIONS[instruction.id],
+                instruction.operands[1].str
             )
         elif instruction.id in MIPS_SIMPLE_DESTINATION_INSTRUCTIONS:
             self._common_generic_register_destination(instruction, emu)

--- a/pwndbg/gdblib/disasm/mips.py
+++ b/pwndbg/gdblib/disasm/mips.py
@@ -114,11 +114,12 @@ MIPS_LOAD_INSTRUCTIONS = {
 }
 
 MIPS_STORE_INSTRUCTIONS = {
-    MIPS_INS_SB:1,
-    MIPS_INS_SH:2,
-    MIPS_INS_SW:4,
-    MIPS_INS_SD:8,
+    MIPS_INS_SB: 1,
+    MIPS_INS_SH: 2,
+    MIPS_INS_SW: 4,
+    MIPS_INS_SD: 8,
 }
+
 
 # This class enhances 32-bit, 64-bit, and micro MIPS
 class DisassemblyAssistant(pwndbg.gdblib.disasm.arch.DisassemblyAssistant):
@@ -147,7 +148,7 @@ class DisassemblyAssistant(pwndbg.gdblib.disasm.arch.DisassemblyAssistant):
                 instruction.operands[1].before_value,
                 instruction.operands[0].before_value,
                 MIPS_STORE_INSTRUCTIONS[instruction.id],
-                instruction.operands[1].str
+                instruction.operands[1].str,
             )
         elif instruction.id in MIPS_SIMPLE_DESTINATION_INSTRUCTIONS:
             self._common_generic_register_destination(instruction, emu)

--- a/pwndbg/gdblib/disasm/riscv.py
+++ b/pwndbg/gdblib/disasm/riscv.py
@@ -96,14 +96,13 @@ class DisassemblyAssistant(pwndbg.gdblib.disasm.arch.DisassemblyAssistant):
                 instruction.operands[1].before_value,
                 instruction.operands[0].before_value,
                 RISCV_STORE_INSTRUCTIONS[instruction.id],
-                instruction.operands[1].str
+                instruction.operands[1].str,
             )
         elif instruction.id in RISCV_COMPRESSED_STORE_INSTRUCTIONS:
             # TODO: remove this branch when updating to Capstone 6
             address = self._resolve_compressed_target_addr(instruction, emu)
 
             if address is not None:
-
                 dest_str = f"[{MemoryColor.get_address_or_symbol(address)}]"
 
                 self._common_store_annotator(
@@ -112,9 +111,9 @@ class DisassemblyAssistant(pwndbg.gdblib.disasm.arch.DisassemblyAssistant):
                     address,
                     instruction.operands[0].before_value,
                     RISCV_COMPRESSED_STORE_INSTRUCTIONS[instruction.id],
-                    dest_str
+                    dest_str,
                 )
-        
+
         return super()._set_annotation_string(instruction, emu)
 
     def _resolve_compressed_target_addr(

--- a/pwndbg/gdblib/disasm/riscv.py
+++ b/pwndbg/gdblib/disasm/riscv.py
@@ -42,7 +42,9 @@ RISCV_STORE_INSTRUCTIONS = {
 # TODO: remove this when updating to Capstone 6
 RISCV_COMPRESSED_STORE_INSTRUCTIONS = {
     RISCV_INS_C_SW: 4,
+    RISCV_INS_C_SWSP: 4,
     RISCV_INS_C_SD: 8,
+    RISCV_INS_C_SDSP: 8,
 }
 
 
@@ -87,6 +89,32 @@ class DisassemblyAssistant(pwndbg.gdblib.disasm.arch.DisassemblyAssistant):
                     dest_str,
                 )
 
+        if instruction.id in RISCV_STORE_INSTRUCTIONS:
+            self._common_store_annotator(
+                instruction,
+                emu,
+                instruction.operands[1].before_value,
+                instruction.operands[0].before_value,
+                RISCV_STORE_INSTRUCTIONS[instruction.id],
+                instruction.operands[1].str
+            )
+        elif instruction.id in RISCV_COMPRESSED_STORE_INSTRUCTIONS:
+            # TODO: remove this branch when updating to Capstone 6
+            address = self._resolve_compressed_target_addr(instruction, emu)
+
+            if address is not None:
+
+                dest_str = f"[{MemoryColor.get_address_or_symbol(address)}]"
+
+                self._common_store_annotator(
+                    instruction,
+                    emu,
+                    address,
+                    instruction.operands[0].before_value,
+                    RISCV_COMPRESSED_STORE_INSTRUCTIONS[instruction.id],
+                    dest_str
+                )
+        
         return super()._set_annotation_string(instruction, emu)
 
     def _resolve_compressed_target_addr(

--- a/pwndbg/gdblib/disasm/x86.py
+++ b/pwndbg/gdblib/disasm/x86.py
@@ -99,7 +99,7 @@ class DisassemblyAssistant(pwndbg.gdblib.disasm.arch.DisassemblyAssistant):
                 instruction.operands[0].before_value,
                 instruction.operands[1].before_value,
                 right.cs_op.size,
-                instruction.operands[0].str
+                instruction.operands[0].str,
             )
         elif left.type == CS_OP_REG and right.before_value is not None:
             # MOV REG, REG|IMM

--- a/pwndbg/gdblib/disasm/x86.py
+++ b/pwndbg/gdblib/disasm/x86.py
@@ -99,7 +99,7 @@ class DisassemblyAssistant(pwndbg.gdblib.disasm.arch.DisassemblyAssistant):
                 instruction.operands[0].before_value,
                 instruction.operands[1].before_value,
                 right.cs_op.size,
-                instruction.operands[1].str
+                instruction.operands[0].str
             )
         elif left.type == CS_OP_REG and right.before_value is not None:
             # MOV REG, REG|IMM


### PR DESCRIPTION
This PR adds annotations to all store instructions in RISC-V, Arm, AArch64, and MIPS. On these instructions, the annotation will display the target memory address and the value that will be placed into it.

Additionally, it checks for segfaults (if the resolved memory operand is not in a mapped paged) and displays a warning text in this case. 

Examples:
# RISC_V
![riscv_store](https://github.com/user-attachments/assets/f4682368-b972-4e88-b641-66de215ea5ce)
# AArch64
![aarch64_store](https://github.com/user-attachments/assets/b2b8e3ba-d009-412f-9014-6c712811ffcd)
# Arm
![arm_store](https://github.com/user-attachments/assets/54133bbc-a7d7-4ac7-a678-939416e48708)
# MIPS
![mips_store](https://github.com/user-attachments/assets/99525673-37f0-415b-b9d4-ada520517af1)

Segfault detection:
![segfault_store](https://github.com/user-attachments/assets/8a4c8097-c795-48fd-83ff-9bb898f4d050)
