### PR TITLE
Remove `one_shot` from `Process.break_at`

### DIFF
--- a/pwndbg/dbg/__init__.py
+++ b/pwndbg/dbg/__init__.py
@@ -437,7 +437,6 @@ class Process:
         self,
         location: BreakpointLocation | WatchpointLocation,
         stop_handler: Callable[[StopPoint], bool] | None = None,
-        one_shot: bool = False,
         internal: bool = False,
     ) -> StopPoint:
         """
@@ -453,11 +452,6 @@ class Process:
         as a signal to stop, and a return value of `False` being interpreted as
         a signal to continue execution. The extent of the actions that may be
         taken during the stop handler is determined by the debugger.
-
-        Breakpoints and watchpoints marked as `one_shot` are removed after they
-        are first triggered. For the purposes of `one_shot`, a breakpoint or
-        watchpoint that has a stop handler is only considered to be triggered
-        when its stop handler returns `True`.
 
         Marking a breakpoint or watchpoint as `internal` hints to the
         implementation that the created breakpoint or watchpoint should not be

--- a/pwndbg/dbg/gdb.py
+++ b/pwndbg/dbg/gdb.py
@@ -641,7 +641,6 @@ class GDBProcess(pwndbg.dbg_mod.Process):
         self,
         location: pwndbg.dbg_mod.BreakpointLocation | pwndbg.dbg_mod.WatchpointLocation,
         stop_handler: Callable[[pwndbg.dbg_mod.StopPoint], bool] | None = None,
-        one_shot: bool = False,
         internal: bool = False,
     ) -> pwndbg.dbg_mod.StopPoint:
         # GDB does not support creating new breakpoints in the middle of a
@@ -658,7 +657,6 @@ class GDBProcess(pwndbg.dbg_mod.Process):
                 f"*{location.address:#x}",
                 gdb.BP_BREAKPOINT,
                 internal=internal,
-                temporary=one_shot,
             )
         elif isinstance(location, pwndbg.dbg_mod.WatchpointLocation):
             if location.watch_read and location.watch_write:
@@ -673,7 +671,6 @@ class GDBProcess(pwndbg.dbg_mod.Process):
                 gdb.BP_WATCHPOINT,
                 wp_class=c,
                 internal=internal,
-                temporary=one_shot,
             )
 
         if internal:

--- a/pwndbg/dbg/lldb/__init__.py
+++ b/pwndbg/dbg/lldb/__init__.py
@@ -1289,7 +1289,6 @@ class LLDBProcess(pwndbg.dbg_mod.Process):
         self,
         location: pwndbg.dbg_mod.BreakpointLocation | pwndbg.dbg_mod.WatchpointLocation,
         stop_handler: Callable[[pwndbg.dbg_mod.StopPoint], bool] | None = None,
-        one_shot: bool = False,
         internal: bool = False,
     ) -> pwndbg.dbg_mod.StopPoint:
         if isinstance(location, pwndbg.dbg_mod.BreakpointLocation):


### PR DESCRIPTION
As noted in #2543, the `one_shot` parameter in the Debugger-agnostic breakpoint interface is unused by Pwndbg. This PR removes it. Users can use an `await ExecutionController.cont()` followed by a `StopPoint.remove()` instead, which achieves the same effect in all of the use cases we currently have in Pwndbg.