### PR TITLE
Don't ignore set safe-linking settings

### DIFF
--- a/pwndbg/glibc.py
+++ b/pwndbg/glibc.py
@@ -197,4 +197,4 @@ def check_safe_linking() -> bool:
     - https://lanph3re.blogspot.com/2020/08/blog-post.html
     - https://research.checkpoint.com/2020/safe-linking-eliminating-a-20-year-old-malloc-exploit-primitive/
     """
-    return (get_version() >= (2, 32) or safe_lnk) and safe_lnk is not False  # type: ignore[return-value]
+    return (get_version() >= (2, 32) or safe_lnk.value) and safe_lnk.value is not False  # type: ignore[return-value]

--- a/pwndbg/glibc.py
+++ b/pwndbg/glibc.py
@@ -197,4 +197,4 @@ def check_safe_linking() -> bool:
     - https://lanph3re.blogspot.com/2020/08/blog-post.html
     - https://research.checkpoint.com/2020/safe-linking-eliminating-a-20-year-old-malloc-exploit-primitive/
     """
-    return (get_version() >= (2, 32) or safe_lnk.value) and safe_lnk.value is not False  # type: ignore[return-value]
+    return (get_version() >= (2, 32) or safe_lnk.value) and safe_lnk.value is not False


### PR DESCRIPTION
The previous code was testing the existance of the safe_lnk option object, which always exists, and therefore was ignoring the actual value of the option. Change the test to safe_lnk.value.

<!-- Please make sure to read the testing and linting instructions at https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md before creating a PR -->
