### PR TITLE
Fixes the `-t bytes -x` combinantion in `search` command and adds more tests to it

### DIFF
--- a/pwndbg/commands/search.py
+++ b/pwndbg/commands/search.py
@@ -267,7 +267,7 @@ def search(
     # [1]: https://sourceware.org/git/?p=binutils-gdb.git;a=blame;f=gdb/python/py-inferior.c;h=a1042ee72ac733091f7572bc04b072546d3c1519;hb=23c84db5b3cb4e8a0d555c76e1a0ab56dc8355f3
     # [2]: https://docs.python.org/3.1/c-api/arg.html#strings-and-buffers
 
-    elif type == "bytes":
+    elif type == "bytes" and not hex:
         try:
             value = value.encode("utf-8")
         except UnicodeError as what:

--- a/tests/gdb-tests/tests/binaries/search_memory.c
+++ b/tests/gdb-tests/tests/binaries/search_memory.c
@@ -10,6 +10,8 @@ void break_here(void) {}
 
 size_t marker = 0xABCDEF1234567890;
 
+static const char* literal = "Hello!";
+
 int main(void)
 {
     void *p;


### PR DESCRIPTION
This PR fixes #2475, which is caused by a a double call to `.encode()` that happens when `-x` is given to `search` when the value of `-t` is `bytes`, that was missed in #2458.

Additionally, this PR adds a test that covers some of the more elemental sets of parameters that `search` can receive (`-x`, `-t string`, and `-t bytes`), which were previously missing in the tests for the `search` command, and that could've prevented much of the breakage that happened with `search`.