### PR TITLE
New Pwndbg Architecture

### DIFF
--- a/pwndbg/gdblib/arch.py
+++ b/pwndbg/gdblib/arch.py
@@ -1,6 +1,18 @@
 from __future__ import annotations
 
 from typing import Literal
+from typing_extensions import override
+
+import struct
+from typing import Literal
+from typing import Dict
+from typing import Tuple
+from typing import TypeVar
+from typing import Type
+
+
+from pwndbg.lib.abi import ABI, SyscallABI,DEFAULT_ABIS,SYSCALL_ABIS,SIGRETURN_ABIS
+from pwndbg.lib.regs import RegisterSet
 
 import gdb
 import pwnlib
@@ -66,12 +78,144 @@ def get_thumb_mode_string() -> Literal["arm", "thumb"] | None:
     return None if thumb_bit is None else "thumb" if thumb_bit == 1 else "arm"
 
 
-arch = Arch("i386", typeinfo.ptrsize, "little")
+# def update_arch_hook(arch: Architecture):
+#     # This might be due to starting a new binary or connecting to another remote process.
+#     # This function will will be pass ed the architecture
+#     # The specific debugger (GDB/LLDB) will detect the arch
+#     # and call this function appropriately
+#     arch = architecture
 
-name: str
-ptrsize: int
-ptrmask: int
-endian: Literal["little", "big"]
+ArchType = Literal["i386","x86-64","rv32","rv64","mips","sparc","arm","iwmmxt","armcm","aarch64","powerpc"]
+EndianType = Literal["little","big"]
+
+FMT_LITTLE_ENDIAN = {1: "B", 2: "<H", 4: "<I", 8: "<Q"}
+FMT_BIG_ENDIAN = {1: "B", 2: ">H", 4: ">I", 8: ">Q"}
+
+
+class PwndbgArchitecture:
+
+    # Registry of all instances
+    arch_registry: Dict[ArchType, PwndbgArchitecture] = {}
+    
+    @staticmethod
+    def get_arch(name: ArchType) -> PwndbgArchitecture:
+        # If a custom class has not been registered for the architecture, use base implementation
+        if name not in PwndbgArchitecture.arch_registry:
+            PwndbgArchitecture.arch_registry[name] = PwndbgArchitecture(name)
+        
+        return PwndbgArchitecture.arch_registry[name]
+
+    def __init__(self, name: ArchType) -> None:
+        """
+        Calling the constructor will register the class with global list of PwndbgArchitectures
+        """
+        if name is not None:
+            self.arch_registry[name] = self
+
+        self.name: ArchType = name
+        self.current = self.name
+
+        # We have to set some values by default
+        # These will be set again by the code that detects the global architecture
+        self.update(typeinfo.ptrsize, "little")
+    
+    def update(self, ptrsize: int, endian: EndianType) -> None:
+        """
+        While debugging a process, certain aspects of the architecture can change.
+
+        In some cases, the architecture can change during a program,
+        such as the early stages of a x86 bootloader (16-bit mode to 32-bit mode).
+        Other architectures can change endianness dynamically.
+
+        This function should be called when a change is detected.
+        """
+        self.endian: EndianType = endian
+
+        # Pointer size in bytes
+        self.ptrsize: int = ptrsize
+        self.ptrbits: int = self.ptrsize * 8
+        self.ptrmask: int = (1 << self.ptrbits) - 1
+
+        # The following three variables are common defaults
+        # But can be explicitely set if there is a special case
+        # Is the syscall ABI non-standard? Just do pwndbg.arch.abi = ...
+
+        abi_identifer = (self.ptrbits,self.name,"linux")
+        self.abi: ABI | None = DEFAULT_ABIS.get(abi_identifer)
+        self.syscall_abi: SyscallABI | None = SYSCALL_ABIS.get(abi_identifer)
+        self.sigreturn_abi: SyscallABI | None = SIGRETURN_ABIS.get(abi_identifer)
+
+
+        self.fmts: Dict[int, str] = FMT_LITTLE_ENDIAN if endian == "little" else FMT_BIG_ENDIAN
+        self.fmt: str = self.fmts[self.ptrsize]
+
+        if self.name == "arm" and self.endian == "big":
+            self.qemu = "armeb"
+        elif self.name == "mips" and self.endian == "little":
+            self.qemu = "mipsel"
+        else:
+            self.qemu = self.name
+
+    def pack(self, integer: int) -> bytes:
+        return struct.pack(self.fmt, integer & self.ptrmask)
+
+    def unpack(self, data: bytes) -> int:
+        return struct.unpack(self.fmt, data)[0]
+
+    def pack_size(self, integer: int, size: int) -> bytes:
+        return struct.pack(self.fmts[size], integer & self.ptrmask)
+
+    def unpack_size(self, data: bytes, size: int) -> int:
+        return struct.unpack(self.fmts[size], data)[0]
+
+    def read_thumb_bit(self) -> Literal[0,1]:
+        return 0
+    
+class ArmArch(PwndbgArchitecture):
+
+    def __init__(self) -> None:
+        super().__init__("arm")
+
+    @override
+    def read_thumb_bit(self) -> Literal[0,1]:
+        # When program initially starts, cpsr may not be readable
+        if (cpsr := pwndbg.gdblib.regs.cpsr) is not None:
+            return (cpsr >> 5) & 1
+        return 0
+
+
+class ArmCortexArch(PwndbgArchitecture):
+    """
+    Cortex-M processors run the M-profile Arm architecture.
+
+    This architecture is prevalent in bare-metal/embedded systems that lack operating systems.
+
+    Only Thumb-2 instructions are supported, and the Thumb bit is always 1.
+    """
+
+    def __init__(self) -> None:
+        super().__init__("armcm")
+
+    @override
+    def read_thumb_bit(self) -> Literal[0,1]:
+        """
+        On Cortex-M processors, the Thumb bit is architecturally defined to be 1.
+        """
+        return 1
+
+# Register all the custom classes
+ArmArch()
+ArmCortexArch()
+
+
+
+# arch = Arch("i386", typeinfo.ptrsize, "little")
+arch = PwndbgArchitecture.get_arch("i386")
+
+# name: str
+# ptrsize: int
+# ptrmask: int
+# endian: Literal["little", "big"]
 
 
 def _get_arch(ptrsize: int):
@@ -112,7 +256,16 @@ def _get_arch(ptrsize: int):
 
 
 def update() -> None:
+    global arch
     arch_name, ptrsize, endian = _get_arch(typeinfo.ptrsize)
-    arch.update(arch_name, ptrsize, endian)
+
+    if arch.name != arch_name:
+        print(arch_name, "SWITCH")
+        # The architecture has changed! Get the instance of the new class
+        arch = PwndbgArchitecture.get_arch(arch_name)
+    print(arch.name)
+    # arch.update(arch_name, ptrsize, endian)
+    arch.update(ptrsize, endian)
+    
     pwnlib.context.context.arch = pwnlib_archs_mapping[arch_name]
     pwnlib.context.context.bits = ptrsize * 8


### PR DESCRIPTION
This PR implements a new class based mechanism to represent architecture in Pwndbg.

There are various different modules around the codebase that relate to inspecting the process based on the current architecture that we detect (is it arm? or x86? In that case, use this set of registers, and this ABI and SyscallABI).

Additionally, spread through the codebase are long `if/else` (`if pwndbg.gdblib.arch.current == "some_arch_name": do this`), that do some minor architecture specific logic - often just setting a local variable, such as fetching the relevent Capstone/Unicorn constants to pass to the external API.

This proposes an API to both simplify and clean up the code. A parent class defines the API - the various attributes and methods - and provides sane defaults. Subclasses for specific architectures can optionally override these defaults to implement logic.

The current architecture is represented at run-time as an instance of a class. This instance is seen globally throughout the codebase.