### PR TITLE
Make `GDBProcess.break_at` handle `stop_handler=None` properly

### DIFF
--- a/pwndbg/dbg/gdb.py
+++ b/pwndbg/dbg/gdb.py
@@ -675,11 +675,17 @@ class GDBProcess(pwndbg.dbg_mod.Process):
 
         sp = GDBStopPoint(bp, self)
 
-        def handler():
-            self.in_bpwp_stop_handler = True
-            stop = stop_handler(sp)
-            self.in_bpwp_stop_handler = False
-            return stop
+        if stop_handler is not None:
+
+            def handler():
+                self.in_bpwp_stop_handler = True
+                stop = stop_handler(sp)
+                self.in_bpwp_stop_handler = False
+                return stop
+        else:
+
+            def handler():
+                return True
 
         bp.stop_handler = handler
 


### PR DESCRIPTION
The GDB backend to the Debugger-agnostic API does not handle breakpoint creation properly when no stop handler function is used. This PR fixes that.
