### PR TITLE
Encode strings passed to the `search` command when `-t bytes` is used

### DIFF
--- a/pwndbg/commands/search.py
+++ b/pwndbg/commands/search.py
@@ -255,6 +255,26 @@ def search(
         bits_for_arch = pwnlib.context.context.architectures.get(arch, {}).get("bits")
         value = pwnlib.asm.asm(value, arch=arch, bits=bits_for_arch)
 
+    # `pwndbg.search.search` expects a `bytes` object for its pattern. Convert the string pattern we
+    # were given to a bytes object by encoding it as an UTF-8 byte sequence. This matches the behavior
+    # we previously got by calling `gdb.Inferior.search_memory` with an `str`, since right about GDB
+    # version 7.x or 8.x[1], as it uses a `Py_buffer` object populated with an `'s*'` pattern, which
+    # has been encoding `str` object as a UTF-8 byte sequence since Python 3.1[2].
+    #
+    # [1]: https://sourceware.org/git/?p=binutils-gdb.git;a=blame;f=gdb/python/py-inferior.c;h=a1042ee72ac733091f7572bc04b072546d3c1519;hb=23c84db5b3cb4e8a0d555c76e1a0ab56dc8355f3
+    # [2]: https://docs.python.org/3.1/c-api/arg.html#strings-and-buffers
+
+    elif type == "bytes":
+        try:
+            value = value.encode("utf-8")
+        except UnicodeError as what:
+            print(
+                message.error(
+                    f"Invalid pattern '{value}'. Patterns of type `bytes` must be encodable in UTF-8: {what}"
+                )
+            )
+            return
+
     # Find the mappings that we're looking for
     mappings = pwndbg.aglib.vmmap.get()
 


### PR DESCRIPTION
Should fix both #2420 and #2455.

As outlined in #2420, the LLDB port broke the `search` command when `-t bytes` is used, even under GDB. This PR should restore the same behavior we had before the refactorings got merged, by encoding the strings we get as UTF-8 before passing them on to `pwndbg.search.search`. This mimics  the way `str` objects passed to `gdb.Inferior.search_memory` get treated, as detailed in the comment right above the fix.