### PR TITLE
Remove `pset` as a command and replace it with the `set` LLDB Pwndbg CLI command override

### DIFF
--- a/pwndbg/dbg/lldb/__init__.py
+++ b/pwndbg/dbg/lldb/__init__.py
@@ -1491,7 +1491,6 @@ class LLDB(pwndbg.dbg_mod.Debugger):
         pwndbg.commands.comments.init()
 
         import pwndbg.dbg.lldb.hooks
-        import pwndbg.dbg.lldb.pset
 
     @override
     def add_command(

--- a/pwndbg/dbg/lldb/pset.py
+++ b/pwndbg/dbg/lldb/pset.py
@@ -8,25 +8,27 @@ import pwndbg.commands
 import pwndbg.lib.config as cfg
 
 
-def pset(name: str, value: str):
+def pset(name: str, value: str) -> bool:
     """
     Parses and sets a Pwndbg configuration value.
     """
     name = name.replace("-", "_")
     if name not in pwndbg.config.params:
         print(message.error(f"Unknown setting '{name}'"))
-        return
+        return False
 
     param = pwndbg.config.params[name]
     try:
         new_value = parse_value(param, value)
     except InvalidParse as e:
         print(message.error(f"Invalid value '{value}' for setting '{name}': {e.message}"))
-        return
+        return False
 
     param.value = new_value
     for trigger in pwndbg.config.triggers[param.name]:
         trigger()
+
+    return True
 
 
 class InvalidParse(Exception):

--- a/pwndbg/dbg/lldb/pset.py
+++ b/pwndbg/dbg/lldb/pset.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import argparse
 from typing import Any
 
 import pwndbg
@@ -8,23 +7,11 @@ import pwndbg.color.message as message
 import pwndbg.commands
 import pwndbg.lib.config as cfg
 
-parser = argparse.ArgumentParser(description="Changes a Pwndbg setting.")
-parser.add_argument(
-    "name",
-    type=str,
-    default=None,
-    help="Name of the setting to be changed",
-)
-parser.add_argument(
-    "value",
-    type=str,
-    default=None,
-    help="Value to change the setting into",
-)
 
-
-@pwndbg.commands.ArgparsedCommand(parser)
-def pset(name, value):
+def pset(name: str, value: str):
+    """
+    Parses and sets a Pwndbg configuration value.
+    """
     name = name.replace("-", "_")
     if name not in pwndbg.config.params:
         print(message.error(f"Unknown setting '{name}'"))
@@ -33,8 +20,8 @@ def pset(name, value):
     param = pwndbg.config.params[name]
     try:
         new_value = parse_value(param, value)
-    except InvalidParse:
-        print(message.error("Invalid value '{value}' for setting '{name}': {e.message}"))
+    except InvalidParse as e:
+        print(message.error(f"Invalid value '{value}' for setting '{name}': {e.message}"))
         return
 
     param.value = new_value
@@ -43,7 +30,9 @@ def pset(name, value):
 
 
 class InvalidParse(Exception):
-    pass
+    def __init__(self, message: str):
+        self.message = message
+        super().__init__()
 
 
 def parse_value(param: pwndbg.lib.config.Parameter, expression: str) -> Any:

--- a/pwndbg/dbg/lldb/pset.py
+++ b/pwndbg/dbg/lldb/pset.py
@@ -21,7 +21,7 @@ def pset(name: str, value: str) -> bool:
     try:
         new_value = parse_value(param, value)
     except InvalidParse as e:
-        print(message.error(f"Invalid value '{value}' for setting '{name}': {e.message}"))
+        print(message.error(f"Invalid value '{value}' for setting '{name}': {e}"))
         return False
 
     param.value = new_value
@@ -32,9 +32,7 @@ def pset(name: str, value: str) -> bool:
 
 
 class InvalidParse(Exception):
-    def __init__(self, message: str):
-        self.message = message
-        super().__init__(message)
+    pass
 
 
 def parse_value(param: pwndbg.lib.config.Parameter, expression: str) -> Any:

--- a/pwndbg/dbg/lldb/pset.py
+++ b/pwndbg/dbg/lldb/pset.py
@@ -34,7 +34,7 @@ def pset(name: str, value: str) -> bool:
 class InvalidParse(Exception):
     def __init__(self, message: str):
         self.message = message
-        super().__init__()
+        super().__init__(message)
 
 
 def parse_value(param: pwndbg.lib.config.Parameter, expression: str) -> Any:

--- a/pwndbg/dbg/lldb/repl/__init__.py
+++ b/pwndbg/dbg/lldb/repl/__init__.py
@@ -352,11 +352,20 @@ def run(startup: List[str] | None = None, debug: bool = False) -> None:
             # to use a name other than "set", or (2) add our settings to the
             # standard debugger settings mechanism, like we do in GDB, but LLDB
             # doesn't support that.
+            warn = False
             if len(bits) != 3:
                 print("Usage: set <name> <value>")
-                continue
+                warn = True
+            else:
+                warn = not pset(bits[1], bits[2])
 
-            pset(bits[1], bits[2])
+            if warn:
+                print(
+                    message.warn(
+                        "The 'set' command is used exclusively for Pwndbg settings. If you meant to change LLDB settings, use the fully spelled-out 'settings' command, instead."
+                    )
+                )
+
             continue
 
         # The command hasn't matched any of our filtered commands, just let LLDB

--- a/pwndbg/dbg/lldb/repl/__init__.py
+++ b/pwndbg/dbg/lldb/repl/__init__.py
@@ -53,6 +53,7 @@ import pwndbg.dbg.lldb
 from pwndbg.color import message
 from pwndbg.dbg import EventType
 from pwndbg.dbg.lldb import LLDB
+from pwndbg.dbg.lldb.pset import pset
 from pwndbg.dbg.lldb.repl.io import IODriver
 from pwndbg.dbg.lldb.repl.io import get_io_driver
 from pwndbg.dbg.lldb.repl.proc import EventHandler
@@ -339,6 +340,23 @@ def run(startup: List[str] | None = None, debug: bool = False) -> None:
             # "connect://" to it. So, from our pespective, it is a separate
             # command, even though it will also end up calling process_launch().
             gdb_remote(driver, relay, bits[1:], dbg)
+            continue
+
+        if bits[0] == "set":
+            # We handle `set` as a command override. We do this so that users
+            # may change Pwndbg-specific settings in the same way that they
+            # would in GDB Pwndbg.
+            #
+            # The alternatives to this are either (1) use a proper command,
+            # but that requires the process to already be running, and needs us
+            # to use a name other than "set", or (2) add our settings to the
+            # standard debugger settings mechanism, like we do in GDB, but LLDB
+            # doesn't support that.
+            if len(bits) != 3:
+                print("Usage: set <name> <value>")
+                continue
+
+            pset(bits[1], bits[2])
             continue
 
         # The command hasn't matched any of our filtered commands, just let LLDB


### PR DESCRIPTION
This PR replaces the `pset` LLDB command with a `set` command override implemented in the LLDB Pwndbg CLI.

For clarity, in this context, a command override is a command that LLDB Pwndbg knows about, but that it doesn't forward to LLDB, instead doing its own processing on it. Other commands in this category include `continue` and `process launch`.

The reason that we choose to implement it this way is that doing so allows us to both execute it before the process starts, and also that it allows us to use the same name `set` as is used in the GDB version of Pwndbg to change Pwndbg settings, as LLDB doesn't allow us to use that name in proper commands.

This should fix #2523, and also remove the need for us to change any of the help strings that have the set command in them when running under LLDB.