### PR TITLE
plist: fixed a few bugs

### DIFF
--- a/pwndbg/commands/plist.py
+++ b/pwndbg/commands/plist.py
@@ -190,7 +190,7 @@ parser.add_argument(
 def plist(
     path: str,
     next: int,
-    sentinel: str,
+    sentinel: int,
     inner_name: str,
     field_name: str,
     offset: int,

--- a/pwndbg/commands/plist.py
+++ b/pwndbg/commands/plist.py
@@ -416,7 +416,7 @@ def plist(
 
             print(f"{target_address:#x} {symbol}: {value}")
         except gdb.error as e:
-            print(message.error(f"Cannot dereference 0x{address:#x} for list link #{i + 1}: {e}"))
+            print(message.error(f"Cannot dereference {address:#x} for list link #{i + 1}: {e}"))
             print(message.error("Is the linked list corrupted or is the sentinel value wrong?"))
             return
 

--- a/pwndbg/commands/plist.py
+++ b/pwndbg/commands/plist.py
@@ -395,7 +395,7 @@ def plist(
     for i, address in enumerate(addresses):
         if i < offset:
             continue
-        if address == sentinel:
+        if address in (0, sentinel):
             break
         try:
             # Always make sure we have the address of the outer structure.


### PR DESCRIPTION
While I'm on plist's subject:

- Fixed sentinel's type from str to int
- If sentinel is set, zero addresses could get dereferenced, yielding an error. Now, they cannot.
- Address field in the error message was displayed as `0x0x112233` because of a formatting error.

Added tests as well.
