### PR TITLE
Add GDB scheduler-locking control to the Debugger-agnostic API

### DIFF
--- a/pwndbg/aglib/tls.py
+++ b/pwndbg/aglib/tls.py
@@ -16,7 +16,11 @@ def __call_pthread_self() -> int:
     if pwndbg.dbg.selected_inferior().symbol_address_from_name("pthread_self") is None:
         return 0
     try:
-        return int(pwndbg.dbg.selected_frame().evaluate_expression("(void *)pthread_self()"))
+        return int(
+            pwndbg.dbg.selected_frame().evaluate_expression(
+                "(void *)pthread_self()", lock_scheduler=True
+            )
+        )
     except pwndbg.dbg_mod.Error:
         return 0
 

--- a/pwndbg/dbg/__init__.py
+++ b/pwndbg/dbg/__init__.py
@@ -154,10 +154,17 @@ class Registers:
 
 
 class Frame:
-    def evaluate_expression(self, expression: str) -> Value:
+    def evaluate_expression(self, expression: str, lock_scheduler: bool = False) -> Value:
         """
         Evaluate the given expression in the context of this frame, and
         return a `Value`.
+
+        # `lock_scheduler`
+        Additionally, callers of this function might specify that they want to
+        enable scheduler locking during the evaluation of this expression. This
+        is a GDB-only option, and is intended for cases in which the result
+        would be incorrect without it enabled, when running in GDB. Other
+        debuggers should ignore this parameter.
         """
         raise NotImplementedError()
 

--- a/pwndbg/dbg/gdb.py
+++ b/pwndbg/dbg/gdb.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import re
 import signal
+from contextlib import nullcontext
 from typing import Any
 from typing import Generator
 from typing import List
@@ -86,10 +87,12 @@ class GDBFrame(pwndbg.dbg_mod.Frame):
         self.inner = inner
 
     @override
-    def evaluate_expression(self, expression: str) -> pwndbg.dbg_mod.Value:
-        from pwndbg.gdblib.scheduler import lock_scheduler
+    def evaluate_expression(
+        self, expression: str, lock_scheduler: bool = False
+    ) -> pwndbg.dbg_mod.Value:
+        from pwndbg.gdblib.scheduler import lock_scheduler as do_lock_scheduler
 
-        with lock_scheduler():
+        with do_lock_scheduler() if lock_scheduler else nullcontext():
             with selection(self.inner, lambda: gdb.selected_frame(), lambda f: f.select()):
                 try:
                     value = parse_and_eval(expression, global_context=False)

--- a/pwndbg/dbg/lldb/__init__.py
+++ b/pwndbg/dbg/lldb/__init__.py
@@ -97,7 +97,9 @@ class LLDBFrame(pwndbg.dbg_mod.Frame):
         self.proc = proc
 
     @override
-    def evaluate_expression(self, expression: str) -> pwndbg.dbg_mod.Value:
+    def evaluate_expression(
+        self, expression: str, lock_scheduler: bool = False
+    ) -> pwndbg.dbg_mod.Value:
         value = self.inner.EvaluateExpression(expression)
         opt_out = _is_optimized_out(value)
 


### PR DESCRIPTION
As pointed out in #2382, always enabling scheduler locking when evaluating expressions can lead to deadlocks in GDB, so we want it to be off by default and let callers enable it only when absolutely required. This PR adds support for that in the Debugger-agnostic API.

It is important to note that, even though this is a fairly important thing to control, and thus I think it deserves a spot in the Debugger-agnostic API, scheduler locking is still a GDB concept, and that LLDB does [its own thing](https://github.com/llvm/llvm-project/blob/1601879f5d690595889a5537c0049b62df4657c7/lldb/source/Expression/ExpressionParser.cpp#L62) with expression evaluation, and does not have a direct equivalent to it, as far as I know. So adding this means we're leaking a GDB concept into a debugger-agnostic interface. This PR tries to minimize the impact of that by clearly documenting that `lock_scheduler` is a GDB-only parameter, and that other implementations should ignore it.