### PR TITLE
Fix/improve UX of start/sstart/entry on remote targets

### DIFF
--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -290,6 +290,7 @@ def OnlyWhenLocal(function: Callable[P, T]) -> Callable[P, Optional[T]]:
             msg += ' Try "help target" or "continue".'
 
         log.error(msg)
+        return None
 
     return _OnlyWhenLocal
 

--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -278,6 +278,22 @@ def fix_int_reraise(*a, **kw) -> int:
     return fix_int(*a, reraise=True, **kw)
 
 
+def OnlyWhenLocal(function: Callable[P, T]) -> Callable[P, Optional[T]]:
+    @functools.wraps(function)
+    def _OnlyWhenLocal(*a: P.args, **kw: P.kwargs) -> Optional[T]:
+        if not pwndbg.aglib.remote.is_remote():
+            return function(*a, **kw)
+
+        msg = f'The "remote" target does not support "{function.__name__}".'
+
+        if pwndbg.dbg.is_gdblib_available():
+            msg += ' Try "help target" or "continue".'
+
+        log.error(msg)
+
+    return _OnlyWhenLocal
+
+
 def OnlyWithFile(function: Callable[P, T]) -> Callable[P, Optional[T]]:
     @functools.wraps(function)
     def _OnlyWithFile(*a: P.args, **kw: P.kwargs) -> Optional[T]:

--- a/pwndbg/commands/start.py
+++ b/pwndbg/commands/start.py
@@ -67,6 +67,7 @@ parser.add_argument(
 
 @pwndbg.commands.ArgparsedCommand(parser, aliases=["main", "init"], category=CommandCategory.START)
 @pwndbg.commands.OnlyWithDbg("gdb")
+@pwndbg.commands.OnlyWhenLocal
 def start(args=None) -> None:
     if args is None:
         args = []
@@ -117,6 +118,7 @@ parser.add_argument(
 
 @pwndbg.commands.ArgparsedCommand(parser, category=CommandCategory.START)
 @pwndbg.commands.OnlyWithFile
+@pwndbg.commands.OnlyWhenLocal
 def entry(args=None) -> None:
     if args is None:
         args = []
@@ -142,6 +144,7 @@ def entry(args=None) -> None:
 )
 @pwndbg.commands.OnlyWithFile
 @pwndbg.commands.OnlyWithDbg("gdb")
+@pwndbg.commands.OnlyWhenLocal
 def sstart() -> None:
     gdb.Breakpoint("__libc_start_main", temporary=True)
     gdb.execute("run")


### PR DESCRIPTION
Fixes #2584 by checking if the target is remote in `start`, `entry` and `sstart` commands.

<!-- Please make sure to read the testing and linting instructions at https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md before creating a PR -->
