### PR TITLE
Fix terminal size calculation

### DIFF
--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -704,10 +704,8 @@ def compact_regs(regs, width=None, target=sys.stdout):
     min_width = max(1, int(pwndbg.config.show_compact_regs_min_width))
     separation = max(1, int(pwndbg.config.show_compact_regs_separation))
 
-    if width is None:  # auto width. In case of stdout, it's better to use stdin (b/c GdbOutputFile)
-        _height, width = pwndbg.ui.get_window_size(
-            target=target if target != sys.stdout else sys.stdin
-        )
+    if width is None:
+        _height, width = pwndbg.ui.get_window_size(target)
 
     if columns > 0:
         # Adjust the minimum_width (column) according to the

--- a/pwndbg/ui.py
+++ b/pwndbg/ui.py
@@ -70,10 +70,12 @@ def get_window_size(target=sys.stdin):
     fallback = (int(os.environ.get("LINES", 20)), int(os.environ.get("COLUMNS", 80)))
     if not target.isatty():
         return fallback
-    rows, cols = get_cmd_window_size()
-    if rows is not None and cols is not None:
-        return rows, cols
-    elif os.environ.get("PWNDBG_IN_TEST") is not None:
+    if target == sys.stdin:
+        # We can ask the debugger for the window size
+        rows, cols = get_cmd_window_size()
+        if rows is not None and cols is not None:
+            return rows, cols
+    if os.environ.get("PWNDBG_IN_TEST") is not None:
         return fallback
     try:
         # get terminal size and force ret buffer len of 4 bytes for safe unpacking by passing equally long arg

--- a/pwndbg/ui.py
+++ b/pwndbg/ui.py
@@ -39,10 +39,10 @@ def check_title_position() -> None:
         title_position.revert_default()
 
 
-def banner(title, target=sys.stdin, width=None, extra=""):
+def banner(title, target=sys.stdout, width=None, extra=""):
     title = title.upper()
-    if width is None:  # auto width. In case of stdout, it's better to use stdin (b/c GdbOutputFile)
-        _height, width = get_window_size(target=target if target != sys.stdout else sys.stdin)
+    if width is None:
+        _height, width = get_window_size(target)
     if title:
         title = "{}{}{}{}".format(
             config.banner_title_surrounding_left,
@@ -66,11 +66,11 @@ def addrsz(address) -> str:
     return pwndbg.dbg.addrsz(address)
 
 
-def get_window_size(target=sys.stdin):
+def get_window_size(target=sys.stdout):
     fallback = (int(os.environ.get("LINES", 20)), int(os.environ.get("COLUMNS", 80)))
     if not target.isatty():
         return fallback
-    if target == sys.stdin:
+    if target in (sys.stdout, sys.stdin):
         # We can ask the debugger for the window size
         rows, cols = get_cmd_window_size()
         if rows is not None and cols is not None:


### PR DESCRIPTION
Fixes https://github.com/pwndbg/pwndbg/issues/2673 .

> Can we somehow detect that the user decided to use panels and then do it properly (and less efficiently, oh well)?

This PR does this, essentially.