### PR TITLE
Update Nix files for LLDB Pwndbg

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -71,6 +71,14 @@
             inputs.pwndbg = self;
             isDev = true;
           };
+          pwndbg-lldb = import ./nix/pwndbg.nix {
+            pkgs = pkgsBySystem.${system};
+            python3 = pkgsBySystem.${system}.python3;
+            gdb = pkgsBySystem.${system}.gdb;
+            inputs.pwndbg = self;
+            isDev = true;
+            isLLDB = true;
+          };
         }
         // (portableDrvs system)
         // (tarballDrv system)
@@ -82,6 +90,7 @@
           pkgs = pkgsBySystem.${system};
           python3 = pkgsBySystem.${system}.python3;
           inputs.pwndbg = self;
+          isLLDB = true;
         }
       );
     };

--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -12,11 +12,12 @@
     import nixpkgs { overlays = [ ]; },
   python3 ? pkgs.python3,
   inputs ? null,
+  isLLDB ? false,
   ...
 }:
 let
   pyEnv = import ./pyenv.nix {
-    inherit pkgs python3 inputs;
+    inherit pkgs python3 inputs isLLDB;
     lib = pkgs.lib;
     isDev = true;
   };
@@ -25,7 +26,7 @@ in
   default = pkgs.mkShell {
     NIX_CONFIG = "extra-experimental-features = nix-command flakes repl-flake";
     # Anything not handled by the poetry env
-    nativeBuildInputs = with pkgs; [
+    nativeBuildInputs = (with pkgs; [
       # from setup-dev.sh
       nasm
       gcc
@@ -38,7 +39,9 @@ in
       go
 
       pyEnv
-    ];
+    ]) ++ pkgs.lib.optionals isLLDB (with pkgs; [
+      lldb_19
+    ]);
     shellHook = ''
       export PWNDBG_VENV_PATH="PWNDBG_PLEASE_SKIP_VENV"
       export ZIGPATH="${pkgs.lib.getBin pkgs.zig_0_10}/bin/"

--- a/nix/pwndbg.nix
+++ b/nix/pwndbg.nix
@@ -75,16 +75,12 @@ let
       cp -r lldbinit.py pwndbg $out/share/pwndbg
       cp pwndbg-lldb.py $out/bin/${pwndbgName}
 
-      # patchShebangs isn't working, so we do it manually.
-      sed -i "1 d" $out/bin/${pwndbgName}
-      sed -i "1 i #!${pkgs.lib.makeBinPath [ python3 ]}/python3" $out/bin/${pwndbgName}
-
       ${fix_init_script { target = "$out/bin/${pwndbgName}"; line = "4"; } }
 
       touch $out/share/pwndbg/.skip-venv
       wrapProgram $out/bin/${pwndbgName} \
         --prefix PATH : ${ pkgs.lib.makeBinPath [ lldb ] } \
-        '' + (pkgs.lib.optionalString !pkgs.stdenv.isDarwin ''
+        '' + (pkgs.lib.optionalString (!pkgs.stdenv.isDarwin) ''
         --set LLDB_DEBUGSERVER_PATH ${ pkgs.lib.makeBinPath [ lldb ] }/lldb-server \
         '') + ''
         --set PWNDBG_LLDBINIT_DIR $out/share/pwndbg

--- a/nix/pwndbg.nix
+++ b/nix/pwndbg.nix
@@ -83,8 +83,10 @@ let
       touch $out/share/pwndbg/.skip-venv
       wrapProgram $out/bin/${pwndbgName} \
         --prefix PATH : ${ pkgs.lib.makeBinPath [ lldb ] } \
-        --set PWNDBG_LLDBINIT_DIR $out/share/pwndbg \
-        --set LLDB_DEBUGSERVER_PATH ${ pkgs.lib.makeBinPath [ lldb ] }/lldb-server
+        '' + (pkgs.lib.optionalString !pkgs.stdenv.isDarwin ''
+        --set LLDB_DEBUGSERVER_PATH ${ pkgs.lib.makeBinPath [ lldb ] }/lldb-server \
+        '') + ''
+        --set PWNDBG_LLDBINIT_DIR $out/share/pwndbg
     '' else ''
       mkdir -p $out/share/pwndbg
 

--- a/nix/pwndbg.nix
+++ b/nix/pwndbg.nix
@@ -57,6 +57,7 @@ let
     ]));
 
     nativeBuildInputs = [ pkgs.makeWrapper ];
+    buildInputs = [ pyEnv ];
 
     installPhase = let
       fix_init_script = { target, line }: ''

--- a/nix/pyenv.nix
+++ b/nix/pyenv.nix
@@ -3,12 +3,13 @@
   python3 ? pkgs.python3,
   inputs ? null,
   isDev ? false,
+  isLLDB ? false,
   lib,
   ...
 }:
 pkgs.poetry2nix.mkPoetryEnv {
-  groups = lib.optionals isDev [ "dev" ];
-  checkGroups = lib.optionals isDev [ "dev" ];
+  groups = lib.optionals isDev [ "dev" ] ++ lib.optionals isLLDB [ "lldb" ];
+  checkGroups = lib.optionals isDev [ "dev" ] ++ lib.optionals isLLDB [ "lldb" ];
   projectDir = inputs.pwndbg;
   python = python3;
   overrides = pkgs.poetry2nix.overrides.withDefaults (

--- a/pwndbg-lldb.py
+++ b/pwndbg-lldb.py
@@ -41,15 +41,23 @@ def find_lldb_python_path() -> str:
 
 
 if __name__ == "__main__":
+    debug = "PWNDBG_LLDB_DEBUG" in os.environ
+
     # Find the path for the LLDB Python bindings.
     path = find_lldb_python_path()
     sys.path.append(path)
+
+    if debug:
+        print(f"[-] Launcher: LLDB Python path: {path}")
 
     # Older LLDB versions crash newer versions of CPython on import, so check
     # for it, and stop early with an error message.
     #
     # See https://github.com/llvm/llvm-project/issues/70453
     lldb_version = find_lldb_version()
+
+    if debug:
+        print(f"[-] Launcher: LLDB version {lldb_version[0]}.{lldb_version[1]}")
 
     if sys.version_info.minor >= 12 and lldb_version[0] <= 18:
         print("LLDB 18 and earlier is incompatible with Python 3.12 and later", file=sys.stderr)
@@ -60,13 +68,32 @@ if __name__ == "__main__":
 
     lldb.SBDebugger.Initialize()
     debugger = lldb.SBDebugger.Create()
-    debugger.HandleCommand("command script import ./lldbinit.py")
 
-    debug = "PWNDBG_LLDB_DEBUG" in os.environ
+    # Resolve the location of lldbinit.py based on the environment, if needed.
+    lldbinit_dir = os.path.dirname(sys.argv[0])
+    if "PWNDBG_LLDBINIT_DIR" in os.environ:
+        lldbinit_dir = os.environ["PWNDBG_LLDBINIT_DIR"]
+    lldbinit_dir = os.path.abspath(lldbinit_dir)
+    lldbinit_path = os.path.join(lldbinit_dir, "lldbinit.py")
+
+    if debug:
+        print(f"[-] Launcher: Importing main LLDB module at '{lldbinit_path}'")
+
+    if not os.path.exists(lldbinit_path):
+        print(f"Could not find '{lldbinit_path}, please specify it with PWNDBG_LLDBINIT_DIR")
+        sys.exit(1)
+
+    if lldbinit_path not in sys.path:
+        sys.path.append(lldbinit_dir)
+
+    # Load the lldbinit module we just found.
+    debugger.HandleCommand(f"command script import {lldbinit_path}")
 
     # Initialize the debugger, proper.
     import lldbinit
 
+    if debug:
+        print("[-] Launcher: Initializing Pwndbg")
     lldbinit.main(debugger, lldb_version[0], lldb_version[1], debug=debug)
 
     # Run our REPL until the user decides to leave.
@@ -79,6 +106,9 @@ if __name__ == "__main__":
         target = sys.argv[1]
 
     from pwndbg.dbg.lldb.repl import run as run_repl
+
+    if debug:
+        print("[-] Launcher: Entering Pwndbg CLI")
 
     run_repl([f"target create '{target}'"] if target else None, debug=debug)
 


### PR DESCRIPTION
This PR updates our Nix files for LLDB Pwndbg support, under a new package, named `pwndbg-lldb`. It also updates `pwndbg-lldb.py` to handle different Pwndbg locations. We pick version 19 of LLDB in our flake, because when running under earlier versions we [hit an LLDB bug specific to Python >=3.12](https://github.com/llvm/llvm-project/issues/70453), which is the version of Python in the flake.

Feedback on my Nix is also especially appreciated, as I'm by no means a Nix guru.