### PR TITLE
Fix MMAP_MIN_ADDR value bug in `{gdblib,aglib}.memory`

### DIFF
--- a/pwndbg/aglib/memory.py
+++ b/pwndbg/aglib/memory.py
@@ -339,8 +339,7 @@ def find_lower_boundary(addr: int, max_pages: int = 1024) -> int:
 
 def update_min_addr() -> None:
     global MMAP_MIN_ADDR
-    if pwndbg.aglib.qemu.is_qemu_kernel():
-        MMAP_MIN_ADDR = 0
+    MMAP_MIN_ADDR = 0 if pwndbg.aglib.qemu.is_qemu_kernel() else 0x8000
 
 
 def pack_struct_into_dictionary(

--- a/pwndbg/gdblib/memory.py
+++ b/pwndbg/gdblib/memory.py
@@ -384,8 +384,7 @@ def find_lower_boundary(addr: int, max_pages: int = 1024) -> int:
 
 def update_min_addr() -> None:
     global MMAP_MIN_ADDR
-    if pwndbg.gdblib.qemu.is_qemu_kernel():
-        MMAP_MIN_ADDR = 0
+    MMAP_MIN_ADDR = 0 if pwndbg.gdblib.qemu.is_qemu_kernel() else 0x8000
 
 
 def fetch_struct_as_dictionary(


### PR DESCRIPTION
Caught during merging of #2412. Both `aglib` and `gdblib` fail to restore the value of `MMAP_MIN_ADDR` to `0x8000` when attaching to a non-QEMU process, after a QEMU process has been debugged. This PR should fix that.