### PR TITLE
Fix ctxp command

### DIFF
--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -360,11 +360,11 @@ parser.add_argument(
 @pwndbg.commands.ArgparsedCommand(parser, aliases=["ctxp"], category=CommandCategory.CONTEXT)
 def contextprev(count) -> None:
     global selected_history_index
-    longest_history = max(len(h) for h in context_history.values())
     if selected_history_index is None:
         if not context_history:
             print(message.error("No context history captured"))
             return
+        longest_history = max(len(h) for h in context_history.values())
         new_index = longest_history - count - 1
     else:
         new_index = selected_history_index - count
@@ -385,11 +385,11 @@ parser.add_argument(
 @pwndbg.commands.ArgparsedCommand(parser, aliases=["ctxn"], category=CommandCategory.CONTEXT)
 def contextnext(count) -> None:
     global selected_history_index
-    longest_history = max(len(h) for h in context_history.values())
     if selected_history_index is None:
         if not context_history:
             print(message.error("No context history captured"))
             return
+        longest_history = max(len(h) for h in context_history.values())
         new_index = longest_history - 1
     else:
         new_index = selected_history_index + count

--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -360,10 +360,10 @@ parser.add_argument(
 @pwndbg.commands.ArgparsedCommand(parser, aliases=["ctxp"], category=CommandCategory.CONTEXT)
 def contextprev(count) -> None:
     global selected_history_index
+    if not context_history:
+        print(message.error("No context history captured"))
+        return
     if selected_history_index is None:
-        if not context_history:
-            print(message.error("No context history captured"))
-            return
         longest_history = max(len(h) for h in context_history.values())
         new_index = longest_history - count - 1
     else:
@@ -385,11 +385,11 @@ parser.add_argument(
 @pwndbg.commands.ArgparsedCommand(parser, aliases=["ctxn"], category=CommandCategory.CONTEXT)
 def contextnext(count) -> None:
     global selected_history_index
+    if not context_history:
+        print(message.error("No context history captured"))
+        return
+    longest_history = max(len(h) for h in context_history.values())
     if selected_history_index is None:
-        if not context_history:
-            print(message.error("No context history captured"))
-            return
-        longest_history = max(len(h) for h in context_history.values())
         new_index = longest_history - 1
     else:
         new_index = selected_history_index + count


### PR DESCRIPTION
Before this commit the `ctxp` could fail with:
```
Launching pytest with args: ['/root/pwndbg/tests/gdb-tests/tests/test_commands.py::test_commands[ctxp]', '-vvv', '-s', '--showlocals', '--color=yes', '--pdb']
======================================================================== test session starts ========================================================================
platform linux -- Python 3.11.6, pytest-8.0.2, pluggy-1.5.0 -- /usr/bin/python
cachedir: .pytest_cache
rootdir: /root/pwndbg/tests
plugins: cov-4.1.0
collected 1 item

gdb-tests/tests/test_commands.py::test_commands[ctxp] Running command ctxp

This GDB supports auto-downloading debuginfo from the following URLs:
  <https://debuginfod.ubuntu.com>
Debuginfod has been disabled.
To make this setting permanent, add 'set debuginfod enabled off' to .gdbinit.

Program stopped.
0x00007ffff7fe4b40 in _start () from /lib64/ld-linux-x86-64.so.2
Traceback (most recent call last):
  File "/root/pwndbg/pwndbg/commands/__init__.py", line 187, in __call__
    return self.function(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/pwndbg/pwndbg/commands/context.py", line 363, in contextprev
    longest_history = max(len(h) for h in context_history.values())
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: max() arg is an empty sequence

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/root/pwndbg/pwndbg/dbg/gdb.py", line 871, in invoke
    self.handler(self.debugger, args, from_tty)
  File "/root/pwndbg/pwndbg/commands/__init__.py", line 105, in _handler
    self.invoke(arguments, is_interactive)
  File "/root/pwndbg/pwndbg/commands/__init__.py", line 153, in invoke
    self(*args, **kwargs)
  File "/root/pwndbg/pwndbg/commands/__init__.py", line 192, in __call__
    pwndbg.exception.handle(self.function.__name__)
  File "/root/pwndbg/pwndbg/exception.py", line 106, in handle
    raise e
  File "/root/pwndbg/pwndbg/commands/__init__.py", line 187, in __call__
    return self.function(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/pwndbg/pwndbg/commands/context.py", line 363, in contextprev
    longest_history = max(len(h) for h in context_history.values())
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: max() arg is an empty sequence
XFAIL (flaky test)
```

<!-- Please make sure to read the testing and linting instructions at https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md before creating a PR -->
