### PR TITLE
Add initial support for Loongarch64

### DIFF
--- a/pwndbg/aglib/arch.py
+++ b/pwndbg/aglib/arch.py
@@ -7,6 +7,7 @@ import pwnlib
 import pwndbg
 from pwndbg.lib.arch import Arch
 
+# List of architectures - used when determining GDB arch, and in OnlyWithArch
 ARCHS = (
     "x86-64",
     "i386",
@@ -19,10 +20,11 @@ ARCHS = (
     "riscv:rv32",
     "riscv:rv64",
     "riscv",
+    "loongarch64",
 )
 
 
-# mapping between gdb and pwntools arch names
+# mapping between pwndbg and pwntools arch names
 pwnlib_archs_mapping = {
     "x86-64": "amd64",
     "i386": "i386",
@@ -35,6 +37,7 @@ pwnlib_archs_mapping = {
     "armcm": "thumb",
     "rv32": "riscv32",
     "rv64": "riscv64",
+    "loongarch64": "none",
 }
 
 

--- a/pwndbg/aglib/disasm/__init__.py
+++ b/pwndbg/aglib/disasm/__init__.py
@@ -23,10 +23,9 @@ import pwndbg.aglib.memory
 import pwndbg.emu.emulator
 import pwndbg.lib.cache
 from pwndbg.aglib.disasm.arch import DEBUG_ENHANCEMENT
-from pwndbg.aglib.disasm.instruction import ALL_JUMP_GROUPS
+from pwndbg.aglib.disasm.instruction import ManualPwndbgInstruction
 from pwndbg.aglib.disasm.instruction import PwndbgInstruction
 from pwndbg.aglib.disasm.instruction import SplitType
-from pwndbg.aglib.disasm.instruction import make_simple_instruction
 from pwndbg.color import message
 from pwndbg.dbg import EventType
 
@@ -206,7 +205,7 @@ def get_one_instruction(
             return cached
 
     if pwndbg.aglib.arch.current not in CapstoneArch:
-        return make_simple_instruction(address)
+        return ManualPwndbgInstruction(address)
 
     md = get_disassembler(address)
     size = VariableInstructionSizeMax.get(pwndbg.aglib.arch.current, 4)

--- a/pwndbg/aglib/disasm/__init__.py
+++ b/pwndbg/aglib/disasm/__init__.py
@@ -25,6 +25,7 @@ import pwndbg.lib.cache
 from pwndbg.aglib.disasm.arch import DEBUG_ENHANCEMENT
 from pwndbg.aglib.disasm.instruction import ManualPwndbgInstruction
 from pwndbg.aglib.disasm.instruction import PwndbgInstruction
+from pwndbg.aglib.disasm.instruction import PwndbgInstructionImpl
 from pwndbg.aglib.disasm.instruction import SplitType
 from pwndbg.color import message
 from pwndbg.dbg import EventType
@@ -211,7 +212,7 @@ def get_one_instruction(
     size = VariableInstructionSizeMax.get(pwndbg.aglib.arch.current, 4)
     data = pwndbg.aglib.memory.read(address, size, partial=True)
     for ins in md.disasm(bytes(data), address, 1):
-        pwn_ins = PwndbgInstruction(ins)
+        pwn_ins: PwndbgInstruction = PwndbgInstructionImpl(ins)
 
         if enhance:
             pwndbg.aglib.disasm.arch.DisassemblyAssistant.enhance(pwn_ins, emu)

--- a/pwndbg/aglib/disasm/instruction.py
+++ b/pwndbg/aglib/disasm/instruction.py
@@ -126,7 +126,7 @@ class PwndbgInstruction:
     def __init__(self, cs_insn: CsInsn) -> None:
         self.cs_insn: CsInsn = cs_insn
         """
-        The underlying Capstone instruction, if present.
+        The underlying Capstone instruction object.
         Ideally, only the enhancement code will access the 'cs_insn' property
         """
 

--- a/pwndbg/dbg/gdb/__init__.py
+++ b/pwndbg/dbg/gdb/__init__.py
@@ -678,6 +678,8 @@ class GDBProcess(pwndbg.dbg_mod.Process):
             arch = gdb.execute("show architecture", to_string=True).strip()
             not_exactly_arch = True
 
+        arch = arch.lower()
+
         # Below, we fix the fetched architecture
         for match in pwndbg.aglib.arch_mod.ARCHS:
             if match in arch:

--- a/pwndbg/lib/regs.py
+++ b/pwndbg/lib/regs.py
@@ -622,6 +622,54 @@ riscv = RegisterSet(
     retval="a0",
 )
 
+# https://docs.kernel.org/arch/loongarch/introduction.html
+loongarch64 = RegisterSet(
+    pc="pc",
+    stack="sp",
+    frame="fp",
+    retaddr=("ra",),
+    gpr=(
+        "a0",
+        "a1",
+        "a2",
+        "a3",
+        "a4",
+        "a5",
+        "a6",
+        "a7",
+        "t0",
+        "t1",
+        "t2",
+        "t3",
+        "t4",
+        "t5",
+        "t6",
+        "t7",
+        "t8",
+        "s0",
+        "s1",
+        "s2",
+        "s3",
+        "s4",
+        "s5",
+        "s6",
+        "s7",
+        "s8",
+    ),
+    args=(
+        "a0",
+        "a1",
+        "a2",
+        "a3",
+        "a4",
+        "a5",
+        "a6",
+        "a7",
+    ),
+    # r21 stores "percpu base address", referred to as "u0" in the kernel
+    misc=("tp", "r21"),
+)
+
 reg_sets = {
     "i386": i386,
     "i8086": i386,
@@ -635,4 +683,5 @@ reg_sets = {
     "armcm": armcm,
     "aarch64": aarch64,
     "powerpc": powerpc,
+    "loongarch64": loongarch64,
 }


### PR DESCRIPTION
This PR adds initial support for the Loongarch64 architecture. Previously, attempting to debug a program in this architecture caused a crash.

There's a new register set definition for Loongarch64 based on the register definitions seen here - https://docs.kernel.org/arch/loongarch/introduction.html

The latest stable release of the Capstone Engine doesn't support Loongarch64. However, using GDB's internal mechanism to disassemble instructions, we can still show some form of disassembly (without any annotations or emulation). I added a new class `ManualPwndbgInstruction` that has the same interface as `PwndbgInstruction`, and gets its data from the GDB API.

I'm not fully familiar with the internals of the new LLDB support, so there may be something special that needs to be implemented and tested for LLDB. I added some GitHub comments on some things to consider/look at.

![image](https://github.com/user-attachments/assets/b29c4e68-9f18-436e-9d2f-ddcd50be7b19)
