### PR TITLE
Add workaround for gdbserver weird bug

### DIFF
--- a/pwndbg/gdblib/events.py
+++ b/pwndbg/gdblib/events.py
@@ -8,12 +8,14 @@ from __future__ import annotations
 
 import sys
 from collections import defaultdict
+from collections import deque
 from enum import Enum
 from enum import auto
 from functools import partial
 from functools import wraps
 from typing import Any
 from typing import Callable
+from typing import Deque
 from typing import Dict
 from typing import List
 from typing import Set
@@ -73,6 +75,48 @@ class StartEvent:
 
 
 gdb.events.start = StartEvent()
+
+
+def _is_safe_event():
+    # Workaround to fix bug in gdbserver: https://github.com/pwndbg/pwndbg/issues/2576
+    try:
+        gdb.selected_frame()
+    except gdb.error as e:
+        if "Remote 'g' packet reply is too long" in str(e):
+            return False
+    return True
+
+
+class _DelayedEventHandler:
+    def __init__(self, func: Callable[[], Any]):
+        self.func = func
+
+    def __call__(self):
+        self.func()
+
+
+def wrap_safe_event_handler(func: Callable[[], T]) -> Callable[[], T]:
+    """
+    Wraps an event handler to ensure it is only executed when the event is safe.
+    Invalid events are queued and executed later when safe.
+
+    Note: Avoid using `gdb.post_event` because of another bug in gdbserver
+    where the `gdb.newest_frame` function may not work properly.
+
+    Workaround to fix bug in gdbserver: https://github.com/pwndbg/pwndbg/issues/2576
+    """
+    queued_invalid_events: Deque[Callable[[], T]] = deque()
+
+    @wraps(func)
+    def _inner():
+        if not _is_safe_event():
+            queued_invalid_events.append(func)
+        else:
+            while queued_invalid_events:
+                queued_invalid_events.popleft()()
+            func()
+
+    return _inner
 
 
 class HandlerPriority(Enum):
@@ -177,7 +221,7 @@ def cont(func: Callable[[], T], **kwargs: Any) -> Callable[[], T]:
 
 
 def new_objfile(func: Callable[[], T], **kwargs: Any) -> Callable[[], T]:
-    return connect(func, gdb.events.new_objfile, "obj", **kwargs)
+    return connect(wrap_safe_event_handler(func), gdb.events.new_objfile, "obj", **kwargs)
 
 
 def stop(func: Callable[[], T], **kwargs: Any) -> Callable[[], T]:

--- a/pwndbg/gdblib/events.py
+++ b/pwndbg/gdblib/events.py
@@ -95,14 +95,6 @@ def _is_safe_event_thread():
     return True
 
 
-class _DelayedEventHandler:
-    def __init__(self, func: Callable[[], Any]):
-        self.func = func
-
-    def __call__(self):
-        self.func()
-
-
 def wrap_safe_event_handler(event_handler: Callable[P, T]) -> Callable[P, T]:
     """
     Wraps an event handler to ensure it is only executed when the event is safe.
@@ -120,7 +112,7 @@ def wrap_safe_event_handler(event_handler: Callable[P, T]) -> Callable[P, T]:
             return
 
         if not _is_safe_event_thread():
-            gdb.post_event(_DelayedEventHandler(_loop_until_thread_ok))
+            gdb.post_event(_loop_until_thread_ok)
             return
 
         while queued_invalid_events:
@@ -131,7 +123,7 @@ def wrap_safe_event_handler(event_handler: Callable[P, T]) -> Callable[P, T]:
         if not _is_safe_event_packet():
             queued_invalid_events.append(lambda: event_handler(*a, **kw))
 
-            gdb.post_event(_DelayedEventHandler(_loop_until_thread_ok))
+            gdb.post_event(_loop_until_thread_ok)
         else:
             while queued_invalid_events:
                 queued_invalid_events.popleft()()

--- a/pwndbg/gdblib/events.py
+++ b/pwndbg/gdblib/events.py
@@ -77,12 +77,20 @@ class StartEvent:
 gdb.events.start = StartEvent()
 
 
-def _is_safe_event():
-    # Workaround to fix bug in gdbserver: https://github.com/pwndbg/pwndbg/issues/2576
+def _is_safe_event_packet():
     try:
         gdb.selected_frame()
     except gdb.error as e:
         if "Remote 'g' packet reply is too long" in str(e):
+            return False
+    return True
+
+
+def _is_safe_event_thread():
+    try:
+        gdb.newest_frame()
+    except gdb.error as e:
+        if "Selected thread is running" in str(e):
             return False
     return True
 
@@ -95,7 +103,7 @@ class _DelayedEventHandler:
         self.func()
 
 
-def wrap_safe_event_handler(func: Callable[[], T]) -> Callable[[], T]:
+def wrap_safe_event_handler(event_handler: Callable[P, T]) -> Callable[P, T]:
     """
     Wraps an event handler to ensure it is only executed when the event is safe.
     Invalid events are queued and executed later when safe.
@@ -105,18 +113,31 @@ def wrap_safe_event_handler(func: Callable[[], T]) -> Callable[[], T]:
 
     Workaround to fix bug in gdbserver: https://github.com/pwndbg/pwndbg/issues/2576
     """
-    queued_invalid_events: Deque[Callable[[], T]] = deque()
+    queued_invalid_events: Deque[Callable[..., Any]] = deque()
 
-    @wraps(func)
-    def _inner():
-        if not _is_safe_event():
-            queued_invalid_events.append(func)
+    def _loop_until_thread_ok():
+        if not queued_invalid_events:
+            return
+
+        if not _is_safe_event_thread():
+            gdb.post_event(_DelayedEventHandler(_loop_until_thread_ok))
+            return
+
+        while queued_invalid_events:
+            queued_invalid_events.popleft()()
+
+    @wraps(event_handler)
+    def _inner_handler(*a: P.args, **kw: P.kwargs):
+        if not _is_safe_event_packet():
+            queued_invalid_events.append(lambda: event_handler(*a, **kw))
+
+            gdb.post_event(_DelayedEventHandler(_loop_until_thread_ok))
         else:
             while queued_invalid_events:
                 queued_invalid_events.popleft()()
-            func()
+            event_handler(*a, **kw)
 
-    return _inner
+    return _inner_handler
 
 
 class HandlerPriority(Enum):
@@ -207,6 +228,10 @@ def connect(
     registered[event_handler].setdefault(priority, []).append(caller)
     if event_handler not in connected:
         handle = partial(invoke_event, event_handler)
+
+        if event_handler == gdb.events.new_objfile:
+            handle = wrap_safe_event_handler(handle)
+
         event_handler.connect(handle)
         connected[event_handler] = handle
     return func
@@ -221,7 +246,7 @@ def cont(func: Callable[[], T], **kwargs: Any) -> Callable[[], T]:
 
 
 def new_objfile(func: Callable[[], T], **kwargs: Any) -> Callable[[], T]:
-    return connect(wrap_safe_event_handler(func), gdb.events.new_objfile, "obj", **kwargs)
+    return connect(func, gdb.events.new_objfile, "obj", **kwargs)
 
 
 def stop(func: Callable[[], T], **kwargs: Any) -> Callable[[], T]:

--- a/pwndbg/gdblib/events.py
+++ b/pwndbg/gdblib/events.py
@@ -120,14 +120,14 @@ def wrap_safe_event_handler(event_handler: Callable[P, T]) -> Callable[P, T]:
 
     @wraps(event_handler)
     def _inner_handler(*a: P.args, **kw: P.kwargs):
-        if not _is_safe_event_packet():
-            queued_invalid_events.append(lambda: event_handler(*a, **kw))
-
-            gdb.post_event(_loop_until_thread_ok)
-        else:
+        if _is_safe_event_packet():
             while queued_invalid_events:
                 queued_invalid_events.popleft()()
             event_handler(*a, **kw)
+            return
+
+        queued_invalid_events.append(lambda: event_handler(*a, **kw))
+        gdb.post_event(_loop_until_thread_ok)
 
     return _inner_handler
 


### PR DESCRIPTION
https://github.com/pwndbg/pwndbg/issues/2576

Disadvantage:  
- ~~Events may not be processed if a single invalid event occurs and no additional events are triggered afterward.~~ Fixed

There are two bugs in gdbserver/GDB:  
1. In certain GDB events (e.g., `new_objfile`, `clear_objfiles`, `executable_changed`), GDB commands cannot be executed when used with gdbserver and a binary performing an `execve` syscall.  
2. Using `gdb.post_event` causes issues with the `gdb.newest_frame` function, resulting in the error: `gdb.error: Selected thread is running.` This error is not true(sic!)

<img width="572" alt="image" src="https://github.com/user-attachments/assets/5e88c576-97b6-42ab-a31f-aacd73ea2261">
