### PR TITLE
Fix memory.poke & makes peek return a bytearray

### DIFF
--- a/pwndbg/aglib/memory.py
+++ b/pwndbg/aglib/memory.py
@@ -65,8 +65,8 @@ def write(addr: int, data: str | bytes | bytearray) -> None:
     pwndbg.dbg.selected_inferior().write_memory(address=addr, data=bytearray(data), partial=False)
 
 
-def peek(address: int) -> str | None:
-    """peek(address) -> str
+def peek(address: int) -> bytearray | None:
+    """peek(address) -> bytearray
 
     Read one byte from the specified address.
 
@@ -74,12 +74,13 @@ def peek(address: int) -> str | None:
         address(int): Address to read
 
     Returns:
-        :class:`str`: A single byte of data, or ``None`` if the
+        :class:`bytearray`: A single byte of data, or ``None`` if the
         address cannot be read.
     """
     try:
-        return chr(read(address, 1)[0])
+        return read(address, 1)
     except Exception:
+        # TODO/FIXME: This should not pass on any exception!
         pass
     return None
 

--- a/pwndbg/gdblib/memory.py
+++ b/pwndbg/gdblib/memory.py
@@ -111,8 +111,8 @@ def write(addr: int, data: str | bytes | bytearray) -> None:
     gdb.selected_inferior().write_memory(addr, data)
 
 
-def peek(address: int) -> str | None:
-    """peek(address) -> str
+def peek(address: int) -> bytearray | None:
+    """peek(address) -> bytearray
 
     Read one byte from the specified address.
 
@@ -120,12 +120,12 @@ def peek(address: int) -> str | None:
         address(int): Address to read
 
     Returns:
-        :class:`str`: A single byte of data, or ``None`` if the
+        :class:`bytearray`: A single byte of data, or ``None`` if the
         address cannot be read.
     """
     try:
-        return chr(read(address, 1)[0])
-    except Exception:
+        return read(address, 1)
+    except gdb.MemoryError:
         pass
     return None
 
@@ -163,7 +163,7 @@ def poke(address: int) -> bool:
     try:
         pwndbg.gdblib.events.pause(gdb.events.memory_changed)
         write(address, c)
-    except Exception:
+    except gdb.MemoryError:
         return False
     finally:
         pwndbg.gdblib.events.unpause(gdb.events.memory_changed)


### PR DESCRIPTION
Fixes #2472 where `poke` could write incorrect bytes to memory when testing if certain address is writable or not (see longer description below).

Summary of changes:
* Changes `{aglib,gdblib}.memory.peek` to return a `bytearray` instead of `str` (which made no sense)
* Changes `gdblib.memory.{peek,poke}` to only `pass` on a `gdb.MemoryError` - when we can't read memory, and not on any error like incorrect argument type
* Add tests for multiple use cases of `gdblib.memory.{peek,poke}`

Longer description:

Before this commit, the `memory.poke` implementation could end up writing a different byte to memory then the byte that was initially there.

This is because it used `memory.peek` which returned a `str` and this `str` was then encoded to `utf-8` to get bytes back again for `memory.write` used by `memory.poke`.

This resulted in writing different bytes to memory then the byte that was initially read from the given address. Below is an example.

If `memory.peek` read the `b\xa9` byte, then this was converted to a `'©'` string via `chr(b'\xa9'[0])` which was returned from `peek`. Then, this was converted back to bytes in `poke` with utf-8 encoding which resulted in `b'\xc2\xa9'` bytes.

```
In [4]: bytes(chr(b'\xa9'[0]), 'utf-8')
Out[4]: b'\xc2\xa9'
```

<!-- Please make sure to read the testing and linting instructions at https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md before creating a PR -->
