### PR TITLE
Fix issues in the Heap Tracker

### DIFF
--- a/pwndbg/gdblib/ptmalloc2_tracking.py
+++ b/pwndbg/gdblib/ptmalloc2_tracking.py
@@ -547,6 +547,7 @@ class FreeEnterBreakpoint(gdb.Breakpoint):
             return False
         if ptr == 0:
             # free(0) is a no-op.
+            print("[*] free(0x0)")
             return False
 
         self.tracker.enter_memory_management(FREE_NAME)


### PR DESCRIPTION
This PR expands inferior support of the Heap Tracker, by handling re-entrant calls to memory management functions. The strategy that we adopt is to simply ignore calls to memory management functions made downstream from other memory management functions, and, consequently, we only consider the top-level effect of these calls - i.e. we don't care how the underlying implementation actually allocates or frees or resizes chunks of memory, just that it does.

This PR also removes the calls to `gdb.Breakpoint.delete` in the middle of GDB's breakpoint stop handlers, which could cause GDB to crash with a UAF. This particular change can be reversed when we port this module to `aglib`, as `GDBStopPoint` allows us to call `GDBStopPoint.delete()` as part of its stop handler. The way we accomplish this is by deferring deletion until the next Pwndbg stop event, at which point deletions are allowed. This is also the exact same strategy employed by `GDBStopPoint` to allow deletions as part of the stop handler.

This PR also makes both `free(0)` and `realloc(..., 0)` into a no-op, with the latter triggering a warning message, due to its behavior being [implementation defined pre-C23, and undefined behavior after C23](https://en.cppreference.com/w/c/memory/realloc).