### PR TITLE
Add support for event suspention to the Debugger API

### DIFF
--- a/pwndbg/dbg/__init__.py
+++ b/pwndbg/dbg/__init__.py
@@ -927,6 +927,24 @@ class Debugger:
         """
         raise NotImplementedError()
 
+    def suspend_events(self, ty: EventType) -> None:
+        """
+        Suspend delivery of all events of the given type until it is resumed
+        through a call to `resume_events`.
+
+        Events triggered during a suspension will be ignored, and will not be
+        delived, even after delivery is resumed.
+        """
+        raise NotImplementedError()
+
+    def resume_events(self, ty: EventType) -> None:
+        """
+        Resume the delivery of all events of the given type, if previously
+        suspeded through a call to `suspend_events`. Does nothing if the
+        delivery has not been previously suspeded.
+        """
+        raise NotImplementedError()
+
     def set_sysroot(self, sysroot: str) -> bool:
         """
         Sets the system root for this debugger.

--- a/pwndbg/dbg/lldb/__init__.py
+++ b/pwndbg/dbg/lldb/__init__.py
@@ -1468,6 +1468,9 @@ class LLDB(pwndbg.dbg_mod.Debugger):
     # them by means of the `_trigger_event()` method.
     event_handlers: Dict[pwndbg.dbg_mod.EventType, List[Callable[..., T]]]
 
+    # Event types may be suspended. We keep track of that here.
+    suspended_events: Dict[pwndbg.dbg_mod.EventType, bool]
+
     # The prompt hook fired right before the prompt is displayed.
     prompt_hook: Callable[[], None]
 
@@ -1486,6 +1489,9 @@ class LLDB(pwndbg.dbg_mod.Debugger):
         self.event_handlers = {}
         self.controllers = []
         self._current_process_is_gdb_remote = False
+
+        import pwndbg
+        self.suspended_events = {a: False for a in pwndbg.dbg_mod.EventType}
 
         debugger = args[0]
         assert (
@@ -1698,6 +1704,14 @@ class LLDB(pwndbg.dbg_mod.Debugger):
 
         return decorator
 
+    @override
+    def suspend_events(self, ty: pwndbg.dbg_mod.EventType) -> None:
+        self.suspended_events[ty] = True
+
+    @override
+    def resume_events(self, ty: pwndbg.dbg_mod.EventType) -> None:
+        self.suspended_events[ty] = False
+
     def _fire_prompt_hook(self) -> None:
         """
         The REPL calls this function in order to signal that the prompt hooks
@@ -1713,6 +1727,9 @@ class LLDB(pwndbg.dbg_mod.Debugger):
         """
         if ty not in self.event_handlers:
             # No one cares about this event type.
+            return
+        if self.suspended_events[ty]:
+            # This event has been suspended.
             return
 
         for handler in self.event_handlers[ty]:

--- a/pwndbg/dbg/lldb/__init__.py
+++ b/pwndbg/dbg/lldb/__init__.py
@@ -1491,6 +1491,7 @@ class LLDB(pwndbg.dbg_mod.Debugger):
         self._current_process_is_gdb_remote = False
 
         import pwndbg
+
         self.suspended_events = {a: False for a in pwndbg.dbg_mod.EventType}
 
         debugger = args[0]


### PR DESCRIPTION
This PR is needed as part of #2592.

This PR adds support for suspension and resuming of event delivery to the Debugger API in the form of the `Debugger.suspend_events` and `Debugger.resume_events` methods. They are meant the be the debugger-agnostic analogues to `pwndbg.gdblib.event.pause` and `pwndbg.gdblib.event.unpause`, and they are meant to behave the same as they do, in that paused event types are dropped, and not delivered at all, even after the event type is unpaused.
