### PR TITLE
Fix failing case in arch CI/CD

### DIFF
--- a/pwndbg/wrappers/checksec.py
+++ b/pwndbg/wrappers/checksec.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 import contextlib
 from typing import Iterator
 
+import pwnlib.elf.elf
 import pwnlib.term.text
 from pwnlib.elf import ELF
 
-import pwnlib.elf.elf
 pwnlib.elf.elf.log._logger.disabled = True
 
 import pwndbg.color.message as M

--- a/pwndbg/wrappers/checksec.py
+++ b/pwndbg/wrappers/checksec.py
@@ -6,6 +6,9 @@ from typing import Iterator
 import pwnlib.term.text
 from pwnlib.elf import ELF
 
+import pwnlib.elf.elf
+pwnlib.elf.elf.log._logger.disabled = True
+
 import pwndbg.color.message as M
 
 


### PR DESCRIPTION
One test related to the `got` command is failing in the Arch Linux build workflow. This is due to logging output from the constructor of the `pwnlib` ELF object which we aren't expecting. This PR disables the the logger for the pwnlib.elf module, fixing the test case.