### PR TITLE
Fix dt command when an address is passed

### DIFF
--- a/pwndbg/commands/dt.py
+++ b/pwndbg/commands/dt.py
@@ -31,5 +31,5 @@ def dt(typename: str, address: int | gdb.Value | None = None) -> None:
     Optionally overlay that information at an address.
     """
     if address is not None:
-        address = pwndbg.commands.fix(address)  # type: ignore[arg-type]
+        address = pwndbg.commands.fix(str(address))
     print(pwndbg.gdblib.dt.dt(typename, addr=address))

--- a/pwndbg/gdblib/dt.py
+++ b/pwndbg/gdblib/dt.py
@@ -151,7 +151,12 @@ def dt(name: str = "", addr: int | gdb.Value | None = None, obj: gdb.Value | Non
 
         if obj:
             line = "    0x%016x +0x%04x%s %-20s : %s" % (
-                int(obj.address) + o, o, bitpos, name, extra)
+                int(obj.address) + o,
+                o,
+                bitpos,
+                name,
+                extra,
+            )
         else:
             line = "    +0x%04x%s %-20s : %s" % (o, bitpos, name, extra)
         rv.append(line)

--- a/pwndbg/gdblib/dt.py
+++ b/pwndbg/gdblib/dt.py
@@ -149,7 +149,11 @@ def dt(name: str = "", addr: int | gdb.Value | None = None, obj: gdb.Value | Non
 
         bitpos = "" if not b else (".%i" % b)
 
-        line = "    +0x%04x%s %-20s : %s" % (o, bitpos, name, extra)
+        if obj:
+            line = "    0x%016x +0x%04x%s %-20s : %s" % (
+                int(obj.address) + o, o, bitpos, name, extra)
+        else:
+            line = "    +0x%04x%s %-20s : %s" % (o, bitpos, name, extra)
         rv.append(line)
 
     return "\n".join(rv)


### PR DESCRIPTION
`pwndbg.commands.fix()` expects a string, while an integer was passed.

```
pwndbg> dt "struct malloc_state" 0x7ffff7b99b78
Traceback (most recent call last):
  File "/home/ubuntu/.local/share/pwndbg/pwndbg/commands/__init__.py", line 187, in __call__
    return self.function(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/.local/share/pwndbg/pwndbg/commands/dt.py", line 34, in dt
    address = pwndbg.commands.fix(address)  # type: ignore[arg-type]
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/.local/share/pwndbg/pwndbg/commands/__init__.py", line 245, in fix
    arg = arg.strip()
          ^^^^^^^^^
AttributeError: 'int' object has no attribute 'strip'

If that is an issue, you can report it on https://github.com/pwndbg/pwndbg/issues
(Please don't forget to search if it hasn't been reported before)
To generate the report and open a browser, you may run `bugreport --run-browser`
PS: Pull requests are welcome
pwndbg>
```

After this patch:

```
pwndbg> dt "struct malloc_state" 0x7ffff7b99b78
struct malloc_state @ 0x7ffff7b99b78
    +0x0000 mutex                : mutex_t
    +0x0004 flags                : int
    +0x0008 fastbinsY            : mfastbinptr [10]
    +0x0058 top                  : mchunkptr
    +0x0060 last_remainder       : mchunkptr
    +0x0068 bins                 : mchunkptr [254]
    +0x0858 binmap               : unsigned int [4]
    +0x0868 next                 : struct malloc_state *
    +0x0870 next_free            : struct malloc_state *
    +0x0878 attached_threads     : size_t
    +0x0880 system_mem           : size_t
    +0x0888 max_system_mem       : size_t
```

<!-- Please make sure to read the testing and linting instructions at https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md before creating a PR -->
