### PR TITLE
Fix vmmap on remote targets

### DIFF
--- a/pwndbg/commands/xinfo.py
+++ b/pwndbg/commands/xinfo.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import os
 
 import pwndbg
 import pwndbg.color.memory as M
@@ -59,6 +60,11 @@ def xinfo_mmap_file(page, addr) -> None:
     # to beginning of file in memory and on disk
 
     file_name = page.objfile
+    # Check if the file exists on the local system, as we may be attached to a gdb-server or qemu.
+    # Even so, the file might exist locally, if we are doing `target remote localhost:1234`
+    if not os.path.exists(file_name):
+        return None
+
     objpages = filter(lambda p: p.objfile == file_name, pwndbg.gdblib.vmmap.get())
     first = sorted(objpages, key=lambda p: p.vaddr)[0]
 


### PR DESCRIPTION
This PR fixes our parsing of `info proc mappings`, resulting in accurate vmmap's on remote qemu targets.

Previously, permissions were absent (always `---p`) and some pages were missing as well due to the parser function missing some cases. The parser didn't consider the case that the objfile column could be empty, leading the code to throw an exception in the try catch block and return None.

Old vmmap of a debugging a process in qemu:
![image](https://github.com/user-attachments/assets/5eb4db8e-8c3e-4d19-98c6-26ea869ce2c5)

Note that the name of the objfile for some pages was the permissions bits. This was due to the parser assuming the objfile field was non-empty.

New:
![image](https://github.com/user-attachments/assets/6a2b8006-455c-4855-af44-de713da730db)

This fixes #2385. While making this change, I found the root cause of #2365 - we assumed that the `.objfile` of Page objects were local files, and didn't check if we could really open them. I added a check for file existence, so xinfo no longer crashes on remote targets.

