### PR TITLE
Fix printing of struct fields in `tcache` command

### DIFF
--- a/pwndbg/aglib/heap/structs.py
+++ b/pwndbg/aglib/heap/structs.py
@@ -161,7 +161,7 @@ class CStruct2GDB:
         """
         output = "{\n"
         for f in self._c_struct._fields_:
-            output += f"  {f[0]} = {self.read_field(f[0])},\n"
+            output += f"  {f[0]} = {self.read_field(f[0]).inner},\n"
         output += "}"
         return output
 

--- a/pwndbg/dbg/__init__.py
+++ b/pwndbg/dbg/__init__.py
@@ -727,12 +727,6 @@ class Value:
         """
         raise NotImplementedError()
 
-    def __repr__(self):
-        raise NotImplementedError()
-
-    def __str__(self):
-        raise NotImplementedError()
-
 
 class CommandHandle:
     """

--- a/pwndbg/dbg/gdb.py
+++ b/pwndbg/dbg/gdb.py
@@ -950,14 +950,6 @@ class GDBValue(pwndbg.dbg_mod.Value):
 
         return GDBValue(self.inner[key])
 
-    @override
-    def __repr__(self):
-        return self.inner.__repr__()
-
-    @override
-    def __str__(self):
-        return self.inner.__str__()
-
 
 class GDB(pwndbg.dbg_mod.Debugger):
     @override


### PR DESCRIPTION
Cleanup of #2418 which is a revisited fix for #2406 because @disconnect3d asked kindly.
This is @itaysnir's change plus a revert of the previous temporary solution.

Fixes #2406
Closes #2418 