### PR TITLE
Unify config parameters between `aglib.nearpc` and `gdblib.nearpc`

### DIFF
--- a/pwndbg/aglib/nearpc.py
+++ b/pwndbg/aglib/nearpc.py
@@ -23,16 +23,6 @@ from pwndbg.color import ColorConfig
 from pwndbg.color import ColorParamSpec
 from pwndbg.color import message
 
-# We prefix all of our configuration options with a special `aglib-` prefix if
-# we detect that gdblib is present. Pwndbg doesn't allow multiple settings under
-# the same name, so we have to add a unique prefix until we move all of Pwndbg
-# to this module, rather than the gdblib one.
-#
-# TODO: Port the rest of Pwndbg to this module and get rid of `pwndbg.gdblib.nearpc`.
-cfg_prefix = ""
-if pwndbg.dbg.is_gdblib_available():
-    cfg_prefix = "aglib-"
-
 
 def ljust_padding(lst):
     longest_len = max(map(len, lst)) if lst else 0
@@ -40,7 +30,7 @@ def ljust_padding(lst):
 
 
 c = ColorConfig(
-    f"{cfg_prefix}nearpc",
+    "nearpc",
     [
         ColorParamSpec("symbol", "normal", "color for nearpc command (symbol)"),
         ColorParamSpec("address", "normal", "color for nearpc command (address)"),
@@ -58,37 +48,35 @@ c = ColorConfig(
 import pwndbg.arguments
 
 nearpc_branch_marker = pwndbg.color.theme.add_param(
-    f"{cfg_prefix}nearpc-branch-marker", "    ↓", "branch marker line for nearpc command"
+    "nearpc-branch-marker", "    ↓", "branch marker line for nearpc command"
 )
 nearpc_branch_marker_contiguous = pwndbg.color.theme.add_param(
-    f"{cfg_prefix}nearpc-branch-marker-contiguous",
+    "nearpc-branch-marker-contiguous",
     " ",
     "contiguous branch marker line for nearpc command",
 )
-pwndbg.color.theme.add_param(
-    f"{cfg_prefix}highlight-pc", True, "whether to highlight the current instruction"
-)
-pwndbg.color.theme.add_param(f"{cfg_prefix}nearpc-prefix", "►", "prefix marker for nearpc command")
-pwndbg.config.add_param(f"{cfg_prefix}left-pad-disasm", True, "whether to left-pad disassembly")
+pwndbg.color.theme.add_param("highlight-pc", True, "whether to highlight the current instruction")
+pwndbg.color.theme.add_param("nearpc-prefix", "►", "prefix marker for nearpc command")
+pwndbg.config.add_param("left-pad-disasm", True, "whether to left-pad disassembly")
 nearpc_lines = pwndbg.config.add_param(
-    f"{cfg_prefix}nearpc-lines", 10, "number of additional lines to print for the nearpc command"
+    "nearpc-lines", 10, "number of additional lines to print for the nearpc command"
 )
 show_args = pwndbg.config.add_param(
-    f"{cfg_prefix}nearpc-show-args", True, "whether to show call arguments below instruction"
+    "nearpc-show-args", True, "whether to show call arguments below instruction"
 )
 show_comments = pwndbg.config.add_param(
-    f"{cfg_prefix}nearpc-integration-comments",
+    "nearpc-integration-comments",
     True,
     "whether to show comments from integration provider",
 )
 show_opcode_bytes = pwndbg.config.add_param(
-    f"{cfg_prefix}nearpc-num-opcode-bytes",
+    "nearpc-num-opcode-bytes",
     0,
     "number of opcode bytes to print for each instruction",
     param_class=pwndbg.lib.config.PARAM_ZUINTEGER,
 )
 opcode_separator_bytes = pwndbg.config.add_param(
-    f"{cfg_prefix}nearpc-opcode-separator-bytes",
+    "nearpc-opcode-separator-bytes",
     1,
     "number of spaces between opcode bytes",
     param_class=pwndbg.lib.config.PARAM_ZUINTEGER,

--- a/pwndbg/gdblib/nearpc.py
+++ b/pwndbg/gdblib/nearpc.py
@@ -22,8 +22,6 @@ import pwndbg.lib.config
 import pwndbg.lib.functions
 import pwndbg.ui
 from pwndbg.aglib.disasm.instruction import SplitType
-from pwndbg.color import ColorConfig
-from pwndbg.color import ColorParamSpec
 from pwndbg.color import message
 
 
@@ -32,51 +30,17 @@ def ljust_padding(lst):
     return [s.ljust(longest_len) for s in lst]
 
 
-c = ColorConfig(
-    "nearpc",
-    [
-        ColorParamSpec("symbol", "normal", "color for nearpc command (symbol)"),
-        ColorParamSpec("address", "normal", "color for nearpc command (address)"),
-        ColorParamSpec("prefix", "none", "color for nearpc command (prefix marker)"),
-        ColorParamSpec("syscall-name", "red", "color for nearpc command (resolved syscall name)"),
-        ColorParamSpec("argument", "bold", "color for nearpc command (target argument)"),
-        ColorParamSpec(
-            "integration-comments", "bold", "color for nearpc command (integration comments)"
-        ),
-        ColorParamSpec("branch-marker", "normal", "color for nearpc command (branch marker line)"),
-    ],
-)
-
-nearpc_branch_marker = pwndbg.color.theme.add_param(
-    "nearpc-branch-marker", "    ↓", "branch marker line for nearpc command"
-)
-nearpc_branch_marker_contiguous = pwndbg.color.theme.add_param(
-    "nearpc-branch-marker-contiguous", " ", "contiguous branch marker line for nearpc command"
-)
-pwndbg.color.theme.add_param("highlight-pc", True, "whether to highlight the current instruction")
-pwndbg.color.theme.add_param("nearpc-prefix", "►", "prefix marker for nearpc command")
-pwndbg.config.add_param("left-pad-disasm", True, "whether to left-pad disassembly")
-nearpc_lines = pwndbg.config.add_param(
-    "nearpc-lines", 10, "number of additional lines to print for the nearpc command"
-)
-show_args = pwndbg.config.add_param(
-    "nearpc-show-args", True, "whether to show call arguments below instruction"
-)
-show_comments = pwndbg.config.add_param(
-    "nearpc-integration-comments", True, "whether to show comments from integration provider"
-)
-show_opcode_bytes = pwndbg.config.add_param(
-    "nearpc-num-opcode-bytes",
-    0,
-    "number of opcode bytes to print for each instruction",
-    param_class=pwndbg.lib.config.PARAM_ZUINTEGER,
-)
-opcode_separator_bytes = pwndbg.config.add_param(
-    "nearpc-opcode-separator-bytes",
-    1,
-    "number of spaces between opcode bytes",
-    param_class=pwndbg.lib.config.PARAM_ZUINTEGER,
-)
+# These would be repeated verbatim here. Since `aglib` is always present, just
+# import them from there, instead of trying to redefine the settings toggles
+# for `nearpc`.
+from pwndbg.aglib.nearpc import c
+from pwndbg.aglib.nearpc import nearpc_branch_marker
+from pwndbg.aglib.nearpc import nearpc_branch_marker_contiguous
+from pwndbg.aglib.nearpc import nearpc_lines
+from pwndbg.aglib.nearpc import opcode_separator_bytes
+from pwndbg.aglib.nearpc import show_args
+from pwndbg.aglib.nearpc import show_comments
+from pwndbg.aglib.nearpc import show_opcode_bytes
 
 
 def nearpc(

--- a/tests/gdb-tests/tests/test_nearpc.py
+++ b/tests/gdb-tests/tests/test_nearpc.py
@@ -123,13 +123,6 @@ def test_nearpc_opcode_bytes(start_binary, opcode_bytes):
     start_binary(SYSCALLS_BINARY)
     gdb.execute("nextsyscall")
 
-    # While aglib.nearpc and gdblib.nearpc coexist in Pwndbg, we have to change
-    # all of our settings for both aglib and gdblib. This sucks, but is only a
-    # temporary measure until `pwndbg.gdblib.nearpc` is fully replaced by
-    # `pwndbg.aglib.nearpc`, which shouldn't be too long.
-    #
-    # TODO: Finish replacing `pwndbg.gdblib.nearpc` with `pwndbg.aglib.nearpc` and remove these
-    gdb.execute(f"set aglib-nearpc-num-opcode-bytes {opcode_bytes}")
     gdb.execute(f"set nearpc-num-opcode-bytes {opcode_bytes}")
     dis = gdb.execute("nearpc", to_string=True)
     expected = (
@@ -155,9 +148,7 @@ def test_nearpc_opcode_bytes(start_binary, opcode_bytes):
 def test_nearpc_opcode_seperator(start_binary, separator_bytes):
     start_binary(SYSCALLS_BINARY)
     gdb.execute("nextsyscall")
-    gdb.execute("set aglib-nearpc-num-opcode-bytes 5")
     gdb.execute("set nearpc-num-opcode-bytes 5")
-    gdb.execute(f"set aglib-nearpc-opcode-separator-bytes {separator_bytes}")
     gdb.execute(f"set nearpc-opcode-separator-bytes {separator_bytes}")
     dis = gdb.execute("nearpc", to_string=True)
     excepted = (
@@ -183,18 +174,11 @@ def test_nearpc_opcode_invalid_config():
     expected = "integer -1 out of range"
     try:
         # We try to catch the output since GDB < 9 won't raise the exception
-        assert (
-            gdb.execute("set aglib-nearpc-num-opcode-bytes -1", to_string=True).rstrip() == expected
-        )
         assert gdb.execute("set nearpc-num-opcode-bytes -1", to_string=True).rstrip() == expected
     except gdb.error as e:
         assert expected == str(e)
 
     try:
-        assert (
-            gdb.execute("set aglib-nearpc-opcode-separator-bytes -1", to_string=True).rstrip()
-            == expected
-        )
         assert (
             gdb.execute("set nearpc-opcode-separator-bytes -1", to_string=True).rstrip() == expected
         )


### PR DESCRIPTION
As noted in #2382, the way we are currently replicating config parameters between `aglib.nearpc` and `gdblib.nearpc` is a very unsightly and janky hack. This PR is a possible way we can fix that. It moves all parameters to `aglib`, and has `gdblib.nearpc` import them from it. `aglib` is always available, even in GDB, so we can import those from there.