### PR TITLE
setup.sh: fix Arch install (add missing libxxhash required by gdb)

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -77,7 +77,7 @@ install_pacman() {
     if [[ "$answer" == "y" ]]; then
         sudo pacman -Syu || true
     fi
-    sudo pacman -S --noconfirm --needed git gdb python which debuginfod curl
+    sudo pacman -S --noconfirm --needed git gdb python which debuginfod curl xxhash
     if ! grep -qs "^set debuginfod enabled on" ~/.gdbinit; then
         echo "set debuginfod enabled on" >> ~/.gdbinit
     fi


### PR DESCRIPTION
Our Arch Linux CI started to fail recently with the following error:

> 4.562 gdb: error while loading shared libraries: libxxhash.so.0: cannot open shared object file: No such file or directory

It seems this library should be a dependency of GDB on Arch, but for some reason it is not? This commit/PR adds this library to be installed with Pacman manually/explicitly.

<!-- Please make sure to read the testing and linting instructions at https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md before creating a PR -->
