### PR TITLE
Resolve instruction operand symbols in register chain

### DIFF
--- a/pwndbg/enhance.py
+++ b/pwndbg/enhance.py
@@ -24,7 +24,6 @@ import pwndbg.color.memory
 import pwndbg.integration
 import pwndbg.lib.cache
 from pwndbg import color
-from pwndbg.color.syntax_highlight import syntax_highlight
 
 
 def format_small_int(value: int) -> str:
@@ -113,11 +112,11 @@ def enhance(
         rwx = exe = False
 
     if exe:
-        pwndbg_instr = pwndbg.aglib.disasm.one(value, enhance=False)
+        pwndbg_instr = pwndbg.aglib.disasm.one(value)
         if pwndbg_instr:
-            instr = f"{pwndbg_instr.mnemonic} {pwndbg_instr.op_str}"
-            if pwndbg.config.syntax_highlight:
-                instr = syntax_highlight(instr)
+            # For telescoping, we don't want the extra spaces between the mnemonic and operands
+            # which are baked in during enhancement. This removes those spaces.
+            instr = " ".join(pwndbg_instr.asm_string.split())
 
     szval = pwndbg.aglib.strings.get(value, maxlen=enhance_string_len) or None
     szval0 = szval


### PR DESCRIPTION
This fixes a small bug where we weren't replacing constant operands with their corresponding symbols when the `chain` function detected an instruction at the end of a pointer chain.

Example before:
![image](https://github.com/user-attachments/assets/7934fd46-498e-4bb2-885e-e2712c4e4bdb)
Note that the `RIP` register points to a `call` instruction, but the constant operand is not replaced with the symbol, like it is in the disasm view.

Example After:
![image](https://github.com/user-attachments/assets/27b1ac48-ed5c-475a-8129-284826fcd681)
