### PR TITLE
Port a handful of commands to the Debugger-agnostic interfaces

### DIFF
--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -694,28 +694,14 @@ def load_commands() -> None:
         import pwndbg.commands.binder
         import pwndbg.commands.binja
         import pwndbg.commands.branch
-        import pwndbg.commands.canary
-        import pwndbg.commands.checksec
-        import pwndbg.commands.comments
-        import pwndbg.commands.config
-        import pwndbg.commands.context
-        import pwndbg.commands.cpsr
-        import pwndbg.commands.cyclic
         import pwndbg.commands.cymbol
-        import pwndbg.commands.dev
-        import pwndbg.commands.distance
         import pwndbg.commands.dt
-        import pwndbg.commands.dumpargs
-        import pwndbg.commands.elf
-        import pwndbg.commands.flags
         import pwndbg.commands.gdt
         import pwndbg.commands.ghidra
         import pwndbg.commands.godbg
         import pwndbg.commands.got
         import pwndbg.commands.got_tracking
-        import pwndbg.commands.heap
         import pwndbg.commands.heap_tracking
-        import pwndbg.commands.hexdump
         import pwndbg.commands.ida
         import pwndbg.commands.ignore
         import pwndbg.commands.integration
@@ -726,42 +712,57 @@ def load_commands() -> None:
         import pwndbg.commands.kconfig
         import pwndbg.commands.killthreads
         import pwndbg.commands.kversion
-        import pwndbg.commands.leakfind
         import pwndbg.commands.linkmap
         import pwndbg.commands.memoize
         import pwndbg.commands.misc
         import pwndbg.commands.mmap
         import pwndbg.commands.mprotect
-        import pwndbg.commands.nearpc
         import pwndbg.commands.next
         import pwndbg.commands.onegadget
-        import pwndbg.commands.p2p
-        import pwndbg.commands.patch
         import pwndbg.commands.pcplist
         import pwndbg.commands.peda
-        import pwndbg.commands.pie
         import pwndbg.commands.plist
-        import pwndbg.commands.probeleak
         import pwndbg.commands.procinfo
         import pwndbg.commands.radare2
         import pwndbg.commands.reload
-        import pwndbg.commands.retaddr
         import pwndbg.commands.rizin
         import pwndbg.commands.rop
         import pwndbg.commands.ropper
-        import pwndbg.commands.search
         import pwndbg.commands.segments
         import pwndbg.commands.shell
-        import pwndbg.commands.sigreturn
         import pwndbg.commands.slab
-        import pwndbg.commands.spray
         import pwndbg.commands.start
-        import pwndbg.commands.telescope
         import pwndbg.commands.tips
         import pwndbg.commands.tls
-        import pwndbg.commands.valist
         import pwndbg.commands.version
-        import pwndbg.commands.vmmap
-        import pwndbg.commands.windbg
-        import pwndbg.commands.xinfo
-        import pwndbg.commands.xor
+
+    import pwndbg.commands.canary
+    import pwndbg.commands.checksec
+    import pwndbg.commands.comments
+    import pwndbg.commands.config
+    import pwndbg.commands.context
+    import pwndbg.commands.cpsr
+    import pwndbg.commands.cyclic
+    import pwndbg.commands.dev
+    import pwndbg.commands.distance
+    import pwndbg.commands.dumpargs
+    import pwndbg.commands.elf
+    import pwndbg.commands.flags
+    import pwndbg.commands.heap
+    import pwndbg.commands.hexdump
+    import pwndbg.commands.leakfind
+    import pwndbg.commands.nearpc
+    import pwndbg.commands.p2p
+    import pwndbg.commands.patch
+    import pwndbg.commands.pie
+    import pwndbg.commands.probeleak
+    import pwndbg.commands.retaddr
+    import pwndbg.commands.search
+    import pwndbg.commands.sigreturn
+    import pwndbg.commands.spray
+    import pwndbg.commands.telescope
+    import pwndbg.commands.valist
+    import pwndbg.commands.vmmap
+    import pwndbg.commands.windbg
+    import pwndbg.commands.xinfo
+    import pwndbg.commands.xor

--- a/pwndbg/commands/canary.py
+++ b/pwndbg/commands/canary.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 import argparse
 
+import pwndbg.aglib.memory
+import pwndbg.aglib.regs
+import pwndbg.aglib.stack
 import pwndbg.auxv
 import pwndbg.commands
 import pwndbg.commands.telescope
-import pwndbg.gdblib.memory
-import pwndbg.gdblib.regs
 import pwndbg.search
 from pwndbg.color import message
 from pwndbg.commands import CommandCategory
@@ -19,10 +20,10 @@ def canary_value():
     if at_random is None:
         return None, None
 
-    global_canary = pwndbg.gdblib.memory.pvoid(at_random)
+    global_canary = pwndbg.aglib.memory.pvoid(at_random)
 
     # masking canary value as canaries on the stack has last byte = 0
-    global_canary &= pwndbg.gdblib.arch.ptrmask ^ 0xFF
+    global_canary &= pwndbg.aglib.arch.ptrmask ^ 0xFF
 
     return global_canary, at_random
 
@@ -51,8 +52,8 @@ def canary(all) -> None:
     print(message.notice("Canary    = 0x%x (may be incorrect on != glibc)" % global_canary))
 
     found_canaries = False
-    global_canary_packed = pwndbg.gdblib.arch.pack(global_canary)
-    thread_stacks = pwndbg.gdblib.stack.get()
+    global_canary_packed = pwndbg.aglib.arch.pack(global_canary)
+    thread_stacks = pwndbg.aglib.stack.get()
 
     for thread in thread_stacks:
         thread_stack = thread_stacks[thread]

--- a/pwndbg/commands/checksec.py
+++ b/pwndbg/commands/checksec.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import argparse
 
+import pwndbg.aglib.file
 import pwndbg.color
 import pwndbg.commands
-import pwndbg.gdblib.file
 import pwndbg.wrappers.checksec
 
 parser = argparse.ArgumentParser(
@@ -17,5 +17,5 @@ parser.add_argument("-f", "--file", type=str, help="Specify the file to run `che
 @pwndbg.commands.ArgparsedCommand(parser, command_name="checksec")
 @pwndbg.commands.OnlyWithFile
 def checksec(file: str) -> None:
-    local_path = file or pwndbg.gdblib.file.get_proc_exe_file()
+    local_path = file or pwndbg.aglib.file.get_proc_exe_file()
     print(pwndbg.wrappers.checksec.get_raw_out(local_path))

--- a/pwndbg/commands/comments.py
+++ b/pwndbg/commands/comments.py
@@ -19,20 +19,20 @@ file_lists: Dict[str, Dict[str, str]] = {}  # This saves all comments.
 @pwndbg.commands.OnlyWhenRunning
 def comm(addr=None, comment=None) -> None:
     if addr is None:
-        addr = hex(pwndbg.gdblib.regs.pc)
+        addr = hex(pwndbg.aglib.regs.pc)
     try:
         with open(".gdb_comments", "a+") as f:
             target = int(addr, 0)
 
-            if not pwndbg.gdblib.memory.peek(target):
+            if not pwndbg.aglib.memory.peek(target):
                 print(message.error("Invalid Address %#x" % target))
 
             else:
-                f.write(f"file:{pwndbg.gdblib.proc.exe}=")
+                f.write(f"file:{pwndbg.aglib.proc.exe}=")
                 f.write(f"{target:#x}:{comment}\n")
-                if pwndbg.gdblib.proc.exe not in file_lists:
-                    file_lists[pwndbg.gdblib.proc.exe] = {}
-                file_lists[pwndbg.gdblib.proc.exe][hex(target)] = comment
+                if pwndbg.aglib.proc.exe not in file_lists:
+                    file_lists[pwndbg.aglib.proc.exe] = {}
+                file_lists[pwndbg.aglib.proc.exe][hex(target)] = comment
     except Exception:
         print(message.error("Permission denied to create file"))
 

--- a/pwndbg/commands/config.py
+++ b/pwndbg/commands/config.py
@@ -8,13 +8,15 @@ import argparse
 
 import pwndbg
 import pwndbg.commands
-import pwndbg.gdblib.config
 import pwndbg.lib.config
 from pwndbg.color import generateColorFunction
 from pwndbg.color import ljust_colored
 from pwndbg.color import strip
 from pwndbg.color.message import hint
 from pwndbg.commands import CommandCategory
+
+if pwndbg.dbg.is_gdblib_available():
+    import pwndbg.gdblib.config
 
 
 def print_row(
@@ -134,9 +136,11 @@ def theme(filter_pattern) -> None:
     display_config(filter_pattern, "theme")
 
 
-@pwndbg.commands.ArgparsedCommand(configfile_parser, category=CommandCategory.PWNDBG)
-def configfile(show_all=False) -> None:
-    configfile_print_scope("config", show_all)
+if pwndbg.dbg.is_gdblib_available():
+
+    @pwndbg.commands.ArgparsedCommand(configfile_parser, category=CommandCategory.PWNDBG)
+    def configfile(show_all=False) -> None:
+        configfile_print_scope("config", show_all)
 
 
 themefile_parser = argparse.ArgumentParser(
@@ -147,9 +151,11 @@ themefile_parser.add_argument(
 )
 
 
-@pwndbg.commands.ArgparsedCommand(themefile_parser, category=CommandCategory.PWNDBG)
-def themefile(show_all=False) -> None:
-    configfile_print_scope("theme", show_all)
+if pwndbg.dbg.is_gdblib_available():
+
+    @pwndbg.commands.ArgparsedCommand(themefile_parser, category=CommandCategory.PWNDBG)
+    def themefile(show_all=False) -> None:
+        configfile_print_scope("theme", show_all)
 
 
 def configfile_print_scope(scope: str, show_all: bool = False) -> None:

--- a/pwndbg/commands/cpsr.py
+++ b/pwndbg/commands/cpsr.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import argparse
 
+import pwndbg.aglib.arch
+import pwndbg.aglib.regs
 import pwndbg.commands
-import pwndbg.gdblib.arch
-import pwndbg.gdblib.regs
 from pwndbg.color import context
 from pwndbg.commands import CommandCategory
 
@@ -23,12 +23,12 @@ parser.add_argument(
 @pwndbg.commands.OnlyWithArch(["arm", "armcm", "aarch64"])
 @pwndbg.commands.OnlyWhenRunning
 def cpsr(cpsr_value=None) -> None:
-    reg = "xpsr" if pwndbg.gdblib.arch.name == "armcm" else "cpsr"
-    reg_flags = pwndbg.gdblib.regs.flags[reg]
+    reg = "xpsr" if pwndbg.aglib.arch.name == "armcm" else "cpsr"
+    reg_flags = pwndbg.aglib.regs.flags[reg]
 
     if cpsr_value is not None:
         reg_val = cpsr_value
     else:
-        reg_val = getattr(pwndbg.gdblib.regs, reg)
+        reg_val = getattr(pwndbg.aglib.regs, reg)
 
     print(f"{reg} {context.format_flags(reg_val, reg_flags)}")

--- a/pwndbg/commands/cyclic.py
+++ b/pwndbg/commands/cyclic.py
@@ -7,8 +7,8 @@ from typing import Optional
 from pwnlib.util.cyclic import cyclic
 from pwnlib.util.cyclic import cyclic_find
 
+import pwndbg.aglib.arch
 import pwndbg.commands
-import pwndbg.gdblib.arch
 from pwndbg.color import message
 
 parser = argparse.ArgumentParser(description="Cyclic pattern creator/finder.")
@@ -63,13 +63,13 @@ parser.add_argument(
 @pwndbg.commands.ArgparsedCommand(parser, command_name="cyclic")
 def cyclic_cmd(alphabet, length: Optional[int], lookup, count=100, filename="") -> None:
     if length is None:
-        length = pwndbg.gdblib.arch.ptrsize
+        length = pwndbg.aglib.arch.ptrsize
 
     if lookup:
         lookup = pwndbg.commands.fix(lookup, sloppy=True)
 
         if isinstance(lookup, (pwndbg.dbg_mod.Value, int)):
-            lookup = int(lookup).to_bytes(length, pwndbg.gdblib.arch.endian)
+            lookup = int(lookup).to_bytes(length, pwndbg.aglib.arch.endian)
         elif isinstance(lookup, str):
             lookup = bytes(lookup, "utf-8")
 

--- a/pwndbg/commands/dev.py
+++ b/pwndbg/commands/dev.py
@@ -6,7 +6,6 @@ import logging
 import pwndbg.aglib.disasm
 import pwndbg.color.message as MessageColor
 import pwndbg.commands
-import pwndbg.gdblib.nearpc
 from pwndbg.commands import CommandCategory
 
 parser = argparse.ArgumentParser(description="Dump internal PwndbgInstruction attributes.")
@@ -58,7 +57,7 @@ def dev_dump_instruction(address=None, force_emulate=False, no_emulate=False) ->
         )
 
         instructions, index_of_pc = pwndbg.aglib.disasm.near(
-            pwndbg.gdblib.regs.pc, 1, emulate=use_emulation, show_prev_insns=False, use_cache=False
+            pwndbg.aglib.regs.pc, 1, emulate=use_emulation, show_prev_insns=False, use_cache=False
         )
 
         if instructions:

--- a/pwndbg/commands/distance.py
+++ b/pwndbg/commands/distance.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import argparse
 
+import pwndbg.aglib.arch
 import pwndbg.color.memory as M
 import pwndbg.commands
-import pwndbg.gdblib.arch
 from pwndbg.commands import CommandCategory
 
 parser = argparse.ArgumentParser(
@@ -19,7 +19,7 @@ def distance(a, b) -> None:
     """Print the distance between the two arguments"""
 
     if b is None:
-        page = pwndbg.gdblib.vmmap.find(a)
+        page = pwndbg.aglib.vmmap.find(a)
 
         if not page:
             print("%#x does not belong to a mapped page in memory" % (a))
@@ -31,17 +31,17 @@ def distance(a, b) -> None:
                 page.vaddr,
                 a,
                 distance,
-                distance // pwndbg.gdblib.arch.ptrsize,
+                distance // pwndbg.aglib.arch.ptrsize,
             )
 
             print(M.get(page.vaddr, text=display_text))
     else:
-        a = int(a) & pwndbg.gdblib.arch.ptrmask
-        b = int(b) & pwndbg.gdblib.arch.ptrmask
+        a = int(a) & pwndbg.aglib.arch.ptrmask
+        b = int(b) & pwndbg.aglib.arch.ptrmask
 
         distance = b - a
 
         print(
             "%#x->%#x is %#x bytes (%#x words)"
-            % (a, b, distance, distance // pwndbg.gdblib.arch.ptrsize)
+            % (a, b, distance, distance // pwndbg.aglib.arch.ptrsize)
         )

--- a/pwndbg/commands/dumpargs.py
+++ b/pwndbg/commands/dumpargs.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 import argparse
 from typing import List
 
+import pwndbg.aglib.arch
 import pwndbg.aglib.disasm
 import pwndbg.arguments
 import pwndbg.chain
 import pwndbg.commands
 import pwndbg.commands.telescope
-import pwndbg.gdblib.arch
 
 parser = argparse.ArgumentParser(description="Prints determined arguments for call instruction.")
 parser.add_argument("-f", "--force", action="store_true", help="Force displaying of all arguments.")
@@ -24,7 +24,7 @@ def dumpargs(force: bool = False) -> None:
     else:
         print("Couldn't resolve call arguments from registers.")
         print(
-            f"Detected ABI: {pwndbg.gdblib.arch.name} ({pwndbg.gdblib.arch.ptrsize * 8} bit) either doesn't pass arguments through registers or is not implemented. Maybe they are passed on the stack?"
+            f"Detected ABI: {pwndbg.aglib.arch.name} ({pwndbg.aglib.arch.ptrsize * 8} bit) either doesn't pass arguments through registers or is not implemented. Maybe they are passed on the stack?"
         )
 
 

--- a/pwndbg/commands/elf.py
+++ b/pwndbg/commands/elf.py
@@ -99,7 +99,7 @@ def get_symbols_in_region(start, end, filter_text=""):
     addr = start
     while addr < end:
         name = pwndbg.dbg.selected_inferior().symbol_name_at_address(addr)
-        if name and name != "" and "+" not in name and filter_text in name:
+        if name and "+" not in name and filter_text in name:
             symbols.append((name, addr))
         addr += ptr_size
 

--- a/pwndbg/commands/elf.py
+++ b/pwndbg/commands/elf.py
@@ -12,7 +12,7 @@ from pwndbg.commands import CommandCategory
 )
 @pwndbg.commands.OnlyWithFile
 def elfsections() -> None:
-    local_path = pwndbg.gdblib.file.get_proc_exe_file()
+    local_path = pwndbg.aglib.file.get_proc_exe_file()
 
     with open(local_path, "rb") as f:
         elffile = ELFFile(f)
@@ -51,7 +51,7 @@ def plt() -> None:
 
 
 def get_section_bounds(section_name):
-    local_path = pwndbg.gdblib.file.get_proc_exe_file()
+    local_path = pwndbg.aglib.file.get_proc_exe_file()
 
     with open(local_path, "rb") as f:
         elffile = ELFFile(f)
@@ -74,8 +74,8 @@ def print_symbols_in_section(section_name, filter_text="") -> None:
         return
 
     # If we started the binary and it has PIE, rebase it
-    if pwndbg.gdblib.proc.alive:
-        bin_base_addr = pwndbg.gdblib.proc.binary_base_addr
+    if pwndbg.aglib.proc.alive:
+        bin_base_addr = pwndbg.aglib.proc.binary_base_addr
 
         # Rebase the start and end addresses if needed
         if start < bin_base_addr:
@@ -95,11 +95,11 @@ def print_symbols_in_section(section_name, filter_text="") -> None:
 
 def get_symbols_in_region(start, end, filter_text=""):
     symbols = []
-    ptr_size = pwndbg.gdblib.typeinfo.pvoid.sizeof
+    ptr_size = pwndbg.aglib.typeinfo.pvoid.sizeof
     addr = start
     while addr < end:
-        name = pwndbg.gdblib.symbol.get(addr, gdb_only=True)
-        if name != "" and "+" not in name and filter_text in name:
+        name = pwndbg.dbg.selected_inferior().symbol_name_at_address(addr)
+        if name and name != "" and "+" not in name and filter_text in name:
             symbols.append((name, addr))
         addr += ptr_size
 

--- a/pwndbg/commands/flags.py
+++ b/pwndbg/commands/flags.py
@@ -35,7 +35,7 @@ parser.add_argument(
 
 @pwndbg.commands.ArgparsedCommand(parser, aliases=["flag"], category=CommandCategory.REGISTER)
 def setflag(flag: str, value: int) -> None:
-    register_set = pwndbg.gdblib.regs.current
+    register_set = pwndbg.aglib.regs.current
 
     flag = flag.upper()
     for flag_reg, flags in register_set.flags.items():
@@ -54,14 +54,14 @@ def setflag(flag: str, value: int) -> None:
                     print(f"Maximum value for flag is {max_val} (size={size})")
                     return
 
-                old_val = int(pwndbg.gdblib.regs[flag_reg])
+                old_val = int(pwndbg.aglib.regs[flag_reg])
                 mask = max_val << bit
                 bit_value = value << bit
 
                 cleared_val = old_val & ~mask
                 new_val = cleared_val | bit_value
 
-                setattr(pwndbg.gdblib.regs, flag_reg, new_val)
+                setattr(pwndbg.aglib.regs, flag_reg, new_val)
                 print(
                     f"Set flag {flag}={value} in flag register {flag_reg} (old val={old_val:#x}, new val={new_val:#x})"
                 )

--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -107,7 +107,7 @@ def format_bin(bins: Bins, verbose: bool = False, offset: int | None = None) -> 
             if bins_type == BinType.LARGE:
                 start_size, end_size = allocator.largebin_size_range_from_index(size)
                 size = hex(start_size) + "-"
-                if end_size != pwndbg.gdblib.arch.ptrmask:
+                if end_size != pwndbg.aglib.arch.ptrmask:
                     size += hex(end_size)
                 else:
                     size += "\u221e"  # Unicode "infinity"
@@ -245,14 +245,14 @@ def hi(addr: int, verbose: bool = False, simple: bool = False, fake: bool = Fals
         if addr in chunk:
             malloc_chunk(chunk.address, verbose=verbose, simple=simple)
             if verbose:
-                start = chunk.address + (pwndbg.gdblib.arch.ptrsize if chunk.prev_inuse else 0x00)
+                start = chunk.address + (pwndbg.aglib.arch.ptrsize if chunk.prev_inuse else 0x00)
                 print(f"Your address: {hex(addr)}")
                 print(f"Head offset: {hex(addr - start)}")
                 if chunk.is_top_chunk is False and chunk.real_size is not None:
                     end = (
                         start
                         + chunk.real_size
-                        + (pwndbg.gdblib.arch.ptrsize if chunk.prev_inuse is False else 0x00)
+                        + (pwndbg.aglib.arch.ptrsize if chunk.prev_inuse is False else 0x00)
                     )
                     print(f"Tail offset: {hex(end - addr)}")
             break
@@ -547,7 +547,7 @@ def malloc_chunk(
     if dump:
         print(C.banner("hexdump"))
 
-        ptr_size = pwndbg.gdblib.arch.ptrsize
+        ptr_size = pwndbg.aglib.arch.ptrsize
         pwndbg.commands.hexdump.hexdump(chunk.address, chunk.real_size + ptr_size)
 
     if next:
@@ -908,7 +908,7 @@ def find_fake_fast(
         candidate = search_region[i : i + size_field_width]
 
         if len(candidate) == size_field_width:
-            size_field = pwndbg.gdblib.arch.unpack_size(candidate, size_field_width)
+            size_field = pwndbg.aglib.arch.unpack_size(candidate, size_field_width)
             size_field &= ~(allocator.malloc_align_mask)
 
             if size_field < min_chunk_size or size_field > max_candidate_size:
@@ -991,7 +991,7 @@ def vis_heap_chunks(
         addr = count
         count = pwndbg.config.default_visualize_chunk_number
 
-    if addr is not None and not pwndbg.gdblib.memory.is_readable_address(int(addr)):
+    if addr is not None and not pwndbg.aglib.memory.is_readable_address(int(addr)):
         print(message.error("The provided address is not readable."))
         return
 
@@ -1117,7 +1117,7 @@ def vis_heap_chunks(
                 out += "\n0x%x" % cursor
 
             data = pwndbg.aglib.memory.read(cursor, ptr_size)
-            cell = pwndbg.gdblib.arch.unpack(data)
+            cell = pwndbg.aglib.arch.unpack(data)
             cell_hex = f"\t0x{cell:0{ptr_size * 2}x}"
 
             out += color_func(cell_hex)
@@ -1220,7 +1220,7 @@ def try_free(addr: str | int) -> None:
     malloc_align_mask = allocator.malloc_align_mask
     chunk_minsize = allocator.minsize
 
-    ptr_size = pwndbg.gdblib.arch.ptrsize
+    ptr_size = pwndbg.aglib.arch.ptrsize
 
     def unsigned_size(size: int):
         # read_chunk()['size'] is signed in pwndbg ;/

--- a/pwndbg/commands/nearpc.py
+++ b/pwndbg/commands/nearpc.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import argparse
 
-import pwndbg.gdblib.nearpc
+import pwndbg.aglib.nearpc
 from pwndbg.commands import CommandCategory
 
 parser = argparse.ArgumentParser(description="Disassemble near a specified address.")
@@ -36,7 +36,7 @@ def nearpc(pc=None, lines=None, emulate=False, use_cache=False, linear=True) -> 
     """
     print(
         "\n".join(
-            pwndbg.gdblib.nearpc.nearpc(
+            pwndbg.aglib.nearpc.nearpc(
                 pc, lines, emulate, nearpc.repeat, use_cache=use_cache, linear=linear
             )
         )

--- a/pwndbg/commands/p2p.py
+++ b/pwndbg/commands/p2p.py
@@ -4,12 +4,12 @@ import argparse
 from typing import List
 from typing import Tuple
 
+import pwndbg.aglib.arch
+import pwndbg.aglib.memory
+import pwndbg.aglib.vmmap
 import pwndbg.color
 import pwndbg.commands
 import pwndbg.commands.telescope
-import pwndbg.gdblib.arch
-import pwndbg.gdblib.memory
-import pwndbg.gdblib.vmmap
 from pwndbg.commands import CommandCategory
 
 ts = pwndbg.commands.telescope.telescope
@@ -25,7 +25,7 @@ class AddrRange:
 
 
 def get_addrrange_any_named() -> List[AddrRange]:
-    return [AddrRange(page.start, page.end) for page in pwndbg.gdblib.vmmap.get()]
+    return [AddrRange(page.start, page.end) for page in pwndbg.aglib.vmmap.get()]
 
 
 def address_range_explicit(section: str) -> AddrRange:
@@ -42,14 +42,14 @@ def address_range_explicit(section: str) -> AddrRange:
 
 def address_range(section: str) -> List[AddrRange] | Tuple[int, int] | None:
     if section in ("*", "any"):
-        return (0, pwndbg.gdblib.arch.ptrmask)
+        return (0, pwndbg.aglib.arch.ptrmask)
 
     # User can use syntax: "begin:end" to specify explicit address range instead of named page.
     # TODO: handle page names that contains ':'.
     if ":" in section:
         return [address_range_explicit(section)]
 
-    pages = list(filter(lambda page: section in page.objfile, pwndbg.gdblib.vmmap.get()))
+    pages = list(filter(lambda page: section in page.objfile, pwndbg.aglib.vmmap.get()))
 
     if pages:
         return [AddrRange(page.start, page.end) for page in pages]
@@ -69,7 +69,7 @@ parser.add_argument("mapping_names", type=address_range, nargs="+", help="Mappin
 
 def maybe_points_to_ranges(ptr: int, rs: List[AddrRange]):
     try:
-        pointee = pwndbg.gdblib.memory.pvoid(ptr)
+        pointee = pwndbg.aglib.memory.pvoid(ptr)
     except Exception:
         return None
 

--- a/pwndbg/commands/patch.py
+++ b/pwndbg/commands/patch.py
@@ -7,11 +7,11 @@ from typing import Tuple
 from pwnlib.asm import asm
 from pwnlib.asm import disasm
 
+import pwndbg.aglib.memory
 import pwndbg.color.context
 import pwndbg.color.memory
 import pwndbg.color.syntax_highlight
 import pwndbg.commands
-import pwndbg.gdblib.memory
 import pwndbg.lib.cache
 from pwndbg.color import message
 
@@ -30,11 +30,11 @@ parser.add_argument("-q", "--quiet", action="store_true", help="don't print anyt
 def patch(address: int, ins: str, quiet: bool) -> None:
     new_mem = asm(ins)
 
-    old_mem = pwndbg.gdblib.memory.read(address, len(new_mem))
+    old_mem = pwndbg.aglib.memory.read(address, len(new_mem))
 
     patches[address] = (old_mem, new_mem)
 
-    pwndbg.gdblib.memory.write(address, new_mem)
+    pwndbg.aglib.memory.write(address, new_mem)
 
     pwndbg.lib.cache.clear_caches()
 
@@ -56,12 +56,12 @@ def patch_revert(address: int) -> None:
 
     if address == -1:
         for addr, (old, _new) in patches.items():
-            pwndbg.gdblib.memory.write(addr, old)
+            pwndbg.aglib.memory.write(addr, old)
             print(message.notice("Reverted patch at %#x" % addr))
         patches.clear()
     elif address in patches:
         old, _new = patches.pop(address)
-        pwndbg.gdblib.memory.write(address, old)
+        pwndbg.aglib.memory.write(address, old)
         print(message.notice("Reverted patch at %#x" % address))
     else:
         print(message.error("Address %#x not found in patch list" % address))

--- a/pwndbg/commands/retaddr.py
+++ b/pwndbg/commands/retaddr.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
+import pwndbg.aglib.arch
+import pwndbg.aglib.regs
+import pwndbg.aglib.vmmap
 import pwndbg.chain
 import pwndbg.commands
-import pwndbg.gdblib.arch
-import pwndbg.gdblib.regs
-import pwndbg.gdblib.vmmap
 from pwndbg.commands import CommandCategory
 
 
@@ -13,20 +13,20 @@ from pwndbg.commands import CommandCategory
 )
 @pwndbg.commands.OnlyWhenRunning
 def retaddr() -> None:
-    addresses = pwndbg.gdblib.stack.callstack()
+    addresses = pwndbg.aglib.stack.callstack()
 
-    sp = pwndbg.gdblib.regs.sp
-    stack = pwndbg.gdblib.vmmap.find(sp)
+    sp = pwndbg.aglib.regs.sp
+    stack = pwndbg.aglib.vmmap.find(sp)
 
     # Find all return addresses on the stack
     start = stack.vaddr
     stop = start + stack.memsz
     while addresses and start < sp < stop:
-        value = pwndbg.gdblib.memory.u(sp)
+        value = pwndbg.aglib.memory.u(sp)
 
         if value in addresses:
             index = addresses.index(value)
             del addresses[:index]
             print(pwndbg.chain.format(sp))
 
-        sp += pwndbg.gdblib.arch.ptrsize
+        sp += pwndbg.aglib.arch.ptrsize

--- a/pwndbg/commands/valist.py
+++ b/pwndbg/commands/valist.py
@@ -25,11 +25,11 @@ def valist(addr: int, count: int) -> None:
     # } va_list[1];
     # ```
 
-    gp_offset = pwndbg.gdblib.memory.u32(addr)
+    gp_offset = pwndbg.aglib.memory.u32(addr)
     gp_index = gp_offset / 8
 
-    overflow_arg_area = pwndbg.gdblib.memory.u64(addr + 8)
-    reg_save_area = pwndbg.gdblib.memory.u64(addr + 16)
+    overflow_arg_area = pwndbg.aglib.memory.u64(addr + 8)
+    reg_save_area = pwndbg.aglib.memory.u64(addr + 16)
 
     indent = " " * len("gp_offset => ")
     print(f"{C.blue('reg_save_area')}")

--- a/pwndbg/commands/xor.py
+++ b/pwndbg/commands/xor.py
@@ -2,10 +2,9 @@ from __future__ import annotations
 
 import argparse
 
-import gdb
-
+import pwndbg
+import pwndbg.aglib.memory
 import pwndbg.commands
-import pwndbg.gdblib.memory
 from pwndbg.commands import CommandCategory
 
 
@@ -13,7 +12,7 @@ def xor_memory(address, key, count):
     """
     Helper function for xorring memory in gdb
     """
-    mem = pwndbg.gdblib.memory.read(address, count, partial=True)
+    mem = pwndbg.aglib.memory.read(address, count, partial=True)
 
     for index, byte in enumerate(mem):
         key_index = index % len(key)
@@ -35,8 +34,8 @@ parser.add_argument("count", type=int, help="The number of bytes to xor.")
 def xor(address, key, count) -> None:
     try:
         xorred_memory = xor_memory(address, key, count)
-        pwndbg.gdblib.memory.write(address, xorred_memory)
-    except gdb.error as e:
+        pwndbg.aglib.memory.write(address, xorred_memory)
+    except pwndbg.dbg_mod.Error as e:
         print(e)
 
 

--- a/pwndbg/dbg/lldb/hooks.py
+++ b/pwndbg/dbg/lldb/hooks.py
@@ -82,8 +82,7 @@ def prompt_hook():
 
     global should_show_context
     if should_show_context:
-        # TODO: Uncomment this once the LLDB command port PR for `context` is merged
-        # pwndbg.commands.context.context()
+        pwndbg.commands.context.context()
         should_show_context = False
 
 


### PR DESCRIPTION
This PR ports a fairly large selection of commands to the Debugger-agnostic interfaces in Pwndbg (`dbg` and `aglib`), and allows them to run in both LLDB and GDB. This is the last PR that was split off #2382 to make it smaller and easier to merge, and it should bring upstream Pwndbg fully up to date with the features in the LLDB port branch. Personally, and like with #2382, I don't like how big this change is, either, but I couldn't come up with a way to split these that wouldn't have us dealing with right around 28 separate PRs. If you'd like me to split this off in some way, though, please tell me about it.

Aside from that, there are a two caveats to this PR:
- Not all commands in the port have tests of their own, and I'm not entirely familiar with how they work. While `aglib` is designed to behave the same as `gdblib` from the POV of these modules, I can't say that there can't be a bug somewhere in `aglib` that makes these commands break under some circumstances. I've tested them with a few inputs before and after the port, and also between GDB and LLDB, and they _look_ okay to me. These commands are: `leakfind`, `p2p`, `sigreturn`, `spray`, `valist`, `xinfo`, and `xor`.
- The `search` command has a bug, which it's had forever, as far as I can tell. It passes an `str` value to `pwndbg.search.search` straight through when `-t bytes` is used (or when no type is given, since that is the default), despite the fact that `pwndbg.search.search` expects a pattern that has a type of `bytes`. When `pwndbg.search` was GDB-only that didn't actually lead to any issues, because GDB [is more than happy to take a string in `gdb.Frame.search_memory`](https://sourceware.org/gdb/current/onlinedocs/gdb.html/Inferiors-In-Python.html#Inferiors-In-Python), but now the Debugger-agnostic API actually expects and enforces that the value be a `bytearray`. So, because of that pre-existing bug, this port actually breaks `search` under both GDB and LLDB when `-t bytes` is used. Also, this issue never got caught in linting, despite being a typing issue, because the code in `pwndbg.commands.search` isn't typed. We should probably do something about `-t bytes`.


