### PR TITLE
Add LLDB build check workflows for x86_64-darwin and aarch64-darwin

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -16,42 +16,87 @@ on:
       - '!*.md'
 
 jobs:
-  check_release_build-gdb-x86_64:
-    runs-on: ubuntu-latest
+  check_release_build-gdb:
+    strategy:
+      fail-fast: false
+      matrix:
+        # https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
+        os: [
+          ubuntu-latest,  # x86_64-linux
+          # ubuntu-arm,  # aarch64-linux, not public yet
+        ]
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     steps:
     - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9  # @v3
-    - uses: cachix/install-nix-action@6ed004b9ccb68dbc28e7c85bee15fa93dbd214ac  # @v22
+    - uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72  # @v30
       with:
         nix_path: nixpkgs=channel:nixos-unstable
 
     - name: build pwndbg
-      run: nix build '.#pwndbg' -o result1
+      run: nix build '.#pwndbg' --accept-flake-config -o result
 
     - name: simple run pwndbg
-      run: ./result1/bin/pwndbg <<< 'exit'
+      run: ./result/bin/pwndbg <<< 'exit'
 
-  check_release_build-lldb-x86_64:
-    runs-on: ubuntu-latest
+    - name: configure cache
+      if: github.ref == 'refs/heads/dev'
+      uses: cachix/cachix-action@ad2ddac53f961de1989924296a1f236fcfbaa4fc  # v15
+      with:
+        name: pwndbg
+        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+        signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
+        skipPush: true
+
+    - name: upload cache
+      if: github.ref == 'refs/heads/dev'
+      run: cachix push -v pwndbg ./result
+
+  check_release_build-lldb:
+    strategy:
+      fail-fast: false
+      matrix:
+        # https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
+        os: [
+          ubuntu-latest,  # x86_64-linux
+          # ubuntu-arm,  # aarch64-linux, not public yet
+          macos-13,  # x86_64-darwin
+          macos-15,  # aarch64-darwin
+        ]
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     steps:
     - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9  # @v3
-    - uses: cachix/install-nix-action@6ed004b9ccb68dbc28e7c85bee15fa93dbd214ac  # @v22
+    - uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72  # @v30
       with:
         nix_path: nixpkgs=channel:nixos-unstable
 
     - name: build pwndbg
-      run: nix build '.#pwndbg-lldb' -o result2
+      run: nix build '.#pwndbg-lldb' --accept-flake-config -o result
 
     - name: simple run pwndbg
-      run: ./result2/bin/pwndbg-lldb <<< 'exit'
+      run: ./result/bin/pwndbg-lldb <<< 'exit'
+
+    - name: configure cache
+      if: github.ref == 'refs/heads/dev'
+      uses: cachix/cachix-action@ad2ddac53f961de1989924296a1f236fcfbaa4fc  # v15
+      with:
+        name: pwndbg
+        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+        signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
+        skipPush: true
+
+    - name: upload cache
+      if: github.ref == 'refs/heads/dev'
+      run: cachix push -v pwndbg ./result
+
 
   lock_flake:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
     - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9  # @v3
-    - uses: cachix/install-nix-action@6ed004b9ccb68dbc28e7c85bee15fa93dbd214ac  # @v22
+    - uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72  # @v30
       with:
         nix_path: nixpkgs=channel:nixos-unstable
 
@@ -63,7 +108,7 @@ jobs:
     timeout-minutes: 60
     steps:
     - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9  # @v3
-    - uses: cachix/install-nix-action@6ed004b9ccb68dbc28e7c85bee15fa93dbd214ac  # @v22
+    - uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72  # @v30
       with:
         nix_path: nixpkgs=channel:nixos-unstable
 

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 60
     steps:
     - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9  # @v3
-    - uses: cachix/install-nix-action@6ed004b9ccb68dbc28e7c85bee15fa93dbd214ac  # @v22
+    - uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72  # @v30
       with:
         nix_path: nixpkgs=channel:nixos-unstable
 
@@ -55,7 +55,7 @@ jobs:
 #    timeout-minutes: 60
 #    steps:
 #    - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9  # @v3
-#    - uses: cachix/install-nix-action@6ed004b9ccb68dbc28e7c85bee15fa93dbd214ac  # @v22
+#    - uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72  # @v30
 #      with:
 #        nix_path: nixpkgs=channel:nixos-unstable
 #

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -22,7 +22,7 @@ jobs:
         nix_path: nixpkgs=channel:nixos-unstable
 
     - name: build pwndbg
-      run: nix build '.#pwndbg' -o result-pwndbg
+      run: nix build '.#pwndbg' --accept-flake-config -o result-pwndbg
 
     - name: build rpm
       run: nix build '.#rpm' -o dist-rpm
@@ -60,7 +60,7 @@ jobs:
 #        nix_path: nixpkgs=channel:nixos-unstable
 #
 #    - name: build pwndbg
-#      run: nix build '.#pwndbg' -o result-pwndbg
+#      run: nix build '.#pwndbg' --accept-flake-config -o result-pwndbg
 #
 #    - name: build rpm
 #      run: nix build '.#rpm' -o dist-rpm

--- a/flake.lock
+++ b/flake.lock
@@ -26,11 +26,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1720066371,
-        "narHash": "sha256-uPlLYH2S0ACj0IcgaK9Lsf4spmJoGejR9DotXiXSBZQ=",
+        "lastModified": 1729742964,
+        "narHash": "sha256-B4mzTcQ0FZHdpeWcpDYPERtyjJd/NIuaQ9+BV1h+MpA=",
         "owner": "nix-community",
         "repo": "nix-github-actions",
-        "rev": "622f829f5fe69310a866c8a6cd07e747c44ef820",
+        "rev": "e04df33f62cdcf93d73e9a04142464753a16db67",
         "type": "github"
       },
       "original": {
@@ -41,11 +41,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1728472043,
-        "narHash": "sha256-+fUCZ7C34cp+bY5E9Hw4biRyI+IINVsO+sXFCieWkZA=",
+        "lastModified": 1731245184,
+        "narHash": "sha256-vmLS8+x+gHRv1yzj3n+GTAEObwmhxmkkukB2DwtJRdU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4fa56ac6d86a213b556d4db9b1cb43a51b3e40ec",
+        "rev": "aebe249544837ce42588aa4b2e7972222ba12e8f",
         "type": "github"
       },
       "original": {
@@ -66,11 +66,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1728266256,
-        "narHash": "sha256-RefXB9kqYch6uGT+mo6m3KTbNerfbDYz+EqkLb6YBbs=",
+        "lastModified": 1731205797,
+        "narHash": "sha256-F7N1mxH1VrkVNHR3JGNMRvp9+98KYO4b832KS8Gl2xI=",
         "owner": "nix-community",
         "repo": "poetry2nix",
-        "rev": "8e965fd42c0da4357c53d987bc62b54a954424da",
+        "rev": "f554d27c1544d9c56e5f1f8e2b8aff399803674e",
         "type": "github"
       },
       "original": {
@@ -122,11 +122,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727984844,
-        "narHash": "sha256-xpRqITAoD8rHlXQafYZOLvUXCF6cnZkPfoq67ThN0Hc=",
+        "lastModified": 1730120726,
+        "narHash": "sha256-LqHYIxMrl/1p3/kvm2ir925tZ8DkI0KA10djk8wecSk=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "4446c7a6fc0775df028c5a3f6727945ba8400e64",
+        "rev": "9ef337e492a5555d8e17a51c911ff1f02635be15",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,15 @@
 {
   description = "pwndbg";
 
+  nixConfig = {
+    extra-substituters = [
+      "https://pwndbg.cachix.org"
+    ];
+    extra-trusted-public-keys = [
+      "pwndbg.cachix.org-1:HhtIpP7j73SnuzLgobqqa8LVTng5Qi36sQtNt79cD3k="
+    ];
+  };
+
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
   inputs.poetry2nix = {
     url = "github:nix-community/poetry2nix";

--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -26,26 +26,28 @@ let
       ;
     isDev = true;
   };
-  jemalloc-static = pkgs.jemalloc.overrideAttrs (finalAttrs: previousAttrs: {
-    version = "5.3.0"; # version match setup-dev.sh
-    src = pkgs.fetchurl {
-      url = "https://github.com/jemalloc/jemalloc/releases/download/${finalAttrs.version}/${finalAttrs.pname}-${finalAttrs.version}.tar.bz2";
-      sha256 = "sha256-LbgtHnEZ3z5xt2QCGbbf6EeJvAU3mDw7esT3GJrs/qo=";
-    };
-    configureFlags = (previousAttrs.configureFlags or [ ]) ++ [
-      "--enable-static"
-      "--disable-shared"
-    ];
-    # debug symbols currently required for jemalloc.py type resolution
-    preBuild = ''
-      makeFlagsArray+=(CFLAGS="-O0 -g")
-    '';
-    postInstall = ''
-      ${previousAttrs.postInstall or ""}
-      cp -v lib/libjemalloc.a $out/lib/
-    '';
-    dontStrip = true; # don't strip the debug symbols we added
-  });
+  jemalloc-static = pkgs.jemalloc.overrideAttrs (
+    finalAttrs: previousAttrs: {
+      version = "5.3.0"; # version match setup-dev.sh
+      src = pkgs.fetchurl {
+        url = "https://github.com/jemalloc/jemalloc/releases/download/${finalAttrs.version}/${finalAttrs.pname}-${finalAttrs.version}.tar.bz2";
+        sha256 = "sha256-LbgtHnEZ3z5xt2QCGbbf6EeJvAU3mDw7esT3GJrs/qo=";
+      };
+      configureFlags = (previousAttrs.configureFlags or [ ]) ++ [
+        "--enable-static"
+        "--disable-shared"
+      ];
+      # debug symbols currently required for jemalloc.py type resolution
+      preBuild = ''
+        makeFlagsArray+=(CFLAGS="-O0 -g")
+      '';
+      postInstall = ''
+        ${previousAttrs.postInstall or ""}
+        cp -v lib/libjemalloc.a $out/lib/
+      '';
+      dontStrip = true; # don't strip the debug symbols we added
+    }
+  );
 in
 {
   default = pkgs.mkShell {

--- a/nix/pwndbg.nix
+++ b/nix/pwndbg.nix
@@ -32,14 +32,11 @@ let
     lib = pkgs.lib;
   };
 
-  pwndbgVersion = pkgs.lib.readFile (
-    pkgs.runCommand "pwndbgVersion" { nativeBuildInputs = [ pkgs.python3 ]; } ''
-      mkdir pkg
-      cd pkg
-      cp ${inputs.pwndbg + "/pwndbg/lib/version.py"} version.py
-      python3 -c 'import version; print(version.__version__, end="")' > $out
-    ''
-  );
+  pwndbgVersion = let
+    versionFile = builtins.readFile "${inputs.pwndbg}/pwndbg/lib/version.py";
+    versionMatch = builtins.match ".*\n__version__ = \"([0-9]+.[0-9]+.[0-9]+)\".*" versionFile;
+    version = if versionMatch == null then "unknown" else (builtins.elemAt versionMatch 0);
+  in version;
 
   pwndbg =
     let


### PR DESCRIPTION
Changes:
- bump nixpkgs:
  - glibc-2.39-52 -> glibc-2.40-36
  - lldb-19.1.1 -> lldb-19.1.1
  - gdb-15.1 -> gdb-15.2
  - python3-3.12.5 -> python3-3.12.7
- fix darwin builds
- add workflows
- add cachix to speedup github-actions

How to add cachix secrets:
`nix shell nixpkgs#cachix`

1. Generate cache `Write+Read` token: https://app.cachix.org/organization/pwndbg/cache/pwndbg/settings/authtokens
2. Store it under `secrets.CACHIX_AUTH_TOKEN` in CI secrets
3. Generate Personal Token `Write+Read`  with **expire tomorrow** https://app.cachix.org/personal-auth-tokens
4. Login into cachix `cachix authtoken YOUR-PERSONAL-TOKEN` 
5. Generate keypair using command: `cachix generate-keypair pwndbg`
6. Store private key under `secrets.CACHIX_SIGNING_KEY` in CI secrets


