### PR TITLE
Add support for attaching to processes to LLDB Pwndbg

### DIFF
--- a/pwndbg/dbg/lldb/repl/__init__.py
+++ b/pwndbg/dbg/lldb/repl/__init__.py
@@ -308,9 +308,7 @@ def run(startup: List[str] | None = None, debug: bool = False) -> None:
                 continue
             if len(bits) > 1 and bits[1].startswith("a") and "attach".startswith(bits[1]):
                 # This is `process attach`.
-                #
-                # TODO: Implement process attach.
-                print(message.error("Pwndbg does not support 'process attach' yet."))
+                process_attach(driver, relay, bits[2:], dbg)
                 continue
             if len(bits) > 1 and bits[1].startswith("conn") and "connect".startswith(bits[1]):
                 # This is `process connect`.
@@ -655,6 +653,78 @@ def process_launch(driver: ProcessDriver, relay: EventRelay, args: List[str], db
         # This means that we have to relay an extra event here to convey that
         # the process stopped at entry, even though what's going on, in reality,
         # is that we're simply not resuming the process.
+        dbg._trigger_event(EventType.STOP)
+
+
+process_attach_ap = argparse.ArgumentParser(add_help=False)
+process_attach_ap.add_argument("-C", "--python-class")
+process_attach_ap.add_argument("-P", "--plugin")
+process_attach_ap.add_argument("-c", "--continue", action="store_true")
+process_attach_ap.add_argument("-i", "--include-existing", action="store_true")
+process_attach_ap.add_argument("-k", "--structured-data-key")
+process_attach_ap.add_argument("-n", "--name")
+process_attach_ap.add_argument("-p", "--pid", type=int)
+process_attach_ap.add_argument("-v", "--structured-data-value")
+process_attach_ap.add_argument("-w", "--waitfor", action="store_true")
+process_attach_unsupported = [
+    "python-class",
+    "plugin",
+    "structured-data-key",
+    "structured-data-value",
+]
+
+
+def process_attach(driver: ProcessDriver, relay: EventRelay, args: List[str], dbg: LLDB) -> None:
+    """
+    Attaches to a process with the given arguments.
+    """
+    args = parse(args, process_attach_ap, process_attach_unsupported)
+    if not args:
+        return
+
+    targets = dbg.debugger.GetNumTargets()
+    assert targets < 2
+    if targets == 0:
+        print(message.error("error: no target, create one using the 'target create' command"))
+        return
+
+    if driver.has_process():
+        print(message.error("error: a process is already being debugged"))
+        return
+
+    # The first two arguments - executable name and wait_for_launch - don't
+    # matter, we set them later. The third one is required, as it tells LLDB the
+    # attach should be asynchronous.
+    params = lldb.SBAttachInfo(None, False, True)
+
+    if args.name is not None:
+        params.SetExecutable(args.name)
+    if args.pid is not None:
+        params.SetProcessID(args.pid)
+    params.SetWaitForLaunch(args.waitfor)
+    if getattr(args, "continue"):
+        params.SetResumeCount(1)
+    params.SetIgnoreExisting(not args.include_existing)
+
+    io_driver = get_io_driver()
+    result = driver.attach(
+        dbg.debugger.GetTargetAtIndex(0),
+        io_driver,
+        params,
+    )
+
+    if not result.success:
+        print(message.error(f"Could not attach to process: {result.description}"))
+        return
+
+    # Continue execution if the user has requested it.
+    if getattr(args, "continue"):
+        # Same logic applies here as in `process_launch`.
+        relay._set_ignore_resumed(1)
+
+        driver.cont()
+    else:
+        # Same logic applies here as in `process_launch`.
         dbg._trigger_event(EventType.STOP)
 
 


### PR DESCRIPTION
This PR plugs one of the gaps in LLDB that we still have, which is the lack of support for attaching to processes. It adds code to support it both to the Pwndbg CLI and the process driver.

It's important to note that the code here isn't entirely correct. Our handling of the process lifecycle in LLDB has a pretty big blind spot when it comes to remote processes, that the code in this PR doesn't work to fix. As this is a problem that also affects our implementation of `process launch`, though, I feel it's better to just add support for `attach` and deal with it later, than to try and fix both things at once.