### PR TITLE
Add hexdump to trailing user data in `vis_heap_chunks` command

### DIFF
--- a/pwndbg/commands/ptmalloc2.py
+++ b/pwndbg/commands/ptmalloc2.py
@@ -1135,6 +1135,11 @@ def vis_heap_chunks(
 
             cursor += ptr_size
 
+    if printed % 2 != 0:
+        # Alignment whitespace of ("0x" + "00" * ptr_size) length.
+        machine_word_string_length = 2 + (2 * ptr_size)
+        out += "\t" + " " * machine_word_string_length + "\t" + color_func(asc)
+
     print(out)
 
     if reached_mapping_end:

--- a/tests/gdb-tests/tests/heap/test_vis_heap_chunks.py
+++ b/tests/gdb-tests/tests/heap/test_vis_heap_chunks.py
@@ -69,7 +69,7 @@ def test_vis_heap_chunk_command(start_binary):
         expected.append(
             "%#x\t0x0000000000000000\t0x0000000000000000\t................" % heap_iter()
         )
-    expected.append("%#x\t0x0000000000000000" % heap_iter())
+    expected.append("%#x\t0x0000000000000000\t                  \t........" % heap_iter())
     assert result == expected
 
     ## This time using `default-visualize-chunk-number` to set `count`, to make sure that the config can work
@@ -92,7 +92,7 @@ def test_vis_heap_chunk_command(start_binary):
     expected2 = expected[:-1] + [
         "%#x\t0x0000000000000000\t0x0000000000000021\t........!......." % heap_iter(0),
         "%#x\t0x0000000000000000\t0x0000000000000000\t................" % heap_iter(),
-        "%#x\t0x0000000000000000" % heap_iter(),
+        "%#x\t0x0000000000000000\t                  \t........" % heap_iter(),
     ]
     assert result2 == expected2
 


### PR DESCRIPTION
The `vis_heap_chunks` command prints a hexdump for every line of heap data, except when the output is not aligned to 2*pointer-size:
<img width="672" alt="Screenshot 2024-12-10 at 15 34 11" src="https://github.com/user-attachments/assets/e58908e7-b4f5-47d8-a2e6-d20f4597960c">

This PR adds a hexdump for this data, aligned for both 32 & 64 bit:
<img width="672" alt="Screenshot 2024-12-10 at 15 32 23" src="https://github.com/user-attachments/assets/dc642ca3-2f72-4b9b-acaf-611b391ca91d">
<img width="672" alt="Screenshot 2024-12-10 at 15 33 19" src="https://github.com/user-attachments/assets/fc75f907-2f5b-4dfa-9146-a556d44ad0ab">

Tests have been updated accordingly.

Fixes #2609 