### PR TITLE
Add checks to avoid dereferencing negative values

### DIFF
--- a/pwndbg/aglib/disasm/arch.py
+++ b/pwndbg/aglib/disasm/arch.py
@@ -316,7 +316,9 @@ class DisassemblyAssistant:
                 # Don't mask immediates - some computations depend on their signed values
                 if op.type is not CS_OP_IMM:
                     op.before_value &= pwndbg.aglib.arch.ptrmask
-                op.symbol = MemoryColor.attempt_colorized_symbol(op.before_value)
+                
+                if op.before_value >= 0:
+                    op.symbol = MemoryColor.attempt_colorized_symbol(op.before_value)
 
                 op.before_value_resolved = self._resolve_used_value(
                     op.before_value, instruction, op, emu

--- a/pwndbg/aglib/disasm/arch.py
+++ b/pwndbg/aglib/disasm/arch.py
@@ -316,7 +316,7 @@ class DisassemblyAssistant:
                 # Don't mask immediates - some computations depend on their signed values
                 if op.type is not CS_OP_IMM:
                     op.before_value &= pwndbg.aglib.arch.ptrmask
-                
+
                 if op.before_value >= 0:
                     op.symbol = MemoryColor.attempt_colorized_symbol(op.before_value)
 

--- a/pwndbg/aglib/vmmap.py
+++ b/pwndbg/aglib/vmmap.py
@@ -33,6 +33,9 @@ def find(address: int | pwndbg.dbg_mod.Value | None) -> pwndbg.lib.memory.Page |
 
     address = int(address)
 
+    if address < 0:
+        return None
+
     for page in get():
         if address in page:
             return page

--- a/pwndbg/color/memory.py
+++ b/pwndbg/color/memory.py
@@ -28,6 +28,10 @@ def sym_name(address: int) -> str | None:
     """
     Retrieves the name of the symbol at the given address, if it exists
     """
+    # The `symbol_name_at_address` function will dereference the passed in address - avoid negative addresses
+    if address < 0:
+        return None
+    
     import pwndbg
 
     return pwndbg.dbg.selected_inferior().symbol_name_at_address(address)
@@ -61,6 +65,9 @@ def attempt_colorized_symbol(address: int) -> str | None:
     """
     Convert address to colorized symbol (if symbol is there), else None
     """
+    if address < 0:
+        return None
+
     symbol = sym_name(address)
     if symbol:
         return get(address, symbol)
@@ -89,6 +96,10 @@ def get(
         prefix(str | None): Optional text to set at beginning in the return value string.
     """
     address = int(address)
+
+    if address < 0:
+        return None
+
     page = pwndbg.aglib.vmmap.find(address)
 
     color: Callable[[str], str]

--- a/pwndbg/color/memory.py
+++ b/pwndbg/color/memory.py
@@ -31,7 +31,7 @@ def sym_name(address: int) -> str | None:
     # The `symbol_name_at_address` function will dereference the passed in address - avoid negative addresses
     if address < 0:
         return None
-    
+
     import pwndbg
 
     return pwndbg.dbg.selected_inferior().symbol_name_at_address(address)

--- a/pwndbg/gdblib/vmmap.py
+++ b/pwndbg/gdblib/vmmap.py
@@ -203,6 +203,9 @@ def find(
 
     address = int(address)
 
+    if address < 0:
+        return None
+
     for page in get():
         if address in page:
             return page
@@ -240,6 +243,8 @@ def explore(address_maybe: int) -> pwndbg.lib.memory.Page | None:
 
         Also assumes the entire contiguous section has the same permission.
     """
+    if address_maybe < 0:
+        return None
 
     address_maybe = pwndbg.lib.memory.page_align(address_maybe)
 


### PR DESCRIPTION
During developing changes for #2483, issues related to dereferencing negative values during calls to `vmmap.find` and colorizing addresses appeared due to changing the type of error that was allowed in the `try/expect` clauses (`gdb.MemoryError`) around GDB/LLDB memory read operations.

This PR adds a sanity check to make sure the address is non-negative when making these calls. I added this check to the top of functions that make these memory calls (vmmap.find). Additionally, to reduce the depth of the call stack in many causes (there's something multiple intermediate functions before the address is passed to a memory read), this check was added to top of the some other functions that logically shouldn't make calls with negative addresses.