### PR TITLE
Fix terminal width to 80 columns in tests

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -51,19 +51,6 @@ We have four types of tests: `gdb-tests`,`qemu-tests`, `unit-tests`, and Linux k
 
 To run these tests, run [`./tests.sh`](./tests.sh). You can filter the tests to run by providing an argument to the script, such as `./tests.sh heap`, which will only run tests that contain "heap" in the name. You can also drop into the PDB debugger when a test fails with `./tests.sh --pdb`.
 
-Some of the tests rely on output that depends on a certain width/height of the terminal, so you will likely see many test failures when simply running `./tests.sh`. To run the tests in the expected environment, you can use:
-
-```sh
-docker compose run --build -T ubuntu24.04 ./tests.sh
-# The `-T` disables the use of a pseudo-TTY
-```
-
-If you want rapidly iterate on tests (waiting for the container to rebuild and all the test source code files to compile can take a while), you can pipe `cat` on both ends to disable the PTY and get the correct terminal width/height for the tests.
-
-```sh
-cat | ./tests.sh | cat
-```
-
 To invoke cross-architecture tests, use `./qemu-tests.sh`, and to run unit tests, use `./unit-tests.sh`
 
 ## Writing Tests

--- a/pwndbg/ui.py
+++ b/pwndbg/ui.py
@@ -73,6 +73,8 @@ def get_window_size(target=sys.stdin):
     rows, cols = get_cmd_window_size()
     if rows is not None and cols is not None:
         return rows, cols
+    elif os.environ.get("PWNDBG_IN_TEST") is not None:
+        return fallback
     try:
         # get terminal size and force ret buffer len of 4 bytes for safe unpacking by passing equally long arg
         rows, cols = struct.unpack("hh", fcntl.ioctl(target.fileno(), termios.TIOCGWINSZ, b"1234"))

--- a/tests/gdb-tests/conftest.py
+++ b/tests/gdb-tests/conftest.py
@@ -4,6 +4,8 @@ This file should consist of global test fixtures.
 
 from __future__ import annotations
 
+import os
+
 import gdb
 import pytest
 
@@ -17,8 +19,12 @@ def start_binary():
     """
 
     def _start_binary(path, *args):
+        os.environ["PWNDBG_IN_TEST"] = "1"
         gdb.execute("file " + path)
         gdb.execute("set exception-verbose on")
+        gdb.execute("set width 80")
+        gdb.execute("set env COLUMNS 80")
+        os.environ["COLUMNS"] = "80"
         gdb.execute("starti " + " ".join(args))
 
         global _start_binary_called

--- a/tests/gdb-tests/conftest.py
+++ b/tests/gdb-tests/conftest.py
@@ -23,7 +23,6 @@ def start_binary():
         gdb.execute("file " + path)
         gdb.execute("set exception-verbose on")
         gdb.execute("set width 80")
-        gdb.execute("set env COLUMNS 80")
         os.environ["COLUMNS"] = "80"
         gdb.execute("starti " + " ".join(args))
 


### PR DESCRIPTION
Set a `PWNDBG_IN_TEST`environment variable when running gdb in tests. Use the dimensions in `LINES` and `COLUMNS` when looking up the window size when that envvar is set.

This makes context output always be 80 columns wide which allows to compare to hardcoded output.