### PR TITLE
Fix #2549: block config.<name> assignments

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -89,7 +89,7 @@ Here's a small snippet of the actual test:
 ```python
 def test_hexdump(start_binary):
     start_binary(BINARY)
-    pwndbg.config.hexdump_group_width = -1
+    pwndbg.config.hexdump_group_width.value = -1
 
     gdb.execute("set hexdump-byte-separator")
     stack_addr = pwndbg.aglib.regs.rsp - 0x100

--- a/pwndbg/lib/config.py
+++ b/pwndbg/lib/config.py
@@ -210,6 +210,6 @@ class Config:
             raise AttributeError(f"'Config' object has no attribute '{name}'")
 
     def __setattr__(self, attr, val):
-        if attr in ('params', 'triggers'):
+        if attr in ("params", "triggers"):
             return super().__setattr__(attr, val)
-        raise AttributeError('Use config.<param>.value to set value of a parameter')
+        raise AttributeError("Use config.<param>.value to set value of a parameter")

--- a/pwndbg/lib/config.py
+++ b/pwndbg/lib/config.py
@@ -208,3 +208,8 @@ class Config:
             return self.params[name]
         else:
             raise AttributeError(f"'Config' object has no attribute '{name}'")
+
+    def __setattr__(self, attr, val):
+        if attr in ('params', 'triggers'):
+            return super().__setattr__(attr, val)
+        raise AttributeError('Use config.<param>.value to set value of a parameter')

--- a/tests/gdb-tests/tests/test_hexdump.py
+++ b/tests/gdb-tests/tests/test_hexdump.py
@@ -13,7 +13,7 @@ BINARY = tests.binaries.get("reference-binary.out")
 
 
 def run_tests(stack, use_big_endian, expected):
-    pwndbg.config.hexdump_group_use_big_endian = use_big_endian
+    pwndbg.config.hexdump_group_use_big_endian.value = use_big_endian
 
     # Put some data onto the stack
     pwndbg.aglib.memory.write(stack, cyclic(0x100))
@@ -35,7 +35,7 @@ def run_tests(stack, use_big_endian, expected):
 
 def test_hexdump(start_binary):
     start_binary(BINARY)
-    pwndbg.config.hexdump_group_width = -1
+    pwndbg.config.hexdump_group_width.value = -1
 
     # TODO: Setting theme options with Python isn't working
     gdb.execute("set hexdump-byte-separator")


### PR DESCRIPTION
This commit blocks `config.<param> = <value>` assignments as they should be done via `config.<param>.value = <value>` instead.

<!-- Please make sure to read the testing and linting instructions at https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md before creating a PR -->

Fixes #2549