### PR TITLE
Heap free bins indication in telescope

### DIFF
--- a/pwndbg/chain.py
+++ b/pwndbg/chain.py
@@ -110,6 +110,7 @@ def format(
     hard_end: int = 0,
     safe_linking: bool = False,
     enhance_string_len: int | None = None,
+    display_heap_free_bins: bool = True
 ) -> str:
     """
     Recursively dereferences an address into string representation, or convert the list representation
@@ -143,7 +144,7 @@ def format(
     arrow_right = c.arrow(f" {config_arrow_right} ")
 
     # Colorize the chain
-    rest = [M.get_address_and_symbol(link) for link in chain]
+    rest = [M.get_address_and_symbol(link, display_heap_free_bins) for link in chain]
 
     # If the dereference limit is zero, skip any enhancements.
     if limit == 0:

--- a/pwndbg/chain.py
+++ b/pwndbg/chain.py
@@ -110,7 +110,7 @@ def format(
     hard_end: int = 0,
     safe_linking: bool = False,
     enhance_string_len: int | None = None,
-    display_heap_free_bins: bool = True
+    display_heap_free_bins: bool = True,
 ) -> str:
     """
     Recursively dereferences an address into string representation, or convert the list representation

--- a/pwndbg/color/memory.py
+++ b/pwndbg/color/memory.py
@@ -30,7 +30,7 @@ c = ColorConfig(
 pwndbg.config.add_param(
     "telescope-free-heap-bins",
     False,
-    "wheteher or not to resolve heap addresses to bin names while telescoping",
+    "whether or not to resolve heap addresses to bin names while telescoping",
 )
 
 

--- a/pwndbg/color/memory.py
+++ b/pwndbg/color/memory.py
@@ -34,14 +34,14 @@ pwndbg.config.add_param(
 )
 
 
-def get_address_and_symbol(address: int) -> str:
+def get_address_and_symbol(address: int, display_heap_free_bins=True) -> str:
     """
     Convert and colorize address 0x7ffff7fcecd0 to string `0x7ffff7fcecd0 (_dl_fini)`
     If no symbol exists for the address, return colorized address
     """
 
     # Attempt to resolve it as a free chunk
-    if pwndbg.config.telescope_free_heap_bins:
+    if display_heap_free_bins and pwndbg.config.telescope_free_heap_bins:
         if (page := pwndbg.gdblib.vmmap.find(address)) is not None and "[heap" in page.objfile:
             if (
                 free_bin_name := pwndbg.gdblib.heap.heap_freebin_address_lookup(address)

--- a/pwndbg/color/memory.py
+++ b/pwndbg/color/memory.py
@@ -46,7 +46,7 @@ def get_address_and_symbol(address: int) -> str:
             if (
                 free_bin_name := pwndbg.gdblib.heap.heap_freebin_address_lookup(address)
             ) is not None:
-                return get(address, f"{address} ({free_bin_name} free chunk)")
+                return get(address, f"{hex(address)} ({free_bin_name} free chunk)")
 
     symbol = pwndbg.gdblib.symbol.get(address) or None
     if symbol:

--- a/pwndbg/color/memory.py
+++ b/pwndbg/color/memory.py
@@ -34,19 +34,19 @@ pwndbg.config.add_param(
 )
 
 
-
-
 def get_address_and_symbol(address: int) -> str:
     """
     Convert and colorize address 0x7ffff7fcecd0 to string `0x7ffff7fcecd0 (_dl_fini)`
     If no symbol exists for the address, return colorized address
     """
 
-    # Attempt resolve it as a free chunk
+    # Attempt to resolve it as a free chunk
     if pwndbg.config.telescope_free_heap_bins:
         if (page := pwndbg.gdblib.vmmap.find(address)) is not None and "[heap" in page.objfile:
-            if (free_bin_name := pwndbg.gdblib.heap.heap_freebin_address_lookup(address)) is not None:
-                return get(address,f"{address} ({free_bin_name} free chunk)")
+            if (
+                free_bin_name := pwndbg.gdblib.heap.heap_freebin_address_lookup(address)
+            ) is not None:
+                return get(address, f"{address} ({free_bin_name} free chunk)")
 
     symbol = pwndbg.gdblib.symbol.get(address) or None
     if symbol:

--- a/pwndbg/color/memory.py
+++ b/pwndbg/color/memory.py
@@ -4,6 +4,7 @@ from typing import Callable
 
 import gdb
 
+from pwndbg.gdblib.heap.ptmalloc import Heap
 import pwndbg.gdblib.symbol
 import pwndbg.gdblib.vmmap
 import pwndbg.integration
@@ -26,12 +27,53 @@ c = ColorConfig(
     ],
 )
 
+def test(addr):
+    try:
+        heap = Heap(addr)
+    except Exception as E:
+        return None
+
+    if heap.arena is None:
+        return None
+
+    allocator = pwndbg.gdblib.heap.current
+    assert isinstance(allocator, GlibcMemoryAllocator)
+
+    for chunk in heap:
+        if addr in chunk:
+            arena = chunk.arena
+            if arena:
+                if chunk.is_top_chunk:
+                    return "top chunk"
+
+            if not chunk.is_top_chunk and arena:
+                bins_list = [
+                    allocator.fastbins(arena.address),
+                    allocator.smallbins(arena.address),
+                    allocator.largebins(arena.address),
+                    allocator.unsortedbin(arena.address),
+                ]
+            if allocator.has_tcache():
+                bins_list.append(allocator.tcachebins(None))
+
+            bins_list = [x for x in bins_list if x is not None]
+            for bins in bins_list:
+                if bins.contains_chunk(chunk.real_size, chunk.address):
+                    return str(bins.bin_type)
+
+    return None
+
+
+
 
 def get_address_and_symbol(address: int) -> str:
     """
     Convert and colorize address 0x7ffff7fcecd0 to string `0x7ffff7fcecd0 (_dl_fini)`
     If no symbol exists for the address, return colorized address
     """
+
+    # First, attempt to resolve it as an heap bins
+
     symbol = pwndbg.gdblib.symbol.get(address) or None
     if symbol:
         symbol = f"{address:#x} ({symbol})"

--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -98,11 +98,19 @@ def format_bin(bins: Bins, verbose: bool = False, offset: int | None = None) -> 
             if count <= 7:
                 limit = count + 1
             formatted_chain = pwndbg.chain.format(
-                chain_fd[0], offset=offset, limit=limit, safe_linking=safe_lnk, display_heap_free_bins=False
+                chain_fd[0],
+                offset=offset,
+                limit=limit,
+                safe_linking=safe_lnk,
+                display_heap_free_bins=False,
             )
         else:
             formatted_chain = pwndbg.chain.format(
-                chain_fd[0], limit=heap_chain_limit, offset=offset, safe_linking=safe_lnk, display_heap_free_bins=False
+                chain_fd[0],
+                limit=heap_chain_limit,
+                offset=offset,
+                safe_linking=safe_lnk,
+                display_heap_free_bins=False,
             )
 
         if isinstance(size, int):

--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -98,11 +98,11 @@ def format_bin(bins: Bins, verbose: bool = False, offset: int | None = None) -> 
             if count <= 7:
                 limit = count + 1
             formatted_chain = pwndbg.chain.format(
-                chain_fd[0], offset=offset, limit=limit, safe_linking=safe_lnk
+                chain_fd[0], offset=offset, limit=limit, safe_linking=safe_lnk, display_heap_free_bins=False
             )
         else:
             formatted_chain = pwndbg.chain.format(
-                chain_fd[0], limit=heap_chain_limit, offset=offset, safe_linking=safe_lnk
+                chain_fd[0], limit=heap_chain_limit, offset=offset, safe_linking=safe_lnk, display_heap_free_bins=False
             )
 
         if isinstance(size, int):
@@ -120,7 +120,7 @@ def format_bin(bins: Bins, verbose: bool = False, offset: int | None = None) -> 
             line = message.hint(size) + message.error(" [corrupted]") + "\n"
             line += message.hint("FD: ") + formatted_chain + "\n"
             line += message.hint("BK: ") + pwndbg.chain.format(
-                chain_bk[0], offset=allocator.chunk_key_offset("bk")
+                chain_bk[0], offset=allocator.chunk_key_offset("bk"), display_heap_free_bins=False
             )
         else:
             if count is not None:

--- a/pwndbg/gdblib/heap/__init__.py
+++ b/pwndbg/gdblib/heap/__init__.py
@@ -126,7 +126,6 @@ def resolve_heap(is_first_run: bool = False) -> None:
         current = pwndbg.gdblib.heap.ptmalloc.DebugSymsHeap()
 
 
-
 def heap_freebin_address_lookup(addr: int) -> str | None:
     """
     Return a string representing the free bin that an address belongs to.
@@ -137,10 +136,10 @@ def heap_freebin_address_lookup(addr: int) -> str | None:
     allocator = pwndbg.gdblib.heap.current
     if not isinstance(allocator, pwndbg.gdblib.heap.ptmalloc.GlibcMemoryAllocator):
         return None
-    
+
     try:
         heap = pwndbg.gdblib.heap.ptmalloc.Heap(addr)
-    except Exception as E:
+    except Exception:
         return None
 
     if heap.arena is None:


### PR DESCRIPTION
This PR adds an indication that a pointer is referencing a free chunk in any heap pointers displayed in any use of the `chain` function (used in telescope, in printing registers (`regs`), and in annotations).

![image](https://github.com/user-attachments/assets/38e03a83-d3b2-4310-b428-5f312a942560)

Due to possible performance concerns, it is gated behind a config setting.