### PR TITLE
VMMAP Cache Issue Fix

### DIFF
--- a/pwndbg/gdblib/vmmap.py
+++ b/pwndbg/gdblib/vmmap.py
@@ -269,6 +269,9 @@ def explore(address_maybe: int) -> pwndbg.lib.memory.Page | None:
 
     explored_pages.append(page)
 
+    # Clear the "get" cache so pages that are explored in the current step are included
+    get.cache.clear()  # type: ignore[attr-defined]
+
     return page
 
 


### PR DESCRIPTION
This PR fixes a caching bug that occurs while exploring memory pages on targets that don't expose any memory mapping information (like `qemu-system`).

After calling `explore`, we now clear the cache of the `get` function which returns all known mappings. Without clearing this cache, we would sometimes see duplicate mappings (when the same page got explored multiple times per step, not knowing that the page had already been seen), and would have to `step` once in order to see the up to date mappings that were explored in the previous step.

Example duplicates:
![vmmap_cache_issue](https://github.com/user-attachments/assets/b1376331-7867-46f6-9083-41015f5ee9a9)
