### PR TITLE
Add support for controlling execution to the Debugger-agnostic API

### DIFF
--- a/pwndbg/dbg/__init__.py
+++ b/pwndbg/dbg/__init__.py
@@ -7,7 +7,9 @@ from __future__ import annotations
 import contextlib
 from enum import Enum
 from typing import Any
+from typing import Awaitable
 from typing import Callable
+from typing import Coroutine
 from typing import Generator
 from typing import List
 from typing import Literal
@@ -266,6 +268,28 @@ class MemoryMap:
         raise NotImplementedError()
 
 
+class ExecutionController:
+    def single_step(self) -> Awaitable[None]:
+        """
+        Steps to the next instruction.
+
+        Throws `CancelledError` if a breakpoint or watchpoint is hit, the program
+        exits, or if any other unexpected event that diverts execution happens
+        while fulfulling the step.
+        """
+        raise NotImplementedError()
+
+    def cont(self, until: StopPoint) -> Awaitable[None]:
+        """
+        Continues execution until the given breakpoint or whatchpoint is hit.
+
+        Throws `CancelledError` if a breakpoint or watchpoint is hit that is not
+        the one given in `until`, the program exits, or if any other unexpected
+        event happens.
+        """
+        raise NotImplementedError()
+
+
 class Process:
     def threads(self) -> List[Thread]:
         """
@@ -499,6 +523,15 @@ class Process:
         the dynamic linker is used.
 
         We should probably sort this out in the future.
+        """
+        raise NotImplementedError()
+
+    def dispatch_execution_controller(
+        self, procedure: Callable[[ExecutionController], Coroutine[Any, Any, None]]
+    ):
+        """
+        Queues up the given execution controller-based coroutine for execution,
+        sometime between the calling of this function and the
         """
         raise NotImplementedError()
 

--- a/pwndbg/dbg/gdb.py
+++ b/pwndbg/dbg/gdb.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import re
 from contextlib import nullcontext
 from typing import Any
-from typing import Awaitable
 from typing import Coroutine
 from typing import Generator
 from typing import List
@@ -831,22 +830,14 @@ class GDBProcess(pwndbg.dbg_mod.Process):
                 break
 
 
-async def empty_awaitable() -> None:
-    """
-    Do nothing. We return this in our execution controller.
-    """
-    pass
-
-
 class GDBExecutionController(pwndbg.dbg_mod.ExecutionController):
     @override
-    def single_step(self) -> Awaitable[None]:
+    async def single_step(self):
         gdb.execute("si")
-        return empty_awaitable()
 
-    def cont(self, until: pwndbg.dbg_mod.StopPoint) -> Awaitable[None]:
+    @override
+    async def cont(self, until: pwndbg.dbg_mod.StopPoint):
         gdb.execute("continue")
-        return empty_awaitable()
 
 
 # Like in LLDB, we only need a single instance of the execution controller.

--- a/pwndbg/dbg/gdb.py
+++ b/pwndbg/dbg/gdb.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import re
 from contextlib import nullcontext
 from typing import Any
+from typing import Awaitable
+from typing import Coroutine
 from typing import Generator
 from typing import List
 from typing import Literal
@@ -805,6 +807,50 @@ class GDBProcess(pwndbg.dbg_mod.Process):
     def is_dynamically_linked(self) -> bool:
         out = gdb.execute("info dll", to_string=True)
         return "No shared libraries loaded at this time." not in out
+
+    @override
+    def dispatch_execution_controller(
+        self, procedure: Callable[[pwndbg.dbg_mod.ExecutionController], Coroutine[Any, Any, None]]
+    ):
+        # GDB isn't nearly as finnicky as LLDB when it comes to us controlling
+        # the execution of the inferior, so we can safely mostly ignore all of
+        # the async plumbing and drive the coroutine by just iterating over it.
+        #
+        # Aditionally, the Debugger-agnostic API allows us enough freedom in how
+        # we schedule execution of the controller that running it immediately is
+        # perfectly acceptable. So that's what we do.
+
+        coroutine = procedure(EXECUTION_CONTROLLER)
+        while True:
+            try:
+                # We don't need to bother communicating with the coroutine, as
+                # it doesn't yield anything we care about.
+                coroutine.send(None)
+            except StopIteration:
+                # We're done.
+                break
+
+
+async def empty_awaitable() -> None:
+    """
+    Do nothing. We return this in our execution controller.
+    """
+    pass
+
+
+class GDBExecutionController(pwndbg.dbg_mod.ExecutionController):
+    @override
+    def single_step(self) -> Awaitable[None]:
+        gdb.execute("si")
+        return empty_awaitable()
+
+    def cont(self, until: pwndbg.dbg_mod.StopPoint) -> Awaitable[None]:
+        gdb.execute("continue")
+        return empty_awaitable()
+
+
+# Like in LLDB, we only need a single instance of the execution controller.
+EXECUTION_CONTROLLER = GDBExecutionController()
 
 
 class GDBCommand(gdb.Command):

--- a/pwndbg/dbg/lldb/__init__.py
+++ b/pwndbg/dbg/lldb/__init__.py
@@ -637,9 +637,7 @@ class LLDBExecutionController(pwndbg.dbg_mod.ExecutionController):
     @override
     def cont(self, target: pwndbg.dbg_mod.StopPoint) -> Awaitable[None]:
         assert isinstance(target, LLDBStopPoint)
-        t: LLDBStopPoint = target
-
-        return OneShotAwaitable(YieldContinue(t))
+        return OneShotAwaitable(YieldContinue(target))
 
 
 # Our execution controller doesn't need to change between uses, as all the state

--- a/pwndbg/dbg/lldb/repl/__init__.py
+++ b/pwndbg/dbg/lldb/repl/__init__.py
@@ -349,6 +349,16 @@ def run(startup: List[str] | None = None, debug: bool = False) -> None:
         else:
             dbg.debugger.HandleCommand(line)
 
+        # At this point, the last command might've queued up some execution
+        # control procedures for us to chew on. Run them now.
+        for process, coroutine in dbg.controllers:
+            assert driver.has_process()
+            assert driver.process == process.process
+
+            driver.run_coroutine(coroutine)
+
+        dbg.controllers.clear()
+
 
 def make_pty() -> Tuple[str, int]:
     """

--- a/pwndbg/dbg/lldb/repl/proc.py
+++ b/pwndbg/dbg/lldb/repl/proc.py
@@ -265,9 +265,9 @@ class ProcessDriver:
         while True:
             try:
                 if exception is None:
-                    step_t = coroutine.send(None)
+                    step = coroutine.send(None)
                 else:
-                    step_t = coroutine.throw(exception)
+                    step = coroutine.throw(exception)
                     # The coroutine has caught the exception. Continue running
                     # it as if nothing happened.
                     exception = None
@@ -279,7 +279,7 @@ class ProcessDriver:
                 # override our decision. We're done.
                 break
 
-            if isinstance(step_t, YieldSingleStep):
+            if isinstance(step, YieldSingleStep):
                 # Pick the currently selected thread and step it forward by one
                 # instruction.
                 #
@@ -301,7 +301,7 @@ class ProcessDriver:
                     continue
 
                 self._run_until_next_stop()
-            elif isinstance(step_t, YieldContinue):
+            elif isinstance(step, YieldContinue):
                 # Continue the process and wait for the next stop-like event.
                 self.process.Continue()
                 event = self._run_until_next_stop()
@@ -310,7 +310,6 @@ class ProcessDriver:
                 ), "None should only be returned by _run_until_next_stop unless start timeouts are enabled"
 
                 # Check whether this stop event is the one we expect.
-                step: YieldContinue = step_t
                 stop: lldb.SBBreakpoint | lldb.SBWatchpoint = step.target.inner
 
                 if lldb.SBProcess.GetStateFromEvent(event) == lldb.eStateStopped:


### PR DESCRIPTION
This PR adds support for process execution control (currently continuing until a given breakpoint is hit, and single stepping) to the Debugger-agnostic API.

This functionality is implemented in terms of coroutines (`async def`) and awaitables, with the LLDB and GDB implementations being responsible for driving to completion all coroutines passed to them through the newly-added `Process.dispatch_execution_controller` method, with help from their respective implementations of `ExecutionController`, at some point in time between the method call and the command ending.

Using `async` has a couple of benefits due to both how we handle process lifetimes in LLDB, and how LLDB itself responds to process execution control commands issued during command processing. For the former, using `async` allows us to both keep all control of the process event loop in `pwndbg.dbg.lldb.repl`, and reap the benefits of cleaner command processing. For the latter, using coroutines allows us to easily and intuitively defer the execution control procedure until after command processing by LLDB is over, as issuing execution control commands during command processing breaks our event loop.

When it comes to GDB, its implementation runs the execution control procedure immediately, and pretty much foregoes all of the `async` piping. This solution does incur a little extra cost in terms of runtime over calling things like `gdb.execute("continue")` directly, but I do believe it is worth paying as it makes a much cleaner interface when one takes into account it has to work for both GDB and LLDB.