### PR TITLE
Improve attachp: fix partial match, add --user and --all

### DIFF
--- a/pwndbg/commands/attachp.py
+++ b/pwndbg/commands/attachp.py
@@ -89,7 +89,7 @@ def attachp(target, no_truncate, all, user=None) -> None:
         else:
             # Note: we can't use `ps -C <target>` because this does not accept process names with spaces
             # so target='a b' would actually match process names 'a' and 'b' here
-# so instead, we will filter by process name or full cmdline later on
+            # so instead, we will filter by process name or full cmdline later on
             # if provided, filter by effective username or uid; otherwise, select all processes
             ps_filter = ["-u", user] if user is not None else ["-e"]
             ps_cmd = ["ps", "-o", "pid,args"] + ps_filter

--- a/pwndbg/commands/attachp.py
+++ b/pwndbg/commands/attachp.py
@@ -89,7 +89,7 @@ def attachp(target, no_truncate, all, user=None) -> None:
         else:
             # Note: we can't use `ps -C <target>` because this does not accept process names with spaces
             # so target='a b' would actually match process names 'a' and 'b' here
-
+# so instead, we will filter by process name or full cmdline later on
             # if provided, filter by effective username or uid; otherwise, select all processes
             ps_filter = ["-u", user] if user is not None else ["-e"]
             ps_cmd = ["ps", "-o", "pid,args"] + ps_filter


### PR DESCRIPTION
This commit fixes the attachp command so it has a better partial matching logic.

It also adds `--user <uid|username>` and `--all` options.

<!-- Please make sure to read the testing and linting instructions at https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md before creating a PR -->
