### PR TITLE
fix lldb signed/unsiged values

### DIFF
--- a/pwndbg/dbg/lldb/__init__.py
+++ b/pwndbg/dbg/lldb/__init__.py
@@ -503,7 +503,12 @@ class LLDBValue(pwndbg.dbg_mod.Value):
 
     @override
     def __int__(self) -> int:
-        return self.inner.signed
+        is_num, is_sign = lldb.is_numeric_type(
+            self.inner.GetType().GetCanonicalType().GetBasicType()
+        )
+        if is_num and not is_sign:
+            return self.inner.GetValueAsUnsigned()
+        return self.inner.GetValueAsSigned()
 
     @override
     def cast(self, type: pwndbg.dbg_mod.Type | Any) -> pwndbg.dbg_mod.Value:

--- a/pwndbg/dbg/lldb/__init__.py
+++ b/pwndbg/dbg/lldb/__init__.py
@@ -503,6 +503,10 @@ class LLDBValue(pwndbg.dbg_mod.Value):
 
     @override
     def __int__(self) -> int:
+        """
+        Logic is copied from lldb.value(self.inner).__int__()
+        """
+        lldb.value
         is_num, is_sign = lldb.is_numeric_type(
             self.inner.GetType().GetCanonicalType().GetBasicType()
         )

--- a/pwndbg/dbg/lldb/__init__.py
+++ b/pwndbg/dbg/lldb/__init__.py
@@ -506,7 +506,6 @@ class LLDBValue(pwndbg.dbg_mod.Value):
         """
         Logic is copied from lldb.value(self.inner).__int__()
         """
-        lldb.value
         is_num, is_sign = lldb.is_numeric_type(
             self.inner.GetType().GetCanonicalType().GetBasicType()
         )


### PR DESCRIPTION
Before this change some register returns wrong (signed) value eg:
```py
In [30]: f = pwndbg.dbg.selected_frame()

In [31]: hex(int(f.regs().by_name('x6')))
Out[31]: '-0x535415ef94e79a86'

In [32]: f.inner.GetRegisters().GetValueAtIndex(0).GetChildMemberWithName('x6')
Out[32]: (unsigned long) x6 = 0xacabea106b18657a

In [33]: hex(int(f.inner.GetRegisters().GetValueAtIndex(0).GetChildMemberWithName('x6').signed))
Out[33]: '-0x535415ef94e79a86'

In [34]: hex(int(f.inner.GetRegisters().GetValueAtIndex(0).GetChildMemberWithName('x6').unsigned))
Out[34]: '0xacabea106b18657a'
```