### PR TITLE
Fix context history with disabled context-sections

### DIFF
--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -337,6 +337,8 @@ def serve_context_history(function: Callable[P, List[str]]) -> Callable[P, List[
 
 
 def history_handle_unchanged_contents() -> None:
+    if not context_history:
+        return
     longest_history = max(len(h) for h in context_history.values())
     for section_name, history in context_history.items():
         # Duplicate the last entry if it is the same as the previous one


### PR DESCRIPTION
When gdb is started and context is disabled by clearing `context-sections` before a context output was ever issued, the context history failed to handle the empty history. It assumed that there would always be data in one of the sections after running the context command.

I wonder why the [test for empty context-sections](https://github.com/pwndbg/pwndbg/blob/6727be246f88df09954c11cf2c8ab79687842813/tests/gdb-tests/tests/test_context_commands.py#L84) didn't catch this. Are gdb tests run in the same gdb session without restarting gdb inbetween?

Fixes #2611