### PR TITLE
Port a lot of commands into debugger agnostic api

### DIFF
--- a/pwndbg/color/disasm.py
+++ b/pwndbg/color/disasm.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import List
 
+import pwndbg.aglib.nearpc
 import pwndbg.aglib.regs
 import pwndbg.chain
 import pwndbg.color.context as C

--- a/pwndbg/color/disasm.py
+++ b/pwndbg/color/disasm.py
@@ -6,6 +6,7 @@ import pwndbg.aglib.nearpc
 import pwndbg.aglib.regs
 import pwndbg.chain
 import pwndbg.color.context as C
+import pwndbg.aglib.nearpc
 from pwndbg.aglib.disasm.instruction import ALL_JUMP_GROUPS
 from pwndbg.aglib.disasm.instruction import InstructionCondition
 from pwndbg.aglib.disasm.instruction import PwndbgInstruction
@@ -81,7 +82,7 @@ def instructions_and_padding(instructions: List[PwndbgInstruction]) -> List[str]
                 current_group = []
         else:
             if ins.syscall is not None:
-                asm += f" <{pwndbg.gdblib.nearpc.c.syscall_name('SYS_' + ins.syscall_name)}>"
+                asm += f" <{pwndbg.aglib.nearpc.c.syscall_name('SYS_' + ins.syscall_name)}>"
 
             # Padding the string for a nicer output
             # This path calculates the padding for each instruction - even if there we don't have annotations for it.

--- a/pwndbg/color/disasm.py
+++ b/pwndbg/color/disasm.py
@@ -6,7 +6,6 @@ import pwndbg.aglib.nearpc
 import pwndbg.aglib.regs
 import pwndbg.chain
 import pwndbg.color.context as C
-import pwndbg.aglib.nearpc
 from pwndbg.aglib.disasm.instruction import ALL_JUMP_GROUPS
 from pwndbg.aglib.disasm.instruction import InstructionCondition
 from pwndbg.aglib.disasm.instruction import PwndbgInstruction

--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -696,7 +696,6 @@ def load_commands() -> None:
         import pwndbg.commands.branch
         import pwndbg.commands.cymbol
         import pwndbg.commands.dt
-        import pwndbg.commands.gdt
         import pwndbg.commands.godbg
         import pwndbg.commands.got
         import pwndbg.commands.got_tracking
@@ -737,6 +736,7 @@ def load_commands() -> None:
     import pwndbg.commands.dumpargs
     import pwndbg.commands.elf
     import pwndbg.commands.flags
+    import pwndbg.commands.gdt
     import pwndbg.commands.ghidra
     import pwndbg.commands.heap
     import pwndbg.commands.hex2ptr

--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -720,7 +720,6 @@ def load_commands() -> None:
         import pwndbg.commands.pcplist
         import pwndbg.commands.peda
         import pwndbg.commands.plist
-        import pwndbg.commands.radare2
         import pwndbg.commands.reload
         import pwndbg.commands.rop
         import pwndbg.commands.ropper
@@ -756,6 +755,7 @@ def load_commands() -> None:
     import pwndbg.commands.pie
     import pwndbg.commands.probeleak
     import pwndbg.commands.procinfo
+    import pwndbg.commands.radare2
     import pwndbg.commands.retaddr
     import pwndbg.commands.rizin
     import pwndbg.commands.search

--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -730,7 +730,6 @@ def load_commands() -> None:
         import pwndbg.commands.slab
         import pwndbg.commands.start
         import pwndbg.commands.tips
-        import pwndbg.commands.tls
         import pwndbg.commands.version
 
     import pwndbg.commands.canary
@@ -763,6 +762,7 @@ def load_commands() -> None:
     import pwndbg.commands.sigreturn
     import pwndbg.commands.spray
     import pwndbg.commands.telescope
+    import pwndbg.commands.tls
     import pwndbg.commands.valist
     import pwndbg.commands.vmmap
     import pwndbg.commands.windbg

--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -709,7 +709,6 @@ def load_commands() -> None:
         import pwndbg.commands.onegadget
         import pwndbg.commands.pcplist
         import pwndbg.commands.peda
-        import pwndbg.commands.plist
         import pwndbg.commands.reload
         import pwndbg.commands.rop
         import pwndbg.commands.ropper
@@ -755,6 +754,7 @@ def load_commands() -> None:
     import pwndbg.commands.pie
     import pwndbg.commands.probeleak
     import pwndbg.commands.procinfo
+    import pwndbg.commands.plist
     import pwndbg.commands.radare2
     import pwndbg.commands.retaddr
     import pwndbg.commands.rizin

--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -704,7 +704,6 @@ def load_commands() -> None:
         import pwndbg.commands.heap_tracking
         import pwndbg.commands.ida
         import pwndbg.commands.ignore
-        import pwndbg.commands.integration
         import pwndbg.commands.ipython_interactive
         import pwndbg.commands.kbase
         import pwndbg.commands.kchecksec
@@ -742,6 +741,7 @@ def load_commands() -> None:
     import pwndbg.commands.heap
     import pwndbg.commands.hex2ptr
     import pwndbg.commands.hexdump
+    import pwndbg.commands.integration
     import pwndbg.commands.leakfind
     import pwndbg.commands.linkmap
     import pwndbg.commands.memoize

--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -690,7 +690,6 @@ def load_commands() -> None:
         import pwndbg.commands.aslr
         import pwndbg.commands.asm
         import pwndbg.commands.attachp
-        import pwndbg.commands.auxv
         import pwndbg.commands.binder
         import pwndbg.commands.binja
         import pwndbg.commands.branch
@@ -723,6 +722,7 @@ def load_commands() -> None:
         import pwndbg.commands.tips
         import pwndbg.commands.version
 
+    import pwndbg.commands.auxv
     import pwndbg.commands.canary
     import pwndbg.commands.checksec
     import pwndbg.commands.comments

--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -695,7 +695,6 @@ def load_commands() -> None:
         import pwndbg.commands.binja
         import pwndbg.commands.branch
         import pwndbg.commands.cymbol
-        import pwndbg.commands.dt
         import pwndbg.commands.godbg
         import pwndbg.commands.got
         import pwndbg.commands.got_tracking
@@ -733,6 +732,7 @@ def load_commands() -> None:
     import pwndbg.commands.cyclic
     import pwndbg.commands.dev
     import pwndbg.commands.distance
+    import pwndbg.commands.dt
     import pwndbg.commands.dumpargs
     import pwndbg.commands.elf
     import pwndbg.commands.flags

--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -714,7 +714,6 @@ def load_commands() -> None:
         import pwndbg.commands.klookup
         import pwndbg.commands.kversion
         import pwndbg.commands.linkmap
-        import pwndbg.commands.memoize
         import pwndbg.commands.onegadget
         import pwndbg.commands.pcplist
         import pwndbg.commands.peda
@@ -745,6 +744,7 @@ def load_commands() -> None:
     import pwndbg.commands.hex2ptr
     import pwndbg.commands.hexdump
     import pwndbg.commands.leakfind
+    import pwndbg.commands.memoize
     import pwndbg.commands.misc
     import pwndbg.commands.mmap
     import pwndbg.commands.mprotect

--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -687,7 +687,6 @@ def load_commands() -> None:
     if pwndbg.dbg.is_gdblib_available():
         import pwndbg.commands.ai
         import pwndbg.commands.argv
-        import pwndbg.commands.aslr
         import pwndbg.commands.attachp
         import pwndbg.commands.binder
         import pwndbg.commands.binja
@@ -721,6 +720,7 @@ def load_commands() -> None:
         import pwndbg.commands.tips
         import pwndbg.commands.version
 
+    import pwndbg.commands.aslr
     import pwndbg.commands.asm
     import pwndbg.commands.auxv
     import pwndbg.commands.canary

--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -713,7 +713,6 @@ def load_commands() -> None:
         import pwndbg.commands.killthreads
         import pwndbg.commands.klookup
         import pwndbg.commands.kversion
-        import pwndbg.commands.linkmap
         import pwndbg.commands.onegadget
         import pwndbg.commands.pcplist
         import pwndbg.commands.peda
@@ -744,6 +743,7 @@ def load_commands() -> None:
     import pwndbg.commands.hex2ptr
     import pwndbg.commands.hexdump
     import pwndbg.commands.leakfind
+    import pwndbg.commands.linkmap
     import pwndbg.commands.memoize
     import pwndbg.commands.misc
     import pwndbg.commands.mmap

--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -697,7 +697,6 @@ def load_commands() -> None:
         import pwndbg.commands.cymbol
         import pwndbg.commands.dt
         import pwndbg.commands.gdt
-        import pwndbg.commands.ghidra
         import pwndbg.commands.godbg
         import pwndbg.commands.got
         import pwndbg.commands.got_tracking
@@ -738,6 +737,7 @@ def load_commands() -> None:
     import pwndbg.commands.dumpargs
     import pwndbg.commands.elf
     import pwndbg.commands.flags
+    import pwndbg.commands.ghidra
     import pwndbg.commands.heap
     import pwndbg.commands.hex2ptr
     import pwndbg.commands.hexdump

--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -688,7 +688,6 @@ def load_commands() -> None:
         import pwndbg.commands.ai
         import pwndbg.commands.argv
         import pwndbg.commands.aslr
-        import pwndbg.commands.asm
         import pwndbg.commands.attachp
         import pwndbg.commands.binder
         import pwndbg.commands.binja
@@ -722,6 +721,7 @@ def load_commands() -> None:
         import pwndbg.commands.tips
         import pwndbg.commands.version
 
+    import pwndbg.commands.asm
     import pwndbg.commands.auxv
     import pwndbg.commands.canary
     import pwndbg.commands.checksec

--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -715,7 +715,6 @@ def load_commands() -> None:
         import pwndbg.commands.kversion
         import pwndbg.commands.linkmap
         import pwndbg.commands.memoize
-        import pwndbg.commands.misc
         import pwndbg.commands.onegadget
         import pwndbg.commands.pcplist
         import pwndbg.commands.peda
@@ -746,6 +745,7 @@ def load_commands() -> None:
     import pwndbg.commands.hex2ptr
     import pwndbg.commands.hexdump
     import pwndbg.commands.leakfind
+    import pwndbg.commands.misc
     import pwndbg.commands.mmap
     import pwndbg.commands.mprotect
     import pwndbg.commands.nearpc

--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -720,7 +720,6 @@ def load_commands() -> None:
         import pwndbg.commands.pcplist
         import pwndbg.commands.peda
         import pwndbg.commands.plist
-        import pwndbg.commands.procinfo
         import pwndbg.commands.radare2
         import pwndbg.commands.reload
         import pwndbg.commands.rizin
@@ -758,6 +757,7 @@ def load_commands() -> None:
     import pwndbg.commands.patch
     import pwndbg.commands.pie
     import pwndbg.commands.probeleak
+    import pwndbg.commands.procinfo
     import pwndbg.commands.retaddr
     import pwndbg.commands.search
     import pwndbg.commands.sigreturn

--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -722,7 +722,6 @@ def load_commands() -> None:
         import pwndbg.commands.plist
         import pwndbg.commands.radare2
         import pwndbg.commands.reload
-        import pwndbg.commands.rizin
         import pwndbg.commands.rop
         import pwndbg.commands.ropper
         import pwndbg.commands.segments
@@ -758,6 +757,7 @@ def load_commands() -> None:
     import pwndbg.commands.probeleak
     import pwndbg.commands.procinfo
     import pwndbg.commands.retaddr
+    import pwndbg.commands.rizin
     import pwndbg.commands.search
     import pwndbg.commands.sigreturn
     import pwndbg.commands.spray

--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -752,9 +752,9 @@ def load_commands() -> None:
     import pwndbg.commands.p2p
     import pwndbg.commands.patch
     import pwndbg.commands.pie
+    import pwndbg.commands.plist
     import pwndbg.commands.probeleak
     import pwndbg.commands.procinfo
-    import pwndbg.commands.plist
     import pwndbg.commands.radare2
     import pwndbg.commands.retaddr
     import pwndbg.commands.rizin

--- a/pwndbg/commands/ai.py
+++ b/pwndbg/commands/ai.py
@@ -16,16 +16,15 @@ from typing import List
 import gdb
 
 import pwndbg
-import pwndbg.ghidra
+import pwndbg.aglib.nearpc
+import pwndbg.aglib.regs
 import pwndbg.color.message as M
 import pwndbg.commands
-import pwndbg.aglib.regs
-import pwndbg.aglib.nearpc
 import pwndbg.commands.context
 import pwndbg.commands.telescope
+import pwndbg.ghidra
 import pwndbg.lib.strings
 from pwndbg.commands import CommandCategory
-
 
 pwndbg.config.add_param(
     "ai-openai-api-key",

--- a/pwndbg/commands/ai.py
+++ b/pwndbg/commands/ai.py
@@ -16,48 +16,51 @@ from typing import List
 import gdb
 
 import pwndbg
+import pwndbg.ghidra
 import pwndbg.color.message as M
 import pwndbg.commands
+import pwndbg.aglib.regs
+import pwndbg.aglib.nearpc
+import pwndbg.commands.context
+import pwndbg.commands.telescope
 import pwndbg.lib.strings
-from pwndbg import config
 from pwndbg.commands import CommandCategory
-from pwndbg.commands import context
-from pwndbg.gdblib import regs as REGS
 
-config.add_param(
+
+pwndbg.config.add_param(
     "ai-openai-api-key",
     "",
     "OpenAI API key (will default to OPENAI_API_KEY environment variable if not set)",
 )
-config.add_param(
+pwndbg.config.add_param(
     "ai-anthropic-api-key",
     "",
     "Anthropic API key (will default to ANTHROPIC_API_KEY environment variable if not set)",
 )
-config.add_param(
+pwndbg.config.add_param(
     "ai-history-size",
     3,
     "maximum number of successive questions and answers to maintain in the prompt for the ai command",
 )
-config.add_param(
+pwndbg.config.add_param(
     "ai-stack-depth", 16, "rows of stack context to include in the prompt for the ai command"
 )
-config.add_param(
+pwndbg.config.add_param(
     "ai-model",
     "gpt-3.5-turbo",  # the new conversational model
     "the name of the OpenAI large language model to query (see <https://platform.openai.com/docs/models> for details)",
 )
-config.add_param(
+pwndbg.config.add_param(
     "ai-temperature",
     0,
     "the temperature specification for the LLM query (this controls the degree of randomness in the response -- see <https://beta.openai.com/docs/api-reference/parameters> for details)",
 )
-config.add_param(
+pwndbg.config.add_param(
     "ai-max-tokens",
     100,
     "the maximum number of tokens to return in the response (see <https://beta.openai.com/docs/api-reference/parameters> for details)",
 )
-config.add_param(
+pwndbg.config.add_param(
     "ai-show-usage",
     False,
     "whether to show how many tokens are used with each OpenAI API call",
@@ -85,27 +88,27 @@ def set_dummy_mode(d=True) -> None:
 
 
 def get_openai_api_key():
-    if config.ai_openai_api_key.value:
-        return config.ai_openai_api_key.value
+    if pwndbg.config.ai_openai_api_key.value:
+        return pwndbg.config.ai_openai_api_key.value
     key = os.environ.get("OPENAI_API_KEY", "")
     if key:
         print(M.warn("Setting OpenAI API key from OPENAI_API_KEY environment variable."))
-        config.ai_openai_api_key.value = key
+        pwndbg.config.ai_openai_api_key.value = key
         return key
     else:
-        return config.ai_openai_api_key.value
+        return pwndbg.config.ai_openai_api_key.value
 
 
 def get_anthropic_api_key():
-    if config.ai_anthropic_api_key.value:
-        return config.ai_anthropic_api_key.value
+    if pwndbg.config.ai_anthropic_api_key.value:
+        return pwndbg.config.ai_anthropic_api_key.value
     key = os.environ.get("ANTHROPIC_API_KEY", "")
     if key:
         print(M.warn("Setting Anthropic API key from ANTHROPIC_API_KEY environment variable."))
-        config.ai_anthropic_api_key.value = key
+        pwndbg.config.ai_anthropic_api_key.value = key
         return key
     else:
-        return config.ai_anthropic_api_key.value
+        return pwndbg.config.ai_anthropic_api_key.value
 
 
 def build_prompt(question, command=None):
@@ -150,13 +153,13 @@ def build_context_prompt_body():
     ## First, get the current GDB context
     ## Let's begin with the assembly near the current instruction
     try:
-        asm_rows = pwndbg.gdblib.nearpc.nearpc(emulate=True, lines=16)
+        asm_rows = pwndbg.aglib.nearpc.nearpc(emulate=True, lines=16)
         asm = "\n".join(asm_rows)
     except Exception as e:
         print(M.error(f"Error: {e}"))
         asm = gdb.execute("x/16i $pc", to_string=True)
     ## Next, let's get the registers
-    regs_rows = context.get_regs()
+    regs_rows = pwndbg.commands.context.get_regs()
     regs = "\n".join(regs_rows)
     flags = None
     try:
@@ -169,9 +172,10 @@ def build_context_prompt_body():
             flags = re.search(r"\[(.*)\]", flags).group(1)
         except Exception:
             pass
+
     ## Finally, let's get the stack
     stack_rows = pwndbg.commands.telescope.telescope(
-        REGS.sp, to_string=True, count=config.ai_stack_depth
+        pwndbg.aglib.regs.sp, to_string=True, count=pwndbg.config.ai_stack_depth
     )
     stack = "\n".join(stack_rows)
     ## and the backtrace
@@ -282,7 +286,7 @@ def query_openai_chat(prompt, model="gpt-3.5-turbo", max_tokens=100, temperature
         url,
         data=json.dumps(data),
         headers={"Content-Type": "application/json"},
-        auth=("Bearer", config.ai_openai_api_key),
+        auth=("Bearer", pwndbg.config.ai_openai_api_key),
     )
     res = r.json()
     if verbosity > 0:
@@ -292,7 +296,7 @@ def query_openai_chat(prompt, model="gpt-3.5-turbo", max_tokens=100, temperature
             error_message = f"{res['error']['message']}: {res['error']['type']}"
             raise Exception(error_message)
         raise Exception(res)
-    if config.ai_show_usage:
+    if pwndbg.config.ai_show_usage:
         print(
             M.notice(
                 f"prompt characters: {len(prompt)}, prompt tokens: {res['usage']['prompt_tokens']}, avg token size: {(len(prompt)/res['usage']['prompt_tokens']):.2f}, completion tokens: {res['usage']['completion_tokens']}, total tokens: {res['usage']['total_tokens']}"
@@ -321,7 +325,7 @@ def query_openai_completions(prompt, model="text-davinci-003", max_tokens=100, t
         url,
         data=json.dumps(data),
         headers={"Content-Type": "application/json"},
-        auth=("Bearer", config.ai_openai_api_key),
+        auth=("Bearer", pwndbg.config.ai_openai_api_key),
     )
     res = r.json()
     if verbosity > 0:
@@ -332,7 +336,7 @@ def query_openai_completions(prompt, model="text-davinci-003", max_tokens=100, t
             raise Exception(error_message)
         raise Exception(res)
     reply = res["choices"][0]["text"]
-    if config.ai_show_usage:
+    if pwndbg.config.ai_show_usage:
         print(
             M.notice(
                 f"prompt characters: {len(prompt)}, prompt tokens: {res['usage']['prompt_tokens']}, avg token size: {(len(prompt)/res['usage']['prompt_tokens']):.2f}, completion tokens: {res['usage']['completion_tokens']}, total tokens: {res['usage']['total_tokens']}"
@@ -367,7 +371,7 @@ def query_anthropic(prompt, model="claude-v1", max_tokens=100, temperature=0.0):
         "stop_sequences": ["\n\nHuman:"],
     }
     headers = {
-        "x-api-key": config.ai_anthropic_api_key.value,
+        "x-api-key": pwndbg.config.ai_anthropic_api_key.value,
         "Content-Type": "application/json",
         "anthropic-version": "2023-06-01",
     }
@@ -383,7 +387,7 @@ def query_anthropic(prompt, model="claude-v1", max_tokens=100, temperature=0.0):
 
 def get_openai_models():
     url = "https://api.openai.com/v1/models"
-    r = _requests().get(url, auth=("Bearer", config.ai_openai_api_key))
+    r = _requests().get(url, auth=("Bearer", pwndbg.config.ai_openai_api_key))
     res = r.json()
     if verbosity > 0:
         print(M.warn(pprint.pformat(res)))
@@ -441,11 +445,11 @@ def ai(question, model, temperature, max_tokens, verbose, list_models=False, com
         return
     verbosity = int(verbose)
     if model is None:
-        model = config.ai_model.value
+        model = pwndbg.config.ai_model.value
     if temperature is None:
-        temperature = config.ai_temperature.value
+        temperature = pwndbg.config.ai_temperature.value
     if max_tokens is None:
-        max_tokens = config.ai_max_tokens.value
+        max_tokens = pwndbg.config.ai_max_tokens.value
 
     question = " ".join(question).strip()
     current_pc = gdb.execute("info reg $pc", to_string=True)
@@ -466,7 +470,7 @@ def ai(question, model, temperature, max_tokens, verbose, list_models=False, com
     last_question.append(question)
     last_answer.append(res)
     last_pc = current_pc
-    if len(last_question) > config.ai_history_size:
+    if len(last_question) > pwndbg.config.ai_history_size:
         last_question.pop(0)
         last_answer.pop(0)
 

--- a/pwndbg/commands/aslr.py
+++ b/pwndbg/commands/aslr.py
@@ -77,11 +77,11 @@ def aslr(state=None) -> None:
     if state:
         if pwndbg.dbg.is_gdblib_available():
             gdb.execute(f"set disable-randomization {options[state]}", from_tty=False, to_string=True)
+
+            if pwndbg.aglib.proc.alive:
+                print("Change will take effect when the process restarts")
         else:
             print("Could not change ASLR on LLDB")
-
-        if pwndbg.aglib.proc.alive:
-            print("Change will take effect when the process restarts")
 
     aslr, method = check_aslr()
 

--- a/pwndbg/commands/aslr.py
+++ b/pwndbg/commands/aslr.py
@@ -1,14 +1,57 @@
 from __future__ import annotations
 
 import argparse
-
-import gdb
+from typing import Tuple
 
 import pwndbg.commands
-import pwndbg.gdblib.proc
-import pwndbg.gdblib.vmmap
+import pwndbg.dbg
+import pwndbg.aglib.proc
+import pwndbg.aglib.vmmap
+import pwndbg.aglib.qemu
+import pwndbg.aglib.file
 from pwndbg.color import message
 from pwndbg.commands import CommandCategory
+
+if pwndbg.dbg.is_gdblib_available():
+    import gdb
+
+def check_aslr() -> Tuple[bool | None, str]:
+    """
+    Detects the ASLR status. Returns True, False or None.
+
+    None is returned when we can't detect ASLR.
+    """
+    # QEMU does not support this concept.
+    if pwndbg.aglib.qemu.is_qemu():
+        return None, "Could not detect ASLR on QEMU targets"
+
+    # Systemwide ASLR is disabled
+    try:
+        data = pwndbg.aglib.file.get("/proc/sys/kernel/randomize_va_space")
+        if b"0" in data:
+            return False, "kernel.randomize_va_space == 0"
+    except Exception:
+        print("Could not check ASLR: can't read randomize_va_space")
+
+    # Check the personality of the process
+    if pwndbg.aglib.proc.alive:
+        try:
+            data = pwndbg.aglib.file.get("/proc/%i/personality" % pwndbg.aglib.proc.tid)
+            personality = int(data, 16)
+            return (personality & 0x40000 == 0), "read status from process' personality"
+        except Exception:
+            print("Could not check ASLR: can't read process' personality")
+
+    if not pwndbg.dbg.is_gdblib_available():
+        return None, "Could not detect ASLR on LLDB"
+
+    # Just go with whatever GDB says it did.
+    #
+    # This should usually be identical to the above, but we may not have
+    # access to procfs.
+    output = gdb.execute("show disable-randomization", to_string=True)
+    return ("is off." in output), "show disable-randomization"
+
 
 options = {"on": "off", "off": "on"}
 
@@ -32,12 +75,15 @@ parser.add_argument(
 @pwndbg.commands.ArgparsedCommand(parser, category=CommandCategory.LINUX)
 def aslr(state=None) -> None:
     if state:
-        gdb.execute(f"set disable-randomization {options[state]}", from_tty=False, to_string=True)
+        if pwndbg.dbg.is_gdblib_available():
+            gdb.execute(f"set disable-randomization {options[state]}", from_tty=False, to_string=True)
+        else:
+            print("Could not change ASLR on LLDB")
 
-        if pwndbg.gdblib.proc.alive:
+        if pwndbg.aglib.proc.alive:
             print("Change will take effect when the process restarts")
 
-    aslr, method = pwndbg.gdblib.vmmap.check_aslr()
+    aslr, method = check_aslr()
 
     if aslr is True:
         status = message.on("ON")

--- a/pwndbg/commands/aslr.py
+++ b/pwndbg/commands/aslr.py
@@ -3,17 +3,18 @@ from __future__ import annotations
 import argparse
 from typing import Tuple
 
+import pwndbg.aglib.file
+import pwndbg.aglib.proc
+import pwndbg.aglib.qemu
+import pwndbg.aglib.vmmap
 import pwndbg.commands
 import pwndbg.dbg
-import pwndbg.aglib.proc
-import pwndbg.aglib.vmmap
-import pwndbg.aglib.qemu
-import pwndbg.aglib.file
 from pwndbg.color import message
 from pwndbg.commands import CommandCategory
 
 if pwndbg.dbg.is_gdblib_available():
     import gdb
+
 
 def check_aslr() -> Tuple[bool | None, str]:
     """
@@ -76,7 +77,9 @@ parser.add_argument(
 def aslr(state=None) -> None:
     if state:
         if pwndbg.dbg.is_gdblib_available():
-            gdb.execute(f"set disable-randomization {options[state]}", from_tty=False, to_string=True)
+            gdb.execute(
+                f"set disable-randomization {options[state]}", from_tty=False, to_string=True
+            )
 
             if pwndbg.aglib.proc.alive:
                 print("Change will take effect when the process restarts")

--- a/pwndbg/commands/binder.py
+++ b/pwndbg/commands/binder.py
@@ -9,7 +9,8 @@ import gdb
 
 import pwndbg.color as C
 import pwndbg.commands
-import pwndbg.gdblib.symbol
+import pwndbg.dbg
+import pwndbg.aglib.memory
 from pwndbg.commands import CommandCategory
 from pwndbg.gdblib.kernel.macros import container_of
 from pwndbg.gdblib.kernel.macros import for_each_entry
@@ -356,7 +357,7 @@ class BinderVisitor:
 
     def format_spinlock(self, lock: gdb.Value) -> str:
         raw_lock = lock["rlock"]["raw_lock"]
-        val = pwndbg.gdblib.memory.ushort(int(raw_lock.address))
+        val = pwndbg.aglib.memory.ushort(int(raw_lock.address))
         locked = val & 0xFF
         pending = val >> 8
 
@@ -372,6 +373,6 @@ parser = argparse.ArgumentParser(description="Show Android Binder information")
 @pwndbg.commands.OnlyWhenPagingEnabled
 def binder():
     log.warning("This command is a work in progress and may not work as expected.")
-    procs_addr = pwndbg.gdblib.symbol.address("binder_procs")
+    procs_addr = pwndbg.dbg.selected_inferior().symbol_address_from_name("binder_procs")
     bv = BinderVisitor(procs_addr)
     bv.visit()

--- a/pwndbg/commands/binder.py
+++ b/pwndbg/commands/binder.py
@@ -7,10 +7,10 @@ from typing import Optional
 
 import gdb
 
+import pwndbg.aglib.memory
 import pwndbg.color as C
 import pwndbg.commands
 import pwndbg.dbg
-import pwndbg.aglib.memory
 from pwndbg.commands import CommandCategory
 from pwndbg.gdblib.kernel.macros import container_of
 from pwndbg.gdblib.kernel.macros import for_each_entry

--- a/pwndbg/commands/binja.py
+++ b/pwndbg/commands/binja.py
@@ -4,10 +4,10 @@ from typing import Tuple
 
 import gdb
 
+import pwndbg.aglib.proc
+import pwndbg.aglib.regs
 import pwndbg.commands
 import pwndbg.gdblib.functions
-import pwndbg.aglib.regs
-import pwndbg.aglib.proc
 import pwndbg.integration.binja
 from pwndbg.color import message
 from pwndbg.commands import CommandCategory

--- a/pwndbg/commands/binja.py
+++ b/pwndbg/commands/binja.py
@@ -5,9 +5,9 @@ from typing import Tuple
 import gdb
 
 import pwndbg.commands
-import pwndbg.gdblib.events
 import pwndbg.gdblib.functions
-import pwndbg.gdblib.regs
+import pwndbg.aglib.regs
+import pwndbg.aglib.proc
 import pwndbg.integration.binja
 from pwndbg.color import message
 from pwndbg.commands import CommandCategory
@@ -24,7 +24,7 @@ def bn_sync(*args) -> None:
     """
     Synchronize Binary Ninja's cursor with GDB
     """
-    pwndbg.integration.binja.navigate_to(pwndbg.gdblib.regs.pc)
+    pwndbg.integration.binja.navigate_to(pwndbg.aglib.regs.pc)
 
 
 @pwndbg.gdblib.functions.GdbFunction()
@@ -44,14 +44,14 @@ def bn_var(name_val: gdb.Value) -> int | None:
     """Lookup a stack variable's address by name from Binary Ninja."""
     name = name_val.string()
     conf_and_offset: Tuple[int, int] | None = pwndbg.integration.binja._bn.get_var_offset_from_sp(
-        pwndbg.integration.binja.l2r(pwndbg.gdblib.regs.pc), name
+        pwndbg.integration.binja.l2r(pwndbg.aglib.regs.pc), name
     )
     if conf_and_offset is None:
         return None
     (conf, offset) = conf_and_offset
     if conf < 64:
         print(message.warn(f"Warning: Stack offset only has {conf / 255 * 100:.2f}% confidence"))
-    return pwndbg.gdblib.regs.sp + offset
+    return pwndbg.aglib.regs.sp + offset
 
 
 @pwndbg.gdblib.functions.GdbFunction()
@@ -65,10 +65,10 @@ def bn_eval(expr: gdb.Value) -> int | None:
     Also adds a $piebase magic variable with the computed executable base.
     """
     magic_vars = {}
-    for r in pwndbg.gdblib.regs.current:
-        v = pwndbg.gdblib.regs[r]
+    for r in pwndbg.aglib.regs.current:
+        v = pwndbg.aglib.regs[r]
         if v is not None:
             magic_vars[r] = v
-    magic_vars["piebase"] = pwndbg.gdblib.proc.binary_base_addr
+    magic_vars["piebase"] = pwndbg.aglib.proc.binary_base_addr
     ret: int | None = pwndbg.integration.binja._bn.parse_expr(expr.string(), magic_vars)
     return ret

--- a/pwndbg/commands/dt.py
+++ b/pwndbg/commands/dt.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 import argparse
 
-import gdb
-
 import pwndbg.color
 import pwndbg.commands
-import pwndbg.gdblib.dt
-import pwndbg.gdblib.vmmap
+import pwndbg.dbg
+
+if pwndbg.dbg.is_gdblib_available():
+    import pwndbg.gdblib.dt
 
 parser = argparse.ArgumentParser(
     formatter_class=argparse.RawTextHelpFormatter,
@@ -24,7 +24,7 @@ parser.add_argument(
 
 
 @pwndbg.commands.ArgparsedCommand(parser)
-def dt(typename: str, address: int | gdb.Value | None = None) -> None:
+def dt(typename: str, address: int | pwndbg.dbg_mod.Value | None = None) -> None:
     """
     Dump out information on a type (e.g. ucontext_t).
 

--- a/pwndbg/commands/dt.py
+++ b/pwndbg/commands/dt.py
@@ -30,6 +30,9 @@ def dt(typename: str, address: int | pwndbg.dbg_mod.Value | None = None) -> None
 
     Optionally overlay that information at an address.
     """
-    if address is not None:
+    if isinstance(address, pwndbg.dbg_mod.Value):
+        address = int(address)
+    elif address is not None:
         address = pwndbg.commands.fix(str(address))
+
     print(pwndbg.gdblib.dt.dt(typename, addr=address))

--- a/pwndbg/commands/godbg.py
+++ b/pwndbg/commands/godbg.py
@@ -2,12 +2,8 @@ from __future__ import annotations
 
 import argparse
 
-import pwndbg.aglib.arch
 import pwndbg.commands
-import pwndbg.gdblib.config
 import pwndbg.gdblib.godbg
-import pwndbg.gdblib.memory
-import pwndbg.gdblib.regs
 from pwndbg.commands import CommandCategory
 
 parser = argparse.ArgumentParser(

--- a/pwndbg/commands/got.py
+++ b/pwndbg/commands/got.py
@@ -7,16 +7,16 @@ from typing import Union
 
 from elftools.elf.elffile import ELFFile
 
-import pwndbg.aglib.arch
 import pwndbg.chain
 import pwndbg.color.memory as M
 import pwndbg.commands
 import pwndbg.enhance
-import pwndbg.gdblib.file
+import pwndbg.aglib.arch
+import pwndbg.aglib.file
 import pwndbg.gdblib.info
-import pwndbg.gdblib.proc
-import pwndbg.gdblib.qemu
-import pwndbg.gdblib.vmmap
+import pwndbg.aglib.proc
+import pwndbg.aglib.qemu
+import pwndbg.aglib.vmmap
 import pwndbg.wrappers.checksec
 import pwndbg.wrappers.readelf
 from pwndbg.color import message
@@ -67,7 +67,7 @@ parser.add_argument(
 @pwndbg.commands.ArgparsedCommand(parser, category=CommandCategory.LINUX)
 @pwndbg.commands.OnlyWhenRunning
 def got(path_filter: str, all_: bool, accept_readonly: bool, symbol_filter: str) -> None:
-    if pwndbg.gdblib.qemu.is_qemu_usermode():
+    if pwndbg.aglib.qemu.is_qemu_usermode():
         print(
             "QEMU target detected - the result might not be accurate when checking if the entry is writable and getting the information for libraries/objfiles"
         )
@@ -86,7 +86,7 @@ def got(path_filter: str, all_: bool, accept_readonly: bool, symbol_filter: str)
     # Calculate the base address
     if not path_filter:
         first_print = False
-        _got(pwndbg.gdblib.proc.exe, accept_readonly, symbol_filter)
+        _got(pwndbg.aglib.proc.exe, accept_readonly, symbol_filter)
     else:
         first_print = True
 
@@ -113,7 +113,7 @@ def got(path_filter: str, all_: bool, accept_readonly: bool, symbol_filter: str)
 
 def _got(path: str, accept_readonly: bool, symbol_filter: str) -> None:
     # Maybe download the file from remote
-    local_path = pwndbg.gdblib.file.get_file(path, try_local_path=True)
+    local_path = pwndbg.aglib.file.get_file(path, try_local_path=True)
 
     relro_status = pwndbg.wrappers.checksec.relro_status(local_path)
     pie_status = pwndbg.wrappers.checksec.pie_status(local_path)
@@ -122,8 +122,8 @@ def _got(path: str, accept_readonly: bool, symbol_filter: str) -> None:
     # The following code is inspired by the "got" command of https://github.com/bata24/gef/blob/dev/gef.py by @bata24, thank you!
     # TODO/FIXME: Maybe a -v option to show more information will be better
     outputs: List[Dict[str, Union[str, int]]] = []
-    if path == pwndbg.gdblib.proc.exe:
-        bin_base_offset = pwndbg.gdblib.proc.binary_base_addr if "PIE enabled" in pie_status else 0
+    if path == pwndbg.aglib.proc.exe:
+        bin_base_offset = pwndbg.aglib.proc.binary_base_addr if "PIE enabled" in pie_status else 0
     else:
         # TODO/FIXME: Is there a better way to get the base address of the loaded shared library?
         # I guess parsing the vmmap result might also work, but what if it's not reliable or not available? (e.g. debugging with qemu-user)
@@ -156,7 +156,7 @@ def _got(path: str, accept_readonly: bool, symbol_filter: str) -> None:
                 value, name = rest
             address = int(offset, 16) + bin_base_offset
             # TODO/FIXME: This check might not work correctly if we failed to get the correct vmmap result
-            if not accept_readonly and not pwndbg.gdblib.vmmap.find(address).write:
+            if not accept_readonly and not pwndbg.aglib.vmmap.find(address).write:
                 continue
             if not name and category == RelocationType.IRELATIVE:
                 # TODO/FIXME: I don't know the naming logic behind this yet, I'm just modifying @bata24's code here :p
@@ -186,5 +186,5 @@ def _got(path: str, accept_readonly: bool, symbol_filter: str) -> None:
     )
     for output in outputs:
         print(
-            f"[{M.get(output['address'])}] {message.hint(output['name'])} -> {pwndbg.chain.format(pwndbg.gdblib.memory.pvoid(output['address']))}"  # type: ignore[arg-type]
+            f"[{M.get(output['address'])}] {message.hint(output['name'])} -> {pwndbg.chain.format(pwndbg.aglib.memory.pvoid(output['address']))}"  # type: ignore[arg-type]
         )

--- a/pwndbg/commands/got.py
+++ b/pwndbg/commands/got.py
@@ -7,16 +7,16 @@ from typing import Union
 
 from elftools.elf.elffile import ELFFile
 
+import pwndbg.aglib.arch
+import pwndbg.aglib.file
+import pwndbg.aglib.proc
+import pwndbg.aglib.qemu
+import pwndbg.aglib.vmmap
 import pwndbg.chain
 import pwndbg.color.memory as M
 import pwndbg.commands
 import pwndbg.enhance
-import pwndbg.aglib.arch
-import pwndbg.aglib.file
 import pwndbg.gdblib.info
-import pwndbg.aglib.proc
-import pwndbg.aglib.qemu
-import pwndbg.aglib.vmmap
 import pwndbg.wrappers.checksec
 import pwndbg.wrappers.readelf
 from pwndbg.color import message

--- a/pwndbg/commands/got_tracking.py
+++ b/pwndbg/commands/got_tracking.py
@@ -5,10 +5,12 @@ import re
 from typing import Any
 from typing import Dict
 
-import pwndbg.aglib.dynamic
 import pwndbg.color.message as message
 import pwndbg.gdblib.got
-import pwndbg.gdblib.proc
+import pwndbg.dbg
+import pwndbg.aglib.dynamic
+import pwndbg.aglib.proc
+import pwndbg.aglib.vmmap
 from pwndbg.commands import CommandCategory
 
 
@@ -139,7 +141,7 @@ def got_report(soname=".*", writable=False, fnname=".*") -> None:
     for _, (tracker, patcher) in pwndbg.gdblib.got.all_tracked_entries():
         objname = tracker.link_map_entry.name()
         if objname == b"":
-            objname = pwndbg.gdblib.proc.exe
+            objname = pwndbg.aglib.proc.exe
         else:
             objname = pwndbg.gdblib.got.display_name(objname)
 
@@ -157,7 +159,7 @@ def got_report(soname=".*", writable=False, fnname=".*") -> None:
         for tracker, patcher in trackers:
             # If requested, filter out entries that are not in a writable
             # portion of memory.
-            if writable and not pwndbg.gdblib.vmmap.find(patcher.entry).write:
+            if writable and not pwndbg.aglib.vmmap.find(patcher.entry).write:
                 continue
 
             dynamic = tracker.dynamic_section
@@ -213,7 +215,7 @@ def got_tracking_status(address) -> None:
 
     objname = tracker.link_map_entry.name()
     if objname == b"":
-        objname = pwndbg.gdblib.proc.exe
+        objname = pwndbg.aglib.proc.exe
     else:
         objname = pwndbg.gdblib.got.display_name(objname)
 
@@ -231,7 +233,7 @@ def got_tracking_status(address) -> None:
         print(f"Called {hits} times from stack:")
         for entry in stack:
             print(f"    - {entry:#x} ", end="")
-            symname = pwndbg.gdblib.symbol.get(entry)
+            symname = pwndbg.dbg.selected_inferior().symbol_name_at_address(entry)
             if symname != "":
                 print(f"<{symname}>", end="")
             print()

--- a/pwndbg/commands/got_tracking.py
+++ b/pwndbg/commands/got_tracking.py
@@ -5,12 +5,12 @@ import re
 from typing import Any
 from typing import Dict
 
-import pwndbg.color.message as message
-import pwndbg.gdblib.got
-import pwndbg.dbg
 import pwndbg.aglib.dynamic
 import pwndbg.aglib.proc
 import pwndbg.aglib.vmmap
+import pwndbg.color.message as message
+import pwndbg.dbg
+import pwndbg.gdblib.got
 from pwndbg.commands import CommandCategory
 
 

--- a/pwndbg/commands/ida.py
+++ b/pwndbg/commands/ida.py
@@ -8,10 +8,10 @@ import os
 import gdb
 
 import pwndbg
+import pwndbg.aglib.regs
 import pwndbg.commands
 import pwndbg.commands.context
 import pwndbg.dbg
-import pwndbg.aglib.regs
 import pwndbg.integration.ida
 from pwndbg.commands import CommandCategory
 from pwndbg.dbg import EventType

--- a/pwndbg/commands/ida.py
+++ b/pwndbg/commands/ida.py
@@ -10,7 +10,8 @@ import gdb
 import pwndbg
 import pwndbg.commands
 import pwndbg.commands.context
-import pwndbg.gdblib.regs
+import pwndbg.dbg
+import pwndbg.aglib.regs
 import pwndbg.integration.ida
 from pwndbg.commands import CommandCategory
 from pwndbg.dbg import EventType
@@ -28,7 +29,7 @@ def j(*args) -> None:
     Synchronize IDA's cursor with GDB
     """
     try:
-        pc = int(gdb.selected_frame().pc())
+        pc = int(pwndbg.dbg.selected_frame().pc())
         pwndbg.integration.ida.Jump(pc)
     except Exception:
         pass

--- a/pwndbg/commands/integration.py
+++ b/pwndbg/commands/integration.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 import argparse
 
+import pwndbg.aglib.regs
 import pwndbg.commands
 import pwndbg.dbg
-import pwndbg.aglib.regs
 import pwndbg.integration
+
 if pwndbg.dbg.is_gdblib_available():
     import pwndbg.integration.binja
+
 from pwndbg.commands import CommandCategory
 
 parser = argparse.ArgumentParser(

--- a/pwndbg/commands/integration.py
+++ b/pwndbg/commands/integration.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 import argparse
 
 import pwndbg.commands
-import pwndbg.gdblib.events
-import pwndbg.gdblib.functions
-import pwndbg.gdblib.regs
+import pwndbg.dbg
+import pwndbg.aglib.regs
 import pwndbg.integration
-import pwndbg.integration.binja
+if pwndbg.dbg.is_gdblib_available():
+    import pwndbg.integration.binja
 from pwndbg.commands import CommandCategory
 
 parser = argparse.ArgumentParser(
@@ -37,7 +37,7 @@ parser.add_argument(
 @pwndbg.commands.OnlyWhenRunning
 def decomp(addr: None | int, lines: None | int) -> None:
     if addr is None:
-        addr = pwndbg.gdblib.regs.pc
+        addr = pwndbg.aglib.regs.pc
     if lines is None:
         lines = 10
     decomp = pwndbg.integration.provider.decompile(int(addr), int(lines))

--- a/pwndbg/commands/kbase.py
+++ b/pwndbg/commands/kbase.py
@@ -6,6 +6,7 @@ import gdb
 
 import pwndbg.color.message as M
 import pwndbg.commands
+import pwndbg.dbg
 import pwndbg.gdblib.kernel
 from pwndbg import config
 from pwndbg.commands import CommandCategory
@@ -34,7 +35,7 @@ def kbase(rebase=False) -> None:
     if not rebase:
         return
 
-    symbol_file = gdb.current_progspace().filename
+    symbol_file = pwndbg.dbg.selected_inferior().main_module_name()
 
     if symbol_file:
         gdb.execute("symbol-file")

--- a/pwndbg/commands/linkmap.py
+++ b/pwndbg/commands/linkmap.py
@@ -4,7 +4,7 @@ import argparse
 
 import pwndbg.aglib.dynamic
 import pwndbg.color as color
-import pwndbg.gdblib.proc
+import pwndbg.aglib.proc
 from pwndbg.commands import CommandCategory
 
 parser = argparse.ArgumentParser(
@@ -23,7 +23,7 @@ def linkmap() -> None:
             name = "<Unknown"
             if is_first:
                 is_first = False
-                name += f", likely {pwndbg.gdblib.proc.exe}"
+                name += f", likely {pwndbg.aglib.proc.exe}"
             name += ">"
         rows.append(
             [f"{obj.link_map_address:#x}", name, f"{obj.load_bias():#x}", f"{obj.dynamic():#x}"]

--- a/pwndbg/commands/linkmap.py
+++ b/pwndbg/commands/linkmap.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import argparse
 
 import pwndbg.aglib.dynamic
-import pwndbg.color as color
 import pwndbg.aglib.proc
+import pwndbg.color as color
 from pwndbg.commands import CommandCategory
 
 parser = argparse.ArgumentParser(

--- a/pwndbg/commands/memoize.py
+++ b/pwndbg/commands/memoize.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 
 import pwndbg.commands
+import pwndbg.lib.cache
 from pwndbg.color import message
 from pwndbg.commands import CommandCategory
 

--- a/pwndbg/commands/misc.py
+++ b/pwndbg/commands/misc.py
@@ -66,10 +66,8 @@ def errno_(err) -> None:
     if err is None:
         try:
             err = _get_errno()
-        except pwndbg.dbg_mod.Error:
-            print(
-                "Could not determine error code automatically: neither `errno` nor `__errno_location` symbols were provided (perhaps libc.so hasn't been not loaded yet?)"
-            )
+        except pwndbg.dbg_mod.Error as e:
+            print(str(e))
             return
 
     msg = errno.errorcode.get(int(err), "Unknown error code")

--- a/pwndbg/commands/misc.py
+++ b/pwndbg/commands/misc.py
@@ -4,14 +4,13 @@ import argparse
 import errno
 from collections import defaultdict
 
-import gdb
-
 import pwndbg.color as C
 import pwndbg.commands
-import pwndbg.gdblib.regs
-import pwndbg.gdblib.symbol
+import pwndbg.dbg
+import pwndbg.aglib.vmmap
+import pwndbg.aglib.memory
+import pwndbg.aglib.regs
 from pwndbg.commands import CommandCategory
-from pwndbg.gdblib.scheduler import parse_and_eval_with_scheduler_lock
 
 # Manually add error code 0 for "OK"
 errno.errorcode[0] = "OK"  # type: ignore[index]
@@ -28,40 +27,48 @@ parser.add_argument(
 )
 
 
+def _get_errno() -> int:
+    # Try to get the `errno` variable value
+    # if it does not exist, get the errno variable from its location
+    try:
+        return int(pwndbg.dbg.selected_frame().evaluate_expression("errno"))
+    except pwndbg.dbg_mod.Error:
+        pass
+
+    # We can't simply call __errno_location because its .plt.got entry may be uninitialized
+    # (e.g. if the binary was just started with `starti` command)
+    # So we have to check the got.plt entry first before calling it
+    errno_loc_gotplt = pwndbg.dbg.selected_inferior().symbol_address_from_name("__errno_location@got.plt")
+    if errno_loc_gotplt is not None:
+        page_loaded = pwndbg.aglib.vmmap.find(pwndbg.aglib.memory.pvoid(errno_loc_gotplt))
+        if page_loaded is None:
+            raise pwndbg.dbg_mod.Error(
+                "Could not determine error code automatically: the __errno_location@got.plt has no valid address yet (perhaps libc.so hasn't been loaded yet?)"
+            )
+
+    try:
+        return int(
+            pwndbg.dbg.selected_frame().evaluate_expression(
+                "*((int *(*) (void)) __errno_location) ()", lock_scheduler=True
+            )
+        )
+    except pwndbg.dbg_mod.Error as e:
+        raise pwndbg.dbg_mod.Error(
+            "Could not determine error code automatically: neither `errno` nor `__errno_location` symbols were provided (perhaps libc.so hasn't been not loaded yet?)"
+        ) from e
+
+
 @pwndbg.commands.ArgparsedCommand(parser, command_name="errno", category=CommandCategory.LINUX)
 @pwndbg.commands.OnlyWhenRunning
 def errno_(err) -> None:
     if err is None:
-        # Try to get the `errno` variable value
-        # if it does not exist, get the errno variable from its location
         try:
-            err = int(gdb.parse_and_eval("errno"))
-        except gdb.error:
-            try:
-                # We can't simply call __errno_location because its .plt.got entry may be uninitialized
-                # (e.g. if the binary was just started with `starti` command)
-                # So we have to check the got.plt entry first before calling it
-                errno_loc_gotplt = pwndbg.gdblib.symbol.address("__errno_location@got.plt")
-
-                # If the got.plt entry is not there (is None), it means the symbol is not used by the binary
-                if errno_loc_gotplt is None or pwndbg.gdblib.vmmap.find(
-                    pwndbg.gdblib.memory.pvoid(errno_loc_gotplt)
-                ):
-                    err = int(
-                        parse_and_eval_with_scheduler_lock(
-                            "*((int *(*) (void)) __errno_location) ()"
-                        )
-                    )
-                else:
-                    print(
-                        "Could not determine error code automatically: the __errno_location@got.plt has no valid address yet (perhaps libc.so hasn't been loaded yet?)"
-                    )
-                    return
-            except gdb.error:
-                print(
-                    "Could not determine error code automatically: neither `errno` nor `__errno_location` symbols were provided (perhaps libc.so hasn't been not loaded yet?)"
-                )
-                return
+            err = _get_errno()
+        except pwndbg.dbg_mod.Error:
+            print(
+                "Could not determine error code automatically: neither `errno` nor `__errno_location` symbols were provided (perhaps libc.so hasn't been not loaded yet?)"
+            )
+            return
 
     msg = errno.errorcode.get(int(err), "Unknown error code")
     print(f"Errno {err}: {msg}")

--- a/pwndbg/commands/misc.py
+++ b/pwndbg/commands/misc.py
@@ -4,12 +4,12 @@ import argparse
 import errno
 from collections import defaultdict
 
+import pwndbg.aglib.memory
+import pwndbg.aglib.regs
+import pwndbg.aglib.vmmap
 import pwndbg.color as C
 import pwndbg.commands
 import pwndbg.dbg
-import pwndbg.aglib.vmmap
-import pwndbg.aglib.memory
-import pwndbg.aglib.regs
 from pwndbg.commands import CommandCategory
 
 # Manually add error code 0 for "OK"
@@ -38,7 +38,9 @@ def _get_errno() -> int:
     # We can't simply call __errno_location because its .plt.got entry may be uninitialized
     # (e.g. if the binary was just started with `starti` command)
     # So we have to check the got.plt entry first before calling it
-    errno_loc_gotplt = pwndbg.dbg.selected_inferior().symbol_address_from_name("__errno_location@got.plt")
+    errno_loc_gotplt = pwndbg.dbg.selected_inferior().symbol_address_from_name(
+        "__errno_location@got.plt"
+    )
     if errno_loc_gotplt is not None:
         page_loaded = pwndbg.aglib.vmmap.find(pwndbg.aglib.memory.pvoid(errno_loc_gotplt))
         if page_loaded is None:

--- a/pwndbg/commands/pcplist.py
+++ b/pwndbg/commands/pcplist.py
@@ -6,7 +6,7 @@ import logging
 import gdb
 
 import pwndbg.commands
-import pwndbg.gdblib.memory
+import pwndbg.aglib.memory
 from pwndbg.commands import CommandCategory
 from pwndbg.gdblib.kernel import per_cpu
 from pwndbg.gdblib.kernel.macros import for_each_entry
@@ -24,7 +24,7 @@ def print_zone(zone, list_num=None) -> None:
     pageset_addr = per_cpu(
         gdb.lookup_global_symbol("contig_page_data").value()["node_zones"][zone]["pageset"]
     )
-    pageset = pwndbg.gdblib.memory.get_typed_pointer_value(
+    pageset = pwndbg.aglib.memory.get_typed_pointer_value(
         gdb.lookup_type("struct per_cpu_pageset"), pageset_addr
     )
     pcp = pageset["pcp"]

--- a/pwndbg/commands/pcplist.py
+++ b/pwndbg/commands/pcplist.py
@@ -5,8 +5,8 @@ import logging
 
 import gdb
 
-import pwndbg.commands
 import pwndbg.aglib.memory
+import pwndbg.commands
 from pwndbg.commands import CommandCategory
 from pwndbg.gdblib.kernel import per_cpu
 from pwndbg.gdblib.kernel.macros import for_each_entry

--- a/pwndbg/commands/pcplist.py
+++ b/pwndbg/commands/pcplist.py
@@ -24,9 +24,7 @@ def print_zone(zone, list_num=None) -> None:
     pageset_addr = per_cpu(
         gdb.lookup_global_symbol("contig_page_data").value()["node_zones"][zone]["pageset"]
     )
-    pageset = pwndbg.aglib.memory.get_typed_pointer_value(
-        gdb.lookup_type("struct per_cpu_pageset"), pageset_addr
-    )
+    pageset = pwndbg.aglib.memory.get_typed_pointer_value("struct per_cpu_pageset", pageset_addr)
     pcp = pageset["pcp"]
     print("count: ", pcp["count"])
     print("high: ", pcp["high"])

--- a/pwndbg/commands/peda.py
+++ b/pwndbg/commands/peda.py
@@ -8,7 +8,8 @@ import pwndbg.auxv
 import pwndbg.commands
 import pwndbg.commands.context
 import pwndbg.commands.telescope
-import pwndbg.gdblib.proc
+import pwndbg.aglib.memory
+import pwndbg.aglib.proc
 from pwndbg.color import message
 from pwndbg.commands import CommandCategory
 
@@ -28,7 +29,7 @@ def xuntil(target) -> None:
     try:
         addr = target
 
-        if not pwndbg.gdblib.memory.peek(addr):
+        if not pwndbg.aglib.memory.peek(addr):
             print(message.error("Invalid address %#x" % addr))
             return
 
@@ -43,7 +44,7 @@ def xuntil(target) -> None:
         spec = target
 
     gdb.Breakpoint(spec, temporary=True)
-    if pwndbg.gdblib.proc.alive:
+    if pwndbg.aglib.proc.alive:
         gdb.execute("continue", from_tty=False)
     else:
         gdb.execute("run", from_tty=False)

--- a/pwndbg/commands/peda.py
+++ b/pwndbg/commands/peda.py
@@ -4,12 +4,12 @@ import argparse
 
 import gdb
 
+import pwndbg.aglib.memory
+import pwndbg.aglib.proc
 import pwndbg.auxv
 import pwndbg.commands
 import pwndbg.commands.context
 import pwndbg.commands.telescope
-import pwndbg.aglib.memory
-import pwndbg.aglib.proc
 from pwndbg.color import message
 from pwndbg.commands import CommandCategory
 

--- a/pwndbg/commands/plist.py
+++ b/pwndbg/commands/plist.py
@@ -188,10 +188,10 @@ parser.add_argument(
 @pwndbg.commands.ArgparsedCommand(parser, command_name="plist")
 def plist(
     path: str,
-    next: int,
+    next: str,
     sentinel: int,
-    inner_name: str,
-    field_name: str,
+    inner_name: Optional[str],
+    field_name: Optional[str],
     offset: int,
     count: Optional[int] = None,
 ) -> None:
@@ -413,7 +413,7 @@ def plist(
             symbol = pwndbg.dbg.selected_inferior().symbol_name_at_address(target_address)
             symbol = f"<{symbol}>" if symbol else ""
 
-            print(f"{target_address:#x} {symbol}: {value.string()}")
+            print(f"{target_address:#x} {symbol}: {value.value_to_human_readable()}")
         except pwndbg.dbg_mod.Error as e:
             print(message.error(f"Cannot dereference {address:#x} for list link #{i + 1}: {e}"))
             print(message.error("Is the linked list corrupted or is the sentinel value wrong?"))

--- a/pwndbg/commands/plist.py
+++ b/pwndbg/commands/plist.py
@@ -413,7 +413,7 @@ def plist(
             symbol = pwndbg.dbg.selected_inferior().symbol_name_at_address(target_address)
             symbol = f"<{symbol}>" if symbol else ""
 
-            print(f"{target_address:#x} {symbol}: {value}")
+            print(f"{target_address:#x} {symbol}: {value.string()}")
         except pwndbg.dbg_mod.Error as e:
             print(message.error(f"Cannot dereference {address:#x} for list link #{i + 1}: {e}"))
             print(message.error("Is the linked list corrupted or is the sentinel value wrong?"))

--- a/pwndbg/commands/plist.py
+++ b/pwndbg/commands/plist.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import argparse
 from typing import Optional
 
-import gdb
-
 import pwndbg.aglib.memory
 import pwndbg.chain
 import pwndbg.commands
@@ -199,8 +197,8 @@ def plist(
 ) -> None:
     # Have GDB parse the path for us and check if it's valid.
     try:
-        first = gdb.parse_and_eval(path)
-    except gdb.error as e:
+        first = pwndbg.dbg.selected_frame().evaluate_expression(path)
+    except pwndbg.dbg_mod.Error as e:
         print(message.error(f"{e}"))
         return
 
@@ -220,16 +218,16 @@ def plist(
     # for the error mesages.
     sep = "."
     deref = ""
-    if first.type.code == gdb.TYPE_CODE_PTR:
+    if first.type.code == pwndbg.dbg_mod.TypeCode.POINTER:
         sep = "->"
         deref = "*"
         try:
             first = first.dereference()
-        except gdb.error as e:
+        except pwndbg.dbg_mod.Error as e:
             print(message.error(f"Pointer at {path} could not be dereferenced: {e}"))
             return
 
-    if first.type.code == gdb.TYPE_CODE_PTR:
+    if first.type.code == pwndbg.dbg_mod.TypeCode.POINTER:
         print(message.error(f"{path} is not a value or a single pointer to one"))
         return
 
@@ -248,7 +246,7 @@ def plist(
         try:
             inner = first[inner_name]
             inner_sep = "->"
-        except gdb.error as e:
+        except pwndbg.dbg_mod.Error as e:
             print(message.error(f"Cannot find component {inner_name} in {path}: {e}"))
             return
         if inner.is_optimized_out:
@@ -266,14 +264,14 @@ def plist(
             next_ptr = inner[next]
             next_ptr_loc = inner
             next_ptr_name = f"{inner_name}.{next}"
-    except gdb.error as e:
+    except pwndbg.dbg_mod.Error as e:
         print(message.error(f"Cannot find component {next_ptr_name} in {path}: {e}"))
         return
 
     if next_ptr.is_optimized_out:
         print(message.error(f"{path}{sep}{next_ptr_name} has been optimized out"))
         return
-    if next_ptr.type.code != gdb.TYPE_CODE_PTR:
+    if next_ptr.type.code != pwndbg.dbg_mod.TypeCode.POINTER:
         print(message.error(f"{path}{sep}{next_ptr_name} is not a pointer"))
         return
 
@@ -283,7 +281,7 @@ def plist(
     if field_name is not None:
         try:
             field = first[field_name]
-        except gdb.error as e:
+        except pwndbg.dbg_mod.Error as e:
             print(message.error(f"Cannot find component {field_name} in {path}: {e}"))
             return
         field_type = field.type
@@ -416,7 +414,7 @@ def plist(
             symbol = f"<{symbol}>" if symbol else ""
 
             print(f"{target_address:#x} {symbol}: {value}")
-        except gdb.error as e:
+        except pwndbg.dbg_mod.Error as e:
             print(message.error(f"Cannot dereference {address:#x} for list link #{i + 1}: {e}"))
             print(message.error("Is the linked list corrupted or is the sentinel value wrong?"))
             return

--- a/pwndbg/commands/plist.py
+++ b/pwndbg/commands/plist.py
@@ -5,10 +5,10 @@ from typing import Optional
 
 import gdb
 
+import pwndbg.aglib.memory
 import pwndbg.chain
 import pwndbg.commands
 import pwndbg.dbg
-import pwndbg.aglib.memory
 from pwndbg.color import message
 
 parser = argparse.ArgumentParser(

--- a/pwndbg/commands/plist.py
+++ b/pwndbg/commands/plist.py
@@ -7,7 +7,8 @@ import gdb
 
 import pwndbg.chain
 import pwndbg.commands
-import pwndbg.gdblib.memory
+import pwndbg.dbg
+import pwndbg.aglib.memory
 from pwndbg.color import message
 
 parser = argparse.ArgumentParser(
@@ -409,9 +410,9 @@ def plist(
                 target_type = field_type
                 target_address = address + field_offset
 
-            value = pwndbg.gdblib.memory.get_typed_pointer_value(target_type, target_address)
+            value = pwndbg.aglib.memory.get_typed_pointer_value(target_type, target_address)
 
-            symbol = pwndbg.gdblib.symbol.get(target_address)
+            symbol = pwndbg.dbg.selected_inferior().symbol_name_at_address(target_address)
             symbol = f"<{symbol}>" if symbol else ""
 
             print(f"{target_address:#x} {symbol}: {value}")

--- a/pwndbg/commands/procinfo.py
+++ b/pwndbg/commands/procinfo.py
@@ -5,10 +5,11 @@ import string
 
 import pwndbg.auxv
 import pwndbg.commands
-import pwndbg.gdblib.file
-import pwndbg.gdblib.net
-import pwndbg.gdblib.proc
+import pwndbg.aglib.file
+import pwndbg.aglib.proc
+import pwndbg.aglib.qemu
 import pwndbg.lib.cache
+import pwndbg.lib.net
 from pwndbg.color import message
 from pwndbg.commands import CommandCategory
 
@@ -66,12 +67,42 @@ capabilities = {
 }
 
 
+class System:
+    @classmethod
+    @property
+    def tcp(cls):
+        # For reference, see:
+        # https://www.kernel.org/doc/Documentation/networking/proc_net_tcp.txt
+        """
+        It will first list all listening TCP sockets, and next list all established
+        TCP connections. A typical entry of /proc/net/tcp would look like this (split
+        up into 3 parts because of the length of the line):
+        """
+        data = pwndbg.aglib.file.get("/proc/net/tcp").decode()
+        return pwndbg.lib.net.tcp(data)
+
+    @classmethod
+    @property
+    def unix(cls):
+        # We use errors=ignore because of https://github.com/pwndbg/pwndbg/issues/1544
+        # TODO/FIXME: this may not be the best solution because we may end up with
+        # invalid UDS data. Can this be a problem?
+        data = pwndbg.aglib.file.get("/proc/net/unix").decode(errors="ignore")
+        return pwndbg.lib.net.unix(data)
+
+    @classmethod
+    @property
+    def netlink(cls):
+        data = pwndbg.aglib.file.get("/proc/net/netlink").decode()
+        return pwndbg.lib.net.netlink(data)
+
+
 class Process:
     def __init__(self, pid=None, tid=None) -> None:
         if pid is None:
-            pid = pwndbg.gdblib.proc.pid
+            pid = pwndbg.aglib.proc.pid
         if tid is None:
-            tid = pwndbg.gdblib.proc.tid
+            tid = pwndbg.aglib.proc.tid
         if not tid:
             tid = pid
         self.pid = pid
@@ -81,25 +112,25 @@ class Process:
     @pwndbg.lib.cache.cache_until("stop")
     def selinux(self):
         path = "/proc/%i/task/%i/attr/current" % (self.pid, self.tid)
-        raw = pwndbg.gdblib.file.get(path)
+        raw = pwndbg.aglib.file.get(path)
         return raw.decode().rstrip("\x00").strip()
 
     @property
     @pwndbg.lib.cache.cache_until("stop")
     def cmdline(self):
-        raw = pwndbg.gdblib.file.get(f"/proc/{self.pid}/cmdline")
+        raw = pwndbg.aglib.file.get(f"/proc/{self.pid}/cmdline")
         return " ".join(map(shlex.quote, raw.decode().split("\x00")))
 
     @property
     @pwndbg.lib.cache.cache_until("stop")
     def cwd(self) -> str:
-        link = pwndbg.gdblib.file.readlink(f"/proc/{self.pid}/cwd")
+        link = pwndbg.aglib.file.readlink(f"/proc/{self.pid}/cwd")
         return f"'{link}'"
 
     @property
     @pwndbg.lib.cache.cache_until("stop")
     def status(self):
-        raw = pwndbg.gdblib.file.get("/proc/%i/task/%i/status" % (self.pid, self.tid))
+        raw = pwndbg.aglib.file.get("/proc/%i/task/%i/status" % (self.pid, self.tid))
 
         status = {}
         for line in raw.splitlines():
@@ -157,7 +188,7 @@ class Process:
         fds = {}
 
         for i in range(self.fdsize):
-            link = pwndbg.gdblib.file.readlink("/proc/%i/fd/%i" % (pwndbg.gdblib.proc.pid, i))
+            link = pwndbg.aglib.file.readlink("/proc/%i/fd/%i" % (pwndbg.aglib.proc.pid, i))
 
             if link:
                 fds[i] = link
@@ -173,7 +204,7 @@ class Process:
         socket = "socket:["
         result = []
 
-        functions = [pwndbg.gdblib.net.tcp, pwndbg.gdblib.net.unix, pwndbg.gdblib.net.netlink]
+        functions = [System.tcp, System.unix, System.netlink]
 
         for fd, path in fds.items():
             if socket not in path:
@@ -196,7 +227,7 @@ class Process:
 )
 @pwndbg.commands.OnlyWhenRunning
 def pid() -> None:
-    print(pwndbg.gdblib.proc.pid)
+    print(pwndbg.aglib.proc.pid)
 
 
 @pwndbg.commands.ArgparsedCommand(
@@ -207,7 +238,7 @@ def procinfo() -> None:
     """
     Display information about the running process.
     """
-    if pwndbg.gdblib.qemu.is_qemu():
+    if pwndbg.aglib.qemu.is_qemu():
         print(
             message.error(
                 "QEMU target detected: showing result for the qemu process"
@@ -241,14 +272,14 @@ def procinfo() -> None:
 
     print("%-10s %s" % ("ppid", proc.ppid))
 
-    if not pwndbg.gdblib.android.is_android():
-        print("%-10s %s" % ("uid", proc.uid))
-        print("%-10s %s" % ("gid", proc.gid))
-        print("%-10s %s" % ("groups", proc.groups))
-    else:
-        print("%-10s %s" % ("uid", list(map(pwndbg.lib.android.aid_name, proc.uid))))
-        print("%-10s %s" % ("gid", list(map(pwndbg.lib.android.aid_name, proc.gid))))
-        print("%-10s %s" % ("groups", list(map(pwndbg.lib.android.aid_name, proc.groups))))
+    # if pwndbg.gdblib.android.is_android():
+    print("%-10s %s" % ("uid", proc.uid))
+    print("%-10s %s" % ("gid", proc.gid))
+    print("%-10s %s" % ("groups", proc.groups))
+    # else:
+    #     print("%-10s %s" % ("uid", list(map(pwndbg.lib.android.aid_name, proc.uid))))
+    #     print("%-10s %s" % ("gid", list(map(pwndbg.lib.android.aid_name, proc.gid))))
+    #     print("%-10s %s" % ("groups", list(map(pwndbg.lib.android.aid_name, proc.groups))))
 
     for fd, path in files.items():
         if not set(path) < set(string.printable):

--- a/pwndbg/commands/procinfo.py
+++ b/pwndbg/commands/procinfo.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 import shlex
 import string
 
-import pwndbg.auxv
-import pwndbg.commands
 import pwndbg.aglib.file
 import pwndbg.aglib.proc
 import pwndbg.aglib.qemu
+import pwndbg.auxv
+import pwndbg.commands
 import pwndbg.lib.cache
 import pwndbg.lib.net
 from pwndbg.color import message
@@ -69,7 +69,6 @@ capabilities = {
 
 class System:
     @classmethod
-    @property
     def tcp(cls):
         # For reference, see:
         # https://www.kernel.org/doc/Documentation/networking/proc_net_tcp.txt
@@ -82,7 +81,6 @@ class System:
         return pwndbg.lib.net.tcp(data)
 
     @classmethod
-    @property
     def unix(cls):
         # We use errors=ignore because of https://github.com/pwndbg/pwndbg/issues/1544
         # TODO/FIXME: this may not be the best solution because we may end up with
@@ -91,7 +89,6 @@ class System:
         return pwndbg.lib.net.unix(data)
 
     @classmethod
-    @property
     def netlink(cls):
         data = pwndbg.aglib.file.get("/proc/net/netlink").decode()
         return pwndbg.lib.net.netlink(data)
@@ -204,7 +201,8 @@ class Process:
         socket = "socket:["
         result = []
 
-        functions = [System.tcp, System.unix, System.netlink]
+        sys = System()
+        functions = [sys.tcp, sys.unix, sys.netlink]
 
         for fd, path in fds.items():
             if socket not in path:

--- a/pwndbg/commands/radare2.py
+++ b/pwndbg/commands/radare2.py
@@ -5,6 +5,10 @@ import subprocess
 
 import pwndbg.commands
 import pwndbg.radare2
+import pwndbg.aglib.file
+import pwndbg.aglib.proc
+import pwndbg.aglib.regs
+import pwndbg.aglib.elf
 from pwndbg.color import message
 from pwndbg.commands import CommandCategory
 
@@ -23,18 +27,18 @@ parser.add_argument("arguments", nargs="*", type=str, help="Arguments to pass to
 )
 @pwndbg.commands.OnlyWithFile
 def r2(arguments, no_seek=False, no_rebase=False) -> None:
-    filename = pwndbg.gdblib.file.get_proc_exe_file()
+    filename = pwndbg.aglib.file.get_proc_exe_file()
 
     # Build up the command line to run
     cmd = ["radare2"]
     flags = ["-e", "io.cache=true"]
-    if pwndbg.gdblib.proc.alive:
-        addr = pwndbg.gdblib.regs.pc
-        if pwndbg.gdblib.elf.get_elf_info(filename).is_pie:
+    if pwndbg.aglib.proc.alive:
+        addr = pwndbg.aglib.regs.pc
+        if pwndbg.aglib.elf.get_elf_info(filename).is_pie:
             if no_rebase:
-                addr -= pwndbg.gdblib.elf.exe().address
+                addr -= pwndbg.aglib.elf.exe().address
             else:
-                flags.extend(["-B", hex(pwndbg.gdblib.elf.exe().address)])
+                flags.extend(["-B", hex(pwndbg.aglib.elf.exe().address)])
         if not no_seek:
             cmd.extend(["-s", hex(addr)])
     cmd.extend(flags)

--- a/pwndbg/commands/radare2.py
+++ b/pwndbg/commands/radare2.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 import argparse
 import subprocess
 
-import pwndbg.commands
-import pwndbg.radare2
+import pwndbg.aglib.elf
 import pwndbg.aglib.file
 import pwndbg.aglib.proc
 import pwndbg.aglib.regs
-import pwndbg.aglib.elf
+import pwndbg.commands
+import pwndbg.radare2
 from pwndbg.color import message
 from pwndbg.commands import CommandCategory
 

--- a/pwndbg/commands/rizin.py
+++ b/pwndbg/commands/rizin.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 import argparse
 import subprocess
 
-import pwndbg.commands
-import pwndbg.rizin
-import pwndbg.aglib.file
 import pwndbg.aglib.elf
+import pwndbg.aglib.file
 import pwndbg.aglib.proc
 import pwndbg.aglib.regs
+import pwndbg.commands
+import pwndbg.rizin
 from pwndbg.color import message
 from pwndbg.commands import CommandCategory
 

--- a/pwndbg/commands/rizin.py
+++ b/pwndbg/commands/rizin.py
@@ -5,6 +5,10 @@ import subprocess
 
 import pwndbg.commands
 import pwndbg.rizin
+import pwndbg.aglib.file
+import pwndbg.aglib.elf
+import pwndbg.aglib.proc
+import pwndbg.aglib.regs
 from pwndbg.color import message
 from pwndbg.commands import CommandCategory
 
@@ -21,18 +25,18 @@ parser.add_argument("arguments", nargs="*", type=str, help="Arguments to pass to
 @pwndbg.commands.ArgparsedCommand(parser, aliases=["rizin"], category=CommandCategory.INTEGRATIONS)
 @pwndbg.commands.OnlyWithFile
 def rz(arguments, no_seek=False, no_rebase=False) -> None:
-    filename = pwndbg.gdblib.file.get_proc_exe_file()
+    filename = pwndbg.aglib.file.get_proc_exe_file()
 
     # Build up the command line to run
     cmd = ["rizin"]
     flags = ["-e", "io.cache=true"]
-    if pwndbg.gdblib.proc.alive:
-        addr = pwndbg.gdblib.regs.pc
-        if pwndbg.gdblib.elf.get_elf_info(filename).is_pie:
+    if pwndbg.aglib.proc.alive:
+        addr = pwndbg.aglib.regs.pc
+        if pwndbg.aglib.elf.get_elf_info(filename).is_pie:
             if no_rebase:
-                addr -= pwndbg.gdblib.elf.exe().address
+                addr -= pwndbg.aglib.elf.exe().address
             else:
-                flags.extend(["-B", hex(pwndbg.gdblib.elf.exe().address)])
+                flags.extend(["-B", hex(pwndbg.aglib.elf.exe().address)])
         if not no_seek:
             cmd.extend(["-s", hex(addr)])
     cmd.extend(flags)

--- a/pwndbg/commands/rop.py
+++ b/pwndbg/commands/rop.py
@@ -8,7 +8,8 @@ import tempfile
 import gdb
 
 import pwndbg.commands
-import pwndbg.gdblib.vmmap
+import pwndbg.aglib.vmmap
+import pwndbg.aglib.proc
 from pwndbg.commands import CommandCategory
 
 parser = argparse.ArgumentParser(
@@ -26,11 +27,11 @@ parser.add_argument("argument", nargs="*", type=str, help="Arguments to pass to 
 def rop(grep, argument) -> None:
     with tempfile.NamedTemporaryFile() as corefile:
         # If the process is running, dump a corefile so we get actual addresses.
-        if pwndbg.gdblib.proc.alive:
+        if pwndbg.aglib.proc.alive:
             filename = corefile.name
             gdb.execute(f"gcore {filename}")
         else:
-            filename = pwndbg.gdblib.proc.exe
+            filename = pwndbg.aglib.proc.exe
 
         # Build up the command line to run
         cmd = ["ROPgadget", "--binary", filename]

--- a/pwndbg/commands/rop.py
+++ b/pwndbg/commands/rop.py
@@ -7,9 +7,9 @@ import tempfile
 
 import gdb
 
-import pwndbg.commands
-import pwndbg.aglib.vmmap
 import pwndbg.aglib.proc
+import pwndbg.aglib.vmmap
+import pwndbg.commands
 from pwndbg.commands import CommandCategory
 
 parser = argparse.ArgumentParser(

--- a/pwndbg/commands/ropper.py
+++ b/pwndbg/commands/ropper.py
@@ -6,9 +6,9 @@ import tempfile
 
 import gdb
 
-import pwndbg.commands
-import pwndbg.aglib.vmmap
 import pwndbg.aglib.proc
+import pwndbg.aglib.vmmap
+import pwndbg.commands
 from pwndbg.commands import CommandCategory
 
 parser = argparse.ArgumentParser(

--- a/pwndbg/commands/ropper.py
+++ b/pwndbg/commands/ropper.py
@@ -7,7 +7,8 @@ import tempfile
 import gdb
 
 import pwndbg.commands
-import pwndbg.gdblib.vmmap
+import pwndbg.aglib.vmmap
+import pwndbg.aglib.proc
 from pwndbg.commands import CommandCategory
 
 parser = argparse.ArgumentParser(
@@ -22,11 +23,11 @@ parser.add_argument("argument", nargs="*", type=str, help="Arguments to pass to 
 def ropper(argument) -> None:
     with tempfile.NamedTemporaryFile() as corefile:
         # If the process is running, dump a corefile so we get actual addresses.
-        if pwndbg.gdblib.proc.alive:
+        if pwndbg.aglib.proc.alive:
             filename = corefile.name
             gdb.execute(f"gcore {filename}")
         else:
-            filename = pwndbg.gdblib.proc.exe
+            filename = pwndbg.aglib.proc.exe
 
         # Build up the command line to run
         cmd = ["ropper", "--file", filename]

--- a/pwndbg/commands/segments.py
+++ b/pwndbg/commands/segments.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import gdb
 
-import pwndbg.commands
 import pwndbg.aglib.regs
+import pwndbg.commands
 from pwndbg.commands import CommandCategory
 
 

--- a/pwndbg/commands/segments.py
+++ b/pwndbg/commands/segments.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import gdb
 
 import pwndbg.commands
-import pwndbg.gdblib.regs
+import pwndbg.aglib.regs
 from pwndbg.commands import CommandCategory
 
 
@@ -15,7 +15,7 @@ class segment(gdb.Function):
         self.name = name
 
     def invoke(self, arg: gdb.Value = gdb.Value(0), *args: gdb.Value) -> int:
-        result = getattr(pwndbg.gdblib.regs, self.name)
+        result = getattr(pwndbg.aglib.regs, self.name)
         return result + int(arg)
 
 
@@ -33,7 +33,7 @@ def fsbase() -> None:
     """
     Prints out the FS base address. See also $fsbase.
     """
-    print(hex(int(pwndbg.gdblib.regs.fsbase)))
+    print(hex(int(pwndbg.aglib.regs.fsbase)))
 
 
 @pwndbg.commands.ArgparsedCommand(
@@ -45,4 +45,4 @@ def gsbase() -> None:
     """
     Prints out the GS base address. See also $gsbase.
     """
-    print(hex(int(pwndbg.gdblib.regs.gsbase)))
+    print(hex(int(pwndbg.aglib.regs.gsbase)))

--- a/pwndbg/commands/tls.py
+++ b/pwndbg/commands/tls.py
@@ -6,12 +6,15 @@ from __future__ import annotations
 
 import argparse
 
-import gdb
 from tabulate import tabulate
 
 import pwndbg.color.memory as M
 import pwndbg.commands
-import pwndbg.gdblib.tls
+import pwndbg.commands.context
+import pwndbg.dbg
+import pwndbg.aglib.tls
+import pwndbg.aglib.memory
+import pwndbg.aglib.vmmap
 from pwndbg.color import message
 from pwndbg.commands import CommandCategory
 
@@ -34,14 +37,14 @@ parser.add_argument(
 @pwndbg.commands.OnlyWhenUserspace
 def tls(pthread_self=False) -> None:
     tls_base = (
-        pwndbg.gdblib.tls.find_address_with_register()
+        pwndbg.aglib.tls.find_address_with_register()
         if not pthread_self
-        else pwndbg.gdblib.tls.find_address_with_pthread_self()
+        else pwndbg.aglib.tls.find_address_with_pthread_self()
     )
-    if pwndbg.gdblib.memory.is_readable_address(tls_base):
+    if pwndbg.aglib.memory.is_readable_address(tls_base):
         print(message.success("Thread Local Storage (TLS) base: %#x" % tls_base))
         print(message.success("TLS is located at:"))
-        print(message.notice(pwndbg.gdblib.vmmap.find(tls_base)))
+        print(message.notice(pwndbg.aglib.vmmap.find(tls_base)))
         return
     print(message.error("Couldn't find Thread Local Storage (TLS) base."))
     if not pthread_self:
@@ -83,6 +86,8 @@ def threads(num_threads, respect_config) -> None:
     table = []
     headers = ["global_num", "name", "status", "pc", "symbol"]
     bold_green = lambda text: pwndbg.color.bold(pwndbg.color.green(text))
+
+    import gdb
 
     try:
         original_thread = gdb.selected_thread()
@@ -130,10 +135,10 @@ def threads(num_threads, respect_config) -> None:
 
         if thread.is_stopped():
             thread.switch()
-            pc = gdb.selected_frame().pc()
+            pc = pwndbg.dbg.selected_frame().pc()
 
             pc_colored = M.get(pc)
-            symbol = pwndbg.gdblib.symbol.get(pc)
+            symbol = pwndbg.dbg.selected_inferior().symbol_name_at_address(pc)
 
             row.append(pc_colored)
 

--- a/pwndbg/commands/tls.py
+++ b/pwndbg/commands/tls.py
@@ -8,13 +8,13 @@ import argparse
 
 from tabulate import tabulate
 
+import pwndbg.aglib.memory
+import pwndbg.aglib.tls
+import pwndbg.aglib.vmmap
 import pwndbg.color.memory as M
 import pwndbg.commands
 import pwndbg.commands.context
 import pwndbg.dbg
-import pwndbg.aglib.tls
-import pwndbg.aglib.memory
-import pwndbg.aglib.vmmap
 from pwndbg.color import message
 from pwndbg.commands import CommandCategory
 

--- a/pwndbg/dbg/__init__.py
+++ b/pwndbg/dbg/__init__.py
@@ -725,6 +725,23 @@ class Value:
         """
         raise NotImplementedError()
 
+    def value_to_human_readable(self) -> str:
+        """
+        Converts a Value to a human-readable string representation.
+
+        The format is similar to what is produced by the `str()` function for gdb.Value,
+        displaying nested fields and pointers in a user-friendly way.
+
+        **Usage Notes:**
+        - This function is intended solely for displaying results to the user.
+        - The output format may differ between debugger implementations (e.g., GDB vs LLDB),
+          as each debugger may format values differently. For instance:
+            - GDB might produce: '{\n  value = 0,\n  inner = {\n    next = 0x555555558098 <inner_a_node_b+8>\n  }\n}'
+            - LLDB might produce: '(inner_a_node) *$PWNDBG_CREATED_VALUE_0 = {\n  value = 0\n  inner = {\n    next = 0x0000555555558098\n  }\n}'
+        - As such, this function should not be relied upon for parsing or programmatic use.
+        """
+        raise NotImplementedError()
+
     # This is a GDB implementation detail.
     def fetch_lazy(self) -> None:
         """

--- a/pwndbg/dbg/__init__.py
+++ b/pwndbg/dbg/__init__.py
@@ -664,6 +664,12 @@ class Type:
         # if there is a better debugger-specific way to do this.
         return [field.name for field in self.fields()]
 
+    def __eq__(self, rhs: object) -> bool:
+        """
+        Returns True if types are the same
+        """
+        raise NotImplementedError()
+
 
 class Value:
     """

--- a/pwndbg/dbg/gdb.py
+++ b/pwndbg/dbg/gdb.py
@@ -910,6 +910,13 @@ class GDBType(pwndbg.dbg_mod.Type):
     def __init__(self, inner: gdb.Type):
         self.inner = inner
 
+    @override
+    def __eq__(self, rhs: object) -> bool:
+        assert isinstance(rhs, GDBType), "tried to compare GDBType to other type"
+        other: GDBType = rhs
+
+        return self.inner == other.inner
+
     @property
     @override
     def sizeof(self) -> int:

--- a/pwndbg/dbg/gdb.py
+++ b/pwndbg/dbg/gdb.py
@@ -1004,7 +1004,10 @@ class GDBValue(pwndbg.dbg_mod.Value):
 
     @override
     def string(self) -> str:
-        return self.inner.string()
+        try:
+            return self.inner.string()
+        except gdb.error as e:
+            raise pwndbg.dbg_mod.Error(e)
 
     @override
     def fetch_lazy(self) -> None:

--- a/pwndbg/dbg/gdb.py
+++ b/pwndbg/dbg/gdb.py
@@ -1010,6 +1010,13 @@ class GDBValue(pwndbg.dbg_mod.Value):
             raise pwndbg.dbg_mod.Error(e)
 
     @override
+    def value_to_human_readable(self) -> str:
+        try:
+            return str(self.inner)
+        except gdb.error as e:
+            raise pwndbg.dbg_mod.Error(e)
+
+    @override
     def fetch_lazy(self) -> None:
         self.inner.fetch_lazy()
 

--- a/pwndbg/dbg/lldb/__init__.py
+++ b/pwndbg/dbg/lldb/__init__.py
@@ -488,6 +488,10 @@ class LLDBValue(pwndbg.dbg_mod.Value):
         return last_str
 
     @override
+    def value_to_human_readable(self) -> str:
+        return str(self.inner)
+
+    @override
     def fetch_lazy(self) -> None:
         # Not needed under LLDB.
         pass

--- a/pwndbg/dbg/lldb/__init__.py
+++ b/pwndbg/dbg/lldb/__init__.py
@@ -319,6 +319,13 @@ class LLDBType(pwndbg.dbg_mod.Type):
     def __init__(self, inner: lldb.SBType):
         self.inner = inner
 
+    @override
+    def __eq__(self, rhs: object) -> bool:
+        assert isinstance(rhs, LLDBType), "tried to compare LLDBType to other type"
+        other: LLDBType = rhs
+
+        return self.inner == other.inner
+
     @property
     @override
     def sizeof(self) -> int:

--- a/pwndbg/ghidra.py
+++ b/pwndbg/ghidra.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 import os
 
+import pwndbg.aglib.proc
+import pwndbg.aglib.regs
 import pwndbg.color.context as C
 import pwndbg.color.syntax_highlight as H
 import pwndbg.dbg
-import pwndbg.aglib.regs
-import pwndbg.aglib.proc
 import pwndbg.radare2
 import pwndbg.rizin
 

--- a/pwndbg/ghidra.py
+++ b/pwndbg/ghidra.py
@@ -2,13 +2,17 @@ from __future__ import annotations
 
 import os
 
-import gdb
-
 import pwndbg.color.context as C
 import pwndbg.color.syntax_highlight as H
-import pwndbg.gdblib.regs
+import pwndbg.dbg
+import pwndbg.aglib.regs
+import pwndbg.aglib.proc
 import pwndbg.radare2
 import pwndbg.rizin
+
+if pwndbg.dbg.is_gdblib_available():
+    import pwndbg.gdblib.symbol
+
 from pwndbg.color import message
 
 r2decompiler = pwndbg.config.add_param(
@@ -56,8 +60,8 @@ def decompile(func=None):
 
     if not func:
         func = (
-            hex(pwndbg.gdblib.regs[pwndbg.gdblib.regs.current.pc])
-            if pwndbg.gdblib.proc.alive
+            hex(pwndbg.aglib.regs[pwndbg.aglib.regs.current.pc])
+            if pwndbg.aglib.proc.alive
             else "main"
         )
 
@@ -69,8 +73,8 @@ def decompile(func=None):
     source = src.get("code", "")
 
     # If not running there is no current pc to mark
-    if pwndbg.gdblib.proc.alive:
-        pc = pwndbg.gdblib.regs[pwndbg.gdblib.regs.current.pc]
+    if pwndbg.aglib.proc.alive:
+        pc = pwndbg.aglib.regs[pwndbg.aglib.regs.current.pc]
 
         closest = 0
         for off in (a.get("offset", 0) for a in src.get("annotations", [])):
@@ -95,7 +99,7 @@ def decompile(func=None):
         # highlighting depends on the file extension to guess the language, so try to get one...
         src_filename = pwndbg.gdblib.symbol.selected_frame_source_absolute_filename()
         if not src_filename:
-            filename = gdb.current_progspace().filename
+            filename = pwndbg.dbg.selected_inferior().main_module_name()
             src_filename = filename + ".c" if os.path.basename(filename).find(".") < 0 else filename
         source = H.syntax_highlight(source, src_filename)
 

--- a/pwndbg/integration/binja.py
+++ b/pwndbg/integration/binja.py
@@ -28,24 +28,24 @@ import pygments.token
 from typing_extensions import ParamSpec
 
 import pwndbg
-import pwndbg.color
-import pwndbg.color.context as context_color
-import pwndbg.decorators
-import pwndbg.dbg
 import pwndbg.aglib.arch
 import pwndbg.aglib.elf
-import pwndbg.aglib.proc
 import pwndbg.aglib.memory
 import pwndbg.aglib.nearpc
+import pwndbg.aglib.proc
 import pwndbg.aglib.regs
+import pwndbg.color
+import pwndbg.color.context as context_color
+import pwndbg.dbg
+import pwndbg.decorators
 import pwndbg.integration
 import pwndbg.lib.cache
 import pwndbg.lib.config
+from pwndbg.aglib.nearpc import c as nearpc_color
+from pwndbg.aglib.nearpc import ljust_padding
 from pwndbg.color import message
 from pwndbg.color import theme
 from pwndbg.dbg import EventType
-from pwndbg.aglib.nearpc import c as nearpc_color
-from pwndbg.aglib.nearpc import ljust_padding
 from pwndbg.lib.functions import Argument
 from pwndbg.lib.functions import Function
 

--- a/pwndbg/integration/binja.py
+++ b/pwndbg/integration/binja.py
@@ -28,23 +28,24 @@ import pygments.token
 from typing_extensions import ParamSpec
 
 import pwndbg
-import pwndbg.aglib.arch
 import pwndbg.color
 import pwndbg.color.context as context_color
 import pwndbg.decorators
-import pwndbg.gdblib.elf
-import pwndbg.gdblib.memory
-import pwndbg.gdblib.nearpc
-import pwndbg.gdblib.regs
-import pwndbg.gdblib.symbol
+import pwndbg.dbg
+import pwndbg.aglib.arch
+import pwndbg.aglib.elf
+import pwndbg.aglib.proc
+import pwndbg.aglib.memory
+import pwndbg.aglib.nearpc
+import pwndbg.aglib.regs
 import pwndbg.integration
 import pwndbg.lib.cache
 import pwndbg.lib.config
 from pwndbg.color import message
 from pwndbg.color import theme
 from pwndbg.dbg import EventType
-from pwndbg.gdblib.nearpc import c as nearpc_color
-from pwndbg.gdblib.nearpc import ljust_padding
+from pwndbg.aglib.nearpc import c as nearpc_color
+from pwndbg.aglib.nearpc import ljust_padding
 from pwndbg.lib.functions import Argument
 from pwndbg.lib.functions import Function
 
@@ -189,18 +190,18 @@ def can_connect() -> bool:
 
 
 def l2r(addr: int) -> int:
-    exe = pwndbg.gdblib.elf.exe()
+    exe = pwndbg.aglib.elf.exe()
     if not exe:
         raise Exception("Can't find EXE base")
-    result = (addr - pwndbg.gdblib.proc.binary_base_addr + base()) & pwndbg.aglib.arch.ptrmask
+    result = (addr - pwndbg.aglib.proc.binary_base_addr + base()) & pwndbg.aglib.arch.ptrmask
     return result
 
 
 def r2l(addr: int) -> int:
-    exe = pwndbg.gdblib.elf.exe()
+    exe = pwndbg.aglib.elf.exe()
     if not exe:
         raise Exception("Can't find EXE base")
-    result = (addr - base() + pwndbg.gdblib.proc.binary_base_addr) & pwndbg.aglib.arch.ptrmask
+    result = (addr - base() + pwndbg.aglib.proc.binary_base_addr) & pwndbg.aglib.arch.ptrmask
     return result
 
 
@@ -212,9 +213,9 @@ def base():
 @pwndbg.dbg.event_handler(EventType.STOP)
 @with_bn()
 def auto_update_pc() -> None:
-    if not pwndbg.gdblib.proc.alive:
+    if not pwndbg.aglib.proc.alive:
         return
-    pc = pwndbg.gdblib.regs.pc
+    pc = pwndbg.aglib.regs.pc
     if bn_autosync.value:
         navigate_to(pc)
     _bn.update_pc_tag(l2r(pc))
@@ -228,7 +229,7 @@ _managed_bps: Dict[int, gdb.Breakpoint] = {}
 @pwndbg.dbg.event_handler(EventType.CONTINUE)
 @with_bn()
 def auto_update_bp() -> None:
-    if not pwndbg.gdblib.proc.alive:
+    if not pwndbg.aglib.proc.alive:
         return
     bps: List[int] = _bn.get_bp_tags()
     binja_bps = {r2l(addr) for addr in bps}
@@ -467,7 +468,7 @@ class BinjaProvider(pwndbg.integration.IntegrationProvider):
         min_indents = None
         for addr, decomp_toks in sliced:
             addrs.append(hex(addr))
-            syms.append(f"<{pwndbg.gdblib.symbol.get(addr)}>")
+            syms.append(f"<{pwndbg.dbg.selected_inferior().symbol_name_at_address(addr)}>")
             indents = 0
             for _, ty in decomp_toks:
                 if ty == "IndentationToken":
@@ -523,7 +524,7 @@ class BinjaProvider(pwndbg.integration.IntegrationProvider):
     def get_stack_var_name(self, addr: int) -> str | None:
         cur = gdb.selected_frame()
         # there is no earlier frame so we give up
-        if addr < pwndbg.gdblib.regs.read_reg("sp", cur):
+        if addr < pwndbg.aglib.regs.read_reg("sp", cur):
             return None
         newest = True
         # try to find the oldest frame that's earlier than the address
@@ -531,19 +532,19 @@ class BinjaProvider(pwndbg.integration.IntegrationProvider):
             upper = cur.older()
             if upper is None:
                 break
-            upper_sp = pwndbg.gdblib.regs.read_reg("sp", upper)
+            upper_sp = pwndbg.aglib.regs.read_reg("sp", upper)
             if upper_sp > addr:
                 break
             cur = upper
             newest = False
         regs = [
             (name, val)
-            for name in pwndbg.gdblib.regs.common
-            if (val := pwndbg.gdblib.regs.read_reg(name, cur)) is not None
+            for name in pwndbg.aglib.regs.common
+            if (val := pwndbg.aglib.regs.read_reg(name, cur)) is not None
         ]
         # put stack pointer and frame pointer at the front
         regs.sort(
-            key=lambda x: {pwndbg.gdblib.regs.stack: 0, pwndbg.gdblib.regs.frame: 1}.get(x[0], 2)
+            key=lambda x: {pwndbg.aglib.regs.stack: 0, pwndbg.aglib.regs.frame: 1}.get(x[0], 2)
         )
         ret: Tuple[int, str, int] | None = _bn.get_stack_var_name(l2r(int(cur.pc())), regs, addr)
         if ret is None:

--- a/pwndbg/integration/binja.py
+++ b/pwndbg/integration/binja.py
@@ -46,6 +46,7 @@ from pwndbg.aglib.nearpc import ljust_padding
 from pwndbg.color import message
 from pwndbg.color import theme
 from pwndbg.dbg import EventType
+from pwndbg.dbg.gdb import GDBFrame
 from pwndbg.lib.functions import Argument
 from pwndbg.lib.functions import Function
 
@@ -522,15 +523,15 @@ class BinjaProvider(pwndbg.integration.IntegrationProvider):
     @with_bn()
     @pwndbg.lib.cache.cache_until("stop")
     def get_stack_var_name(self, addr: int) -> str | None:
-        cur = gdb.selected_frame()
+        cur = GDBFrame(gdb.selected_frame())
         # there is no earlier frame so we give up
         if addr < pwndbg.aglib.regs.read_reg("sp", cur):
             return None
         newest = True
         # try to find the oldest frame that's earlier than the address
         while True:
-            upper = cur.older()
-            if upper is None:
+            upper = GDBFrame(cur.inner.older())
+            if upper.inner is None:
                 break
             upper_sp = pwndbg.aglib.regs.read_reg("sp", upper)
             if upper_sp > addr:

--- a/pwndbg/lib/net.py
+++ b/pwndbg/lib/net.py
@@ -10,7 +10,6 @@ import socket
 from typing import List
 
 import pwndbg.aglib.arch
-import pwndbg.gdblib.file
 
 # http://students.mimuw.edu.pl/lxr/source/include/net/tcp_states.h
 TCP_STATUSES = {

--- a/pwndbg/radare2.py
+++ b/pwndbg/radare2.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-import gdb
-
-import pwndbg.gdblib.elf
+import pwndbg.aglib.elf
 import pwndbg.lib.cache
 
 
@@ -21,15 +19,15 @@ def r2pipe():
 
     Returns a r2pipe.open handle.
     """
-    filename = gdb.current_progspace().filename
+    filename = pwndbg.dbg.selected_inferior().main_module_name()
     if not filename:
         raise Exception("Could not find objfile to create a r2pipe for")
 
     import r2pipe
 
     flags = ["-e", "io.cache=true"]
-    if pwndbg.gdblib.elf.get_elf_info(filename).is_pie and pwndbg.gdblib.elf.exe():
-        flags.extend(["-B", hex(pwndbg.gdblib.elf.exe().address)])
+    if pwndbg.aglib.elf.get_elf_info(filename).is_pie and pwndbg.aglib.elf.exe():
+        flags.extend(["-B", hex(pwndbg.aglib.elf.exe().address)])
     r2 = r2pipe.open(filename, flags=flags)
     r2.cmd("aaaa")
     return r2

--- a/pwndbg/rizin.py
+++ b/pwndbg/rizin.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import pwndbg.dbg
 import pwndbg.aglib.elf
+import pwndbg.dbg
 import pwndbg.lib.cache
 
 

--- a/pwndbg/rizin.py
+++ b/pwndbg/rizin.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-import gdb
-
-import pwndbg.gdblib.elf
+import pwndbg.dbg
+import pwndbg.aglib.elf
 import pwndbg.lib.cache
 
 
@@ -18,15 +17,15 @@ def rzpipe():
     Raises Exception if anything goes fatally wrong.
     Returns a rzpipe.open handle.
     """
-    filename = gdb.current_progspace().filename
+    filename = pwndbg.dbg.selected_inferior().main_module_name()
     if not filename:
         raise Exception("Could not find objfile to create a rzpipe for")
 
     import rzpipe
 
     flags = ["-e", "io.cache=true"]
-    if pwndbg.gdblib.elf.get_elf_info(filename).is_pie and pwndbg.gdblib.elf.exe():
-        flags.extend(["-B", hex(pwndbg.gdblib.elf.exe().address)])
+    if pwndbg.aglib.elf.get_elf_info(filename).is_pie and pwndbg.aglib.elf.exe():
+        flags.extend(["-B", hex(pwndbg.aglib.elf.exe().address)])
     rz = rzpipe.open(filename, flags=flags)
     rz.cmd("aaaa")
     return rz


### PR DESCRIPTION
Port a lot of commands into debug-agnostic api.
Some of them are just partially ported.

Additional changes:
- fix https://github.com/pwndbg/pwndbg/issues/2534 crash

New available from lldb/aglib:
- auxv ✅
- procinfo ✅
- memoize ✅
- pwndbg ✅
- tls (❌ aarch64,  x86_64 ✅)
- errno ✅
- rizin - ❓ don't know how to test
- radare2 - ❓ don't know how to test
- linkmap ✅
- gdt - ❓ don't know how to test
- plist ✅
- asm ✅
- aslr ✅
