### PR TITLE
Fix display of gdb functions documentation

### DIFF
--- a/pwndbg/commands/binja.py
+++ b/pwndbg/commands/binja.py
@@ -30,9 +30,7 @@ def bn_sync(*args) -> None:
 @pwndbg.gdblib.functions.GdbFunction()
 @pwndbg.integration.binja.with_bn()
 def bn_sym(name_val: gdb.Value) -> int | None:
-    """
-    Lookup a symbol's address by name from Binary Ninja.
-    """
+    """Lookup a symbol's address by name from Binary Ninja."""
     name = name_val.string()
     addr: int | None = pwndbg.integration.binja._bn.get_symbol_addr(name)
     if addr is None:
@@ -43,9 +41,7 @@ def bn_sym(name_val: gdb.Value) -> int | None:
 @pwndbg.gdblib.functions.GdbFunction()
 @pwndbg.integration.binja.with_bn()
 def bn_var(name_val: gdb.Value) -> int | None:
-    """
-    Lookup a stack variable's address by name from Binary Ninja.
-    """
+    """Lookup a stack variable's address by name from Binary Ninja."""
     name = name_val.string()
     conf_and_offset: Tuple[int, int] | None = pwndbg.integration.binja._bn.get_var_offset_from_sp(
         pwndbg.integration.binja.l2r(pwndbg.gdblib.regs.pc), name
@@ -61,8 +57,8 @@ def bn_var(name_val: gdb.Value) -> int | None:
 @pwndbg.gdblib.functions.GdbFunction()
 @pwndbg.integration.binja.with_bn()
 def bn_eval(expr: gdb.Value) -> int | None:
-    """
-    Parse and evaluate a Binary Ninja expression.
+    """Parse and evaluate a Binary Ninja expression.
+
     Docs: https://api.binary.ninja/binaryninja.binaryview-module.html#binaryninja.binaryview.BinaryView.parse_expression
 
     Adds all registers in the current register set as magic variables (e.g. $rip).

--- a/pwndbg/gdblib/functions.py
+++ b/pwndbg/gdblib/functions.py
@@ -28,13 +28,13 @@ class _GdbFunction(gdb.Function):
         self.name = func.__name__
         self.func = func
         self.only_when_running = only_when_running
+        self.__doc__ = func.__doc__
 
         functions.append(self)
 
         super().__init__(self.name)
 
         functools.update_wrapper(self, func)
-        self.__doc__ = func.__doc__
 
     def invoke(self, *args: gdb.Value) -> Any:
         if self.only_when_running and not pwndbg.gdblib.proc.alive:
@@ -57,6 +57,7 @@ def rebase(addr: gdb.Value | int) -> int:
 
 @GdbFunction(only_when_running=True)
 def base(name_pattern: gdb.Value | str) -> int:
+    """Return base address of the first memory mapping containing the given name."""
     if isinstance(name_pattern, gdb.Value):
         name = name_pattern.string()
     else:


### PR DESCRIPTION
The __doc__ is read in the gdb.Function constructor, so copy it from the function to the class in the decorator before calling the parent constructor.

`apropos` displays the first line of the docstring only, so move it up in the `bn_*` commands.

Fixes #2424