### PR TITLE
Introduce `pwndbg.aglib.arch` and port `pwndbg.lib.memory` to it

### DIFF
--- a/pwndbg/aglib/arch.py
+++ b/pwndbg/aglib/arch.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import pwndbg
+
+# We will optimize this module in the future, by having it work in the same
+# way the `gdblib` version of it works, and that will come at the same
+# time this module gets expanded to have the full feature set of its `gdlib`
+# coutnerpart. For now, though, this should be good enough.
+
+
+def __getattr__(name):
+    if name == "endian":
+        return pwndbg.dbg.selected_inferior().arch().endian
+    elif name == "ptrsize":
+        return pwndbg.dbg.selected_inferior().arch().ptrsize

--- a/pwndbg/lib/memory.py
+++ b/pwndbg/lib/memory.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 
 import os
 
+import pwndbg.aglib.arch
+
 PAGE_SIZE = 0x1000
 PAGE_MASK = ~(PAGE_SIZE - 1)
 
@@ -132,12 +134,7 @@ class Page:
         )
 
     def __str__(self) -> str:
-        # This module requires GDB, so it causes import failures in unit tests.
-        # This will stop being a problem as soon as this module gets ported to
-        # aglib.arch, but, for now we have to add this as a quick stopgap.
-        import pwndbg.gdblib.arch
-
-        return f"{self.vaddr:#{2 + 2 * pwndbg.gdblib.arch.ptrsize}x} {self.vaddr + self.memsz:#{2 + 2 * pwndbg.gdblib.arch.ptrsize}x} {self.permstr} {self.memsz:8x} {self.offset:6x} {self.objfile or ''}"
+        return f"{self.vaddr:#{2 + 2 * pwndbg.aglib.arch.ptrsize}x} {self.vaddr + self.memsz:#{2 + 2 * pwndbg.aglib.arch.ptrsize}x} {self.permstr} {self.memsz:8x} {self.offset:6x} {self.objfile or ''}"
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self.__str__()!r})"


### PR DESCRIPTION
This PR introduces the Debugger-agnostic `pwndbg.aglib.arch` interface, that mirrors some of the `gdblib` version of the module, and ports `pwndbg.lib.memory` to it. It also introduces the beginnings of the `aglib` module, so I think it's important to go over the rationale behind it, and where it slots into the effort of porting Pwndbg to LLDB.

`gdblib`, as it currently exists, is an interesting module. While it does communicate directly with GDB and abstract a lot of it from the rest of Pwndbg, that's far from the only thing it does. Much of `gdblib` concerns itself with things that have nothing to do with talking to GDB, including, but not limited to: Parsing ELF files, dealing with QEMU, detecting Android, managing files gotten from remote file transfers, exploring the virtual memory space searching for virtual memory maps, disassembly, heap analysis, hooking to the dynamic linker and parsing DYNAMIC structures, and _so_ much more. In fact, many of these things are so far removed from GDB, that many of these modules either only interact directly with GDB very sparingly, or  even not all, preferring instead to use the other abstractions in `gdblib`. 

When I started the work of porting Pwndbg to LLDB, I didn't plan to touch `gdblib` at all, only moving the few bits of code that could be shared between LLDB and GDB, and porting each command individually to the Debugger-agnostic API. But, as time went on, and I examined `gdblib` with a more careful eye, I realized that a _vast_ amount of `gdblib` could be shared between LLDB and GDB. By focusing on the primitives that `gdblib` uses to talk to GDB and pushing those to the Debugger-agnostic API, then porting the few uses of those primitives in the code to it, one can obtain what's effectively a debugger-agnostic version of `gdblib`.

This port of `gdblib` that's had its debugger-dependent bits taken out and its debugger-independent bits ported to run on top of the Debugger-agnostic API is called `aglib`, and it's meant to, over some time, replace most of the original `gdblib`, with the parts that remain being exclusively intended for use by `pwndbg.dbg.gdb.GDB` (The GDB implementation of the Debugger-agnostic API).

On the most up-to-date branch, `aglib` has allowed me to not only reuse most of the code in Pwndbg for LLDB[^1], it has turned much of the work of porting many commands into a simple string search and replace. Additionally, sharing this code between the two versions should allow for easier maintenance of Pwndbg after the port, compared to having to repeat many large chunks of code that do the same thing, one for LLDB, and the other for GDB.

One obvious downside to `aglib` is that it will introduce what's effectively a copy of `gdblib` to Pwndbg, under a different name. This should only be a temporary problem, however, since, as previously stated, the whole point to `aglib` is to replace `gdblib` in the long run. So, as porting wraps up, more and more of `gdblib` should end up being removed in favor of `aglib` modules. As I see it, though, this is still preferable to having, say, an `lldblib` module, seeing as in that case, we would also end up having vast code duplication, but it would be rather more permanent.

[^1]: For instance, LLDB Pwndbg shares even the same QEMU code paths as GDB Pwndbg. In fact, most behaviors ends up being identical between the two because they share so much code now.