### PR TITLE
Removing redundant function OnlyWithArch from `pwndbg/commands/__init__.py`

### DIFF
--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -332,31 +332,6 @@ def OnlyWhenUserspace(function: Callable[P, T]) -> Callable[P, Optional[T]]:
     return _OnlyWhenUserspace
 
 
-def OnlyWithArch(arch_names: List[str]) -> Callable[[Callable[P, T]], Callable[P, Optional[T]]]:
-    """Decorates function to work only with the specified archictectures."""
-    for arch in arch_names:
-        if arch not in pwndbg.aglib.arch_mod.ARCHS:
-            raise ValueError(
-                f"OnlyWithArch used with unsupported arch={arch}. Must be one of {', '.join(arch_names)}"
-            )
-
-    def decorator(function: Callable[P, T]) -> Callable[P, Optional[T]]:
-        @functools.wraps(function)
-        def _OnlyWithArch(*a: P.args, **kw: P.kwargs) -> Optional[T]:
-            if pwndbg.aglib.arch.name in arch_names:
-                return function(*a, **kw)
-            else:
-                arches_str = ", ".join(arch_names)
-                log.error(
-                    f"{function.__name__}: This command may only be run on the {arches_str} architecture(s)"
-                )
-                return None
-
-        return _OnlyWithArch
-
-    return decorator
-
-
 def OnlyWithDbg(
     *dbg_names: Literal["lldb", "gdb"],
 ) -> Callable[[Callable[P, T]], Callable[P, Optional[T]]]:

--- a/pwndbg/commands/cpsr.py
+++ b/pwndbg/commands/cpsr.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 
 import pwndbg.aglib.arch
+import pwndbg.aglib.proc
 import pwndbg.aglib.regs
 import pwndbg.commands
 from pwndbg.color import context
@@ -20,7 +21,7 @@ parser.add_argument(
     aliases=["xpsr", "pstate"],
     category=CommandCategory.REGISTER,
 )
-@pwndbg.commands.OnlyWithArch(["arm", "armcm", "aarch64"])
+@pwndbg.aglib.proc.OnlyWithArch(["arm", "armcm", "aarch64"])
 @pwndbg.commands.OnlyWhenRunning
 def cpsr(cpsr_value=None) -> None:
     reg = "xpsr" if pwndbg.aglib.arch.name == "armcm" else "cpsr"

--- a/pwndbg/commands/gdt.py
+++ b/pwndbg/commands/gdt.py
@@ -4,6 +4,7 @@ import argparse
 
 import pwndbg
 import pwndbg.aglib.memory
+import pwndbg.aglib.proc
 import pwndbg.color as C
 import pwndbg.commands
 from pwndbg.commands import CommandCategory
@@ -34,7 +35,7 @@ parser.add_argument(
 
 @pwndbg.commands.ArgparsedCommand(parser, category=CommandCategory.MEMORY)
 @pwndbg.commands.OnlyWhenRunning
-@pwndbg.commands.OnlyWithArch(["x86-64"])
+@pwndbg.aglib.proc.OnlyWithArch(["x86-64"])
 def gdt(address, count) -> None:
     address = int(address)
     count = int(count)

--- a/pwndbg/commands/onegadget.py
+++ b/pwndbg/commands/onegadget.py
@@ -4,6 +4,7 @@ import argparse
 import shutil
 
 import pwndbg.aglib.onegadget
+import pwndbg.aglib.proc
 import pwndbg.color.message as M
 import pwndbg.commands
 import pwndbg.glibc
@@ -24,7 +25,7 @@ parser.add_argument("-v", "--verbose", help="Show verbose output.", action="stor
 
 
 @pwndbg.commands.ArgparsedCommand(parser, category=CommandCategory.LINUX)
-@pwndbg.commands.OnlyWithArch(["x86-64", "i386", "aarch64"])
+@pwndbg.aglib.proc.OnlyWithArch(["x86-64", "i386", "aarch64"])
 @pwndbg.commands.OnlyWhenRunning
 def onegadget(show_unsat: bool = False, no_unknown: bool = False, verbose: bool = False) -> None:
     if not shutil.which("one_gadget"):

--- a/pwndbg/commands/segments.py
+++ b/pwndbg/commands/segments.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import gdb
 
+import pwndbg.aglib.proc
 import pwndbg.aglib.regs
 import pwndbg.commands
 from pwndbg.commands import CommandCategory
@@ -28,7 +29,7 @@ segment("gsbase")
     "Prints out the FS base address. See also $fsbase.", category=CommandCategory.REGISTER
 )
 @pwndbg.commands.OnlyWhenRunning
-@pwndbg.commands.OnlyWithArch(["i386", "x86-64"])
+@pwndbg.aglib.proc.OnlyWithArch(["i386", "x86-64"])
 def fsbase() -> None:
     """
     Prints out the FS base address. See also $fsbase.
@@ -40,7 +41,7 @@ def fsbase() -> None:
     "Prints out the GS base address. See also $gsbase.", category=CommandCategory.REGISTER
 )
 @pwndbg.commands.OnlyWhenRunning
-@pwndbg.commands.OnlyWithArch(["i386", "x86-64"])
+@pwndbg.aglib.proc.OnlyWithArch(["i386", "x86-64"])
 def gsbase() -> None:
     """
     Prints out the GS base address. See also $gsbase.

--- a/pwndbg/commands/sigreturn.py
+++ b/pwndbg/commands/sigreturn.py
@@ -10,6 +10,7 @@ import pwnlib.rop.srop
 
 import pwndbg.aglib.arch
 import pwndbg.aglib.memory
+import pwndbg.aglib.proc
 import pwndbg.aglib.regs
 import pwndbg.color.context as C
 import pwndbg.color.memory as M
@@ -65,7 +66,7 @@ parser.add_argument(
 
 @pwndbg.commands.ArgparsedCommand(parser)
 @pwndbg.commands.OnlyWhenRunning
-@pwndbg.commands.OnlyWithArch(["x86-64", "i386", "aarch64", "arm"])
+@pwndbg.aglib.proc.OnlyWithArch(["x86-64", "i386", "aarch64", "arm"])
 def sigreturn(address: int = None, display_all=False, print_address=False) -> None:
     address = pwndbg.aglib.regs.sp if address is None else address
 


### PR DESCRIPTION
Resolves https://github.com/pwndbg/pwndbg/issues/2692

This PR removes the function from init.py and a few other dependent files is changed to call that function from pwndbg.aglib.proc instead of pwndbg.commands