### PR TITLE
Setting to disable inline symbols replacement in disasm

### DIFF
--- a/pwndbg/gdblib/disasm/arch.py
+++ b/pwndbg/gdblib/disasm/arch.py
@@ -90,6 +90,7 @@ pwndbg.config.add_param(
     "Enable replacing constant operands with their symbol in the disassembly",
 )
 
+
 def syntax_highlight(ins):
     return H.syntax_highlight(ins, filename=".asm")
 

--- a/pwndbg/gdblib/disasm/arch.py
+++ b/pwndbg/gdblib/disasm/arch.py
@@ -84,6 +84,11 @@ pwndbg.config.add_param(
     "Number of characters in strings to display in disasm annotations",
 )
 
+pwndbg.config.add_param(
+    "disasm-inline-symbols",
+    True,
+    "Enable replacing constant operands with their symbol in the disassembly",
+)
 
 def syntax_highlight(ins):
     return H.syntax_highlight(ins, filename=".asm")
@@ -297,7 +302,7 @@ class DisassemblyAssistant:
                     op.before_value, instruction, op, emu
                 )
 
-                if op.symbol and op.type == CS_OP_IMM:
+                if op.symbol and op.type == CS_OP_IMM and pwndbg.config.disasm_inline_symbols:
                     # Make an inline replacement, so `jmp 0x400122` becomes `jmp function_name`
                     instruction.asm_string = instruction.asm_string.replace(
                         hex(op.before_value), op.symbol


### PR DESCRIPTION
This PR adds a config setting to enable/disable replacing constants operands (`je     0x5555555570b1`) with the symbol associated with the address (je     main+4225).