### PR TITLE
Fix canary when no canaries

### DIFF
--- a/pwndbg/commands/canary.py
+++ b/pwndbg/commands/canary.py
@@ -54,6 +54,7 @@ def canary(all) -> None:
     found_canaries = False
     global_canary_packed = pwndbg.aglib.arch.pack(global_canary)
     thread_stacks = pwndbg.aglib.stack.get()
+    some_canaries_not_shown = False
 
     for thread in thread_stacks:
         thread_stack = thread_stacks[thread]
@@ -70,7 +71,6 @@ def canary(all) -> None:
         found_canaries = True
         num_canaries = len(stack_canaries)
         num_canaries_to_display = num_canaries
-        some_canaries_not_shown = False
 
         if not all:
             num_canaries_to_display = min(DEFAULT_NUM_CANARIES_TO_DISPLAY, num_canaries)


### PR DESCRIPTION
Fixes the following bug uncovered by our test_commands[canary] test suite:

```
(.venv) root@pwndbg:~/pwndbg# RUN_FLAKY=1 ./tests.sh 'test_commands' --pdb
Will run tests in serial and with Python debugger
ZIGPATH set to /root/pwndbg/.zig
make: Nothing to be done for 'all'.
pwndbg: loaded 173 pwndbg commands and 47 shell commands. Type pwndbg [--shell | --all] [filter] for a list.
pwndbg: created $rebase, $base, $bn_sym, $bn_var, $bn_eval, $ida GDB functions (can be used with print/break)
Launching pytest with args: ['/root/pwndbg/tests/gdb-tests/tests/test_commands.py::test_commands[canary]', '-vvv', '-s', '--showlocals', '--color=yes', '--pdb']
======================================================================== test session starts ========================================================================
platform linux -- Python 3.11.6, pytest-8.0.2, pluggy-1.5.0 -- /usr/bin/python
cachedir: .pytest_cache
rootdir: /root/pwndbg/tests
plugins: cov-4.1.0
collected 1 item

gdb-tests/tests/test_commands.py::test_commands[canary] Running command canary

This GDB supports auto-downloading debuginfo from the following URLs:
  <https://debuginfod.ubuntu.com/>
Debuginfod has been disabled.
To make this setting permanent, add 'set debuginfod enabled off' to .gdbinit.

Program stopped.
0x00007ffff7fe4b40 in _start () from /lib64/ld-linux-x86-64.so.2
AT_RANDOM = 0x7fffffffe3d9 # points to (not masked) global canary value
Canary    = 0x37492280ae2b3000 (may be incorrect on != glibc)
No canaries found.
Traceback (most recent call last):
  File "/root/pwndbg/pwndbg/commands/__init__.py", line 187, in __call__
    return self.function(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/pwndbg/pwndbg/commands/__init__.py", line 378, in _OnlyWhenRunning
    return function(*a, **kw)
           ^^^^^^^^^^^^^^^^^^
  File "/root/pwndbg/pwndbg/commands/canary.py", line 91, in canary
    if some_canaries_not_shown is True:
       ^^^^^^^^^^^^^^^^^^^^^^^
UnboundLocalError: cannot access local variable 'some_canaries_not_shown' where it is not associated with a value

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/root/pwndbg/pwndbg/dbg/gdb.py", line 871, in invoke
    self.handler(self.debugger, args, from_tty)
  File "/root/pwndbg/pwndbg/commands/__init__.py", line 105, in _handler
    self.invoke(arguments, is_interactive)
  File "/root/pwndbg/pwndbg/commands/__init__.py", line 153, in invoke
    self(*args, **kwargs)
  File "/root/pwndbg/pwndbg/commands/__init__.py", line 192, in __call__
    pwndbg.exception.handle(self.function.__name__)
  File "/root/pwndbg/pwndbg/exception.py", line 106, in handle
    raise e
  File "/root/pwndbg/pwndbg/commands/__init__.py", line 187, in __call__
    return self.function(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/pwndbg/pwndbg/commands/__init__.py", line 378, in _OnlyWhenRunning
    return function(*a, **kw)
           ^^^^^^^^^^^^^^^^^^
  File "/root/pwndbg/pwndbg/commands/canary.py", line 91, in canary
    if some_canaries_not_shown is True:
       ^^^^^^^^^^^^^^^^^^^^^^^
UnboundLocalError: cannot access local variable 'some_canaries_not_shown' where it is not associated with a value
```

