### PR TITLE
Fix jemalloc #2502

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -93,5 +93,6 @@
           isLLDB = true;
         }
       );
+      formatter = forAllSystems (system: pkgsBySystem.${system}.nixfmt-rfc-style);
     };
 }

--- a/nix/bundle/pkg.nix
+++ b/nix/bundle/pkg.nix
@@ -16,7 +16,8 @@ let
     {
       drv ? null,
       config ? "nfpm.yaml",
-      packager ? null, # apk|deb|rpm|archlinux
+      packager ? null,
+      # apk|deb|rpm|archlinux
       preremove ? null,
       ...
     }@attrs:

--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -1,7 +1,6 @@
 # This should be kept in sync with setup-dev.sh and lint.sh requirements
 {
-  pkgs ?
-    # If pkgs is not defined, instantiate nixpkgs from locked commit
+  pkgs ? # If pkgs is not defined, instantiate nixpkgs from locked commit
     let
       lock = (builtins.fromJSON (builtins.readFile ./flake.lock)).nodes.nixpkgs.locked;
       nixpkgs = fetchTarball {
@@ -17,7 +16,12 @@
 }:
 let
   pyEnv = import ./pyenv.nix {
-    inherit pkgs python3 inputs isLLDB;
+    inherit
+      pkgs
+      python3
+      inputs
+      isLLDB
+      ;
     lib = pkgs.lib;
     isDev = true;
   };
@@ -26,22 +30,27 @@ in
   default = pkgs.mkShell {
     NIX_CONFIG = "extra-experimental-features = nix-command flakes repl-flake";
     # Anything not handled by the poetry env
-    nativeBuildInputs = (with pkgs; [
-      # from setup-dev.sh
-      nasm
-      gcc
-      curl
-      gdb
-      parallel
-      qemu
-      netcat-openbsd
-      zig_0_10 # matches setup-dev.sh
-      go
+    nativeBuildInputs =
+      (with pkgs; [
+        # from setup-dev.sh
+        nasm
+        gcc
+        curl
+        gdb
+        parallel
+        qemu
+        netcat-openbsd
+        zig_0_10 # matches setup-dev.sh
+        go
 
-      pyEnv
-    ]) ++ pkgs.lib.optionals isLLDB (with pkgs; [
-      lldb_19
-    ]);
+        pyEnv
+      ])
+      ++ pkgs.lib.optionals isLLDB (
+        with pkgs;
+        [
+          lldb_19
+        ]
+      );
     shellHook = ''
       export PWNDBG_VENV_PATH="PWNDBG_PLEASE_SKIP_VENV"
       export ZIGPATH="${pkgs.lib.getBin pkgs.zig_0_10}/bin/"

--- a/pwndbg/aglib/heap/jemalloc.py
+++ b/pwndbg/aglib/heap/jemalloc.py
@@ -269,9 +269,10 @@ class RTree:
         subkey = self.__subkey(key, 1)
 
         addr = int(self.root.address) + subkey * rtree_node_elm_s.sizeof
-        node = pwndbg.aglib.memory.fetch_struct_as_dictionary("rtree_node_elm_s", addr)
-
-        child_repr: int = node["child"]["repr"]  # type: ignore[index]
+        fetched_struct = pwndbg.aglib.memory.get_typed_pointer_value(
+            "struct rtree_node_elm_s", addr
+        )
+        child_repr = int(fetched_struct["child"]["repr"])
 
         # on node element, child contains the bits with which we can find another node or leaf element
         if child_repr == 0:
@@ -280,10 +281,12 @@ class RTree:
         # For subkey 1
         subkey = self.__subkey(key, 2)
         addr = child_repr + subkey * rtree_leaf_elm_s.sizeof
-        leaf = pwndbg.aglib.memory.fetch_struct_as_dictionary("rtree_leaf_elm_s", addr)
+        fetched_struct = pwndbg.aglib.memory.get_typed_pointer_value(
+            "struct rtree_leaf_elm_s", addr
+        )
 
         # On leaf element, le_bits contains the virtual memory address bits so we can use it to find the extent address
-        val: int = leaf["le_bits"]["repr"]  # type: ignore[index]
+        val = int(fetched_struct["le_bits"]["repr"])
         if val == 0:
             return None
 
@@ -335,9 +338,7 @@ class RTree:
                     fetched_struct = pwndbg.aglib.memory.get_typed_pointer_value(
                         rtree_node_elm_s, node_address
                     )
-                    node = pwndbg.aglib.memory.pack_struct_into_dictionary(fetched_struct)
-
-                    leaf0: int = node["child"]["repr"]  # type: ignore[index]
+                    leaf0 = int(fetched_struct["child"]["repr"])
                     if leaf0 == 0:
                         continue
 
@@ -351,9 +352,8 @@ class RTree:
                         fetched_struct = pwndbg.aglib.memory.get_typed_pointer_value(
                             rtree_leaf_elm_s, leaf_address
                         )
-                        leaf = pwndbg.aglib.memory.pack_struct_into_dictionary(fetched_struct)
-
-                        if (val := int(leaf["le_bits"]["repr"])) == 0:  # type: ignore[index, arg-type]
+                        val = int(fetched_struct["le_bits"]["repr"])
+                        if val == 0:
                             continue
 
                         # print("leaf: ", hex(leaf_address))

--- a/pwndbg/aglib/heap/jemalloc.py
+++ b/pwndbg/aglib/heap/jemalloc.py
@@ -1,10 +1,7 @@
 from __future__ import annotations
 
-import gdb
-
-import pwndbg.gdblib.info
-import pwndbg.gdblib.memory
-import pwndbg.gdblib.typeinfo
+import pwndbg.aglib.memory
+import pwndbg.aglib.typeinfo
 
 # adapted from jemalloc source 5.3.0
 LG_VADDR = 48
@@ -193,24 +190,23 @@ class RTree:
     def __init__(self, addr: int) -> None:
         self._addr = addr
 
-        rtree_s = pwndbg.gdblib.typeinfo.load("struct rtree_s")
-        # self._Value = pwndbg.gdblib.memory.poi(emap_s, self._addr)
+        # self._Value = pwndbg.aglib.memory.poi(emap_s, self._addr)
 
-        # self._Value = pwndbg.gdblib.memory.fetch_struct_as_dictionary(
+        # self._Value = pwndbg.aglib.memory.fetch_struct_as_dictionary(
         #     "rtree_s", self._addr, include_only_fields={"root"}
         # )
-        self._Value = gdb.Value(self._addr).cast(rtree_s.pointer()).dereference()
+        # pwndbg.aglib.memory
+        self._Value = pwndbg.aglib.memory.get_typed_pointer_value("struct rtree_s", self._addr)
 
         self._extents = None
 
     @staticmethod
     def get_rtree() -> RTree:
         try:
-            addr = pwndbg.gdblib.info.address("je_arena_emap_global")
+            addr = pwndbg.dbg.selected_inferior().symbol_address_from_name("je_arena_emap_global")
             if addr is None:
                 return None
-
-        except gdb.MemoryError:
+        except pwndbg.dbg_mod.Error:
             return None
 
         return RTree(addr)
@@ -262,8 +258,8 @@ class RTree:
         How it works:
         - Jemalloc stores the extent address in the rtree as a node and to find a specific node we need a address key.
         """
-        rtree_node_elm_s = pwndbg.gdblib.typeinfo.load("struct rtree_node_elm_s")
-        rtree_leaf_elm_s = pwndbg.gdblib.typeinfo.load("struct rtree_leaf_elm_s")
+        rtree_node_elm_s = pwndbg.aglib.typeinfo.load("struct rtree_node_elm_s")
+        rtree_leaf_elm_s = pwndbg.aglib.typeinfo.load("struct rtree_leaf_elm_s")
 
         # Credits: 盏一's jegdb
 
@@ -271,7 +267,7 @@ class RTree:
         subkey = self.__subkey(key, 1)
 
         addr = int(self.root.address) + subkey * rtree_node_elm_s.sizeof
-        node = pwndbg.gdblib.memory.fetch_struct_as_dictionary("rtree_node_elm_s", addr)
+        node = pwndbg.aglib.memory.fetch_struct_as_dictionary("rtree_node_elm_s", addr)
 
         child_repr: int = node["child"]["repr"]  # type: ignore[index]
 
@@ -282,7 +278,7 @@ class RTree:
         # For subkey 1
         subkey = self.__subkey(key, 2)
         addr = child_repr + subkey * rtree_leaf_elm_s.sizeof
-        leaf = pwndbg.gdblib.memory.fetch_struct_as_dictionary("rtree_leaf_elm_s", addr)
+        leaf = pwndbg.aglib.memory.fetch_struct_as_dictionary("rtree_leaf_elm_s", addr)
 
         # On leaf element, le_bits contains the virtual memory address bits so we can use it to find the extent address
         val: int = leaf["le_bits"]["repr"]  # type: ignore[index]
@@ -325,19 +321,19 @@ class RTree:
                 last_addr = None
                 extent_addresses = []
 
-                rtree_node_elm_s = pwndbg.gdblib.typeinfo.load("struct rtree_node_elm_s")
-                rtree_leaf_elm_s = pwndbg.gdblib.typeinfo.load("struct rtree_leaf_elm_s")
+                rtree_node_elm_s = pwndbg.aglib.typeinfo.load("struct rtree_node_elm_s")
+                rtree_leaf_elm_s = pwndbg.aglib.typeinfo.load("struct rtree_leaf_elm_s")
 
                 max_subkeys = 1 << rtree_levels[RTREE_HEIGHT - 1][0]["bits"]
                 # print("max_subkeys: ", max_subkeys)
 
                 for i in range(max_subkeys):
                     node_address = int(root.address) + i * rtree_node_elm_s.sizeof
-                    # node = pwndbg.gdblib.memory.poi(rtree_node_elm_s, node)
-                    fetched_struct = pwndbg.gdblib.memory.get_typed_pointer_value(
+                    # node = pwndbg.aglib.memory.poi(rtree_node_elm_s, node)
+                    fetched_struct = pwndbg.aglib.memory.get_typed_pointer_value(
                         rtree_node_elm_s, node_address
                     )
-                    node = pwndbg.gdblib.memory.pack_struct_into_dictionary(fetched_struct)
+                    node = pwndbg.aglib.memory.pack_struct_into_dictionary(fetched_struct)
 
                     leaf0: int = node["child"]["repr"]  # type: ignore[index]
                     if leaf0 == 0:
@@ -349,11 +345,11 @@ class RTree:
                     # level 1
                     for j in range(max_subkeys):
                         leaf_address = leaf0 + j * rtree_leaf_elm_s.sizeof
-                        # leaf = pwndbg.gdblib.memory.poi(rtree_leaf_elm_s, leaf)
-                        fetched_struct = pwndbg.gdblib.memory.get_typed_pointer_value(
+                        # leaf = pwndbg.aglib.memory.poi(rtree_leaf_elm_s, leaf)
+                        fetched_struct = pwndbg.aglib.memory.get_typed_pointer_value(
                             rtree_leaf_elm_s, leaf_address
                         )
-                        leaf = pwndbg.gdblib.memory.pack_struct_into_dictionary(fetched_struct)
+                        leaf = pwndbg.aglib.memory.pack_struct_into_dictionary(fetched_struct)
 
                         if (val := int(leaf["le_bits"]["repr"])) == 0:  # type: ignore[index, arg-type]
                             continue
@@ -389,7 +385,7 @@ class RTree:
 
                         self._extents.append(extent_tmp)
 
-            except gdb.MemoryError:
+            except pwndbg.dbg_mod.Error:
                 pass
 
         return self._extents
@@ -409,8 +405,7 @@ class Extent:
         self._addr = addr
 
         # fetch_struct_as_dictionary does not support union currently
-        edata_s = pwndbg.gdblib.typeinfo.load("struct edata_s")
-        self._Value = gdb.Value(self._addr).cast(edata_s.pointer()).dereference()
+        self._Value = pwndbg.aglib.memory.get_typed_pointer_value("struct edata_s", self._addr)
 
         self._bitfields = None
 

--- a/pwndbg/aglib/heap/jemalloc.py
+++ b/pwndbg/aglib/heap/jemalloc.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Dict
+
 import pwndbg.aglib.memory
 import pwndbg.aglib.typeinfo
 
@@ -228,12 +230,12 @@ class RTree:
         return ptrbits - cumbits
 
     # Can be used to lookup key quickly in cache
-    def __rtree_leafkey(self, key, level):
+    def __rtree_leafkey(self, key: int, level: int) -> int:
         mask = ~((1 << self.__rtree_leaf_maskbits(level)) - 1)
         # print("mask: ", mask, bin(mask))
         return key & mask
 
-    def __subkey(self, key, level):
+    def __subkey(self, key: int, level: int) -> int:
         """
         Return a portion of the key that is used to find the node/leaf in the rtree at a specific level.
         Source: https://github.com/jemalloc/jemalloc/blob/5b72ac098abce464add567869d082f2097bd59a2/include/jemalloc/internal/rtree.h#L161
@@ -251,7 +253,7 @@ class RTree:
     def __alignment_addr2base(addr, alignment=64):
         return addr - (addr - (addr & (~(alignment - 1))))
 
-    def lookup_hard(self, key):
+    def lookup_hard(self, key: int):
         """
         Lookup the key in the rtree and return the value.
 
@@ -418,14 +420,14 @@ class Extent:
         return (int(self._Value["e_size_esn"]) >> LG_PAGE) << LG_PAGE
 
     @property
-    def extent_address(self):
+    def extent_address(self) -> int:
         """
         Address of the extent data structure (not the actual memory).
         """
         return self._addr
 
     @property
-    def allocated_address(self):
+    def allocated_address(self) -> int:
         """
         Starting address of allocated memory
         cache-oblivious large allocation alignment:
@@ -433,18 +435,18 @@ class Extent:
             However, the pointer returned to user is randomized between the 'base' and 'base + 4 KiB' (0x1000) range.
             Source code: https://github.com/jemalloc/jemalloc/blob/a25b9b8ba91881964be3083db349991bbbbf1661/include/jemalloc/internal/arena_inlines_b.h#L505
         """
-        return self._Value["e_addr"]
+        return int(self._Value["e_addr"])
 
     @property
-    def bsize(self):
-        return self._Value["e_bsize"]
+    def bsize(self) -> int:
+        return int(self._Value["e_bsize"])
 
     @property
-    def bits(self):
-        return self._Value["e_bits"]
+    def bits(self) -> int:
+        return int(self._Value["e_bits"])
 
     @property
-    def bitfields(self):
+    def bitfields(self) -> Dict[str, int]:
         """
         Extract bitfields
 
@@ -477,13 +479,13 @@ class Extent:
         return self._bitfields
 
     @property
-    def state_name(self):
+    def state_name(self) -> str:
         state_mapping = ["Active", "Dirty", "Muzzy", "Retained"]
 
         return state_mapping[self.bitfields["state"]]
 
     @property
-    def has_slab(self):
+    def has_slab(self) -> bool:
         """
         Returns True if the extent is used for small size classes.
         Reference for size in Table 1 at https://jemalloc.net/jemalloc.3.html
@@ -492,14 +494,14 @@ class Extent:
         return self.bitfields["slab"] != 0
 
     @property
-    def is_free(self):
+    def is_free(self) -> bool:
         """
         Returns True if the extent is free.
         """
         pass
 
     @property
-    def pai(self):
+    def pai(self) -> str:
         """
         Page Allocator Interface
         """

--- a/pwndbg/aglib/heap/jemalloc.py
+++ b/pwndbg/aglib/heap/jemalloc.py
@@ -203,7 +203,7 @@ class RTree:
         self._extents = None
 
     @staticmethod
-    def get_rtree() -> RTree:
+    def get_rtree() -> RTree | None:
         try:
             addr = pwndbg.dbg.selected_inferior().symbol_address_from_name("je_arena_emap_global")
             if addr is None:

--- a/pwndbg/aglib/memory.py
+++ b/pwndbg/aglib/memory.py
@@ -343,6 +343,16 @@ def update_min_addr() -> None:
     MMAP_MIN_ADDR = 0 if pwndbg.aglib.qemu.is_qemu_kernel() else 0x8000
 
 
+def fetch_struct_as_dictionary(
+    struct_name: str,
+    struct_address: int | pwndbg.dbg_mod.Value,
+    include_only_fields: Set[str] | None = None,
+    exclude_fields: Set[str] | None = None,
+) -> GdbDict:
+    fetched_struct = get_typed_pointer_value("struct " + struct_name, struct_address)
+    return pack_struct_into_dictionary(fetched_struct, include_only_fields, exclude_fields)
+
+
 def pack_struct_into_dictionary(
     fetched_struct: pwndbg.dbg_mod.Value,
     include_only_fields: Set[str] | None = None,

--- a/pwndbg/dbg/gdb.py
+++ b/pwndbg/dbg/gdb.py
@@ -1046,7 +1046,7 @@ class GDBValue(pwndbg.dbg_mod.Value):
 
     @override
     def __getitem__(self, key: str | int) -> pwndbg.dbg_mod.Value:
-        if self.inner.type.strip_typedefs().code == gdb.TYPE_CODE_STRUCT and isinstance(key, int):
+        if isinstance(key, int) and self.inner.type.strip_typedefs().code == gdb.TYPE_CODE_STRUCT:
             # GDB doesn't normally support indexing fields in a struct by int,
             # so we nudge it a little.
             key = self.inner.type.fields()[key]

--- a/pwndbg/dbg/gdb.py
+++ b/pwndbg/dbg/gdb.py
@@ -1046,7 +1046,7 @@ class GDBValue(pwndbg.dbg_mod.Value):
 
     @override
     def __getitem__(self, key: str | int) -> pwndbg.dbg_mod.Value:
-        if self.inner.type.code == gdb.TYPE_CODE_STRUCT and isinstance(key, int):
+        if self.inner.type.strip_typedefs().code == gdb.TYPE_CODE_STRUCT and isinstance(key, int):
             # GDB doesn't normally support indexing fields in a struct by int,
             # so we nudge it a little.
             key = self.inner.type.fields()[key]


### PR DESCRIPTION
Fixes https://github.com/pwndbg/pwndbg/issues/2502

Changes:
- add nix fmt
- fmt all nix files
- fix Darwin capstone
- fix broken ptmalloc func fetch_chunk_metadata
- port jemalloc

Improve jemalloc times (tests on `heap_jemalloc_heap.out`):
Before:
```
pwndbg> pi
>>> import pwndbg.aglib.heap.jemalloc as jemalloc; import time; a = jemalloc.RTree.get_rtree(); cc=time.time(); c = a.extents; print(time.time()-cc)
10.668266773223877
>>> import pwndbg.aglib.heap.jemalloc as jemalloc; import time; a = jemalloc.RTree.get_rtree(); cc=time.time(); c = a.extents; print(time.time()-cc)
13.819007873535156
>>> import pwndbg.aglib.heap.jemalloc as jemalloc; import time; a = jemalloc.RTree.get_rtree(); cc=time.time(); c = a.extents; print(time.time()-cc)
10.568771839141846
```

After:
```
pwndbg> pi
>>> import pwndbg.aglib.heap.jemalloc as jemalloc; import time; a = jemalloc.RTree.get_rtree(); cc=time.time(); c = a.extents; print(time.time()-cc)
8.293617963790894
>>> import pwndbg.aglib.heap.jemalloc as jemalloc; import time; a = jemalloc.RTree.get_rtree(); cc=time.time(); c = a.extents; print(time.time()-cc)
9.450842380523682
>>> import pwndbg.aglib.heap.jemalloc as jemalloc; import time; a = jemalloc.RTree.get_rtree(); cc=time.time(); c = a.extents; print(time.time()-cc)
7.8145482540130615
>>> quit
```