### PR TITLE
Add `context [section(s)] [--on|--off]` to temporarily disable sub-sections

### DIFF
--- a/pwndbg/gdblib/tui/context.py
+++ b/pwndbg/gdblib/tui/context.py
@@ -10,8 +10,7 @@ import gdb
 from pwndbg.commands.context import context
 from pwndbg.commands.context import context_sections
 from pwndbg.commands.context import contextoutput
-from pwndbg.commands.context import output_settings
-from pwndbg.commands.context import outputs
+from pwndbg.commands.context import resetcontextoutput
 
 
 class ContextTUIWindow:
@@ -101,8 +100,7 @@ class ContextTUIWindow:
     def _disable(self):
         _static_enabled = False
         self._old_width = 0
-        del outputs[self._section]
-        del output_settings[self._section]
+        resetcontextoutput(self._section)
         self._enabled = False
 
     def _update(self):

--- a/tests/gdb-tests/tests/test_context_commands.py
+++ b/tests/gdb-tests/tests/test_context_commands.py
@@ -417,3 +417,43 @@ def test_context_disasm_call_instruction_split(start_binary):
     )
 
     assert dis == expected
+
+
+def test_context_hide_sections(start_binary):
+    start_binary(SYSCALLS_BINARY)
+
+    # Disable one section
+    out = gdb.execute("context", to_string=True)
+    assert "REGISTERS" in out
+    assert "STACK" in out
+    gdb.execute("context regs --off")
+    out = gdb.execute("context", to_string=True)
+    assert "REGISTERS" not in out
+    assert "STACK" in out
+    gdb.execute("context regs --on")
+    out = gdb.execute("context", to_string=True)
+    assert "REGISTERS" in out
+    assert "STACK" in out
+
+    # Disable multiple sections
+    gdb.execute("context stack disasm --off")
+    out = gdb.execute("context", to_string=True)
+    assert "STACK" not in out
+    assert "DISASM" not in out
+    gdb.execute("context stack --on")
+    out = gdb.execute("context", to_string=True)
+    assert "STACK" in out
+    assert "DISASM" not in out
+    gdb.execute("context stack disasm --on")
+    out = gdb.execute("context", to_string=True)
+    assert "STACK" in out
+    assert "DISASM" in out
+
+    # Disable all sections at once
+    gdb.execute("context --off")
+    out = gdb.execute("context", to_string=True)
+    assert len(out) == 0
+    gdb.execute("context --on")
+    out = gdb.execute("context", to_string=True)
+    assert "REGISTERS" in out
+    assert "DISASM" in out


### PR DESCRIPTION
Allow to temporarily disable sub-sections in the context output without touching the `context-sections` config parameter.

I went with `ctx [section(s)] --on` instead of `ctx [section(s)] on` suggested in #1479, since the subsection vararg would have to be awkwardly checked for sections "on" and "off" afaict and this was easier to document.

Fixes #1479