### PR TITLE
Add history of context output

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -21,6 +21,8 @@ The output of the context may be redirected to a file (including other tty) by u
 
 ![](caps/context.png)
 
+A history of previous context output is kept which can be accessed using the `contextprev` and `contextnext` commands.
+
 ### Splitting / Layouting Context
 
 The context sections can be distributed among different tty by using the `contextoutput` command.

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -75,7 +75,7 @@ The context sections are available as native gdb TUI windows as well as `pwndbg_
 
 Try creating a layout and selecting it:
 ```
-tui new-layout pwndbg {-horizontal { { -horizontal { pwndbg_code 2 pwndbg_disasm 8 } 2 { pwndbg_legend 1 pwndbg_regs 6 pwndbg_stack 6 } 3 } 7 cmd 3 } 3 { pwndbg_backtrace 1 } 1 } 1 status 1
+tui new-layout pwndbg {-horizontal { { -horizontal { pwndbg_code 2 pwndbg_disasm 8 } 2 { { -horizontal pwndbg_legend 8 pwndbg_control 2 } 1 pwndbg_regs 6 pwndbg_stack 6 } 3 } 7 cmd 3 } 3 { pwndbg_backtrace 1 } 1 } 1 status 1
 layout pwndbg
 ```
 

--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -587,15 +587,15 @@ def context(subcontext=None) -> None:
     if len(args) == 0:
         args = config_context_sections.split()
 
-    def get_history_legend():
-        if selected_history_index is not None:
+    sections = []
+    if args:
+        if selected_history_index is None:
+            sections.append(("legend", lambda *args, **kwargs: [M.legend()]))
+        else:
             longest_history = max(len(h) for h in context_history.values())
-            return f" (history {selected_history_index + 1}/{longest_history})"
-        return ""
+            history_status = f" (history {selected_history_index + 1}/{longest_history})"
+            sections.append(("legend", lambda *args, **kwargs: [M.legend() + history_status]))
 
-    sections = (
-        [("legend", lambda *args, **kwargs: [M.legend() + get_history_legend()])] if args else []
-    )
     sections += [(arg, context_sections.get(arg[0], None)) for arg in args]
 
     result = defaultdict(list)

--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -2,14 +2,20 @@ from __future__ import annotations
 
 import argparse
 import ast
+import functools
+import logging
 import os
 import sys
 from collections import defaultdict
 from typing import Any
+from typing import Callable
 from typing import DefaultDict
 from typing import Dict
 from typing import List
+from typing import Optional
 from typing import Tuple
+
+from typing_extensions import ParamSpec
 
 import pwndbg
 import pwndbg.aglib.arch
@@ -39,6 +45,10 @@ if pwndbg.dbg.is_gdblib_available():
     import pwndbg.gdblib.heap_tracking
     import pwndbg.gdblib.symbol
     import pwndbg.ghidra
+
+log = logging.getLogger(__name__)
+
+P = ParamSpec("P")
 
 theme.add_param("backtrace-prefix", "►", "prefix for current backtrace label")
 
@@ -254,6 +264,186 @@ def contextoutput(section, path, clearing, banner="both", width: int = None):
     }
 
 
+# Context history
+context_history: DefaultDict[str, List[List[str]]] = defaultdict(list)
+selected_history_index: Optional[int] = None
+
+context_history_size = pwndbg.config.add_param(
+    "context-history-size", 50, "number of context history entries to store"
+)
+
+
+@pwndbg.config.trigger(context_history_size)
+def history_size_changed() -> None:
+    if context_history_size <= 0:
+        context_history.clear()
+    else:
+        for section in context_history:
+            context_history[section] = context_history[section][-int(context_history_size) :]
+
+
+def serve_context_history(function: Callable[P, List[str]]) -> Callable[P, List[str]]:
+    @functools.wraps(function)
+    def _serve_context_history(*a: P.args, **kw: P.kwargs) -> List[str]:
+        global selected_history_index
+        assert "context_" in function.__name__
+        section_name = function.__name__.replace("context_", "")
+
+        # If the history is disabled, just return the current output
+        if context_history_size <= 0:
+            return function(*a, **kw)
+
+        # Add the current section to the history if it is not already there
+        current_output = []
+        if pwndbg.aglib.proc.alive:
+            current_output = function(*a, **kw)
+            if (
+                len(context_history[section_name]) == 0
+                or context_history[section_name][-1] != current_output
+            ):
+                context_history[section_name].append(current_output)
+                selected_history_index = None
+        # Show the history if the process is not running anymore
+        elif context_history[section_name] and selected_history_index is None:
+            selected_history_index = len(context_history[section_name]) - 1
+
+        # Truncate the history to the configured size
+        context_history[section_name] = context_history[section_name][-int(context_history_size) :]
+        history = context_history[section_name]
+
+        if selected_history_index is None:
+            return current_output or function(*a, **kw)
+        if not history or selected_history_index >= len(history):
+            return []
+        return history[selected_history_index]
+
+    return _serve_context_history
+
+
+def history_handle_unchanged_contents() -> None:
+    longest_history = max(len(h) for h in context_history.values())
+    for section_name, history in context_history.items():
+        # Duplicate the last entry if it is the same as the previous one
+        # and wasn't added when the history was updated
+        if len(history) == longest_history - 1:
+            context_history[section_name].append(history[-1])
+        # Prepend empty entries to the history to make all sections have the same length
+        elif len(history) < longest_history - 1:
+            context_history[section_name] = [
+                [] for _ in range(longest_history - 1 - len(history))
+            ] + history
+
+
+parser = argparse.ArgumentParser(description="Select previous entry in context history.")
+parser.add_argument(
+    "count",
+    type=int,
+    nargs="?",
+    default=1,
+    help="The number of entries to go back in history",
+)
+
+
+@pwndbg.commands.ArgparsedCommand(parser, aliases=["ctxp"], category=CommandCategory.CONTEXT)
+def contextprev(count) -> None:
+    global selected_history_index
+    longest_history = max(len(h) for h in context_history.values())
+    if selected_history_index is None:
+        if not context_history:
+            print(message.error("No context history captured"))
+            return
+        new_index = longest_history - count - 1
+    else:
+        new_index = selected_history_index - count
+    selected_history_index = max(0, new_index)
+    context()
+
+
+parser = argparse.ArgumentParser(description="Select next entry in context history.")
+parser.add_argument(
+    "count",
+    type=int,
+    nargs="?",
+    default=1,
+    help="The number of entries to go forward in history",
+)
+
+
+@pwndbg.commands.ArgparsedCommand(parser, aliases=["ctxn"], category=CommandCategory.CONTEXT)
+def contextnext(count) -> None:
+    global selected_history_index
+    longest_history = max(len(h) for h in context_history.values())
+    if selected_history_index is None:
+        if not context_history:
+            print(message.error("No context history captured"))
+            return
+        new_index = longest_history - 1
+    else:
+        new_index = selected_history_index + count
+    selected_history_index = min(longest_history - 1, new_index)
+    context()
+
+
+parser = argparse.ArgumentParser(
+    description="Search for a string in the context history and select that entry."
+)
+parser.add_argument(
+    "needle",
+    type=str,
+    help="The string to search for in the context history",
+)
+parser.add_argument(
+    "section",
+    type=str,
+    nargs="?",
+    default=None,
+    help="The section to search in. If not provided, search in all sections",
+)
+
+
+@pwndbg.commands.ArgparsedCommand(parser, aliases=["ctxsearch"], category=CommandCategory.CONTEXT)
+def contextsearch(needle, section) -> None:
+    if not section:
+        sections = context_history.keys()
+    else:
+        if section not in context_history:
+            print(message.error(f"Section '{section}' not found in context history."))
+            return
+        sections = [section]
+
+    matches: List[Tuple[str, int]] = []
+    for section in sections:
+        for i, entry in enumerate(context_history[section]):
+            if not any(m[1] == i for m in matches) and any(needle in line for line in entry):
+                matches.append((section, i))
+    matches.sort(key=lambda m: m[1], reverse=True)
+
+    if not matches:
+        print(message.error(f"String '{needle}' not found in context history."))
+        return
+
+    # Select first match before currently selected entry
+    global selected_history_index
+    if selected_history_index is None:
+        next_match = matches[0]
+    else:
+        for match in matches:
+            if match[1] < selected_history_index:
+                next_match = match
+                break
+        else:
+            next_match = matches[0]
+            print(message.warn("No more matches before the current entry. Starting from the top."))
+
+    selected_history_index = next_match[1]
+    print(
+        message.info(
+            f"Found {len(matches)} match{'es' if len(matches) > 1 else ''}. Selected entry {next_match[1] + 1} for match in section '{next_match[0]}'."
+        )
+    )
+    context()
+
+
 # Watches
 expressions = []
 
@@ -304,6 +494,7 @@ def contextunwatch(num) -> None:
     expressions.pop(int(num) - 1)
 
 
+@serve_context_history
 def context_expressions(target=sys.stdout, with_banner=True, width=None):
     if not expressions:
         return []
@@ -339,6 +530,7 @@ config_context_ghidra = pwndbg.config.add_param(
 )
 
 
+@serve_context_history
 def context_ghidra(target=sys.stdout, with_banner=True, width=None):
     """
     Print out the source of the current function decompiled by ghidra.
@@ -377,13 +569,17 @@ parser.add_argument(
 
 
 @pwndbg.commands.ArgparsedCommand(parser, aliases=["ctx"], category=CommandCategory.CONTEXT)
-@pwndbg.commands.OnlyWhenRunning
 def context(subcontext=None) -> None:
     """
     Print out the current register, instruction, and stack context.
 
     Accepts subcommands 'reg', 'disasm', 'code', 'stack', 'backtrace', 'ghidra', 'args', 'threads', 'heap_tracker', 'expressions', and/or 'last_signal'.
     """
+    # Allow to view history after the program has exited
+    if not pwndbg.aglib.proc.alive and (context_history_size <= 0 or not context_history):
+        log.error("context: The program is not being run.")
+        return None
+
     if subcontext is None:
         subcontext = []
     args = subcontext
@@ -391,7 +587,15 @@ def context(subcontext=None) -> None:
     if len(args) == 0:
         args = config_context_sections.split()
 
-    sections = [("legend", lambda *args, **kwargs: [M.legend()])] if args else []
+    def get_history_legend():
+        if selected_history_index is not None:
+            longest_history = max(len(h) for h in context_history.values())
+            return f" (history {selected_history_index + 1}/{longest_history})"
+        return ""
+
+    sections = (
+        [("legend", lambda *args, **kwargs: [M.legend() + get_history_legend()])] if args else []
+    )
     sections += [(arg, context_sections.get(arg[0], None)) for arg in args]
 
     result = defaultdict(list)
@@ -410,6 +614,8 @@ def context(subcontext=None) -> None:
                         with_banner=settings.get("banner_top", True),
                     )
                 )
+
+    history_handle_unchanged_contents()
 
     for target, res in result.items():
         settings = result_settings[target]
@@ -509,6 +715,7 @@ def compact_regs(regs, width=None, target=sys.stdout):
     return result
 
 
+@serve_context_history
 def context_regs(target=sys.stdout, with_banner=True, width=None):
     regs = get_regs()
     if pwndbg.config.show_compact_regs:
@@ -522,6 +729,7 @@ def context_regs(target=sys.stdout, with_banner=True, width=None):
     return banner + regs if with_banner else regs
 
 
+@serve_context_history
 def context_heap_tracker(target=sys.stdout, with_banner=True, width=None):
     if not pwndbg.gdblib.heap_tracking.is_enabled():
         return []
@@ -613,6 +821,7 @@ disasm_lines = pwndbg.config.add_param(
 )
 
 
+@serve_context_history
 def context_disasm(target=sys.stdout, with_banner=True, width=None):
     flavor = pwndbg.dbg.x86_disassembly_flavor()
     syntax = pwndbg.aglib.disasm.CapstoneSyntax[flavor]
@@ -738,6 +947,7 @@ should_decompile = pwndbg.config.add_param(
 )
 
 
+@serve_context_history
 def context_code(target=sys.stdout, with_banner=True, width=None):
     filename, formatted_source, line = get_filename_and_formatted_source()
 
@@ -766,6 +976,7 @@ stack_lines = pwndbg.config.add_param(
 )
 
 
+@serve_context_history
 def context_stack(target=sys.stdout, with_banner=True, width=None):
     result = [pwndbg.ui.banner("stack", target=target, width=width)] if with_banner else []
     telescope = pwndbg.commands.telescope.telescope(
@@ -784,6 +995,7 @@ backtrace_frame_label = theme.add_param(
 )
 
 
+@serve_context_history
 def context_backtrace(with_banner=True, target=sys.stdout, width=None):
     result = []
 
@@ -833,6 +1045,7 @@ def context_backtrace(with_banner=True, target=sys.stdout, width=None):
     return result
 
 
+@serve_context_history
 def context_args(with_banner=True, target=sys.stdout, width=None):
     args = pwndbg.arguments.format_args(pwndbg.aglib.disasm.one())
 
@@ -866,6 +1079,7 @@ def get_thread_status(thread):
         return "unknown"
 
 
+@serve_context_history
 def context_threads(with_banner=True, target=sys.stdout, width=None):
     try:
         original_thread = gdb.selected_thread()
@@ -981,6 +1195,7 @@ if pwndbg.dbg.is_gdblib_available():
     gdb.events.exited.connect(save_signal)
 
 
+@serve_context_history
 def context_last_signal(with_banner=True, target=sys.stdout, width=None):
     if not last_signal:
         return []

--- a/pwndbg/gdblib/prompt.py
+++ b/pwndbg/gdblib/prompt.py
@@ -81,6 +81,7 @@ def prompt_hook(*a: Any) -> None:
         cur = new
 
     if pwndbg.gdblib.proc.alive and pwndbg.gdblib.proc.thread_is_stopped and not context_shown:
+        pwndbg.commands.context.selected_history_index = None
         pwndbg.commands.context.context()
         context_shown = True
 

--- a/pwndbg/gdblib/tui/__init__.py
+++ b/pwndbg/gdblib/tui/__init__.py
@@ -1,3 +1,4 @@
 from __future__ import annotations
 
 import pwndbg.gdblib.tui.context
+import pwndbg.gdblib.tui.control

--- a/pwndbg/gdblib/tui/control.py
+++ b/pwndbg/gdblib/tui/control.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import gdb
+
+
+class ControlTUIWindow:
+    _tui_window: "gdb.TuiWindow"
+    _button_text: str = "[←]  [→]"
+    _button_spans = {"contextprev": (0, 2), "contextnext": (5, 7)}
+
+    def __init__(self, tui_window: "gdb.TuiWindow") -> None:
+        self._tui_window = tui_window
+        self._tui_window.title = "history"
+
+    def close(self) -> None:
+        pass
+
+    def render(self) -> None:
+        self._tui_window.write(self._button_text, True)
+
+    def hscroll(self, num: int) -> None:
+        pass
+
+    def vscroll(self, num: int) -> None:
+        pass
+
+    def click(self, x: int, y: int, button: int) -> None:
+        # button specifies which mouse button was used, whose values can be 1 (left), 2 (middle), or 3 (right).
+        if button != 1:
+            return
+
+        for command, (start, end) in self._button_spans.items():
+            start_x = start % self._tui_window.width
+            end_x = end % self._tui_window.width
+            start_y = start // self._tui_window.width
+            end_y = end // self._tui_window.width
+            if start_x <= x <= end_x and start_y <= y <= end_y:
+                gdb.execute(command, to_string=True)
+                break
+
+
+if hasattr(gdb, "register_window_type"):
+    gdb.register_window_type("pwndbg_control", ControlTUIWindow)

--- a/pwndbg/gdblib/tui/control.py
+++ b/pwndbg/gdblib/tui/control.py
@@ -6,6 +6,10 @@ import gdb
 class ControlTUIWindow:
     _tui_window: "gdb.TuiWindow"
     _button_text: str = "[←]  [→]"
+    # Map from command to the span of the button in the _button_text.
+    # The span is represented as (start, end) where start is the index
+    # of the first character of the button and end is the index of the
+    # last character of the button to react to on mouse click.
     _button_spans = {"contextprev": (0, 2), "contextnext": (5, 7)}
 
     def __init__(self, tui_window: "gdb.TuiWindow") -> None:

--- a/pwndbg/lib/tips.py
+++ b/pwndbg/lib/tips.py
@@ -46,6 +46,7 @@ TIPS: List[str] = [
     "Use `track-got enable|info|query` to track GOT accesses - useful for hijacking control flow via writable GOT/PLT",
     "Need to `mmap` or `mprotect` memory in the debugee? Use commands with the same name to inject and run such syscalls",
     "Use `hi` to see if a an address belongs to a glibc heap chunk",
+    "Use `contextprev` and `contextnext` to display a previous context output again without scrolling",
 ]
 
 


### PR DESCRIPTION
Every context section is cached individually to allow to display older output again. You can scroll through the old context output using `contextprev` and `contextnext`. This allows to "scroll" in TUI mode. When you cause a new stop using e.g. `si` while browsing the context history, the history position is reset and the new context is displayed right away. You can control or disable the history size using `set context-history-size 50` which is a scrollback-memory tradeoff. I don't think memory is an issue here though for a few strings.

The history position is displayed next to the memory legend:

![grafik](https://github.com/user-attachments/assets/eaadc463-d002-4b5c-b341-768e0589f93f)


The history is kept over multiple runs of a binary and you can display old contexts after the program exited. You can skip multiple entries by passing an argument to `contextprev`. `contextprev 10` would go back 10 entries into the past. `contextsearch something` allows to search the history for something and select the entry in the history matching that.

There is no hotkey key combination like `ctrl+shift+pageup/down` yet and you have to use `ctxp`/`ctxn` or the buttons in the TUI to scroll through the history.

Fixes #1899 