### PR TITLE
Add partial overwrite support to find_fake_fast command

### DIFF
--- a/pwndbg/commands/ptmalloc2.py
+++ b/pwndbg/commands/ptmalloc2.py
@@ -804,6 +804,12 @@ parser.add_argument(
     default=False,
     help="Does the GLIBC fastbin size field bug affect the candidate size field width?",
 )
+parser.add_argument(
+    "--partial-overwrite",
+    "-p",
+    action="store_true",
+    help="Consider partial overwrite candidates, default behavior only shows word-size overwrites.",
+)
 
 
 @pwndbg.commands.ArgparsedCommand(parser, category=CommandCategory.PTMALLOC2)
@@ -815,6 +821,7 @@ def find_fake_fast(
     max_candidate_size: int | None = None,
     align: bool = False,
     glibc_fastbin_bug: bool = False,
+    partial_overwrite: bool = False,
 ) -> None:
     """Find candidate fake fast chunks overlapping the specified address."""
     allocator = pwndbg.aglib.heap.current

--- a/pwndbg/commands/ptmalloc2.py
+++ b/pwndbg/commands/ptmalloc2.py
@@ -874,7 +874,11 @@ def find_fake_fast(
 
     max_candidate_size &= ~(allocator.malloc_align_mask)
 
-    search_start = target_address - max_candidate_size + size_sz
+    if partial_overwrite:
+        search_start = (target_address - max_candidate_size + size_sz) - (size_sz - 1)
+    else:
+        search_start = target_address - max_candidate_size + size_sz
+
     search_end = target_address
 
     if pwndbg.aglib.memory.peek(search_start) is None:
@@ -923,8 +927,14 @@ def find_fake_fast(
                 continue
 
             candidate_address = search_start + i
-            if (candidate_address + size_field) >= (target_address + size_sz):
-                malloc_chunk(candidate_address - size_sz, fake=True)
+
+            if partial_overwrite:
+                if (candidate_address + size_field) > target_address:
+                    malloc_chunk(candidate_address - size_sz, fake=True)
+            else:
+                if (candidate_address + size_field) >= (target_address + size_sz):
+                    malloc_chunk(candidate_address - size_sz, fake=True)
+
         else:
             break
 

--- a/tests/gdb-tests/tests/heap/test_find_fake_fast.py
+++ b/tests/gdb-tests/tests/heap/test_find_fake_fast.py
@@ -164,3 +164,10 @@ def test_find_fake_fast_command(start_binary):
     result = gdb.execute("find_fake_fast &target_address --glibc-fastbin-bug", to_string=True)
     check_result(result, 0xAABBCCDD00000020)
     gdb.execute("continue")
+
+    # setup_mem(0x8000, 0x80)
+    result = gdb.execute("find_fake_fast &target_address", to_string=True)
+    check_no_results(result)
+
+    result = gdb.execute("find_fake_fast &target_address --partial-overwrite", to_string=True)
+    check_result(result, 0x80)


### PR DESCRIPTION
Add a `--partial-overwrite` option to the `find_fake_fast` command along with a supporting test case.

The option allows users to search for fake fastbin chunks that overlap as little as one byte of their target, rather than a complete word which is the default behavior.

Also format heap_find_fake_fast.c

Closes #1291 