### PR TITLE
AArch64 Conditional Instructions + More

### DIFF
--- a/pwndbg/dbg/gdb.py
+++ b/pwndbg/dbg/gdb.py
@@ -164,7 +164,7 @@ class GDBProcess(pwndbg.dbg_mod.Process):
         try:
             return GDBValue(parse_and_eval(expression, global_context=True))
         except gdb.error as e:
-            pwndbg.dbg_mod.Error(e)
+            raise pwndbg.dbg_mod.Error(e)
 
     @override
     def vmmap(self) -> pwndbg.dbg_mod.MemoryMap:

--- a/pwndbg/dbg/gdb.py
+++ b/pwndbg/dbg/gdb.py
@@ -164,7 +164,7 @@ class GDBProcess(pwndbg.dbg_mod.Process):
         try:
             return GDBValue(parse_and_eval(expression, global_context=True))
         except gdb.error as e:
-            raise pwndbg.dbg_mod.Error(e)
+            pwndbg.dbg_mod.Error(e)
 
     @override
     def vmmap(self) -> pwndbg.dbg_mod.MemoryMap:

--- a/pwndbg/gdblib/disasm/mips.py
+++ b/pwndbg/gdblib/disasm/mips.py
@@ -77,6 +77,7 @@ MIPS_SIMPLE_DESTINATION_INSTRUCTIONS = {
     MIPS_INS_SLTI,
     MIPS_INS_SLTIU,
     MIPS_INS_SLTU,
+    MIPS_INS_MOVN,
     # Rare - unaligned read - have complex loading logic
     MIPS_INS_LDL,
     MIPS_INS_LDR,
@@ -129,6 +130,10 @@ MIPS_BINARY_OPERATIONS = {
     MIPS_INS_SLLV: "<<",
     MIPS_INS_DSLL: "<<",
     MIPS_INS_DSLLV: "<<",
+    MIPS_INS_SRL: ">>",
+    MIPS_INS_SRLV: ">>",
+    MIPS_INS_DSRL: ">>",
+    MIPS_INS_DSRLV: ">>",
 }
 
 


### PR DESCRIPTION
This PR replaces #2268 and adds support for AArch64 conditional instructions. For these 8 instructions, when the condition is satisfied, a green checkmark appears.

![csel_aarch64](https://github.com/user-attachments/assets/929d600b-f922-4458-af87-b68630e354f5)

There is also a fix to RISC-V JALR target resolution (broken before), and a couple misc annotations for common instructions that were missing.