### PR TITLE
Add .readthedocs.yaml to enable readthedocs builds again

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,26 @@
+# Read the Docs configuration file for MkDocs projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
+  # https://docs.readthedocs.io/en/stable/build-customization.html#install-dependencies-with-poetry
+  jobs:
+    post_create_environment:
+      # Install poetry
+      # https://python-poetry.org/docs/#installing-manually
+      - pip install poetry
+    post_install:
+      # Install dependencies with 'docs' dependency group
+      # https://python-poetry.org/docs/managing-dependencies/#dependency-groups
+      # VIRTUAL_ENV needs to be set manually for now.
+      # See https://github.com/readthedocs/readthedocs.org/pull/11152/
+      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry install --with docs
+
+mkdocs:
+  configuration: mkdocs.yml


### PR DESCRIPTION
Read the docs [requires a config file](https://blog.readthedocs.com/migrate-configuration-v2/) to trigger builds since September 2023. Add one which hopefully installs using poetry and builds using mkdocs.

https://docs.readthedocs.io/en/stable/config-file/index.html

Fixes #2383