### PR TITLE
Fix history crash

### DIFF
--- a/pwndbg/dbg/gdb.py
+++ b/pwndbg/dbg/gdb.py
@@ -1050,7 +1050,12 @@ class GDB(pwndbg.dbg_mod.Debugger):
 
             parsed_lines = []
             for line in lines:
-                number_str, command = line.split(maxsplit=1)
+                try:
+                    number_str, command = line.split(maxsplit=1)
+                except ValueError:
+                    # In rare cases GDB stores a number with no command, and the split()
+                    # then only returns one element. We can safely ignore these.
+                    continue
                 try:
                     number = int(number_str)
                 except ValueError:

--- a/pwndbg/dbg/gdb.py
+++ b/pwndbg/dbg/gdb.py
@@ -1056,6 +1056,7 @@ class GDB(pwndbg.dbg_mod.Debugger):
                     # In rare cases GDB stores a number with no command, and the split()
                     # then only returns one element. We can safely ignore these.
                     continue
+
                 try:
                     number = int(number_str)
                 except ValueError:


### PR DESCRIPTION
In some cases, GDB stores an history line with a number but no command. The parsing in `gdb.history()` then crashes, and it blocks some commands from executing until we fill up the history with enough commands to "remove" that broken up line. I have not been able to reproduce (sending an empty command does not log anything) so, no test.

It however happens fairly often with my current config (GNU gdb (Ubuntu 12.1-0ubuntu1~22.04.2) 12.1, pwndbg/dev).