### PR TITLE
Fix `GetTypeCode` typo in the LLDB backend

### DIFF
--- a/pwndbg/dbg/lldb/__init__.py
+++ b/pwndbg/dbg/lldb/__init__.py
@@ -250,7 +250,7 @@ def map_type_code(type: lldb.SBType) -> pwndbg.dbg_mod.TypeCode:
     """
     Determines the type code of a given LLDB SBType.
     """
-    c = type.GetTypeCode()
+    c = type.GetTypeClass()
 
     assert c != lldb.eTypeClassInvalid, "passed eTypeClassInvalid to map_type_code"
 


### PR DESCRIPTION
This is a pretty small one, stumbled on it when I was working on another fix. At some point I mistook `SBType::GetTypeClass` to be `SBType::GetTypeCode` in the LLDB back-end. Oops.