### PR TITLE
codecov: disable PR annotations

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -8,3 +8,5 @@ coverage:
     patch:
       default:
         informational: true
+github_checks:
+    annotations: false


### PR DESCRIPTION
TL;DR: Disable annoying annotations about "this line is not covered by tests" from codecov when reviewing PRs

<!-- Please make sure to read the testing and linting instructions at https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md before creating a PR -->

As per https://docs.codecov.com/docs/github-checks#yaml-configuration-for-github-checks-and-codecov
