### PR TITLE
Fix crash in hexdump with large counts

### DIFF
--- a/pwndbg/aglib/memory.py
+++ b/pwndbg/aglib/memory.py
@@ -16,6 +16,7 @@ GdbDict = Dict[str, Union["GdbDict", int]]
 
 
 MMAP_MIN_ADDR = 0x8000
+MAX_HEXDUMP_SIZE = 1 * 1024 * 1024 * 1024  # 1 GB
 
 
 def read(addr: int, count: int, partial: bool = False) -> bytearray:
@@ -32,6 +33,10 @@ def read(addr: int, count: int, partial: bool = False) -> bytearray:
         :class:`bytearray`: The memory at the specified address,
         or ``None``.
     """
+    if count > MAX_HEXDUMP_SIZE:
+        raise ValueError(
+            f"Request size too large: {count} bytes, max allowed is {MAX_HEXDUMP_SIZE} bytes"
+        )
     return pwndbg.dbg.selected_inferior().read_memory(address=addr, size=count, partial=partial)
 
 

--- a/pwndbg/aglib/memory.py
+++ b/pwndbg/aglib/memory.py
@@ -16,7 +16,6 @@ GdbDict = Dict[str, Union["GdbDict", int]]
 
 
 MMAP_MIN_ADDR = 0x8000
-MAX_HEXDUMP_SIZE = 1 * 1024 * 1024 * 1024  # 1 GB
 
 
 def read(addr: int, count: int, partial: bool = False) -> bytearray:
@@ -33,10 +32,6 @@ def read(addr: int, count: int, partial: bool = False) -> bytearray:
         :class:`bytearray`: The memory at the specified address,
         or ``None``.
     """
-    if count > MAX_HEXDUMP_SIZE:
-        raise ValueError(
-            f"Request size too large: {count} bytes, max allowed is {MAX_HEXDUMP_SIZE} bytes"
-        )
     return pwndbg.dbg.selected_inferior().read_memory(address=addr, size=count, partial=partial)
 
 

--- a/pwndbg/hexdump.py
+++ b/pwndbg/hexdump.py
@@ -20,6 +20,8 @@ from pwndbg.commands.windbg import enhex
 color_scheme = None
 printable = None
 
+MAX_HEXDUMP_SIZE = 5 * 1024 * 1024
+
 
 def groupby(width: int, array, fill=None):
     return pwnlib.util.lists.group(width, array, underfull_action="fill", fill_value=fill)
@@ -83,6 +85,20 @@ def hexdump(
     repeat: bool = False,
     dX_call: bool = False,
 ):
+    # Check for invalid address
+    if not pwndbg.aglib.memory.peek(address):
+        print(H.error(f"Invalid address: {address:#x}"))
+        return
+
+    # Validate maximum size
+    if count > MAX_HEXDUMP_SIZE:
+        print(
+            H.error(
+                f"Request size too large: {count} bytes (max allowed is {MAX_HEXDUMP_SIZE} bytes)"
+            )
+        )
+        return
+
     if not dX_call:
         if not color_scheme or not printable:
             load_color_scheme()

--- a/tests/gdb-tests/tests/test_hexdump.py
+++ b/tests/gdb-tests/tests/test_hexdump.py
@@ -103,3 +103,21 @@ def test_hexdump_saved_address_and_offset(start_binary):
     assert out1 == out2
     assert pwndbg.commands.hexdump.hexdump.last_address == sp + SIZE
     assert pwndbg.commands.hexdump.hexdump.offset == SIZE
+
+def test_hexdump_large_count_handling(start_binary):
+    start_binary(BINARY)
+    sp = pwndbg.aglib.regs.rsp
+
+    # Test with a large count value that could lead to OOM
+    large_count = 2**31
+
+    # Ensure the hexdump doesn't crash
+    try:
+        result = gdb.execute(f"hexdump $rsp {large_count}", to_string=True)
+        # Optionally assert that the result is reasonable
+        assert result.startswith(
+            f"+0000 0x{sp:x}"
+        )  # Check that the result starts with correct address
+    except gdb.error as e:
+        # Ensure it raises an expected error or gracefully handles large counts
+        assert "cannot allocate" in str(e), f"Unexpected error: {e}"

--- a/tests/gdb-tests/tests/test_hexdump.py
+++ b/tests/gdb-tests/tests/test_hexdump.py
@@ -122,22 +122,3 @@ def test_hexdump_large_count_handling(start_binary):
     except gdb.error as e:
         # Ensure it raises an expected error or gracefully handles large counts
         assert "Request size too large" in str(e), f"Unexpected error: {e}"
-
-
-def test_hexdump_large_count_handling(start_binary):
-    start_binary(BINARY)
-    sp = pwndbg.aglib.regs.sp
-
-    # Test with a large count value that could lead to OOM
-    large_count = 2**31
-
-    # Ensure the hexdump doesn't crash
-    try:
-        result = gdb.execute(f"hexdump $rsp {large_count}", to_string=True)
-        # Optionally assert that the result is reasonable
-        assert result.startswith(
-            f"+0000 0x{sp:x}"
-        )  # Check that the result starts with correct address
-    except gdb.error as e:
-        # Ensure it raises an expected error or gracefully handles large counts
-        assert "Request size too large" in str(e), f"Unexpected error: {e}"

--- a/tests/gdb-tests/tests/test_hexdump.py
+++ b/tests/gdb-tests/tests/test_hexdump.py
@@ -114,6 +114,25 @@ def test_hexdump_large_count_handling(start_binary):
 
     # Ensure the hexdump doesn't crash
     try:
+        result = gdb.execute(f"hexdump $sp {large_count}", to_string=True)
+        # Optionally assert that the result is reasonable
+        assert result.startswith(
+            f"+0000 0x{sp:x}"
+        )  # Check that the result starts with correct address
+    except gdb.error as e:
+        # Ensure it raises an expected error or gracefully handles large counts
+        assert "Request size too large" in str(e), f"Unexpected error: {e}"
+
+
+def test_hexdump_large_count_handling(start_binary):
+    start_binary(BINARY)
+    sp = pwndbg.aglib.regs.sp
+
+    # Test with a large count value that could lead to OOM
+    large_count = 2**31
+
+    # Ensure the hexdump doesn't crash
+    try:
         result = gdb.execute(f"hexdump $rsp {large_count}", to_string=True)
         # Optionally assert that the result is reasonable
         assert result.startswith(

--- a/tests/gdb-tests/tests/test_hexdump.py
+++ b/tests/gdb-tests/tests/test_hexdump.py
@@ -106,7 +106,7 @@ def test_hexdump_saved_address_and_offset(start_binary):
 
 def test_hexdump_large_count_handling(start_binary):
     start_binary(BINARY)
-    sp = pwndbg.aglib.regs.rsp
+    sp = pwndbg.aglib.regs.sp
 
     # Test with a large count value that could lead to OOM
     large_count = 2**31

--- a/tests/gdb-tests/tests/test_hexdump.py
+++ b/tests/gdb-tests/tests/test_hexdump.py
@@ -104,6 +104,7 @@ def test_hexdump_saved_address_and_offset(start_binary):
     assert pwndbg.commands.hexdump.hexdump.last_address == sp + SIZE
     assert pwndbg.commands.hexdump.hexdump.offset == SIZE
 
+
 def test_hexdump_large_count_handling(start_binary):
     start_binary(BINARY)
     sp = pwndbg.aglib.regs.sp
@@ -120,4 +121,4 @@ def test_hexdump_large_count_handling(start_binary):
         )  # Check that the result starts with correct address
     except gdb.error as e:
         # Ensure it raises an expected error or gracefully handles large counts
-        assert "cannot allocate" in str(e), f"Unexpected error: {e}"
+        assert "Request size too large" in str(e), f"Unexpected error: {e}"


### PR DESCRIPTION
Description:

This is an attempt to fix the issue mentioned in [Issue #2608](https://github.com/pwndbg/pwndbg/issues/2608).

Changes:
I added a check to make sure the count value is within reasonable bounds (currently set to 1 GB) before proceeding with the hexdump.
I also added a test to try and verify that the hexdump function handles larger count values without crashing.
Testing: The test should check that large count values don’t cause crashes, but I’m not totally sure it covers everything.