### PR TITLE
Patch _fs_gs_helper when debugging windows remotely

### DIFF
--- a/pwndbg/gdblib/regs.py
+++ b/pwndbg/gdblib/regs.py
@@ -9,7 +9,13 @@ import ctypes
 import re
 import sys
 from types import ModuleType
-from typing import Any, Callable, Dict, Generator, List, Tuple, cast
+from typing import Any
+from typing import Callable
+from typing import Dict
+from typing import Generator
+from typing import List
+from typing import Tuple
+from typing import cast
 
 import gdb
 
@@ -21,7 +27,9 @@ import pwndbg.gdblib.remote
 import pwndbg.gdblib.typeinfo
 import pwndbg.lib.cache
 from pwndbg.dbg import EventType
-from pwndbg.lib.regs import BitFlags, RegisterSet, reg_sets
+from pwndbg.lib.regs import BitFlags
+from pwndbg.lib.regs import RegisterSet
+from pwndbg.lib.regs import reg_sets
 
 
 @pwndbg.gdblib.proc.OnlyWhenRunning

--- a/pwndbg/gdblib/regs.py
+++ b/pwndbg/gdblib/regs.py
@@ -9,13 +9,7 @@ import ctypes
 import re
 import sys
 from types import ModuleType
-from typing import Any
-from typing import Callable
-from typing import Dict
-from typing import Generator
-from typing import List
-from typing import Tuple
-from typing import cast
+from typing import Any, Callable, Dict, Generator, List, Tuple, cast
 
 import gdb
 
@@ -27,9 +21,7 @@ import pwndbg.gdblib.remote
 import pwndbg.gdblib.typeinfo
 import pwndbg.lib.cache
 from pwndbg.dbg import EventType
-from pwndbg.lib.regs import BitFlags
-from pwndbg.lib.regs import RegisterSet
-from pwndbg.lib.regs import reg_sets
+from pwndbg.lib.regs import BitFlags, RegisterSet, reg_sets
 
 
 @pwndbg.gdblib.proc.OnlyWhenRunning
@@ -246,13 +238,13 @@ class module(ModuleType):
         """Supports fetching based on segmented addressing, a la fs:[0x30].
         Requires ptrace'ing the child directory if i386."""
 
-        if pwndbg.aglib.arch.name == "x86-64":
-            reg_value = gdb_get_register(regname)
-            return int(reg_value) if reg_value is not None else 0
-
         # We can't really do anything if the process is remote.
         if pwndbg.gdblib.remote.is_remote():
             return 0
+
+        if pwndbg.aglib.arch.name == "x86-64":
+            reg_value = gdb_get_register(regname)
+            return int(reg_value) if reg_value is not None else 0
 
         # Use the lightweight process ID
         _, lwpid, _ = gdb.selected_thread().ptid

--- a/pwndbg/gdblib/regs.py
+++ b/pwndbg/gdblib/regs.py
@@ -33,17 +33,22 @@ from pwndbg.lib.regs import reg_sets
 
 
 @pwndbg.gdblib.proc.OnlyWhenRunning
+def register_exists(register_name: str, frame: gdb.Frame | None = None) -> bool:
+    if frame is None:
+        frame = gdb.selected_frame()
+    return any(
+        register_name.lower() == reg.name.lower() for reg in frame.architecture().registers()
+    )
+
+
+@pwndbg.gdblib.proc.OnlyWhenRunning
 def gdb_get_register(name: str, frame: gdb.Frame | None = None) -> gdb.Value | None:
     if frame is None:
         frame = gdb.selected_frame()
     try:
         return frame.read_register(name)
     except ValueError:
-        pass
-    try:
         return frame.read_register(name.upper())
-    except ValueError:
-        return None
 
 
 @pwndbg.gdblib.proc.OnlyWhenQemuKernel
@@ -249,6 +254,9 @@ class module(ModuleType):
     def _fs_gs_helper(self, regname: str, which: int) -> int:
         """Supports fetching based on segmented addressing, a la fs:[0x30].
         Requires ptrace'ing the child directory if i386."""
+
+        if not register_exists(regname):
+            return 0
 
         if pwndbg.aglib.arch.name == "x86-64":
             reg_value = gdb_get_register(regname)

--- a/pwndbg/gdblib/regs.py
+++ b/pwndbg/gdblib/regs.py
@@ -36,9 +36,7 @@ from pwndbg.lib.regs import reg_sets
 def register_exists(register_name: str, frame: gdb.Frame | None = None) -> bool:
     if frame is None:
         frame = gdb.selected_frame()
-    return any(
-        register_name.lower() == reg.name.lower() for reg in frame.architecture().registers()
-    )
+    return bool(frame.architecture().registers().find(register_name))
 
 
 @pwndbg.gdblib.proc.OnlyWhenRunning

--- a/pwndbg/gdblib/regs.py
+++ b/pwndbg/gdblib/regs.py
@@ -255,10 +255,9 @@ class module(ModuleType):
         """Supports fetching based on segmented addressing, a la fs:[0x30].
         Requires ptrace'ing the child directory if i386."""
 
-        if not register_exists(regname):
-            return 0
-
         if pwndbg.aglib.arch.name == "x86-64":
+            if not register_exists(regname):
+                return 0
             reg_value = gdb_get_register(regname)
             return int(reg_value) if reg_value is not None else 0
 


### PR DESCRIPTION
I am using mingw64's gdbserver.exe to debug a windows PE remotely from Linux. Pwndbg will crash because the `fs_base` and `gs_base` registers does not exist when debugging in this way. By moving the `is_remote` check earlier (before it looks up the registers and crashes) pwndbg seems to work fine.