### PR TITLE
Don't perform heap chain corruption check for only one chunk

### DIFF
--- a/pwndbg/gdblib/heap/ptmalloc.py
+++ b/pwndbg/gdblib/heap/ptmalloc.py
@@ -1383,7 +1383,7 @@ class GlibcMemoryAllocator(pwndbg.gdblib.heap.heap.MemoryAllocator, Generic[TheT
         corrupt_chain_bk = full_chain_bk[: (corrupt_chain_size + 1)]
 
         is_chain_corrupted = False
-        if corrupt_chain_size > 0:
+        if corrupt_chain_size > 1:
             is_chain_corrupted = self.check_chain_corrupted(corrupt_chain_fd, corrupt_chain_bk)
 
         return (chain_fd, chain_bk, is_chain_corrupted)


### PR DESCRIPTION
Doing `set heap-corruption-check-limit 1` will give a false positive (saying there is corruption when there really isn't) since the branch
```python
        elif len(chain_fd) == len(chain_bk) == 2:
```
will be wrongly entered and
```py
            # Check if the bin points to itself (is empty)

            if chain_fd != chain_bk:
                return True
```
will fail.

A special case could be added to mitigate this, but logically it doesn't make much sense to check *chain* corruption for one chunk anyways.