### PR TITLE
Enhance canary in telescope function

### DIFF
--- a/pwndbg/enhance.py
+++ b/pwndbg/enhance.py
@@ -44,6 +44,14 @@ def format_small_int_pair(first: int, second: int) -> Tuple[str, str]:
 
 
 def int_str(value: int) -> str:
+    """
+    This function attempts to enhance the value of an int.
+    First, it checks if the integer is a stack canary.
+    Then, it attempts to interpret the bytes as a short strings
+    """
+    if value == pwndbg.commands.canary.canary_value()[0]:
+        return f"{value} (canary)"
+
     retval = format_small_int(value)
 
     # Try to unpack the value as a string

--- a/pwndbg/enhance.py
+++ b/pwndbg/enhance.py
@@ -49,10 +49,11 @@ def int_str(value: int) -> str:
     First, it checks if the integer is a stack canary.
     Then, it attempts to interpret the bytes as a short strings
     """
-    if value == pwndbg.commands.canary.canary_value()[0]:
-        return f"{value} (canary)"
 
     retval = format_small_int(value)
+
+    if value == pwndbg.commands.canary.canary_value()[0]:
+        return f"{retval} (canary)"
 
     # Try to unpack the value as a string
     packed = pwndbg.gdblib.arch.pack(int(value))


### PR DESCRIPTION
This PR adds text to indicate a canary value whenever it is encountered in the telescope function.

![canary](https://github.com/user-attachments/assets/fa7c71f4-f150-4d4a-b390-2a343dfdcb07)
![reg_canary](https://github.com/user-attachments/assets/831d9cfc-8d76-4a52-bc4a-ab6c1e42bc5a)
