### PR TITLE
Fix handling of absolute paths in `LLDBProcess._resolve_path_name`

### DIFF
--- a/pwndbg/dbg/lldb/__init__.py
+++ b/pwndbg/dbg/lldb/__init__.py
@@ -1383,7 +1383,11 @@ class LLDBProcess(pwndbg.dbg_mod.Process):
         if len(link) == 0:
             return spec.fullpath
 
-        return os.path.normpath(f"{spec.dirname}/{link}")
+        # Get the absolute path if it is not already absolute.
+        if not os.path.isabs(link):
+            link = os.path.normpath(f"{spec.dirname}/{link}")
+
+        return link
 
     @override
     def module_section_locations(self) -> List[Tuple[int, int, str, str]]:


### PR DESCRIPTION
The `_resolve_fullpath` method in `LLDBProcess` doesn't properly handle relative paths, as pointed out in #2590. This PR should fix that.