### PR TITLE
Fix try_free command: make addr argument required

### DIFF
--- a/pwndbg/commands/heap.py
+++ b/pwndbg/commands/heap.py
@@ -1186,7 +1186,7 @@ def bin_labels_mapping(collections):
 try_free_parser = argparse.ArgumentParser(
     description="Check what would happen if free was called with given address."
 )
-try_free_parser.add_argument("addr", nargs="?", help="Address passed to free")
+try_free_parser.add_argument("addr", help="Address passed to free")
 
 
 @pwndbg.commands.ArgparsedCommand(try_free_parser, category=CommandCategory.HEAP)


### PR DESCRIPTION
Fixes the following problem:
```
pwndbg> try_free
TypeError: int() argument must be a string, a bytes-like object or a real number, not 'NoneType'
> /root/pwndbg/pwndbg/commands/heap.py(1195)try_free()
   1194 def try_free(addr: str | int) -> None:
-> 1195     addr = int(addr)
   1196
```

<!-- Please make sure to read the testing and linting instructions at https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md before creating a PR -->
