### PR TITLE
Remove assertion from `aglib.get_register`

### DIFF
--- a/pwndbg/aglib/regs.py
+++ b/pwndbg/aglib/regs.py
@@ -41,9 +41,11 @@ def get_register(
 ) -> pwndbg.dbg_mod.Value | None:
     if frame is None:
         frame = pwndbg.dbg.selected_frame()
-    assert (
-        frame is not None
-    ), "pwndbg.dbg.selected_frame() should never return None when marked with @OnlyWhenRunning"
+    if frame is None:
+        # `read_reg` will return None when it catches this exception. This
+        # mirrors how a `gdb.error` causes `read_reg` to return `None` in
+        # gdblib when no frame is selected.
+        raise pwndbg.dbg_mod.Error("No currently selected frame to read registers from")
 
     regs = regs_in_frame(frame)
 


### PR DESCRIPTION
There are contexts in which GDB can report that an inferior is live but have no selected frame. In these contexts, calling `pwndbg.aglib.regs.read_reg` will trigger an assertion. In contrast, `pwndbg.gdblib.regs.reg_read` will simply return `None`. 

This PR brings the behavior of `aglib.regs` in line with the one of `gdblib.regs` in these contexts.

Personally, I’m not a fan of failing silently the way we do here, but given that this is the behavior gdblib has, I think it makes sense for us to mirror it. For now, at least.