### PR TITLE
Fix pwnlib terminal initialization

### DIFF
--- a/gdbinit.py
+++ b/gdbinit.py
@@ -178,7 +178,9 @@ def main() -> None:
     except gdb.error as e:
         print(f"Warning: Cannot set gdb charset: '{e}'")
 
-    os.environ["PWNLIB_NOTERM"] = "1"
+    # Add the original stdout methods back to gdb._GdbOutputFile for pwnlib colors
+    sys.stdout.isatty = sys.__stdout__.isatty
+    sys.stdout.fileno = sys.__stdout__.fileno
 
     import pwndbg  # noqa: F811
     import pwndbg.dbg.gdb


### PR DESCRIPTION
GDB wraps stdout and doesn't proxy some functions through to the underlying TextIOWrapper. This causes pwnlib to error out when trying to detect terminal support.

By monkey patching the functions back onto the _GdbOutputFile object, we can use `pwnlib.term.text.red("hi")` to print colored text.

This is useful for #2157 as well as other plugins using pwntools for output in gdb.