### PR TITLE
mypy: fix typing issues

### DIFF
--- a/pwndbg/gdblib/events.py
+++ b/pwndbg/gdblib/events.py
@@ -122,11 +122,11 @@ def unpause(event_registry) -> None:
 
 
 def connect(
-    func: Callable[P, T],
+    func: Callable[[], T],
     event_handler: Any,
     name: str = "",
     priority: HandlerPriority = HandlerPriority.LOW,
-) -> Callable[P, T]:
+) -> Callable[[], T]:
     if debug:
         print("Connecting", func.__name__, event_handler)
 


### PR DESCRIPTION
Before it was reported:
```
pwndbg/gdblib/events.py: note: In function "connect":
pwndbg/gdblib/events.py:156: error: Too few arguments  [call-arg]
                func()
                ^~~~~~
Found 1 error in 1 file (checked 233 source files)
```