### PR TITLE
Fix gdt command: require address argument

### DIFF
--- a/pwndbg/commands/gdt.py
+++ b/pwndbg/commands/gdt.py
@@ -24,7 +24,6 @@ In 64-bit mode, the Base and Limit values are ignored, each descriptor covers th
 parser.add_argument(
     "address",
     type=int,
-    nargs="?",
     help="x86-64 GDTR base address (e.g. read from sgdt instruction from [16:79] bits)",
 )
 


### PR DESCRIPTION
Before this commit, the `gdt` command incorrectly did not require the `address` argument, while it was required.

Because of that, the command crashed like this:

```
pwndbg> gdt
Exception occurred: gdt: int() argument must be a string, a bytes-like object or a real number, not 'NoneType' (<class 'TypeError'>)
For more info invoke `set exception-verbose on` and rerun the command
or debug it by yourself with `set exception-debugger on`
```

<!-- Please make sure to read the testing and linting instructions at https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md before creating a PR -->
