### PR TITLE
fix for issue #2430

### DIFF
--- a/pwndbg/aglib/proc.py
+++ b/pwndbg/aglib/proc.py
@@ -75,18 +75,15 @@ class module(ModuleType):
         return pwndbg.dbg.selected_inferior().alive()
 
     @property
+    @pwndbg.lib.cache.cache_until("objfile")
     def exe(self) -> str | None:
         """
-        Returns the debugged file name.
+        Returns the executed file path.
 
-        On remote targets, this may be prefixed with "target:" string.
-        See this by executing those in two terminals:
-        1. gdbserver 127.0.0.1:1234 /bin/ls
-        2. gdb -ex "target remote :1234" -ex "pi pwndbg.gdblib.proc.exe"
+        On remote targets, this path most definitly won't exist locally.
 
-        If you need to process the debugged file use:
-            `pwndbg.gdblib.file.get_proc_exe_file()`
-            (This will call `pwndbg.gdblib.file.get_file(pwndbg.gdblib.proc.exe, try_local_path=True)`)
+        If you need the locally referenced file use:
+            `gdb.current_process().filename`
         """
 
         return pwndbg.dbg.selected_inferior().main_module_name()

--- a/pwndbg/aglib/proc.py
+++ b/pwndbg/aglib/proc.py
@@ -80,7 +80,7 @@ class module(ModuleType):
         """
         Returns the executed file path.
 
-        On remote targets, this path most definitly won't exist locally.
+        On remote targets, this path may not exist locally.
 
         If you need the locally referenced file use:
             `gdb.current_process().filename`

--- a/pwndbg/dbg/gdb.py
+++ b/pwndbg/dbg/gdb.py
@@ -738,7 +738,11 @@ class GDBProcess(pwndbg.dbg_mod.Process):
     def main_module_name(self) -> str | None:
         # Can GDB ever return a different value here from what we'd get with
         # `info files`, give or take a "remote:"?
-        return gdb.current_progspace().filename
+        if not self.alive():
+            return gdb.current_progspace().filename
+
+        exe = gdb.execute("info proc exe", to_string=True)
+        return exe[exe.find("exe = '") + 7 : exe.rfind("'")]
 
     @override
     def main_module_entry(self) -> int | None:

--- a/pwndbg/gdblib/proc.py
+++ b/pwndbg/gdblib/proc.py
@@ -117,7 +117,7 @@ class module(ModuleType):
         If you need the locally referenced file use:
             `gdb.current_process().filename`
 
-        info proc exe is the only command to actually get the executed file.
+        info proc exe is the only command to actually get the executed file path.
         The gdb `file` command overwrites all internal references, this includes:
         + `filename`
         + `executable_filename`

--- a/pwndbg/gdblib/proc.py
+++ b/pwndbg/gdblib/proc.py
@@ -112,7 +112,7 @@ class module(ModuleType):
         """
         Returns the executed file path.
 
-        On remote targets, this path most definitly won't exist locally.
+        On remote targets, this path may not exist locally.
 
         If you need the locally referenced file use:
             `gdb.current_process().filename`

--- a/pwndbg/integration/binja.py
+++ b/pwndbg/integration/binja.py
@@ -158,7 +158,7 @@ def with_bn(fallback: K = None) -> Callable[[Callable[P, T]], Callable[P, T | K]
         def wrapper(*args: P.args, **kwargs: P.kwargs) -> T | K:
             if _bn is None:
                 init_bn_rpc_client()
-            if _bn is not None:
+            if _bn is not None and pwndbg.gdblib.proc.alive:
                 return func(*args, **kwargs)
             return fallback
 


### PR DESCRIPTION
<!-- Please make sure to read the testing and linting instructions at https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md before creating a PR -->

fixes #2430, that compares base file names instead of absolute paths for `pwndbg.gdblib.proc.binary_vmmap`, if the target is run on remote.