### PR TITLE
Don't try to attach to gdb itself in `attachp`

### DIFF
--- a/pwndbg/commands/attachp.py
+++ b/pwndbg/commands/attachp.py
@@ -100,6 +100,10 @@ def find_pids(target, user, all):
         pid, args = process_info
         cmd = args.split(maxsplit=1)[0]
 
+        # Cannot attach to gdb itself.
+        if int(pid) == os.getpid():
+            continue
+
         if target == cmd:
             pids_exact_match_cmd.append(pid)
         elif target in cmd:


### PR DESCRIPTION
gdb doesn't allow debugging itself:

```
attachp some-nonexistent-process-name
Attaching to 361478
Error: I refuse to debug myself!
```

This fixes the test_attachp_command_nonexistent_procname test for me.