### PR TITLE
Fix #2391

### DIFF
--- a/pwndbg/gdblib/vmmap.py
+++ b/pwndbg/gdblib/vmmap.py
@@ -484,7 +484,7 @@ def info_proc_maps(parse_flags=True) -> Tuple[pwndbg.lib.memory.Page, ...]:
         info_proc_mappings = []
 
     # See if "Perms" is in the header line
-    perms_available = "Perms" in info_proc_mappings[3]
+    perms_available = len(info_proc_mappings) >= 4 and "Perms" in info_proc_mappings[3]
 
     pages: List[pwndbg.lib.memory.Page] = []
     for line in info_proc_mappings:


### PR DESCRIPTION
This fixes #2391 - we call `info proc mappings` when debugging qemu-user-mode, and rely that the output will exist. However, even on QEMU >= 8.1, the call can fail to produce mappings, which this catches.