### PR TITLE
Implement remaining functions in `aglib.memory` and tie some loose ends

### DIFF
--- a/pwndbg/aglib/memory.py
+++ b/pwndbg/aglib/memory.py
@@ -387,7 +387,7 @@ def convert_pwndbg_value_to_python_value(dbg_value: pwndbg.dbg_mod.Value) -> int
 
 
 def resolve_renamed_struct_field(struct_name: str, possible_field_names: Set[str]) -> str:
-    struct_types = pwndbg.dbg.selected_inferior().types_with_name("struct " + struct_name)
+    struct_types = pwndbg.dbg.selected_inferior().types_with_name(f"struct {struct_name}")
     if len(struct_types) == 0:
         raise pwndbg.dbg_mod.Error(f"could not find type 'struct {struct_name}'")
     struct_type = struct_types[0]

--- a/pwndbg/aglib/memory.py
+++ b/pwndbg/aglib/memory.py
@@ -338,22 +338,62 @@ def find_lower_boundary(addr: int, max_pages: int = 1024) -> int:
 
 
 def update_min_addr() -> None:
-    # FIXME: Debugger-agnostic API can't do QEMU detection yet.
-    #
-    # global MMAP_MIN_ADDR
-    # if pwndbg.gdblib.qemu.is_qemu_kernel():
-    #    MMAP_MIN_ADDR = 0
-    pass
+    global MMAP_MIN_ADDR
+    if pwndbg.aglib.qemu.is_qemu_kernel():
+        MMAP_MIN_ADDR = 0
 
 
-def fetch_struct_as_dictionary(
-    struct_name: str,
-    struct_address: int,
+def pack_struct_into_dictionary(
+    fetched_struct: pwndbg.dbg_mod.Value,
     include_only_fields: Set[str] | None = None,
     exclude_fields: Set[str] | None = None,
 ) -> GdbDict:
-    raise NotImplementedError()
+    struct_as_dictionary = {}
+
+    if exclude_fields is None:
+        exclude_fields = set()
+
+    if include_only_fields is not None:
+        for field_name in include_only_fields:
+            key = field_name
+            value = convert_pwndbg_value_to_python_value(fetched_struct[field_name])
+            struct_as_dictionary[key] = value
+    else:
+        for index, field in enumerate(fetched_struct.type.fields()):
+            if field.name is None:
+                # Flatten anonymous structs/unions
+                anon_type = convert_pwndbg_value_to_python_value(fetched_struct[index])
+                assert isinstance(anon_type, dict)
+                struct_as_dictionary.update(anon_type)
+            elif field.name not in exclude_fields:
+                key = field.name
+                value = convert_pwndbg_value_to_python_value(fetched_struct[index])
+                struct_as_dictionary[key] = value
+
+    return struct_as_dictionary
+
+
+def convert_pwndbg_value_to_python_value(dbg_value: pwndbg.dbg_mod.Value) -> int | GdbDict:
+    ty = dbg_value.type.strip_typedefs()
+
+    if ty.code == pwndbg.dbg_mod.TypeCode.POINTER:
+        return int(dbg_value)
+    elif ty.code == pwndbg.dbg_mod.TypeCode.INT:
+        return int(dbg_value)
+    elif ty.code == pwndbg.dbg_mod.TypeCode.STRUCT:
+        return pack_struct_into_dictionary(dbg_value)
+
+    raise NotImplementedError
 
 
 def resolve_renamed_struct_field(struct_name: str, possible_field_names: Set[str]) -> str:
-    raise NotImplementedError()
+    struct_types = pwndbg.dbg.selected_inferior().types_with_name("struct " + struct_name)
+    if len(struct_types) == 0:
+        raise pwndbg.dbg_mod.Error(f"could not find type 'struct {struct_name}'")
+    struct_type = struct_types[0]
+
+    for field_name in possible_field_names:
+        if struct_type.has_field(field_name):
+            return field_name
+
+    raise ValueError(f"Field name did not match any of {possible_field_names}.")

--- a/pwndbg/dbg/gdb.py
+++ b/pwndbg/dbg/gdb.py
@@ -936,6 +936,11 @@ class GDBValue(pwndbg.dbg_mod.Value):
 
     @override
     def __getitem__(self, key: str | int) -> pwndbg.dbg_mod.Value:
+        if self.inner.type.code == gdb.TYPE_CODE_STRUCT and isinstance(key, int):
+            # GDB doesn't normally support indexing fields in a struct by int,
+            # so we nudge it a little.
+            key = self.inner.type.fields()[key]
+
         return GDBValue(self.inner[key])
 
 

--- a/pwndbg/dbg/lldb/hooks.py
+++ b/pwndbg/dbg/lldb/hooks.py
@@ -19,9 +19,19 @@ def update_typeinfo() -> None:
     pwndbg.aglib.arch_mod.update()
 
 
+@pwndbg.dbg.event_handler(EventType.START)
+def on_start() -> None:
+    pwndbg.aglib.memory.update_min_addr()
+
+
 @pwndbg.dbg.event_handler(EventType.STOP)
 def on_stop() -> None:
     pwndbg.aglib.strings.update_length()
+
+
+@pwndbg.dbg.event_handler(EventType.EXIT)
+def on_exit() -> None:
+    pwndbg.aglib.file.reset_remote_files()
 
 
 import pwndbg.lib.cache

--- a/pwndbg/gdblib/hooks.py
+++ b/pwndbg/gdblib/hooks.py
@@ -59,11 +59,13 @@ def reset_config() -> None:
 def on_start() -> None:
     pwndbg.gdblib.abi.update()
     pwndbg.gdblib.memory.update_min_addr()
+    pwndbg.aglib.memory.update_min_addr()
 
 
 @pwndbg.dbg.event_handler(EventType.EXIT)
 def on_exit() -> None:
     pwndbg.gdblib.file.reset_remote_files()
+    pwndbg.aglib.file.reset_remote_files()
     pwndbg.gdblib.next.clear_temp_breaks()
 
 


### PR DESCRIPTION
`aglib.memory` is currently missing two very important functions, notably used by the `heap` module. This PR implements them. This PR also adds a few missing `aglib` hook calls.