### PR TITLE
Disable stack and vmmap exploration

### DIFF
--- a/pwndbg/aglib/__init__.py
+++ b/pwndbg/aglib/__init__.py
@@ -22,6 +22,7 @@ def load_aglib():
     import pwndbg.aglib.file
     import pwndbg.aglib.heap
     import pwndbg.aglib.kernel
+    import pwndbg.aglib.kernel.vmmap
     import pwndbg.aglib.memory
     import pwndbg.aglib.nearpc
     import pwndbg.aglib.next
@@ -35,6 +36,7 @@ def load_aglib():
     import pwndbg.aglib.symbol
     import pwndbg.aglib.typeinfo
     import pwndbg.aglib.vmmap
+    import pwndbg.aglib.vmmap_custom
 
     # This is necessary so that mypy understands the actual type of the regs module
     regs_: regs_mod.module = regs_mod

--- a/pwndbg/aglib/elf.py
+++ b/pwndbg/aglib/elf.py
@@ -32,14 +32,12 @@ import pwndbg.aglib.proc
 import pwndbg.aglib.qemu
 import pwndbg.aglib.symbol
 import pwndbg.aglib.vmmap
+import pwndbg.auxv
 import pwndbg.lib.cache
 import pwndbg.lib.elftypes
 import pwndbg.lib.memory
 from pwndbg.color import message
 from pwndbg.dbg import EventType
-
-if pwndbg.dbg.is_gdblib_available():
-    import pwndbg.auxv
 
 # ELF constants
 PF_X, PF_W, PF_R = 1, 2, 4
@@ -255,10 +253,9 @@ def entry() -> int:
     """
     Return the address of the entry point for the main executable.
     """
-    if pwndbg.dbg.is_gdblib_available():
-        entry = pwndbg.auxv.get().AT_ENTRY
-        if entry:
-            return entry
+    entry = pwndbg.auxv.get().AT_ENTRY
+    if entry:
+        return entry
 
     inf = pwndbg.dbg.selected_inferior()
     entry = inf.main_module_entry()

--- a/pwndbg/aglib/file.py
+++ b/pwndbg/aglib/file.py
@@ -11,6 +11,7 @@ import shutil
 import tempfile
 from typing import Iterator
 from typing import Tuple
+import errno
 
 import pwndbg.aglib.proc
 import pwndbg.aglib.qemu

--- a/pwndbg/aglib/file.py
+++ b/pwndbg/aglib/file.py
@@ -6,12 +6,12 @@ debugging a remote process over SSH or similar, where e.g.
 
 from __future__ import annotations
 
+import errno
 import os
 import shutil
 import tempfile
 from typing import Iterator
 from typing import Tuple
-import errno
 
 import pwndbg.aglib.proc
 import pwndbg.aglib.qemu

--- a/pwndbg/aglib/file.py
+++ b/pwndbg/aglib/file.py
@@ -93,7 +93,7 @@ def get_file(path: str, try_local_path: bool = False) -> str:
     local_path = path
     if not pwndbg.aglib.remote.is_remote():
         if not os.path.exists(local_path):
-            raise OSError(f"Path '{local_path}' does not exist", errno.ENOENT)
+            raise OSError(f"File '{local_path}' does not exist", errno.ENOENT)
 
         return local_path
 
@@ -113,6 +113,7 @@ def get_file(path: str, try_local_path: bool = False) -> str:
                 f"pwndbg.aglib.file.get_file({path}) returns local path as we can't download file"
             )
         )
+        raise OSError(f"Path '{local_path}' does not exist", errno.ENODEV)
 
     # FIXME: get_sysroot, if nonempty only then get-local-file by default
     #   GDB is only getting local files when `set sysroot /` in remote debugging

--- a/pwndbg/aglib/file.py
+++ b/pwndbg/aglib/file.py
@@ -113,7 +113,7 @@ def get_file(path: str, try_local_path: bool = False) -> str:
                 f"pwndbg.aglib.file.get_file({path}) returns local path as we can't download file"
             )
         )
-        raise OSError(f"Path '{local_path}' does not exist", errno.ENODEV)
+        raise OSError(f"File '{local_path}' does not exist", errno.ENODEV)
 
     # FIXME: get_sysroot, if nonempty only then get-local-file by default
     #   GDB is only getting local files when `set sysroot /` in remote debugging

--- a/pwndbg/aglib/file.py
+++ b/pwndbg/aglib/file.py
@@ -16,7 +16,6 @@ from typing import Tuple
 import pwndbg.aglib.proc
 import pwndbg.aglib.qemu
 import pwndbg.aglib.remote
-import pwndbg.color.message as M
 import pwndbg.lib.cache
 
 _remote_files_dir = None

--- a/pwndbg/aglib/file.py
+++ b/pwndbg/aglib/file.py
@@ -106,8 +106,10 @@ def get_file(path: str, try_local_path: bool = False) -> str:
         except pwndbg.dbg_mod.Error as e:
             # This module originally raised this as an OSError.
             raise OSError(e)
+    else:
+        raise OSError(f"get_file('{local_path}') is not supported for your target", errno.ENODEV)
 
-    raise OSError(f"get_file('{local_path}') is not supported for your target", errno.ENODEV)
+    return local_path
 
 
 def get(path: str) -> bytes:

--- a/pwndbg/aglib/file.py
+++ b/pwndbg/aglib/file.py
@@ -91,6 +91,9 @@ def get_file(path: str, try_local_path: bool = False) -> str:
 
     local_path = path
     if not pwndbg.aglib.remote.is_remote():
+        if not os.path.exists(local_path):
+            raise OSError(f"Path '{local_path}' does not exist", errno.ENOENT)
+
         return local_path
 
     if try_local_path and not has_target_prefix and os.path.exists(local_path):
@@ -114,6 +117,9 @@ def get_file(path: str, try_local_path: bool = False) -> str:
     #   GDB is only getting local files when `set sysroot /` in remote debugging
     #   So we should show warning to user `set sysroot /` and remote debugging will be faster?
     # TODO: don't fallback to local filesystem
+    if not os.path.exists(local_path):
+        raise OSError(f"Path '{local_path}' does not exist", errno.ENOENT)
+
     return local_path
 
 

--- a/pwndbg/aglib/file.py
+++ b/pwndbg/aglib/file.py
@@ -82,11 +82,11 @@ def get_file(path: str, try_local_path: bool = False) -> str:
     Returns:
         The local path to the file
     """
-    assert path.startswith(("/", "./", "../")) or path.startswith(
-        "target:"
-    ), "get_file called with incorrect path"
-
     has_target_prefix = path.startswith("target:")
+    has_good_prefix = path.startswith(("/", "./", "../")) or has_target_prefix
+    if not has_good_prefix:
+        raise OSError("get_file called with incorrect path", errno.ENOENT)
+
     if has_target_prefix:
         path = path[7:]  # len('target:') == 7
 
@@ -107,22 +107,8 @@ def get_file(path: str, try_local_path: bool = False) -> str:
         except pwndbg.dbg_mod.Error as e:
             # This module originally raised this as an OSError.
             raise OSError(e)
-    else:
-        print(
-            M.warn(
-                f"pwndbg.aglib.file.get_file({path}) returns local path as we can't download file"
-            )
-        )
-        raise OSError(f"File '{local_path}' does not exist", errno.ENODEV)
 
-    # FIXME: get_sysroot, if nonempty only then get-local-file by default
-    #   GDB is only getting local files when `set sysroot /` in remote debugging
-    #   So we should show warning to user `set sysroot /` and remote debugging will be faster?
-    # TODO: don't fallback to local filesystem
-    if not os.path.exists(local_path):
-        raise OSError(f"Path '{local_path}' does not exist", errno.ENOENT)
-
-    return local_path
+    raise OSError(f"get_file('{local_path}') is not supported for your target", errno.ENODEV)
 
 
 def get(path: str) -> bytes:

--- a/pwndbg/aglib/kernel/__init__.py
+++ b/pwndbg/aglib/kernel/__init__.py
@@ -21,6 +21,7 @@ import pwndbg.aglib.vmmap
 import pwndbg.lib.cache
 import pwndbg.lib.kernel.kconfig
 import pwndbg.lib.kernel.structs
+import pwndbg.lib.memory
 import pwndbg.search
 
 _kconfig: pwndbg.lib.kernel.kconfig.Kconfig | None = None
@@ -91,9 +92,11 @@ def nproc() -> int:
     return val
 
 
-def get_first_kernel_ro():
+def get_first_kernel_ro() -> pwndbg.lib.memory.Page | None:
     """Returns the first kernel mapping which contains the linux_banner"""
     base = kbase()
+    if base is None:
+        return None
 
     for mapping in pwndbg.aglib.vmmap.get():
         if mapping.vaddr < base:

--- a/pwndbg/aglib/stack.py
+++ b/pwndbg/aglib/stack.py
@@ -15,9 +15,19 @@ import pwndbg.aglib.elf
 import pwndbg.aglib.memory
 import pwndbg.aglib.regs
 import pwndbg.aglib.vmmap
+import pwndbg.color.message as M
 import pwndbg.lib.cache
+import pwndbg.lib.config
 import pwndbg.lib.memory
 from pwndbg.dbg import EventType
+
+auto_explore = pwndbg.config.add_param(
+    "auto-explore-stack",
+    "warn",
+    "Enable or disable stack exploration; it may be really slow.",
+    param_class=pwndbg.lib.config.PARAM_ENUM,
+    enum_sequence=["warn", "yes", "no"],
+)
 
 
 def find(address: int):
@@ -120,6 +130,19 @@ def _fetch_via_exploration() -> Dict[int, pwndbg.lib.memory.Page]:
     An alternative to this is dumping this functionality completely and this
     will be decided hopefully after a next release.
     """
+    if auto_explore.value == "warn":
+        print(
+            M.warn(
+                "Warning: All methods to detect STACK have failed.\n"
+                "You can explore STACK using exploration, but it may be very slow.\n"
+                "To explicitly explore, use the command: `stack_explore`\n"
+                "Alternatively, enable it by default with: `set auto-explore-stack yes`"
+            )
+        )
+        return {}
+    elif auto_explore.value == "no":
+        return {}
+
     stacks: Dict[int, pwndbg.lib.memory.Page] = {}
 
     for thread in pwndbg.dbg.selected_inferior().threads():

--- a/pwndbg/aglib/stack.py
+++ b/pwndbg/aglib/stack.py
@@ -109,9 +109,10 @@ def _fetch_via_vmmap() -> Dict[int, pwndbg.lib.memory.Page]:
                 page = p
                 break
 
-        if page:
-            stacks[thread.index()] = page
+        if not page:
+            # page not found, should we explore `sp` register?
             continue
+        stacks[thread.index()] = page
 
     return stacks
 

--- a/pwndbg/aglib/stack.py
+++ b/pwndbg/aglib/stack.py
@@ -19,7 +19,9 @@ import pwndbg.color.message as M
 import pwndbg.lib.cache
 import pwndbg.lib.config
 import pwndbg.lib.memory
-from pwndbg.dbg import EventType
+
+if pwndbg.dbg.is_gdblib_available():
+    import pwndbg.gdblib.vmmap
 
 auto_explore = pwndbg.config.add_param(
     "auto-explore-stack",
@@ -76,8 +78,7 @@ def current():
     return find(pwndbg.aglib.regs.sp)
 
 
-@pwndbg.dbg.event_handler(EventType.STOP)
-@pwndbg.lib.cache.cache_until("exit")
+@pwndbg.lib.cache.cache_until("start")
 def is_executable() -> bool:
     ehdr = pwndbg.aglib.elf.exe()
 
@@ -163,7 +164,9 @@ def _fetch_via_exploration() -> Dict[int, pwndbg.lib.memory.Page]:
             start, stop - start, 6 if not is_executable() else 7, 0, f"[stack:{thread.index()}]"
         )
         stacks[thread.index()] = page
-        continue
+
+        if pwndbg.dbg.is_gdblib_available():
+            pwndbg.gdblib.vmmap.add_custom_page(page)
 
     return stacks
 

--- a/pwndbg/aglib/stack.py
+++ b/pwndbg/aglib/stack.py
@@ -167,7 +167,7 @@ def _fetch_via_exploration() -> Dict[int, pwndbg.lib.memory.Page]:
 
         stop = find_upper_stack_boundary(sp)
         page = pwndbg.lib.memory.Page(
-            start, stop - start, 6 if not is_executable() else 7, 0, "[stack]"
+            start, stop - start, 6 if not is_executable() else 7, 0, f"[stack:{thread_idx}]"
         )
         stacks[thread_idx] = page
         pwndbg.aglib.vmmap_custom.add_custom_page(page)

--- a/pwndbg/aglib/stack.py
+++ b/pwndbg/aglib/stack.py
@@ -106,7 +106,8 @@ def _fetch_via_vmmap() -> Dict[int, pwndbg.lib.memory.Page]:
         # Find the given SP in pages
         page = next((page for page in pages if sp in page), None)
         if not page:
-            # page not found, should we explore `sp` register?
+            # TODO: Handle case where the page is not found;
+            #  consider exploring the `sp` register using method `_fetch_via_exploration`?
             continue
         stacks[thread.index()] = page
 

--- a/pwndbg/aglib/stack.py
+++ b/pwndbg/aglib/stack.py
@@ -140,7 +140,7 @@ def _fetch_via_exploration() -> Dict[int, pwndbg.lib.memory.Page]:
     elif auto_explore.value == "no":
         return {}
 
-    stacks: Dict[int, pwndbg.lib.memory.Page] = {}
+    thread_sp = []
     for thread in reversed(pwndbg.dbg.selected_inferior().threads()):
         with thread.bottom_frame() as frame:
             sp = frame.sp()
@@ -149,20 +149,27 @@ def _fetch_via_exploration() -> Dict[int, pwndbg.lib.memory.Page]:
         # (it might be 0 if we debug a qemu kernel)
         if not sp:
             continue
+        thread_sp.append((sp, thread.index()))
 
+    # Sort by the `sp` register (stack pointer), starting with the smallest value.
+    # This helps prevent scanning the same page multiple times.
+    thread_sp.sort(key=lambda t: t[0])
+
+    stacks: Dict[int, pwndbg.lib.memory.Page] = {}
+    for sp, thread_idx in thread_sp:
         start = pwndbg.lib.memory.page_align(sp) - pwndbg.lib.memory.PAGE_SIZE
 
         page_found = next((page for page in stacks.values() if start in page), None)
         if page_found:
             # Skip further exploration of stacks that have already been scanned.
-            stacks[thread.index()] = page_found
+            stacks[thread_idx] = page_found
             continue
 
         stop = find_upper_stack_boundary(sp)
         page = pwndbg.lib.memory.Page(
             start, stop - start, 6 if not is_executable() else 7, 0, "[stack]"
         )
-        stacks[thread.index()] = page
+        stacks[thread_idx] = page
         pwndbg.aglib.vmmap_custom.add_custom_page(page)
 
     return stacks

--- a/pwndbg/aglib/stack.py
+++ b/pwndbg/aglib/stack.py
@@ -99,7 +99,7 @@ def _fetch_via_vmmap() -> Dict[int, pwndbg.lib.memory.Page]:
         try:
             sp = thread.bottom_frame().sp()
         except Exception:
-            # Exception will happen when `sp` is None, and is trying to cast to none
+            # Exception will happen when `sp` is None, and is trying to cast to int(none)
             # This happen when debugging esp32-c3
             continue
 

--- a/pwndbg/aglib/stack.py
+++ b/pwndbg/aglib/stack.py
@@ -141,7 +141,7 @@ def _fetch_via_exploration() -> Dict[int, pwndbg.lib.memory.Page]:
         return {}
 
     stacks: Dict[int, pwndbg.lib.memory.Page] = {}
-    for thread in pwndbg.dbg.selected_inferior().threads():
+    for thread in reversed(pwndbg.dbg.selected_inferior().threads()):
         with thread.bottom_frame() as frame:
             sp = frame.sp()
 

--- a/pwndbg/aglib/stack.py
+++ b/pwndbg/aglib/stack.py
@@ -141,7 +141,7 @@ def _fetch_via_exploration() -> Dict[int, pwndbg.lib.memory.Page]:
         return {}
 
     thread_sp = []
-    for thread in reversed(pwndbg.dbg.selected_inferior().threads()):
+    for thread in pwndbg.dbg.selected_inferior().threads():
         with thread.bottom_frame() as frame:
             sp = frame.sp()
 

--- a/pwndbg/aglib/stack.py
+++ b/pwndbg/aglib/stack.py
@@ -96,7 +96,12 @@ def _fetch_via_vmmap() -> Dict[int, pwndbg.lib.memory.Page]:
     pages = pwndbg.aglib.vmmap.get()
 
     for thread in pwndbg.dbg.selected_inferior().threads():
-        sp = thread.bottom_frame().sp()
+        try:
+            sp = thread.bottom_frame().sp()
+        except Exception:
+            # Exception will happen when `sp` is None, and is trying to cast to none
+            # This happen when debugging esp32-c3
+            continue
 
         # Skip if sp is 0 (it might be 0 if we debug a qemu kernel)
         if not sp:

--- a/pwndbg/aglib/stack.py
+++ b/pwndbg/aglib/stack.py
@@ -96,12 +96,8 @@ def _fetch_via_vmmap() -> Dict[int, pwndbg.lib.memory.Page]:
     pages = pwndbg.aglib.vmmap.get()
 
     for thread in pwndbg.dbg.selected_inferior().threads():
-        try:
-            sp = thread.bottom_frame().sp()
-        except Exception:
-            # Exception will happen when `sp` is None, and is trying to cast to int(none)
-            # This happen when debugging esp32-c3
-            continue
+        with thread.bottom_frame() as frame:
+            sp = frame.sp()
 
         # Skip if sp is 0 (it might be 0 if we debug a qemu kernel)
         if not sp:
@@ -153,7 +149,8 @@ def _fetch_via_exploration() -> Dict[int, pwndbg.lib.memory.Page]:
     stacks: Dict[int, pwndbg.lib.memory.Page] = {}
 
     for thread in pwndbg.dbg.selected_inferior().threads():
-        sp = thread.bottom_frame().sp()
+        with thread.bottom_frame() as frame:
+            sp = frame.sp()
 
         # Skip if sp is None or 0
         # (it might be 0 if we debug a qemu kernel)

--- a/pwndbg/aglib/stack.py
+++ b/pwndbg/aglib/stack.py
@@ -15,13 +15,11 @@ import pwndbg.aglib.elf
 import pwndbg.aglib.memory
 import pwndbg.aglib.regs
 import pwndbg.aglib.vmmap
+import pwndbg.aglib.vmmap_custom
 import pwndbg.color.message as M
 import pwndbg.lib.cache
 import pwndbg.lib.config
 import pwndbg.lib.memory
-
-if pwndbg.dbg.is_gdblib_available():
-    import pwndbg.gdblib.vmmap
 
 auto_explore = pwndbg.config.add_param(
     "auto-explore-stack",
@@ -32,7 +30,7 @@ auto_explore = pwndbg.config.add_param(
 )
 
 
-def find(address: int):
+def find(address: int) -> pwndbg.lib.memory.Page | None:
     """
     Returns a pwndbg.lib.memory.Page object which corresponds to given address stack
     or None if it does not exist
@@ -71,7 +69,7 @@ def get() -> Dict[int, pwndbg.lib.memory.Page]:
 
 
 @pwndbg.lib.cache.cache_until("stop")
-def current():
+def current() -> pwndbg.lib.memory.Page | None:
     """
     Returns the bounds for the stack for the current thread.
     """
@@ -81,6 +79,8 @@ def current():
 @pwndbg.lib.cache.cache_until("start")
 def is_executable() -> bool:
     ehdr = pwndbg.aglib.elf.exe()
+    if ehdr is None:
+        return True
 
     for phdr in pwndbg.aglib.elf.iter_phdrs(ehdr):
         # check if type is PT_GNU_STACK
@@ -103,14 +103,8 @@ def _fetch_via_vmmap() -> Dict[int, pwndbg.lib.memory.Page]:
         if not sp:
             continue
 
-        page = None
-
         # Find the given SP in pages
-        for p in pages:
-            if sp in p:
-                page = p
-                break
-
+        page = next((page for page in pages if sp in page), None)
         if not page:
             # page not found, should we explore `sp` register?
             continue
@@ -147,7 +141,6 @@ def _fetch_via_exploration() -> Dict[int, pwndbg.lib.memory.Page]:
         return {}
 
     stacks: Dict[int, pwndbg.lib.memory.Page] = {}
-
     for thread in pwndbg.dbg.selected_inferior().threads():
         with thread.bottom_frame() as frame:
             sp = frame.sp()
@@ -157,18 +150,20 @@ def _fetch_via_exploration() -> Dict[int, pwndbg.lib.memory.Page]:
         if not sp:
             continue
 
-        sp_low = sp & ~(0xFFF)
-        sp_low -= 0x1000
+        start = pwndbg.lib.memory.page_align(sp) - pwndbg.lib.memory.PAGE_SIZE
 
-        start = sp_low
+        page_found = next((page for page in stacks.values() if start in page), None)
+        if page_found:
+            # Skip further exploration of stacks that have already been scanned.
+            stacks[thread.index()] = page_found
+            continue
+
         stop = find_upper_stack_boundary(sp)
         page = pwndbg.lib.memory.Page(
-            start, stop - start, 6 if not is_executable() else 7, 0, f"[stack:{thread.index()}]"
+            start, stop - start, 6 if not is_executable() else 7, 0, "[stack]"
         )
         stacks[thread.index()] = page
-
-        if pwndbg.dbg.is_gdblib_available():
-            pwndbg.gdblib.vmmap.add_custom_page(page)
+        pwndbg.aglib.vmmap_custom.add_custom_page(page)
 
     return stacks
 

--- a/pwndbg/aglib/vmmap.py
+++ b/pwndbg/aglib/vmmap.py
@@ -3,19 +3,9 @@ from __future__ import annotations
 from typing import Tuple
 
 import pwndbg
+import pwndbg.aglib.vmmap_custom
 import pwndbg.lib.cache
 import pwndbg.lib.memory
-
-if pwndbg.dbg.is_gdblib_available():
-    # The code in pwndbg.gdblib.vmmap does _so much_ more than just getting the
-    # entries of the vmmap. We'll probably have to port it to run on top of the
-    # Debugger-agnostic API, rather than embed its functionality inside it. When
-    # that happens, this file will become that port. For now, we just fall back
-    # on gdblib if possible, and expose weaker versions of these functions when
-    # it's not available.
-    #
-    # TODO: Port `pwndbg.gdblib.vmmap` to `aglib`.
-    import pwndbg.gdblib.vmmap
 
 
 @pwndbg.lib.cache.cache_until("start", "stop")
@@ -36,6 +26,4 @@ def find(address: int | pwndbg.dbg_mod.Value | None) -> pwndbg.lib.memory.Page |
         if address in page:
             return page
 
-    if pwndbg.dbg.is_gdblib_available():
-        return pwndbg.gdblib.vmmap.explore(address)
-    return None
+    return pwndbg.aglib.vmmap_custom.explore(address)

--- a/pwndbg/aglib/vmmap_custom.py
+++ b/pwndbg/aglib/vmmap_custom.py
@@ -43,9 +43,7 @@ def get_custom_pages() -> Tuple[pwndbg.lib.memory.Page, ...]:
     Returns a tuple of `Page` objects representing the memory mappings of the
     target, sorted by virtual address ascending.
     """
-    pages: List[pwndbg.lib.memory.Page] = []
-    pages.extend(explored_pages)
-    pages.extend(custom_pages)
+    pages: List[pwndbg.lib.memory.Page] = [*explored_pages, *custom_pages]
     pages.sort()
     return tuple(pages)
 

--- a/pwndbg/aglib/vmmap_custom.py
+++ b/pwndbg/aglib/vmmap_custom.py
@@ -69,7 +69,7 @@ def clear_custom_page() -> None:
     pwndbg.lib.cache.clear_caches()
 
 
-def explore(address_maybe: int, skip_config_guard: bool = False) -> pwndbg.lib.memory.Page | None:
+def explore(address_maybe: int) -> pwndbg.lib.memory.Page | None:
     """
     Given a potential address, check to see what permissions it has.
 

--- a/pwndbg/aglib/vmmap_custom.py
+++ b/pwndbg/aglib/vmmap_custom.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import bisect
+from typing import List
+from typing import Set
+from typing import Tuple
+
+import pwndbg
+import pwndbg.aglib.memory
+import pwndbg.aglib.stack
+import pwndbg.color.message as M
+import pwndbg.lib.cache
+import pwndbg.lib.config
+import pwndbg.lib.memory
+from pwndbg.dbg import EventType
+
+# List of manually-explored pages which were discovered
+# by analyzing the stack or register context.
+explored_pages: List[pwndbg.lib.memory.Page] = []
+
+# List of custom pages that can be managed manually by vmmap_* commands family
+custom_pages: List[pwndbg.lib.memory.Page] = []
+
+auto_explore = pwndbg.config.add_param(
+    "auto-explore-pages",
+    "warn",
+    "whether to try to infer page permissions when memory maps missing (can cause errors)",
+    param_class=pwndbg.lib.config.PARAM_ENUM,
+    enum_sequence=["yes", "warn", "no"],
+)
+
+
+_warn_cache: Set[int] = set()
+
+
+@pwndbg.dbg.event_handler(EventType.NEW_MODULE)
+def clear_warn_cache():
+    _warn_cache.clear()
+
+
+def get_custom_pages() -> Tuple[pwndbg.lib.memory.Page, ...]:
+    """
+    Returns a tuple of `Page` objects representing the memory mappings of the
+    target, sorted by virtual address ascending.
+    """
+    pages: List[pwndbg.lib.memory.Page] = []
+    pages.extend(explored_pages)
+    pages.extend(custom_pages)
+    pages.sort()
+    return tuple(pages)
+
+
+def add_custom_page(page: pwndbg.lib.memory.Page) -> None:
+    bisect.insort(custom_pages, page)
+
+    # Reset all the cache
+    # We can not reset get() only, since the result may be used by others.
+    # TODO: avoid flush all caches
+    pwndbg.lib.cache.clear_caches()
+
+
+def clear_custom_page() -> None:
+    while custom_pages:
+        custom_pages.pop()
+
+    # Reset all the cache
+    # We can not reset get() only, since the result may be used by others.
+    # TODO: avoid flush all caches
+    pwndbg.lib.cache.clear_caches()
+
+
+def explore(address_maybe: int, skip_config_guard: bool = False) -> pwndbg.lib.memory.Page | None:
+    """
+    Given a potential address, check to see what permissions it has.
+
+    Returns:
+        Page object
+
+    Note:
+        Adds the Page object to a persistent list of pages which are
+        only reset when the process dies. This means pages which are
+        added this way will not be removed when unmapped.
+
+        Also assumes the entire contiguous section has the same permission.
+    """
+    if not pwndbg.dbg.selected_inferior().is_linux():
+        return None
+
+    if auto_explore.value == "warn":
+        page_start = pwndbg.lib.memory.page_align(address_maybe)
+        if page_start not in _warn_cache:
+            _warn_cache.add(page_start)
+            is_readable_addr = pwndbg.aglib.memory.peek(page_start)
+            if is_readable_addr:
+                print(
+                    M.warn(
+                        f"Warning: Avoided exploring possible address {address_maybe:#x}.\n"
+                        f"You can explicitly explore it with `vmmap_explore {page_start:#x}`"
+                    )
+                )
+        return None
+    elif auto_explore.value == "no":
+        return None
+
+    address_maybe = pwndbg.lib.memory.page_align(address_maybe)
+    flags = get_memory_flags(address_maybe)
+    if flags is None:
+        return None
+
+    page = find_boundaries(address_maybe)
+    page.objfile = "<explored>"
+    page.flags = flags
+
+    explored_pages.append(page)
+
+    # Reset all the cache
+    # We can not reset get() only, since the result may be used by others.
+    # TODO: avoid flush all caches
+    pwndbg.lib.cache.clear_caches()
+
+    return page
+
+
+def get_memory_flags(address_maybe: int) -> int | None:
+    flags = 4 if pwndbg.aglib.memory.peek(address_maybe) else 0
+    if not flags:
+        return None
+
+    if pwndbg.aglib.memory.poke(address_maybe):
+        flags |= 2
+    # It's really hard to check for executability, so we just make some guesses:
+    # If it's in the same page as the stack pointer, try to check the NX bit
+    # If it's in the same page as the instruction pointer, assume it's executable
+    # Otherwise, just say it's not executable
+    if address_maybe == pwndbg.lib.memory.page_align(pwndbg.aglib.regs.pc):
+        flags |= 1
+    # TODO: could maybe make this check look at the stacks in pwndbg.aglib.stack.get() but that might have issues
+    elif (
+        address_maybe == pwndbg.lib.memory.page_align(pwndbg.aglib.regs.sp)
+        and pwndbg.aglib.stack.is_executable()
+    ):
+        flags |= 1
+    return flags
+
+
+def find_boundaries(addr: int, name: str = "", min: int = 0) -> pwndbg.lib.memory.Page:
+    """
+    Given a single address, find all contiguous pages
+    which are mapped.
+    """
+    start = pwndbg.aglib.memory.find_lower_boundary(addr)
+    end = pwndbg.aglib.memory.find_upper_boundary(addr)
+
+    start = max(start, min)
+
+    return pwndbg.lib.memory.Page(start, end - start, 4, 0, name)

--- a/pwndbg/aglib/vmmap_custom.py
+++ b/pwndbg/aglib/vmmap_custom.py
@@ -106,7 +106,7 @@ def explore(address_maybe: int) -> pwndbg.lib.memory.Page | None:
         return None
 
     page = find_boundaries(address_maybe)
-    page.objfile = "<explored>"
+    page.objfile = f"<explored_{address_maybe >> 12:05x}>"
     page.flags = flags
 
     explored_pages.append(page)

--- a/pwndbg/aglib/vmmap_custom.py
+++ b/pwndbg/aglib/vmmap_custom.py
@@ -126,10 +126,11 @@ def get_memory_flags(address_maybe: int) -> int | None:
 
     if pwndbg.aglib.memory.poke(address_maybe):
         flags |= 2
+
     # It's really hard to check for executability, so we just make some guesses:
-    # If it's in the same page as the stack pointer, try to check the NX bit
-    # If it's in the same page as the instruction pointer, assume it's executable
-    # Otherwise, just say it's not executable
+    # 1. If it's in the same page as the instruction pointer, assume it's executable.
+    # 2. If it's in the same page as the stack pointer, try to check the NX bit.
+    # 3. Otherwise, just say it's not executable.
     if address_maybe == pwndbg.lib.memory.page_align(pwndbg.aglib.regs.pc):
         flags |= 1
     # TODO: could maybe make this check look at the stacks in pwndbg.aglib.stack.get() but that might have issues
@@ -138,6 +139,7 @@ def get_memory_flags(address_maybe: int) -> int | None:
         and pwndbg.aglib.stack.is_executable()
     ):
         flags |= 1
+
     return flags
 
 
@@ -150,5 +152,6 @@ def find_boundaries(addr: int, name: str = "", min: int = 0) -> pwndbg.lib.memor
     end = pwndbg.aglib.memory.find_upper_boundary(addr)
 
     start = max(start, min)
+    end = max(end, min)
 
     return pwndbg.lib.memory.Page(start, end - start, 4, 0, name)

--- a/pwndbg/auxv.py
+++ b/pwndbg/auxv.py
@@ -141,12 +141,6 @@ def explore_stack_auxv() -> AUXV | None:
         return None
 
     auxv = walk_stack2(0)
-
-    if not auxv:
-        # For whatever reason, sometimes the ARM AUXV under qemu-user is
-        # not aligned properly.
-        auxv = walk_stack2(1)
-
     if not auxv.get("AT_EXECFN", None):
         try:
             auxv["AT_EXECFN"] = _get_execfn()

--- a/pwndbg/auxv.py
+++ b/pwndbg/auxv.py
@@ -157,7 +157,8 @@ def explore_stack_auxv() -> AUXV | None:
 
 
 def walk_stack2(offset: int = 0) -> AUXV:
-    # to nie zadziala np. w golang bo golang ma dwa stosy
+    # FIXME: This function doesn't work in Go (Golang), as Golang uses two stacks.
+    # NOTE: This function is intended to work only with real binaries, not those emulated under qemu-user.
     sp = pwndbg.aglib.regs.sp
 
     if not sp:
@@ -175,7 +176,7 @@ def walk_stack2(offset: int = 0) -> AUXV:
     #    set of known AT_ enums.
     # 5) Vacuum up between the two.
     #
-    end = _find_stack_boundary(sp)
+    end = pwndbg.aglib.stack.find_upper_stack_boundary(sp)
     p = pwndbg.dbg.selected_inferior().create_value(end).cast(pwndbg.aglib.typeinfo.ulong.pointer())
 
     p -= offset
@@ -235,29 +236,6 @@ def walk_stack2(offset: int = 0) -> AUXV:
         # If SP is inaccessible or we went past through stack and haven't found AUXV
         # then return an empty AUXV...
         return AUXV()
-
-
-def _find_stack_boundary(addr: int) -> int:
-    # For real binaries, we can just use pwndbg.aglib.memory.find_upper_boundary
-    # to search forward until we walk off the end of the stack.
-    #
-    # Unfortunately, qemu-user emulation likes to paste the stack right
-    # before binaries in memory.  This means that we walk right past the
-    # stack and to the end of some random ELF.
-    #
-    # In order to mitigate this, we search page-by-page until either:
-    #
-    # 1) We get a page fault, and stop
-    # 2) We find an ELF header, and stop
-    addr = pwndbg.lib.memory.page_align(addr)
-    try:
-        while True:
-            if b"\x7fELF" == pwndbg.aglib.memory.read(addr, 4):
-                break
-            addr += pwndbg.lib.memory.PAGE_SIZE
-    except pwndbg.dbg_mod.Error:
-        pass
-    return addr
 
 
 def _get_execfn() -> str | None:

--- a/pwndbg/auxv.py
+++ b/pwndbg/auxv.py
@@ -139,7 +139,7 @@ def explore_stack_auxv() -> AUXV | None:
     elif auto_explore.value == "no":
         return None
 
-    return walk_stack2(0)
+    return walk_stack2()
 
 
 def walk_stack2(offset: int = 0) -> AUXV:

--- a/pwndbg/auxv.py
+++ b/pwndbg/auxv.py
@@ -157,6 +157,7 @@ def explore_stack_auxv() -> AUXV | None:
 
 
 def walk_stack2(offset: int = 0) -> AUXV:
+    # to nie zadziala np. w golang bo golang ma dwa stosy
     sp = pwndbg.aglib.regs.sp
 
     if not sp:

--- a/pwndbg/auxv.py
+++ b/pwndbg/auxv.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 import re
 import struct
 from typing import Optional
@@ -140,18 +139,11 @@ def explore_stack_auxv() -> AUXV | None:
     elif auto_explore.value == "no":
         return None
 
-    auxv = walk_stack2(0)
-    if not auxv.get("AT_EXECFN", None):
-        try:
-            auxv["AT_EXECFN"] = _get_execfn()
-        except pwndbg.dbg_mod.Error:
-            pass
-
-    return auxv
+    return walk_stack2(0)
 
 
 def walk_stack2(offset: int = 0) -> AUXV:
-    # FIXME: This function doesn't work in Go (Golang), as Golang has two stacks.
+    # FIXME: This function doesn't work with Go (Golang) binaries, as Golang has two stacks.
     # NOTE: This function is intended to work only with real binaries, not those emulated under qemu-user.
     sp = pwndbg.aglib.regs.sp
 
@@ -230,32 +222,3 @@ def walk_stack2(offset: int = 0) -> AUXV:
         # If SP is inaccessible or we went past through stack and haven't found AUXV
         # then return an empty AUXV...
         return AUXV()
-
-
-def _get_execfn() -> str | None:
-    # If the stack is not sane, this won't work
-    if not pwndbg.aglib.memory.peek(pwndbg.aglib.regs.sp):
-        return None
-
-    # QEMU does not put AT_EXECFN in the Auxiliary Vector
-    # on the stack.
-    #
-    # However, it does put it at the very top of the stack.
-    #
-    # 32c:1960|      0x7fffffffefe0 <-- '/home/user/pwndbg/ld....'
-    # 32d:1968|      0x7fffffffefe8 <-- 'er/pwndbg/ld.so'
-    # 32e:1970|      0x7fffffffeff0 <-- 0x6f732e646c2f67 /* 'g/ld.so' */
-    # 32f:1978|      0x7fffffffeff8 <-- 0
-    # 330:1980|      0x7ffffffff000
-    addr = pwndbg.aglib.stack.find_upper_stack_boundary(pwndbg.aglib.regs.sp)
-
-    while pwndbg.aglib.memory.byte(addr - 1) == 0:
-        addr -= 1
-
-    while pwndbg.aglib.memory.byte(addr - 1) != 0:
-        addr -= 1
-
-    v = pwndbg.aglib.strings.get(addr, 1024)
-    if v:
-        return os.path.abspath(v)
-    return None

--- a/pwndbg/auxv.py
+++ b/pwndbg/auxv.py
@@ -151,7 +151,7 @@ def explore_stack_auxv() -> AUXV | None:
 
 
 def walk_stack2(offset: int = 0) -> AUXV:
-    # FIXME: This function doesn't work in Go (Golang), as Golang uses two stacks.
+    # FIXME: This function doesn't work in Go (Golang), as Golang has two stacks.
     # NOTE: This function is intended to work only with real binaries, not those emulated under qemu-user.
     sp = pwndbg.aglib.regs.sp
 

--- a/pwndbg/commands/retaddr.py
+++ b/pwndbg/commands/retaddr.py
@@ -49,5 +49,5 @@ def stack_explore() -> None:
         pwndbg.config.auto_explore_stack.value = old_value
 
     print_vmmap_table_header()
-    for page in pages:
+    for page in pages.values():
         print(page)

--- a/pwndbg/commands/retaddr.py
+++ b/pwndbg/commands/retaddr.py
@@ -3,8 +3,11 @@ from __future__ import annotations
 import pwndbg.aglib.arch
 import pwndbg.aglib.regs
 import pwndbg.aglib.vmmap
+import pwndbg.aglib.stack
+import pwndbg.aglib.memory
 import pwndbg.chain
 import pwndbg.commands
+from pwndbg.commands.vmmap import print_vmmap_table_header
 from pwndbg.commands import CommandCategory
 
 
@@ -30,3 +33,21 @@ def retaddr() -> None:
             print(pwndbg.chain.format(sp))
 
         sp += pwndbg.aglib.arch.ptrsize
+
+
+@pwndbg.commands.ArgparsedCommand(
+    "Explore stack from all threads.", category=CommandCategory.STACK
+)
+@pwndbg.commands.OnlyWhenRunning
+def stack_explore() -> None:
+    old_value = pwndbg.config.auto_explore_stack.value
+    pwndbg.config.auto_explore_stack.value = "yes"
+    try:
+        pwndbg.aglib.stack.get.cache.clear()  # type: ignore[attr-defined]
+        pages = pwndbg.aglib.stack.get()
+    finally:
+        pwndbg.config.auto_explore_stack.value = old_value
+
+    print_vmmap_table_header()
+    for page in pages:
+        print(page)

--- a/pwndbg/commands/retaddr.py
+++ b/pwndbg/commands/retaddr.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
 import pwndbg.aglib.arch
-import pwndbg.aglib.regs
-import pwndbg.aglib.vmmap
-import pwndbg.aglib.stack
 import pwndbg.aglib.memory
+import pwndbg.aglib.regs
+import pwndbg.aglib.stack
+import pwndbg.aglib.vmmap
 import pwndbg.chain
 import pwndbg.commands
-from pwndbg.commands.vmmap import print_vmmap_table_header
 from pwndbg.commands import CommandCategory
+from pwndbg.commands.vmmap import print_vmmap_table_header
 
 
 @pwndbg.commands.ArgparsedCommand(
@@ -35,9 +35,7 @@ def retaddr() -> None:
         sp += pwndbg.aglib.arch.ptrsize
 
 
-@pwndbg.commands.ArgparsedCommand(
-    "Explore stack from all threads.", category=CommandCategory.STACK
-)
+@pwndbg.commands.ArgparsedCommand("Explore stack from all threads.", category=CommandCategory.STACK)
 @pwndbg.commands.OnlyWhenRunning
 def stack_explore() -> None:
     old_value = pwndbg.config.auto_explore_stack.value

--- a/pwndbg/commands/vmmap.py
+++ b/pwndbg/commands/vmmap.py
@@ -286,8 +286,8 @@ def vmmap(
 
 if pwndbg.dbg.is_gdblib_available():
     parser = argparse.ArgumentParser(description="Add virtual memory map page.")
-    parser.add_argument("start", help="Starting virtual address")
-    parser.add_argument("size", help="Size of the address space, in bytes")
+    parser.add_argument("start", type=int, help="Starting virtual address")
+    parser.add_argument("size", type=int, help="Size of the address space, in bytes")
     parser.add_argument(
         "flags",
         nargs="?",
@@ -297,6 +297,7 @@ if pwndbg.dbg.is_gdblib_available():
     )
     parser.add_argument(
         "offset",
+        type=int,
         nargs="?",
         default=0,
         help="Offset into the original ELF file that the data is loaded from",
@@ -304,7 +305,7 @@ if pwndbg.dbg.is_gdblib_available():
 
     @pwndbg.commands.ArgparsedCommand(parser, category=CommandCategory.MEMORY)
     @pwndbg.commands.OnlyWhenRunning
-    def vmmap_add(start, size, flags, offset) -> None:
+    def vmmap_add(start: int, size: int, flags: str, offset: int) -> None:
         page_flags = {
             "r": pwndbg.aglib.elf.PF_R,
             "w": pwndbg.aglib.elf.PF_W,
@@ -318,7 +319,7 @@ if pwndbg.dbg.is_gdblib_available():
                 return
             perm |= flag_val
 
-        page = pwndbg.lib.memory.Page(start, size, perm, offset)
+        page = pwndbg.lib.memory.Page(int(start), int(size), perm, offset)
 
         pwndbg.gdblib.vmmap.add_custom_page(page)
 

--- a/pwndbg/commands/vmmap.py
+++ b/pwndbg/commands/vmmap.py
@@ -5,6 +5,7 @@ Command to print the virtual memory map a la /proc/self/maps.
 from __future__ import annotations
 
 import argparse
+import os.path
 from typing import Tuple
 
 from elftools.elf.constants import SH_FLAGS
@@ -365,6 +366,7 @@ if pwndbg.dbg.is_gdblib_available():
             filename = pwndbg.aglib.file.get_proc_exe_file()
 
         print(f'Load "{filename}" ...')
+        file_basename = os.path.basename(filename)
 
         # TODO: Add an argument to let use to choose loading the page information from sections or segments
 
@@ -394,7 +396,9 @@ if pwndbg.dbg.is_gdblib_available():
                 if sh_flags & SH_FLAGS.SHF_EXECINSTR:
                     flags |= pwndbg.aglib.elf.PF_X
 
-                page = pwndbg.lib.memory.Page(vaddr, memsz, flags, offset, f'[{section.name}] {filename}')
+                page = pwndbg.lib.memory.Page(
+                    vaddr, memsz, flags, offset, f"[{section.name}]: {file_basename}"
+                )
                 pages.append(page)
 
         for page in pages:

--- a/pwndbg/commands/vmmap.py
+++ b/pwndbg/commands/vmmap.py
@@ -292,7 +292,7 @@ parser.add_argument(
     nargs="?",
     type=str,
     default="",
-    help="Flags set by the ELF file, see PF_X, PF_R, PF_W",
+    help="Flags set by the ELF file (r - read, w - write, x - executable)",
 )
 parser.add_argument(
     "offset",

--- a/pwndbg/commands/vmmap.py
+++ b/pwndbg/commands/vmmap.py
@@ -14,6 +14,8 @@ from elftools.elf.elffile import ELFFile
 import pwndbg.aglib.arch
 import pwndbg.aglib.elf
 import pwndbg.aglib.file
+import pwndbg.aglib.vmmap
+import pwndbg.aglib.vmmap_custom
 import pwndbg.color.memory as M
 import pwndbg.commands
 from pwndbg.color import cyan
@@ -21,9 +23,6 @@ from pwndbg.color import green
 from pwndbg.color import red
 from pwndbg.commands import CommandCategory
 from pwndbg.lib.memory import Page
-
-if pwndbg.dbg.is_gdblib_available():
-    import pwndbg.gdblib.vmmap
 
 integer_types = (int, pwndbg.dbg_mod.Value)
 
@@ -285,122 +284,135 @@ def vmmap(
         )
 
 
-if pwndbg.dbg.is_gdblib_available():
-    parser = argparse.ArgumentParser(description="Add virtual memory map page.")
-    parser.add_argument("start", type=int, help="Starting virtual address")
-    parser.add_argument("size", type=int, help="Size of the address space, in bytes")
-    parser.add_argument(
-        "flags",
-        nargs="?",
-        type=str,
-        default="",
-        help="Flags set by the ELF file, see PF_X, PF_R, PF_W",
-    )
-    parser.add_argument(
-        "offset",
-        type=int,
-        nargs="?",
-        default=0,
-        help="Offset into the original ELF file that the data is loaded from",
-    )
+parser = argparse.ArgumentParser(description="Add virtual memory map page.")
+parser.add_argument("start", type=int, help="Starting virtual address")
+parser.add_argument("size", type=int, help="Size of the address space, in bytes")
+parser.add_argument(
+    "flags",
+    nargs="?",
+    type=str,
+    default="",
+    help="Flags set by the ELF file, see PF_X, PF_R, PF_W",
+)
+parser.add_argument(
+    "offset",
+    type=int,
+    nargs="?",
+    default=0,
+    help="Offset into the original ELF file that the data is loaded from",
+)
 
-    @pwndbg.commands.ArgparsedCommand(parser, category=CommandCategory.MEMORY)
-    @pwndbg.commands.OnlyWhenRunning
-    def vmmap_add(start: int, size: int, flags: str, offset: int) -> None:
-        page_flags = {
-            "r": pwndbg.aglib.elf.PF_R,
-            "w": pwndbg.aglib.elf.PF_W,
-            "x": pwndbg.aglib.elf.PF_X,
-        }
-        perm = 0
-        for flag in flags:
-            flag_val = page_flags.get(flag, None)
-            if flag_val is None:
-                print('Invalid page flag "%s"', flag)
-                return
-            perm |= flag_val
 
-        page = pwndbg.lib.memory.Page(start, size, perm, offset)
+@pwndbg.commands.ArgparsedCommand(parser, category=CommandCategory.MEMORY)
+@pwndbg.commands.OnlyWhenRunning
+def vmmap_add(start: int, size: int, flags: str, offset: int) -> None:
+    page_flags = {
+        "r": pwndbg.aglib.elf.PF_R,
+        "w": pwndbg.aglib.elf.PF_W,
+        "x": pwndbg.aglib.elf.PF_X,
+    }
+    perm = 0
+    for flag in flags:
+        flag_val = page_flags.get(flag, None)
+        if flag_val is None:
+            print('Invalid page flag "%s"', flag)
+            return
+        perm |= flag_val
 
-        pwndbg.gdblib.vmmap.add_custom_page(page)
+    page = pwndbg.lib.memory.Page(start, size, perm, offset)
+    pwndbg.aglib.vmmap_custom.add_custom_page(page)
 
+    print("%r added" % page)
+
+
+parser = argparse.ArgumentParser(description="Explore a page, trying to guess permissions.")
+parser.add_argument(
+    "address", type=pwndbg.commands.sloppy_gdb_parse, help="Address of the page to explore"
+)
+
+
+@pwndbg.commands.ArgparsedCommand(parser, category=CommandCategory.MEMORY)
+@pwndbg.commands.OnlyWhenRunning
+def vmmap_explore(address: int) -> None:
+    if not isinstance(address, int):
+        print("Address is not a valid integer.")
+        return
+
+    old_value = pwndbg.config.auto_explore_pages.value
+    pwndbg.config.auto_explore_pages.value = "yes"
+    try:
+        pwndbg.aglib.vmmap.find.cache.clear()  # type: ignore[attr-defined]
+        page = pwndbg.aglib.vmmap.find(address)
+    finally:
+        pwndbg.config.auto_explore_pages.value = old_value
+
+    if page is None:
+        print("Exploration failed. Maybe the address isn't readable?")
+        return
+
+    print_vmmap_table_header()
+    print(page)
+
+
+@pwndbg.commands.ArgparsedCommand(
+    "Clear the vmmap cache.", category=CommandCategory.MEMORY
+)  # TODO is this accurate?
+@pwndbg.commands.OnlyWhenRunning
+def vmmap_clear() -> None:
+    pwndbg.aglib.vmmap_custom.clear_custom_page()
+
+
+parser = argparse.ArgumentParser(description="Load virtual memory map pages from ELF file.")
+parser.add_argument(
+    "filename",
+    nargs="?",
+    type=str,
+    help="ELF filename, by default uses current loaded filename.",
+)
+
+
+@pwndbg.commands.ArgparsedCommand(parser, category=CommandCategory.MEMORY)
+@pwndbg.commands.OnlyWhenRunning
+def vmmap_load(filename) -> None:
+    if filename is None:
+        filename = pwndbg.aglib.file.get_proc_exe_file()
+
+    print(f'Load "{filename}" ...')
+    file_basename = os.path.basename(filename)
+
+    # TODO: Add an argument to let use to choose loading the page information from sections or segments
+
+    # Use section information to recover the segment information.
+    # The entry point of bare metal environment is often at the first segment.
+    # For example, assume the entry point is at 0x8000.
+    # In most of case, link will create a segment and starts from 0x0.
+    # This cause all values less than 0x8000 be considered as a valid pointer.
+    pages = []
+    with open(filename, "rb") as f:
+        elffile = ELFFile(f)
+
+        for section in elffile.iter_sections():
+            vaddr = section["sh_addr"]
+            memsz = section["sh_size"]
+            sh_flags = section["sh_flags"]
+            offset = section["sh_offset"]
+
+            # Don't add the sections that aren't mapped into memory
+            if not sh_flags & SH_FLAGS.SHF_ALLOC:
+                continue
+
+            # Guess the segment flags from section flags
+            flags = pwndbg.aglib.elf.PF_R
+            if sh_flags & SH_FLAGS.SHF_WRITE:
+                flags |= pwndbg.aglib.elf.PF_W
+            if sh_flags & SH_FLAGS.SHF_EXECINSTR:
+                flags |= pwndbg.aglib.elf.PF_X
+
+            page = pwndbg.lib.memory.Page(
+                vaddr, memsz, flags, offset, f"[{section.name}]: {file_basename}"
+            )
+            pages.append(page)
+
+    for page in pages:
+        pwndbg.aglib.vmmap_custom.add_custom_page(page)
         print("%r added" % page)
-
-    parser = argparse.ArgumentParser(description="Explore a page, trying to guess permissions.")
-    parser.add_argument(
-        "address", type=pwndbg.commands.sloppy_gdb_parse, help="Address of the page to explore"
-    )
-
-    @pwndbg.commands.ArgparsedCommand(parser, category=CommandCategory.MEMORY)
-    @pwndbg.commands.OnlyWhenRunning
-    def vmmap_explore(address: int) -> None:
-        if not isinstance(address, int):
-            print("Address is not a valid integer.")
-            return
-        page = pwndbg.gdblib.vmmap.explore(address, skip_config_guard=True)
-        if page is None:
-            print("Exploration failed. Maybe the address isn't readable?")
-            return
-        print_vmmap_table_header()
-        print(page)
-
-    @pwndbg.commands.ArgparsedCommand(
-        "Clear the vmmap cache.", category=CommandCategory.MEMORY
-    )  # TODO is this accurate?
-    @pwndbg.commands.OnlyWhenRunning
-    def vmmap_clear() -> None:
-        pwndbg.gdblib.vmmap.clear_custom_page()
-
-    parser = argparse.ArgumentParser(description="Load virtual memory map pages from ELF file.")
-    parser.add_argument(
-        "filename",
-        nargs="?",
-        type=str,
-        help="ELF filename, by default uses current loaded filename.",
-    )
-
-    @pwndbg.commands.ArgparsedCommand(parser, category=CommandCategory.MEMORY)
-    @pwndbg.commands.OnlyWhenRunning
-    def vmmap_load(filename) -> None:
-        if filename is None:
-            filename = pwndbg.aglib.file.get_proc_exe_file()
-
-        print(f'Load "{filename}" ...')
-        file_basename = os.path.basename(filename)
-
-        # TODO: Add an argument to let use to choose loading the page information from sections or segments
-
-        # Use section information to recover the segment information.
-        # The entry point of bare metal environment is often at the first segment.
-        # For example, assume the entry point is at 0x8000.
-        # In most of case, link will create a segment and starts from 0x0.
-        # This cause all values less than 0x8000 be considered as a valid pointer.
-        pages = []
-        with open(filename, "rb") as f:
-            elffile = ELFFile(f)
-
-            for section in elffile.iter_sections():
-                vaddr = section["sh_addr"]
-                memsz = section["sh_size"]
-                sh_flags = section["sh_flags"]
-                offset = section["sh_offset"]
-
-                # Don't add the sections that aren't mapped into memory
-                if not sh_flags & SH_FLAGS.SHF_ALLOC:
-                    continue
-
-                # Guess the segment flags from section flags
-                flags = pwndbg.aglib.elf.PF_R
-                if sh_flags & SH_FLAGS.SHF_WRITE:
-                    flags |= pwndbg.aglib.elf.PF_W
-                if sh_flags & SH_FLAGS.SHF_EXECINSTR:
-                    flags |= pwndbg.aglib.elf.PF_X
-
-                page = pwndbg.lib.memory.Page(
-                    vaddr, memsz, flags, offset, f"[{section.name}]: {file_basename}"
-                )
-                pages.append(page)
-
-        for page in pages:
-            pwndbg.gdblib.vmmap.add_custom_page(page)
-            print("%r added" % page)

--- a/pwndbg/commands/vmmap.py
+++ b/pwndbg/commands/vmmap.py
@@ -335,7 +335,7 @@ if pwndbg.dbg.is_gdblib_available():
         if not isinstance(address, int):
             print("Address is not a valid integer.")
             return
-        page = pwndbg.gdblib.vmmap.explore(address)
+        page = pwndbg.gdblib.vmmap.explore(address, skip_config_guard=True)
         if page is None:
             print("Exploration failed. Maybe the address isn't readable?")
             return

--- a/pwndbg/commands/vmmap.py
+++ b/pwndbg/commands/vmmap.py
@@ -394,7 +394,7 @@ if pwndbg.dbg.is_gdblib_available():
                 if sh_flags & SH_FLAGS.SHF_EXECINSTR:
                     flags |= pwndbg.aglib.elf.PF_X
 
-                page = pwndbg.lib.memory.Page(vaddr, memsz, flags, offset, filename)
+                page = pwndbg.lib.memory.Page(vaddr, memsz, flags, offset, f'[{section.name}] {filename}')
                 pages.append(page)
 
         for page in pages:

--- a/pwndbg/commands/vmmap.py
+++ b/pwndbg/commands/vmmap.py
@@ -319,7 +319,7 @@ if pwndbg.dbg.is_gdblib_available():
                 return
             perm |= flag_val
 
-        page = pwndbg.lib.memory.Page(int(start), int(size), perm, offset)
+        page = pwndbg.lib.memory.Page(start, size, perm, offset)
 
         pwndbg.gdblib.vmmap.add_custom_page(page)
 

--- a/pwndbg/dbg/__init__.py
+++ b/pwndbg/dbg/__init__.py
@@ -262,7 +262,7 @@ class Frame:
 
 
 class Thread:
-    def bottom_frame(self) -> Frame:
+    def bottom_frame(self) -> Generator[pwndbg.dbg_mod.Frame, None, None]:
         """
         Frame at the bottom of the call stack for this thread.
         """

--- a/pwndbg/dbg/__init__.py
+++ b/pwndbg/dbg/__init__.py
@@ -11,6 +11,7 @@ from typing import Awaitable
 from typing import Callable
 from typing import Coroutine
 from typing import Generator
+from typing import Iterator
 from typing import List
 from typing import Literal
 from typing import Sequence
@@ -262,6 +263,7 @@ class Frame:
 
 
 class Thread:
+    @contextlib.contextmanager
     def bottom_frame(self) -> Iterator[Frame]:
         """
         Frame at the bottom of the call stack for this thread.

--- a/pwndbg/dbg/__init__.py
+++ b/pwndbg/dbg/__init__.py
@@ -262,7 +262,7 @@ class Frame:
 
 
 class Thread:
-    def bottom_frame(self) -> Generator[pwndbg.dbg_mod.Frame, None, None]:
+    def bottom_frame(self) -> Iterator[Frame]:
         """
         Frame at the bottom of the call stack for this thread.
         """

--- a/pwndbg/dbg/gdb/__init__.py
+++ b/pwndbg/dbg/gdb/__init__.py
@@ -390,6 +390,8 @@ class GDBProcess(pwndbg.dbg_mod.Process):
 
     @override
     def read_memory(self, address: int, size: int, partial: bool = False) -> bytearray:
+        print(f'read_memory @ {address:X} @ {size:d}')
+
         result = b""
         count = max(int(size), 0)
         addr = address

--- a/pwndbg/dbg/gdb/__init__.py
+++ b/pwndbg/dbg/gdb/__init__.py
@@ -394,6 +394,10 @@ class GDBProcess(pwndbg.dbg_mod.Process):
         count = max(int(size), 0)
         addr = address
 
+        # TODO: remove debug
+        import traceback
+        print(f'read_memory {address:#x} @ {size:#x} @ {traceback.format_stack()}')
+
         try:
             result = gdb.selected_inferior().read_memory(addr, count)
         except gdb.error as e:

--- a/pwndbg/dbg/gdb/__init__.py
+++ b/pwndbg/dbg/gdb/__init__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import binascii
 import re
 from asyncio import CancelledError
-from contextlib import nullcontext
+from contextlib import nullcontext, contextmanager
 from typing import Any
 from typing import Coroutine
 from typing import Generator
@@ -197,10 +197,10 @@ class GDBThread(pwndbg.dbg_mod.Thread):
         self.inner = inner
 
     @override
-    def bottom_frame(self) -> pwndbg.dbg_mod.Frame:
+    @contextmanager
+    def bottom_frame(self) -> Generator[pwndbg.dbg_mod.Frame, None, None]:
         with selection(self.inner, lambda: gdb.selected_thread(), lambda t: t.switch()):
-            value = gdb.newest_frame()
-        return GDBFrame(value)
+            yield GDBFrame(gdb.newest_frame())
 
     @override
     def ptid(self) -> int | None:

--- a/pwndbg/dbg/gdb/__init__.py
+++ b/pwndbg/dbg/gdb/__init__.py
@@ -390,8 +390,6 @@ class GDBProcess(pwndbg.dbg_mod.Process):
 
     @override
     def read_memory(self, address: int, size: int, partial: bool = False) -> bytearray:
-        print(f'read_memory @ {address:X} @ {size:d}')
-
         result = b""
         count = max(int(size), 0)
         addr = address

--- a/pwndbg/dbg/gdb/__init__.py
+++ b/pwndbg/dbg/gdb/__init__.py
@@ -5,6 +5,7 @@ import re
 from asyncio import CancelledError
 from contextlib import nullcontext, contextmanager
 from typing import Any
+from typing import Iterator
 from typing import Coroutine
 from typing import Generator
 from typing import List
@@ -198,7 +199,7 @@ class GDBThread(pwndbg.dbg_mod.Thread):
 
     @override
     @contextmanager
-    def bottom_frame(self) -> Generator[pwndbg.dbg_mod.Frame, None, None]:
+    def bottom_frame(self) -> Iterator[pwndbg.dbg_mod.Frame]:
         with selection(self.inner, lambda: gdb.selected_thread(), lambda t: t.switch()):
             yield GDBFrame(gdb.newest_frame())
 

--- a/pwndbg/dbg/gdb/__init__.py
+++ b/pwndbg/dbg/gdb/__init__.py
@@ -394,10 +394,6 @@ class GDBProcess(pwndbg.dbg_mod.Process):
         count = max(int(size), 0)
         addr = address
 
-        # TODO: remove debug
-        import traceback
-        print(f'read_memory {address:#x} @ {size:#x} @ {traceback.format_stack()}')
-
         try:
             result = gdb.selected_inferior().read_memory(addr, count)
         except gdb.error as e:

--- a/pwndbg/dbg/gdb/__init__.py
+++ b/pwndbg/dbg/gdb/__init__.py
@@ -383,11 +383,23 @@ class GDBProcess(pwndbg.dbg_mod.Process):
     @override
     def vmmap(self) -> pwndbg.dbg_mod.MemoryMap:
         import pwndbg.aglib.qemu
-        import pwndbg.gdblib.vmmap
+        from pwndbg.aglib.kernel.vmmap import kernel_vmmap
+        from pwndbg.aglib.vmmap_custom import get_custom_pages
+        from pwndbg.gdblib.vmmap import get_known_maps
 
-        pages = pwndbg.gdblib.vmmap.get()
         qemu = pwndbg.aglib.qemu.is_old_qemu_user()
+        proc_maps = get_known_maps()
+        # The `proc_maps` is usually a tuple of Page objects but it can also be:
+        #   None    - when /proc/$tid/maps does not exist/is not available
+        #   tuple() - when the process has no maps yet which happens only during its very early init
+        #             (usually when we attach to a process)
+        if proc_maps is not None:
+            return GDBMemoryMap(qemu, proc_maps)
 
+        pages: List[pwndbg.lib.memory.Page] = []
+        pages.extend(kernel_vmmap())
+        pages.extend(get_custom_pages())
+        pages.sort()
         return GDBMemoryMap(qemu, pages)
 
     @override

--- a/pwndbg/dbg/gdb/__init__.py
+++ b/pwndbg/dbg/gdb/__init__.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 import binascii
 import re
 from asyncio import CancelledError
-from contextlib import nullcontext, contextmanager
+from contextlib import contextmanager
+from contextlib import nullcontext
 from typing import Any
-from typing import Iterator
 from typing import Coroutine
 from typing import Generator
+from typing import Iterator
 from typing import List
 from typing import Literal
 from typing import Optional

--- a/pwndbg/dbg/lldb/__init__.py
+++ b/pwndbg/dbg/lldb/__init__.py
@@ -1094,6 +1094,10 @@ class LLDBProcess(pwndbg.dbg_mod.Process):
             # Packets not implemented return empty
             return b""
 
+        is_err = response.index("response: \nerror: ") > -1
+        if is_err:
+            return b""
+
         return response[idx + len("response: "):].encode()
 
     @override

--- a/pwndbg/dbg/lldb/__init__.py
+++ b/pwndbg/dbg/lldb/__init__.py
@@ -1089,15 +1089,12 @@ class LLDBProcess(pwndbg.dbg_mod.Process):
         response = self.dbg._execute_lldb_command(f"process plugin packet send {packet}")
 
         # We need extract response
-        for line in response.split("\n"):
-            if line.startswith("response: "):
-                ret = line[10:]
-                if not ret:
-                    continue
-                return ret.encode()
+        idx = response.index("response: ")
+        if idx == -1:
+            # Packets not implemented return empty
+            return b""
 
-        # Packets not implemented return empty
-        return b""
+        return response[idx + len("response: "):].encode()
 
     @override
     def send_monitor(self, cmd: str) -> str:

--- a/pwndbg/dbg/lldb/__init__.py
+++ b/pwndbg/dbg/lldb/__init__.py
@@ -10,7 +10,6 @@ import sys
 from contextlib import contextmanager
 from typing import Any
 from typing import Awaitable
-from typing import Iterator
 from typing import Callable
 from typing import Coroutine
 from typing import Dict
@@ -1107,7 +1106,7 @@ class LLDBProcess(pwndbg.dbg_mod.Process):
             # Packets not implemented return empty
             return b""
 
-        out = response[idx + len("\nresponse: "):].encode()
+        out = response[idx + len("\nresponse: ") :].encode()
         if out[-1:] == b"\n":
             out = out[:-1]
         return out
@@ -1509,10 +1508,7 @@ class LLDBProcess(pwndbg.dbg_mod.Process):
                 with thread.bottom_frame() as frame:
                     return frame.regs().by_name("xpsr") is not None
 
-            has_xpsr = [
-                _has_xpsr(thread)
-                for thread in self.threads()
-            ]
+            has_xpsr = [_has_xpsr(thread) for thread in self.threads()]
             assert (
                 all(has_xpsr) or not any(has_xpsr)
             ), "Either all threads are Cortex-M or none are, Pwndbg doesn't know how to handle other cases"

--- a/pwndbg/dbg/lldb/__init__.py
+++ b/pwndbg/dbg/lldb/__init__.py
@@ -1105,18 +1105,19 @@ class LLDBProcess(pwndbg.dbg_mod.Process):
         response = self.dbg._execute_lldb_command(f"process plugin packet send {packet}")
 
         # We need extract response
+        size = len("\nresponse: ")
         try:
             idx = response.index("\nresponse: ")
         except ValueError:
             # Packets not implemented return empty
             return b""
 
-        is_err = response[idx:].startswith("\nerror: ")
+        is_err = response[idx + size :].startswith("\nerror: ")
         if is_err:
             # Packets not implemented return empty
             return b""
 
-        out = response[idx + len("\nresponse: ") :].encode()
+        out = response[idx + size :].encode()
         if out[-1:] == b"\n":
             out = out[:-1]
         return out

--- a/pwndbg/dbg/lldb/__init__.py
+++ b/pwndbg/dbg/lldb/__init__.py
@@ -1096,6 +1096,7 @@ class LLDBProcess(pwndbg.dbg_mod.Process):
 
         is_err = response.index("response: \nerror: ") > -1
         if is_err:
+            # Packets not implemented return empty
             return b""
 
         return response[idx + len("response: "):].encode()

--- a/pwndbg/dbg/lldb/__init__.py
+++ b/pwndbg/dbg/lldb/__init__.py
@@ -803,8 +803,7 @@ class LLDBProcess(pwndbg.dbg_mod.Process):
 
         return LLDBValue(value, self)
 
-    @override
-    def vmmap(self) -> pwndbg.dbg_mod.MemoryMap:
+    def get_known_pages(self) -> List[pwndbg.lib.memory.Page]:
         regions = self.process.GetMemoryRegions()
 
         pages = []
@@ -871,6 +870,21 @@ class LLDBProcess(pwndbg.dbg_mod.Process):
                 )
             )
 
+        return pages
+
+    @override
+    def vmmap(self) -> pwndbg.dbg_mod.MemoryMap:
+        pages = self.get_known_pages()
+        if pages:
+            return LLDBMemoryMap(pages)
+
+        from pwndbg.aglib.kernel.vmmap import kernel_vmmap
+        from pwndbg.aglib.vmmap_custom import get_custom_pages
+
+        pages: List[pwndbg.lib.memory.Page] = []
+        pages.extend(kernel_vmmap())
+        pages.extend(get_custom_pages())
+        pages.sort()
         return LLDBMemoryMap(pages)
 
     def find_largest_range_len(

--- a/pwndbg/dbg/lldb/__init__.py
+++ b/pwndbg/dbg/lldb/__init__.py
@@ -1110,7 +1110,7 @@ class LLDBProcess(pwndbg.dbg_mod.Process):
             # Packets not implemented return empty
             return b""
 
-        out = response[idx + 11:]  # len("\nresponse: ") == 11
+        out = response[idx + 11 :]  # len("\nresponse: ") == 11
         if out.startswith("\nerror: "):
             # Packets not implemented return empty
             return b""

--- a/pwndbg/dbg/lldb/__init__.py
+++ b/pwndbg/dbg/lldb/__init__.py
@@ -7,6 +7,7 @@ import random
 import re
 import shlex
 import sys
+from contextlib import contextmanager
 from typing import Any
 from typing import Awaitable
 from typing import Callable
@@ -269,11 +270,12 @@ class LLDBThread(pwndbg.dbg_mod.Thread):
         self.proc = proc
 
     @override
-    def bottom_frame(self) -> pwndbg.dbg_mod.Frame:
+    @contextlib.contextmanager
+    def bottom_frame(self) -> Generator[pwndbg.dbg_mod.Frame, None, None]:
         if self.inner.GetNumFrames() <= 0:
-            return None
+            raise pwndbg.dbg_mod.Error("no frames")
 
-        return LLDBFrame(self.inner.GetFrameAtIndex(0), self.proc)
+        yield LLDBFrame(self.inner.GetFrameAtIndex(0), self.proc)
 
     @override
     def ptid(self) -> int | None:
@@ -1494,8 +1496,12 @@ class LLDBProcess(pwndbg.dbg_mod.Process):
             # of ARM. Pwndbg needs that distinction, so we attempt to detect
             # Cortex-M varieties by querying for the presence of the `xpsr`
             # register.
+            def _has_xpsr(thread) -> bool:
+                with thread.bottom_frame() as frame:
+                    return frame.regs().by_name("xpsr") is not None
+
             has_xpsr = [
-                thread.bottom_frame().regs().by_name("xpsr") is not None
+                _has_xpsr(thread)
                 for thread in self.threads()
             ]
             assert (

--- a/pwndbg/dbg/lldb/__init__.py
+++ b/pwndbg/dbg/lldb/__init__.py
@@ -1104,23 +1104,21 @@ class LLDBProcess(pwndbg.dbg_mod.Process):
         # [1] https://github.com/llvm/llvm-project/blob/6c42d0d7df55f28084e41b482dd7c25d4e7bcd10/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp#L5660
         response = self.dbg._execute_lldb_command(f"process plugin packet send {packet}")
 
-        # We need extract response
-        size = len("\nresponse: ")
         try:
             idx = response.index("\nresponse: ")
         except ValueError:
             # Packets not implemented return empty
             return b""
 
-        is_err = response[idx + size :].startswith("\nerror: ")
-        if is_err:
+        out = response[idx + 11:]  # len("\nresponse: ") == 11
+        if out.startswith("\nerror: "):
             # Packets not implemented return empty
             return b""
 
-        out = response[idx + size :].encode()
-        if out[-1:] == b"\n":
+        if out[-1] == "\n":
             out = out[:-1]
-        return out
+
+        return out.encode()
 
     @override
     def send_monitor(self, cmd: str) -> str:

--- a/pwndbg/dbg/lldb/__init__.py
+++ b/pwndbg/dbg/lldb/__init__.py
@@ -1505,6 +1505,12 @@ class LLDBProcess(pwndbg.dbg_mod.Process):
         elif name == "arm64":
             # Apple uses a different name for AArch64 than we do.
             name = "aarch64"
+        elif name == "riscv32":
+            # Pwndbg use a different name for riscv32.
+            name = "rv32"
+        elif name == "riscv64":
+            # Pwndbg use a different name for riscv64.
+            name = "rv64"
 
         return LLDBArch(name, ptrsize0, endian)
 

--- a/pwndbg/dbg/lldb/__init__.py
+++ b/pwndbg/dbg/lldb/__init__.py
@@ -1106,7 +1106,7 @@ class LLDBProcess(pwndbg.dbg_mod.Process):
             # Packets not implemented return empty
             return b""
 
-        return response[idx + len("response: "):].encode()
+        return response[idx + len("\nresponse: "):].encode()
 
     @override
     def send_monitor(self, cmd: str) -> str:

--- a/pwndbg/dbg/lldb/__init__.py
+++ b/pwndbg/dbg/lldb/__init__.py
@@ -270,7 +270,7 @@ class LLDBThread(pwndbg.dbg_mod.Thread):
         self.proc = proc
 
     @override
-    @contextlib.contextmanager
+    @contextmanager
     def bottom_frame(self) -> Generator[pwndbg.dbg_mod.Frame, None, None]:
         if self.inner.GetNumFrames() <= 0:
             raise pwndbg.dbg_mod.Error("no frames")

--- a/pwndbg/dbg/lldb/__init__.py
+++ b/pwndbg/dbg/lldb/__init__.py
@@ -1106,7 +1106,10 @@ class LLDBProcess(pwndbg.dbg_mod.Process):
             # Packets not implemented return empty
             return b""
 
-        return response[idx + len("\nresponse: "):].encode()
+        out = response[idx + len("\nresponse: "):].encode()
+        if out[-1:] == b"\n":
+            out = out[:-1]
+        return out
 
     @override
     def send_monitor(self, cmd: str) -> str:

--- a/pwndbg/dbg/lldb/__init__.py
+++ b/pwndbg/dbg/lldb/__init__.py
@@ -1111,11 +1111,7 @@ class LLDBProcess(pwndbg.dbg_mod.Process):
             # Packets not implemented return empty
             return b""
 
-        try:
-            is_err = response.index("\nresponse: \nerror: ") > -1
-        except ValueError:
-            is_err = False
-
+        is_err = response[idx:].startswith("\nerror: ")
         if is_err:
             # Packets not implemented return empty
             return b""

--- a/pwndbg/dbg/lldb/__init__.py
+++ b/pwndbg/dbg/lldb/__init__.py
@@ -1089,12 +1089,12 @@ class LLDBProcess(pwndbg.dbg_mod.Process):
         response = self.dbg._execute_lldb_command(f"process plugin packet send {packet}")
 
         # We need extract response
-        idx = response.index("response: ")
+        idx = response.index("\nresponse: ")
         if idx == -1:
             # Packets not implemented return empty
             return b""
 
-        is_err = response.index("response: \nerror: ") > -1
+        is_err = response.index("\nresponse: \nerror: ") > -1
         if is_err:
             # Packets not implemented return empty
             return b""

--- a/pwndbg/dbg/lldb/__init__.py
+++ b/pwndbg/dbg/lldb/__init__.py
@@ -10,6 +10,7 @@ import sys
 from contextlib import contextmanager
 from typing import Any
 from typing import Awaitable
+from typing import Iterator
 from typing import Callable
 from typing import Coroutine
 from typing import Dict
@@ -271,7 +272,7 @@ class LLDBThread(pwndbg.dbg_mod.Thread):
 
     @override
     @contextmanager
-    def bottom_frame(self) -> Generator[pwndbg.dbg_mod.Frame, None, None]:
+    def bottom_frame(self) -> Iterator[pwndbg.dbg_mod.Frame]:
         if self.inner.GetNumFrames() <= 0:
             raise pwndbg.dbg_mod.Error("no frames")
 

--- a/pwndbg/dbg/lldb/__init__.py
+++ b/pwndbg/dbg/lldb/__init__.py
@@ -1091,12 +1091,17 @@ class LLDBProcess(pwndbg.dbg_mod.Process):
         response = self.dbg._execute_lldb_command(f"process plugin packet send {packet}")
 
         # We need extract response
-        idx = response.index("\nresponse: ")
-        if idx == -1:
+        try:
+            idx = response.index("\nresponse: ")
+        except ValueError:
             # Packets not implemented return empty
             return b""
 
-        is_err = response.index("\nresponse: \nerror: ") > -1
+        try:
+            is_err = response.index("\nresponse: \nerror: ") > -1
+        except ValueError:
+            is_err = False
+
         if is_err:
             # Packets not implemented return empty
             return b""

--- a/pwndbg/dbg/lldb/__init__.py
+++ b/pwndbg/dbg/lldb/__init__.py
@@ -834,7 +834,7 @@ class LLDBProcess(pwndbg.dbg_mod.Process):
 
                 # Try to resolve the name anyway by using SBAddress.
                 file = lldb.SBAddress(region.GetRegionBase(), self.target).GetModule().GetFileSpec()
-                objfile = file.fullpath if file.IsValid() else "<unknown>"
+                objfile = file.fullpath if file.IsValid() else f"[anon_{start >> 12:05x}]"
 
             perms = 0
             if region.IsReadable():

--- a/pwndbg/dbg/lldb/repl/__init__.py
+++ b/pwndbg/dbg/lldb/repl/__init__.py
@@ -626,7 +626,7 @@ def process_launch(driver: ProcessDriver, relay: EventRelay, args: List[str], db
         dbg.debugger.GetTargetAtIndex(0),
         io_driver,
         [f"{name}={value}" for name, value in os.environ.items()],
-        getattr(args, 'run-args', []),
+        getattr(args, "run-args", []),
         os.getcwd(),
     )
 

--- a/pwndbg/dbg/lldb/repl/__init__.py
+++ b/pwndbg/dbg/lldb/repl/__init__.py
@@ -622,6 +622,8 @@ def process_launch(driver: ProcessDriver, relay: EventRelay, args: List[str], db
     dbg._current_process_is_gdb_remote = False
 
     io_driver = get_io_driver()
+    print(args)
+    print(args.__dict__)
     result = driver.launch(
         dbg.debugger.GetTargetAtIndex(0),
         io_driver,

--- a/pwndbg/dbg/lldb/repl/__init__.py
+++ b/pwndbg/dbg/lldb/repl/__init__.py
@@ -618,12 +618,17 @@ def process_launch(driver: ProcessDriver, relay: EventRelay, args: List[str], db
         print(message.error("error: a process is already being debugged"))
         return
 
+    target: lldb.SBTarget = dbg.debugger.GetTargetAtIndex(0)
     # Make sure the LLDB driver knows that this is a local process.
     dbg._current_process_is_gdb_remote = False
 
+    if target.GetPlatform().GetName() == "qemu-user":
+        # Force qemu-user as remote, pwndbg depends on that, eg: for download procfs files
+        dbg._current_process_is_gdb_remote = True
+
     io_driver = get_io_driver()
     result = driver.launch(
-        dbg.debugger.GetTargetAtIndex(0),
+        target,
         io_driver,
         [f"{name}={value}" for name, value in os.environ.items()],
         getattr(args, "run-args", []),

--- a/pwndbg/dbg/lldb/repl/__init__.py
+++ b/pwndbg/dbg/lldb/repl/__init__.py
@@ -626,7 +626,7 @@ def process_launch(driver: ProcessDriver, relay: EventRelay, args: List[str], db
         dbg.debugger.GetTargetAtIndex(0),
         io_driver,
         [f"{name}={value}" for name, value in os.environ.items()],
-        args.run_args,
+        args.run-args,
         os.getcwd(),
     )
 

--- a/pwndbg/dbg/lldb/repl/__init__.py
+++ b/pwndbg/dbg/lldb/repl/__init__.py
@@ -626,7 +626,7 @@ def process_launch(driver: ProcessDriver, relay: EventRelay, args: List[str], db
         dbg.debugger.GetTargetAtIndex(0),
         io_driver,
         [f"{name}={value}" for name, value in os.environ.items()],
-        [],
+        args.run_args,
         os.getcwd(),
     )
 

--- a/pwndbg/dbg/lldb/repl/__init__.py
+++ b/pwndbg/dbg/lldb/repl/__init__.py
@@ -622,13 +622,11 @@ def process_launch(driver: ProcessDriver, relay: EventRelay, args: List[str], db
     dbg._current_process_is_gdb_remote = False
 
     io_driver = get_io_driver()
-    print(args)
-    print(args.__dict__)
     result = driver.launch(
         dbg.debugger.GetTargetAtIndex(0),
         io_driver,
         [f"{name}={value}" for name, value in os.environ.items()],
-        args.run-args,
+        getattr(args, 'run-args', []),
         os.getcwd(),
     )
 

--- a/pwndbg/gdblib/vmmap.py
+++ b/pwndbg/gdblib/vmmap.py
@@ -161,37 +161,6 @@ def clear_warn_cache():
     _warn_cache.clear()
 
 
-@pwndbg.lib.cache.cache_until("stop")
-def find(
-    address: int | gdb.Value | None, *, should_explore: bool | None = None
-) -> pwndbg.lib.memory.Page | None:
-    if address is None:
-        return None
-
-    address = int(address)
-
-    for page in get():
-        if address in page:
-            return page
-
-    if should_explore is None:
-        if auto_explore.value == "warn":
-            page_start = pwndbg.lib.memory.page_align(address)
-            if page_start not in _warn_cache:
-                _warn_cache.add(page_start)
-                print(
-                    M.warn(
-                        f"Warning: Avoided exploring possible address {address:#x}. You can explicitly explore it with `vmmap_explore {page_start:#x}`"
-                    )
-                )
-        elif auto_explore.value == "yes":
-            return explore(address)
-    elif should_explore and not proc_tid_maps():
-        return explore(address)
-
-    return None
-
-
 def explore(address_maybe: int) -> pwndbg.lib.memory.Page | None:
     """
     Given a potential address, check to see what permissions it has.
@@ -207,6 +176,19 @@ def explore(address_maybe: int) -> pwndbg.lib.memory.Page | None:
         Also assumes the entire contiguous section has the same permission.
     """
     if not pwndbg.dbg.selected_inferior().is_linux():
+        return None
+
+    if auto_explore.value == "warn":
+        page_start = pwndbg.lib.memory.page_align(address_maybe)
+        if page_start not in _warn_cache:
+            _warn_cache.add(page_start)
+            print(
+                M.warn(
+                    f"Warning: Avoided exploring possible address {address_maybe:#x}. You can explicitly explore it with `vmmap_explore {page_start:#x}`"
+                )
+            )
+        return None
+    elif auto_explore.value == "no":
         return None
 
     address_maybe = pwndbg.lib.memory.page_align(address_maybe)

--- a/pwndbg/gdblib/vmmap.py
+++ b/pwndbg/gdblib/vmmap.py
@@ -82,9 +82,6 @@ def is_corefile() -> bool:
     return "Local core dump file:\n" in pwndbg.gdblib.info.target()
 
 
-inside_no_proc_maps_search = False
-
-
 @pwndbg.lib.cache.cache_until("start", "stop")
 def get_known_maps() -> Tuple[pwndbg.lib.memory.Page, ...] | None:
     """

--- a/pwndbg/gdblib/vmmap.py
+++ b/pwndbg/gdblib/vmmap.py
@@ -117,9 +117,6 @@ def get() -> Tuple[pwndbg.lib.memory.Page, ...]:
     target, sorted by virtual address ascending.
     """
     proc_maps = get_known_maps()
-    if proc_maps is not None:
-        return proc_maps
-
     # The `proc_maps` is usually a tuple of Page objects but it can also be:
     #   None    - when /proc/$tid/maps does not exist/is not available
     #   tuple() - when the process has no maps yet which happens only during its very early init

--- a/pwndbg/gdblib/vmmap.py
+++ b/pwndbg/gdblib/vmmap.py
@@ -112,7 +112,9 @@ def clear_warn_cache():
     _warn_cache.clear()
 
 
-def explore(address_maybe: int, objfile_name: str = None, skip_config_guard: bool = False) -> pwndbg.lib.memory.Page | None:
+def explore(
+    address_maybe: int, objfile_name: str = None, skip_config_guard: bool = False
+) -> pwndbg.lib.memory.Page | None:
     """
     Given a potential address, check to see what permissions it has.
 
@@ -127,7 +129,7 @@ def explore(address_maybe: int, objfile_name: str = None, skip_config_guard: boo
         Also assumes the entire contiguous section has the same permission.
     """
     if objfile_name is None:
-        objfile_name = '<explored>'
+        objfile_name = "<explored>"
 
     if not pwndbg.dbg.selected_inferior().is_linux():
         return None

--- a/pwndbg/gdblib/vmmap.py
+++ b/pwndbg/gdblib/vmmap.py
@@ -67,7 +67,7 @@ Note that the page-tables method will require the QEMU kernel process to be on t
 
 auto_explore = pwndbg.config.add_param(
     "auto-explore-pages",
-    "yes",
+    "warn",
     "whether to try to infer page permissions when memory maps missing (can cause errors)",
     param_class=pwndbg.lib.config.PARAM_ENUM,
     enum_sequence=["yes", "warn", "no"],

--- a/pwndbg/gdblib/vmmap.py
+++ b/pwndbg/gdblib/vmmap.py
@@ -183,11 +183,14 @@ def explore(address_maybe: int, skip_config_guard: bool = False) -> pwndbg.lib.m
             page_start = pwndbg.lib.memory.page_align(address_maybe)
             if page_start not in _warn_cache:
                 _warn_cache.add(page_start)
-                print(
-                    M.warn(
-                        f"Warning: Avoided exploring possible address {address_maybe:#x}. You can explicitly explore it with `vmmap_explore {page_start:#x}`"
+                is_readable_addr = pwndbg.aglib.memory.peek(page_start)
+                if is_readable_addr:
+                    print(
+                        M.warn(
+                            f"Warning: Avoided exploring possible address {address_maybe:#x}.\n"
+                            f"You can explicitly explore it with `vmmap_explore {page_start:#x}`"
+                        )
                     )
-                )
             return None
         elif auto_explore.value == "no":
             return None
@@ -224,13 +227,6 @@ def explore(address_maybe: int, skip_config_guard: bool = False) -> pwndbg.lib.m
     get.cache.clear()  # type: ignore[attr-defined]
 
     return page
-
-
-# Automatically ensure that all registers are explored on each stop
-# @pwndbg.dbg.event_handler(EventType.STOP)
-def explore_registers() -> None:
-    for regname in pwndbg.aglib.regs.common:
-        find(pwndbg.aglib.regs[regname])
 
 
 # @pwndbg.dbg.event_handler(EventType.EXIT)

--- a/pwndbg/gdblib/vmmap.py
+++ b/pwndbg/gdblib/vmmap.py
@@ -31,8 +31,7 @@ import pwndbg.gdblib.info
 import pwndbg.lib.cache
 import pwndbg.lib.config
 import pwndbg.lib.memory
-from pwndbg.aglib.kernel.vmmap import kernel_vmmap_via_monitor_info_mem
-from pwndbg.aglib.kernel.vmmap import kernel_vmmap_via_page_tables
+from pwndbg.aglib.kernel.vmmap import kernel_vmmap
 
 # List of manually-explored pages which were discovered
 # by analyzing the stack or register context.
@@ -40,22 +39,6 @@ explored_pages: List[pwndbg.lib.memory.Page] = []
 
 # List of custom pages that can be managed manually by vmmap_* commands family
 custom_pages: List[pwndbg.lib.memory.Page] = []
-
-kernel_vmmap = pwndbg.config.add_param(
-    "kernel-vmmap",
-    "page-tables",
-    "the method to get vmmap information when debugging via QEMU kernel",
-    help_docstring="""\
-kernel-vmmap can be:
-page-tables    - read /proc/$qemu-pid/mem to parse kernel page tables to render vmmap
-monitor        - use QEMU's `monitor info mem` to render vmmap
-none           - disable vmmap rendering; useful if rendering is particularly slow
-
-Note that the page-tables method will require the QEMU kernel process to be on the same machine and within the same PID namespace. Running QEMU kernel and GDB in different Docker containers will not work. Consider running both containers with --pid=host (meaning they will see and so be able to interact with all processes on the machine).
-""",
-    param_class=pwndbg.lib.config.PARAM_ENUM,
-    enum_sequence=["page-tables", "monitor", "none"],
-)
 
 auto_explore = pwndbg.config.add_param(
     "auto-explore-pages",
@@ -114,18 +97,7 @@ def get() -> Tuple[pwndbg.lib.memory.Page, ...]:
         return proc_maps
 
     pages: List[pwndbg.lib.memory.Page] = []
-    if pwndbg.aglib.qemu.is_qemu_kernel() and pwndbg.aglib.arch.current in (
-        "i386",
-        "x86-64",
-        "aarch64",
-        "rv32",
-        "rv64",
-    ):
-        if kernel_vmmap == "page-tables":
-            pages.extend(kernel_vmmap_via_page_tables())
-        elif kernel_vmmap == "monitor":
-            pages.extend(kernel_vmmap_via_monitor_info_mem())
-
+    pages.extend(kernel_vmmap())
     pages.extend(explored_pages)
     pages.extend(custom_pages)
     pages.sort()

--- a/pwndbg/gdblib/vmmap.py
+++ b/pwndbg/gdblib/vmmap.py
@@ -90,9 +90,6 @@ def is_corefile() -> bool:
     return "Local core dump file:\n" in pwndbg.gdblib.info.target()
 
 
-inside_no_proc_maps_search = False
-
-
 @pwndbg.lib.cache.cache_until("start", "stop")
 def get_known_maps() -> Tuple[pwndbg.lib.memory.Page, ...] | None:
     """
@@ -149,27 +146,6 @@ def get() -> Tuple[pwndbg.lib.memory.Page, ...]:
             pages.extend(kernel_vmmap_via_page_tables())
         elif kernel_vmmap == "monitor":
             pages.extend(kernel_vmmap_via_monitor_info_mem())
-
-    # TODO/FIXME: Add tests for  QEMU-user targets when this is needed
-    global inside_no_proc_maps_search
-    if not pages and not inside_no_proc_maps_search:
-        inside_no_proc_maps_search = True
-        # If debuggee is launched from a symlink the debuggee memory maps will be
-        # labeled with symlink path while in normal scenario the /proc/pid/maps
-        # labels debuggee memory maps with real path (after symlinks).
-        # This is because the exe path in AUXV (and so `info auxv`) is before
-        # following links.
-        pages.extend(info_auxv())
-
-        if pages:
-            pages.extend(info_sharedlibrary())
-        else:
-            if pwndbg.aglib.qemu.is_qemu():
-                return (pwndbg.lib.memory.Page(0, pwndbg.aglib.arch.ptrmask, 7, 0, "[qemu]"),)
-            pages.extend(info_files())
-
-        pages.extend(pwndbg.aglib.stack.get().values())
-        inside_no_proc_maps_search = False
 
     pages.extend(explored_pages)
     pages.extend(custom_pages)

--- a/pwndbg/gdblib/vmmap.py
+++ b/pwndbg/gdblib/vmmap.py
@@ -90,6 +90,9 @@ def is_corefile() -> bool:
     return "Local core dump file:\n" in pwndbg.gdblib.info.target()
 
 
+inside_no_proc_maps_search = False
+
+
 @pwndbg.lib.cache.cache_until("start", "stop")
 def get_known_maps() -> Tuple[pwndbg.lib.memory.Page, ...] | None:
     """
@@ -146,6 +149,27 @@ def get() -> Tuple[pwndbg.lib.memory.Page, ...]:
             pages.extend(kernel_vmmap_via_page_tables())
         elif kernel_vmmap == "monitor":
             pages.extend(kernel_vmmap_via_monitor_info_mem())
+
+    # TODO/FIXME: Add tests for  QEMU-user targets when this is needed
+    global inside_no_proc_maps_search
+    if not pages and not inside_no_proc_maps_search:
+        inside_no_proc_maps_search = True
+        # If debuggee is launched from a symlink the debuggee memory maps will be
+        # labeled with symlink path while in normal scenario the /proc/pid/maps
+        # labels debuggee memory maps with real path (after symlinks).
+        # This is because the exe path in AUXV (and so `info auxv`) is before
+        # following links.
+        pages.extend(info_auxv())
+
+        if pages:
+            pages.extend(info_sharedlibrary())
+        else:
+            if pwndbg.aglib.qemu.is_qemu():
+                return (pwndbg.lib.memory.Page(0, pwndbg.aglib.arch.ptrmask, 7, 0, "[qemu]"),)
+            pages.extend(info_files())
+
+        pages.extend(pwndbg.aglib.stack.get().values())
+        inside_no_proc_maps_search = False
 
     pages.extend(explored_pages)
     pages.extend(custom_pages)

--- a/pwndbg/gdblib/vmmap.py
+++ b/pwndbg/gdblib/vmmap.py
@@ -216,6 +216,7 @@ def explore(address_maybe: int, skip_config_guard: bool = False) -> pwndbg.lib.m
     # TODO: could maybe make this check look at the stacks in pwndbg.aglib.stack.get() but that might have issues
     elif (
         address_maybe == pwndbg.lib.memory.page_align(pwndbg.aglib.regs.sp)
+    # todo: remov pwndbg.aglib.stack.is_executable bo robi rekurencje
         and pwndbg.aglib.stack.is_executable()
     ):
         flags |= 1

--- a/pwndbg/gdblib/vmmap.py
+++ b/pwndbg/gdblib/vmmap.py
@@ -8,7 +8,6 @@ system has /proc/$$/maps, which backs 'info proc mapping'.
 
 from __future__ import annotations
 
-import bisect
 from typing import List
 from typing import Optional
 from typing import Set
@@ -19,34 +18,13 @@ import gdb
 import pwndbg
 import pwndbg.aglib.elf
 import pwndbg.aglib.file
-import pwndbg.aglib.kernel
-import pwndbg.aglib.memory
 import pwndbg.aglib.proc
 import pwndbg.aglib.qemu
-import pwndbg.aglib.regs
-import pwndbg.aglib.stack
 import pwndbg.auxv
-import pwndbg.color.message as M
 import pwndbg.gdblib.info
 import pwndbg.lib.cache
 import pwndbg.lib.config
 import pwndbg.lib.memory
-from pwndbg.aglib.kernel.vmmap import kernel_vmmap
-
-# List of manually-explored pages which were discovered
-# by analyzing the stack or register context.
-explored_pages: List[pwndbg.lib.memory.Page] = []
-
-# List of custom pages that can be managed manually by vmmap_* commands family
-custom_pages: List[pwndbg.lib.memory.Page] = []
-
-auto_explore = pwndbg.config.add_param(
-    "auto-explore-pages",
-    "warn",
-    "whether to try to infer page permissions when memory maps missing (can cause errors)",
-    param_class=pwndbg.lib.config.PARAM_ENUM,
-    enum_sequence=["yes", "warn", "no"],
-)
 
 
 @pwndbg.lib.cache.cache_until("objfile", "start")
@@ -80,134 +58,6 @@ def get_known_maps() -> Tuple[pwndbg.lib.memory.Page, ...] | None:
         return tuple(coredump_maps())
 
     return proc_tid_maps()
-
-
-@pwndbg.lib.cache.cache_until("start", "stop")
-def get() -> Tuple[pwndbg.lib.memory.Page, ...]:
-    """
-    Returns a tuple of `Page` objects representing the memory mappings of the
-    target, sorted by virtual address ascending.
-    """
-    proc_maps = get_known_maps()
-    # The `proc_maps` is usually a tuple of Page objects but it can also be:
-    #   None    - when /proc/$tid/maps does not exist/is not available
-    #   tuple() - when the process has no maps yet which happens only during its very early init
-    #             (usually when we attach to a process)
-    if proc_maps is not None:
-        return proc_maps
-
-    pages: List[pwndbg.lib.memory.Page] = []
-    pages.extend(kernel_vmmap())
-    pages.extend(explored_pages)
-    pages.extend(custom_pages)
-    pages.sort()
-    return tuple(pages)
-
-
-_warn_cache: Set[int] = set()
-
-
-@pwndbg.gdblib.events.new_objfile
-def clear_warn_cache():
-    _warn_cache.clear()
-
-
-def explore(
-    address_maybe: int, objfile_name: str = None, skip_config_guard: bool = False
-) -> pwndbg.lib.memory.Page | None:
-    """
-    Given a potential address, check to see what permissions it has.
-
-    Returns:
-        Page object
-
-    Note:
-        Adds the Page object to a persistent list of pages which are
-        only reset when the process dies.  This means pages which are
-        added this way will not be removed when unmapped.
-
-        Also assumes the entire contiguous section has the same permission.
-    """
-    if objfile_name is None:
-        objfile_name = "<explored>"
-
-    if not pwndbg.dbg.selected_inferior().is_linux():
-        return None
-
-    if not skip_config_guard:
-        if auto_explore.value == "warn":
-            page_start = pwndbg.lib.memory.page_align(address_maybe)
-            if page_start not in _warn_cache:
-                _warn_cache.add(page_start)
-                is_readable_addr = pwndbg.aglib.memory.peek(page_start)
-                if is_readable_addr:
-                    print(
-                        M.warn(
-                            f"Warning: Avoided exploring possible address {address_maybe:#x}.\n"
-                            f"You can explicitly explore it with `vmmap_explore {page_start:#x}`"
-                        )
-                    )
-            return None
-        elif auto_explore.value == "no":
-            return None
-
-    address_maybe = pwndbg.lib.memory.page_align(address_maybe)
-
-    flags = 4 if pwndbg.aglib.memory.peek(address_maybe) else 0
-
-    if not flags:
-        return None
-
-    if pwndbg.aglib.memory.poke(address_maybe):
-        flags |= 2
-    # It's really hard to check for executability, so we just make some guesses:
-    # If it's in the same page as the stack pointer, try to check the NX bit
-    # If it's in the same page as the instruction pointer, assume it's executable
-    # Otherwise, just say it's not executable
-    if address_maybe == pwndbg.lib.memory.page_align(pwndbg.aglib.regs.pc):
-        flags |= 1
-    # TODO: could maybe make this check look at the stacks in pwndbg.aglib.stack.get() but that might have issues
-    elif (
-        address_maybe == pwndbg.lib.memory.page_align(pwndbg.aglib.regs.sp)
-        and pwndbg.aglib.stack.is_executable()
-    ):
-        flags |= 1
-
-    page = find_boundaries(address_maybe)
-    page.objfile = objfile_name
-    page.flags = flags
-
-    explored_pages.append(page)
-
-    # Clear the "get" cache so pages that are explored in the current step are included
-    get.cache.clear()  # type: ignore[attr-defined]
-
-    return page
-
-
-# @pwndbg.dbg.event_handler(EventType.EXIT)
-def clear_explored_pages() -> None:
-    while explored_pages:
-        explored_pages.pop()
-
-
-def add_custom_page(page: pwndbg.lib.memory.Page) -> None:
-    bisect.insort(custom_pages, page)
-
-    # Reset all the cache
-    # We can not reset get() only, since the result may be used by others.
-    # TODO: avoid flush all caches
-    pwndbg.lib.cache.clear_caches()
-
-
-def clear_custom_page() -> None:
-    while custom_pages:
-        custom_pages.pop()
-
-    # Reset all the cache
-    # We can not reset get() only, since the result may be used by others.
-    # TODO: avoid flush all caches
-    pwndbg.lib.cache.clear_caches()
 
 
 @pwndbg.lib.cache.cache_until("objfile", "start")
@@ -631,16 +481,3 @@ def info_auxv(skip_exe: bool = False) -> Tuple[pwndbg.lib.memory.Page, ...]:
         pages.extend(pwndbg.aglib.elf.map(vdso, "[vdso]"))
 
     return tuple(sorted(pages))
-
-
-def find_boundaries(addr: int, name: str = "", min: int = 0) -> pwndbg.lib.memory.Page:
-    """
-    Given a single address, find all contiguous pages
-    which are mapped.
-    """
-    start = pwndbg.aglib.memory.find_lower_boundary(addr)
-    end = pwndbg.aglib.memory.find_upper_boundary(addr)
-
-    start = max(start, min)
-
-    return pwndbg.lib.memory.Page(start, end - start, 4, 0, name)

--- a/pwndbg/gdblib/vmmap.py
+++ b/pwndbg/gdblib/vmmap.py
@@ -41,14 +41,6 @@ explored_pages: List[pwndbg.lib.memory.Page] = []
 # List of custom pages that can be managed manually by vmmap_* commands family
 custom_pages: List[pwndbg.lib.memory.Page] = []
 
-
-kernel_vmmap_via_pt = pwndbg.config.add_param(
-    "kernel-vmmap-via-page-tables",
-    "deprecated",
-    "the deprecated config of the method get kernel vmmap",
-    help_docstring="Deprecated in favor of `kernel-vmmap`",
-)
-
 kernel_vmmap = pwndbg.config.add_param(
     "kernel-vmmap",
     "page-tables",
@@ -132,16 +124,6 @@ def get() -> Tuple[pwndbg.lib.memory.Page, ...]:
         "rv32",
         "rv64",
     ):
-        # If kernel_vmmap_via_pt is not set to the default value of "deprecated",
-        # That means the user was explicitly setting it themselves and need to
-        # be warned that the option is deprecated
-        if kernel_vmmap_via_pt != "deprecated":
-            print(
-                M.warn(
-                    "`kernel-vmmap-via-page-tables` is deprecated, please use `kernel-vmmap` instead."
-                )
-            )
-
         if kernel_vmmap == "page-tables":
             pages.extend(kernel_vmmap_via_page_tables())
         elif kernel_vmmap == "monitor":

--- a/pwndbg/gdblib/vmmap.py
+++ b/pwndbg/gdblib/vmmap.py
@@ -161,7 +161,7 @@ def clear_warn_cache():
     _warn_cache.clear()
 
 
-def explore(address_maybe: int) -> pwndbg.lib.memory.Page | None:
+def explore(address_maybe: int, skip_config_guard: bool = False) -> pwndbg.lib.memory.Page | None:
     """
     Given a potential address, check to see what permissions it has.
 
@@ -178,18 +178,19 @@ def explore(address_maybe: int) -> pwndbg.lib.memory.Page | None:
     if not pwndbg.dbg.selected_inferior().is_linux():
         return None
 
-    if auto_explore.value == "warn":
-        page_start = pwndbg.lib.memory.page_align(address_maybe)
-        if page_start not in _warn_cache:
-            _warn_cache.add(page_start)
-            print(
-                M.warn(
-                    f"Warning: Avoided exploring possible address {address_maybe:#x}. You can explicitly explore it with `vmmap_explore {page_start:#x}`"
+    if not skip_config_guard:
+        if auto_explore.value == "warn":
+            page_start = pwndbg.lib.memory.page_align(address_maybe)
+            if page_start not in _warn_cache:
+                _warn_cache.add(page_start)
+                print(
+                    M.warn(
+                        f"Warning: Avoided exploring possible address {address_maybe:#x}. You can explicitly explore it with `vmmap_explore {page_start:#x}`"
+                    )
                 )
-            )
-        return None
-    elif auto_explore.value == "no":
-        return None
+            return None
+        elif auto_explore.value == "no":
+            return None
 
     address_maybe = pwndbg.lib.memory.page_align(address_maybe)
 

--- a/pwndbg/gdblib/vmmap.py
+++ b/pwndbg/gdblib/vmmap.py
@@ -150,27 +150,6 @@ def get() -> Tuple[pwndbg.lib.memory.Page, ...]:
         elif kernel_vmmap == "monitor":
             pages.extend(kernel_vmmap_via_monitor_info_mem())
 
-    # TODO/FIXME: Add tests for  QEMU-user targets when this is needed
-    global inside_no_proc_maps_search
-    if not pages and not inside_no_proc_maps_search:
-        inside_no_proc_maps_search = True
-        # If debuggee is launched from a symlink the debuggee memory maps will be
-        # labeled with symlink path while in normal scenario the /proc/pid/maps
-        # labels debuggee memory maps with real path (after symlinks).
-        # This is because the exe path in AUXV (and so `info auxv`) is before
-        # following links.
-        pages.extend(info_auxv())
-
-        if pages:
-            pages.extend(info_sharedlibrary())
-        else:
-            if pwndbg.aglib.qemu.is_qemu():
-                return (pwndbg.lib.memory.Page(0, pwndbg.aglib.arch.ptrmask, 7, 0, "[qemu]"),)
-            pages.extend(info_files())
-
-        pages.extend(pwndbg.aglib.stack.get().values())
-        inside_no_proc_maps_search = False
-
     pages.extend(explored_pages)
     pages.extend(custom_pages)
     pages.sort()

--- a/pwndbg/gdblib/vmmap.py
+++ b/pwndbg/gdblib/vmmap.py
@@ -112,7 +112,7 @@ def clear_warn_cache():
     _warn_cache.clear()
 
 
-def explore(address_maybe: int, skip_config_guard: bool = False) -> pwndbg.lib.memory.Page | None:
+def explore(address_maybe: int, objfile_name: str = None, skip_config_guard: bool = False) -> pwndbg.lib.memory.Page | None:
     """
     Given a potential address, check to see what permissions it has.
 
@@ -126,6 +126,9 @@ def explore(address_maybe: int, skip_config_guard: bool = False) -> pwndbg.lib.m
 
         Also assumes the entire contiguous section has the same permission.
     """
+    if objfile_name is None:
+        objfile_name = '<explored>'
+
     if not pwndbg.dbg.selected_inferior().is_linux():
         return None
 
@@ -169,7 +172,7 @@ def explore(address_maybe: int, skip_config_guard: bool = False) -> pwndbg.lib.m
         flags |= 1
 
     page = find_boundaries(address_maybe)
-    page.objfile = "<explored>"
+    page.objfile = objfile_name
     page.flags = flags
 
     explored_pages.append(page)

--- a/pwndbg/gdblib/vmmap.py
+++ b/pwndbg/gdblib/vmmap.py
@@ -195,7 +195,6 @@ def explore(address_maybe: int, skip_config_guard: bool = False) -> pwndbg.lib.m
     # TODO: could maybe make this check look at the stacks in pwndbg.aglib.stack.get() but that might have issues
     elif (
         address_maybe == pwndbg.lib.memory.page_align(pwndbg.aglib.regs.sp)
-    # todo: remov pwndbg.aglib.stack.is_executable bo robi rekurencje
         and pwndbg.aglib.stack.is_executable()
     ):
         flags |= 1

--- a/pwndbg/lib/memory.py
+++ b/pwndbg/lib/memory.py
@@ -87,7 +87,7 @@ class Page:
 
     @property
     def is_stack(self) -> bool:
-        return self.objfile == "[stack]"
+        return self.objfile.startswith("[stack")
 
     @property
     def is_memory_mapped_file(self) -> bool:

--- a/tests/qemu-tests/tests/user/test_aarch64.py
+++ b/tests/qemu-tests/tests/user/test_aarch64.py
@@ -452,6 +452,7 @@ def test_aarch64_reference(qemu_start_binary):
     gdb.execute("telescope", to_string=True)
 
     # TODO: Broken
+    gdb.execute("stack_explore", to_string=True)
     gdb.execute("retaddr", to_string=True)
 
     # Broken

--- a/tests/qemu-tests/tests/user/test_aarch64.py
+++ b/tests/qemu-tests/tests/user/test_aarch64.py
@@ -452,7 +452,6 @@ def test_aarch64_reference(qemu_start_binary):
     gdb.execute("telescope", to_string=True)
 
     # TODO: Broken
-    gdb.execute("stack_explore", to_string=True)
     gdb.execute("retaddr", to_string=True)
 
     # Broken


### PR DESCRIPTION
Fixes:
- https://github.com/pwndbg/pwndbg/issues/1953

Changes:
- add new option `set auto-explore-stack yes/warn/no` (default: warn)
- add new command `stack_explore`
- Disable vmmap auto exploration, `auto-explore-pages` now defaults to `warn` 

<img width="635" alt="image" src="https://github.com/user-attachments/assets/9da85c31-a332-4906-a373-201de19f8a98" />
<img width="541" alt="image" src="https://github.com/user-attachments/assets/1faa2709-138b-434a-ade0-09792ee255ec" />

Additional changes:
- port vmmap custom pages to aglib / lldb
- `pwndbg.aglib.file.get_file`: Avoid falling back to the local path when the remote does not support vFile.
- `vmmap_load`: Now stores the section name in the `objfile` attribute.
<img width="596" alt="image" src="https://github.com/user-attachments/assets/31febdda-4bb8-4208-9611-479d15e9e7b2" />

