### PR TITLE
Sort core dump pages with start address

### DIFF
--- a/pwndbg/gdblib/vmmap.py
+++ b/pwndbg/gdblib/vmmap.py
@@ -392,6 +392,7 @@ def coredump_maps() -> Tuple[pwndbg.lib.memory.Page, ...]:
                 page.offset = 0
                 break
 
+    pages.sort(key=lambda page: page.start)
     return tuple(pages)
 
 


### PR DESCRIPTION
This PR should resolve #2473

----

Before this PR:

![before](https://github.com/user-attachments/assets/1e053344-cf24-4f5f-97fa-0d63c09f1ed8)

After this PR:

![after](https://github.com/user-attachments/assets/cae48947-26e4-48dd-b265-f45b3598cd8f)