### PR TITLE
Fix the lexing of arguments in LLDB to match the behavior of gdb

### DIFF
--- a/pwndbg/dbg/lldb/__init__.py
+++ b/pwndbg/dbg/lldb/__init__.py
@@ -4,6 +4,7 @@ import bisect
 import collections
 import os
 import random
+import shlex
 import sys
 from typing import Any
 from typing import Awaitable
@@ -1556,7 +1557,7 @@ class LLDB(pwndbg.dbg_mod.Debugger):
 
     @override
     def lex_args(self, command_line: str) -> List[str]:
-        return command_line.split()
+        return shlex.split(command_line)
 
     def _any_inferior(self) -> LLDBProcess | None:
         """


### PR DESCRIPTION
Right now commands have issue:
```python
def rop(grep: str | None, argument: List[str]) -> None:
    print(f'grep = {repr(grep)}')
    print(f'argument = {repr(argument)}')
    
# pwndbg-lldb> rop --grep 'pop rdi'
# grep = "'pop"
# argument = ["rdi'"]
```

Gdb:
```python
>>> input_string = 'arg1 "arg two" \'arg three\' arg\\ four --arg="1 2"'
>>> gdb.string_to_argv(input_string)
['arg1', 'arg two', 'arg three', 'arg four', '--arg=1 2']
```

Shlex split:
```python
>>> input_string = 'arg1 "arg two" \'arg three\' arg\\ four --arg="1 2"'
>>> shlex.split(input_string)
['arg1', 'arg two', 'arg three', 'arg four', '--arg=1 2']
```


