### PR TITLE
Fix context history with `cwatch`'d expressions

### DIFF
--- a/tests/gdb-tests/tests/test_context_commands.py
+++ b/tests/gdb-tests/tests/test_context_commands.py
@@ -493,6 +493,28 @@ def test_context_history_prev_next(start_binary):
     assert history_ctx != third_ctx
     assert "(history " not in third_ctx
 
+    # Check if cwatch expressions are also stored in the history
+    gdb.execute("cwatch $rip")
+    gdb.execute("cwatch execute 'p/z $rsp'")
+    fourth_ctx = gdb.execute("ctx", to_string=True)
+    assert "1: $rip = " in fourth_ctx
+    assert "2: p/z $rsp\n$1 = 0x" in fourth_ctx
+
+    # The next context shows a different output variable $2
+    gdb.execute("si")
+    fifth_ctx = gdb.execute("ctx", to_string=True)
+    assert "1: $rip = " in fifth_ctx
+    assert "2: p/z $rsp\n$2 = 0x" in fifth_ctx
+
+    # Check that the expression section shows the old gdb variable $1 again.
+    gdb.execute("contextprev")
+    history_ctx = gdb.execute("ctx", to_string=True)
+    assert "1: $rip = " in history_ctx
+    assert "2: p/z $rsp\n$1 = 0x" in history_ctx
+
+    gdb.execute("cunwatch 2")
+    gdb.execute("cunwatch 1")
+
 
 def test_context_history_search(start_binary):
     start_binary(REFERENCE_BINARY)


### PR DESCRIPTION
The output of the expressions section changes even when running `context` multiple times after each other. The output variables in GDB are counted up when reexecuting the watched commands for example. The other sections don't change their output. This caused the history to be extended infinitely when using `ctxp` while having a `cwatch` command executed.

Special case the `expressions` context section in the history handling to avoid reevaluating the watched commands/expressions while browsing the history. This doesn't add the context output to the history when the expressions VALUES change somehow like it is done for the other sections, but since we cannot know if gdb counted up their output variable names from $1 to $2 or the value changed, this is a compromise.

Fixes #2579
