### PR TITLE
fix(nix): add missing one_gadget package for devshell

### DIFF
--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -67,6 +67,9 @@ in
           zig_0_10 # version match setup-dev.sh
           go
 
+          # for onegadget command
+          one_gadget
+
           # from qemu-tests.sh
           binutils
           ;


### PR DESCRIPTION
I had to test the onegadget command due to some bold text related to #2157, and noticed the tool didn't exist in the devshell, so added.