### PR TITLE
Change DEVELOPING.md to better reflect ported LLDB

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -140,7 +140,7 @@ In addition, you need to import this file in the `load_commands` function in `pw
 # Adding a Configuration Option
 
 ```python
-import pwndbg.config
+import pwndbg
 
 pwndbg.config.add_param("config-name", False, "example configuration option")
 ```


### PR DESCRIPTION
This PR changes `DEVELOPING.md` to better reflect Pwndbg after the LLDB port. It updates some code snippets, adds a few new notes, and explains the debugger-agnostic interfaces.

This is intended to help with https://github.com/pwndbg/pwndbg/issues/2522.