### PR TITLE
Fix `entry` command

### DIFF
--- a/pwndbg/commands/start.py
+++ b/pwndbg/commands/start.py
@@ -12,6 +12,7 @@ from shlex import quote
 import pwndbg
 import pwndbg.aglib.elf
 import pwndbg.aglib.proc
+import pwndbg.aglib.regs
 import pwndbg.color.message as M
 import pwndbg.commands
 import pwndbg.dbg
@@ -26,6 +27,11 @@ def breakpoint_at_entry():
     addr = int(pwndbg.aglib.elf.entry())
     if not addr:
         print(M.error("No entry address found for the binary."))
+        return
+
+    if int(pwndbg.aglib.regs.pc) == addr:
+        # Skip setting the breakpoint because we are already at the entry point.
+        # This occurs when execution started with `starti` or `run -s`.
         return
 
     proc = pwndbg.dbg.selected_inferior()


### PR DESCRIPTION
This bug was only trigger for static linked binary 