### PR TITLE
Relay parsing error information to argparse, don't except on command argument parse error

### DIFF
--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -271,7 +271,7 @@ def fix_reraise(*a, **kw) -> str | pwndbg.dbg_mod.Value | None:
 def fix_reraise_arg(arg) -> pwndbg.dbg_mod.Value:
     """fix_reraise wrapper for evaluating command arguments"""
     try:
-        # Will always return pwndbg.gdb_mod.Value because
+        # Will always return pwndbg.dbg_mod.Value because
         # sloppy=False (not str) and reraise=True (not None)
         fixed = fix(arg, sloppy=False, quiet=True, reraise=True)
         assert isinstance(fixed, pwndbg.dbg_mod.Value)

--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -123,6 +123,9 @@ class Command:
     def split_args(self, argument: str) -> Tuple[List[str], Dict[Any, Any]]:
         """Split a command-line string from the user into arguments.
 
+        This is only used by pwndbg/commands/shell.py which is deprecated.
+        Usually _ArgparsedCommand.split_args is called.
+
         Returns:
             A ``(tuple, dict)``, in the form of ``*args, **kwargs``.
             The contents of the tuple/dict are undefined.
@@ -139,6 +142,7 @@ class Command:
             args, kwargs = self.split_args(argument)
         except SystemExit:
             # Raised when the usage is printed by an ArgparsedCommand
+            # because of an error in argument parsing
             return
         except (TypeError, pwndbg.dbg_mod.Error):
             pwndbg.exception.handle(self.function.__name__)
@@ -264,12 +268,35 @@ def fix_reraise(*a, **kw) -> str | pwndbg.dbg_mod.Value | None:
     return fix(*a, reraise=True, **kw)  # type: ignore[misc]
 
 
+def fix_reraise_arg(arg) -> pwndbg.dbg_mod.Value:
+    """fix_reraise wrapper for evaluating command arguments"""
+    try:
+        # Will always return pwndbg.gdb_mod.Value because
+        # sloppy=False (not str) and reraise=True (not None)
+        fixed = fix(arg, sloppy=False, quiet=True, reraise=True)
+        assert isinstance(fixed, pwndbg.dbg_mod.Value)
+        return fixed
+    except pwndbg.dbg_mod.Error as dbge:
+        raise argparse.ArgumentTypeError(f"debugger couldn't resolve argument '{arg}': {dbge}")
+
+
 def fix_int(*a, **kw) -> int:
     return int(fix(*a, **kw))
 
 
 def fix_int_reraise(*a, **kw) -> int:
     return fix_int(*a, reraise=True, **kw)
+
+
+def fix_int_reraise_arg(arg) -> int:
+    """fix_int_reraise wrapper for evaluating command arguments"""
+    try:
+        fixed = fix_reraise_arg(arg)
+        return int(fixed)
+    except pwndbg.dbg_mod.Error as e:
+        raise argparse.ArgumentTypeError(
+            f"couldn't convert '{arg}' ({fixed.type.name_to_human_readable}) to int: {e}"
+        )
 
 
 def OnlyWhenLocal(function: Callable[P, T]) -> Callable[P, Optional[T]]:
@@ -604,10 +631,10 @@ class ArgparsedCommand:
                 action.type = str
             if action.dest == "help":
                 continue
-            if action.type == int:
-                action.type = fix_int_reraise
+            if action.type is int:
+                action.type = fix_int_reraise_arg
             if action.type is None:
-                action.type = fix_reraise
+                action.type = fix_reraise_arg
             if action.default is not None:
                 action.help += " (default: %(default)s)"
 


### PR DESCRIPTION
Before:
```
pwndbg> hi nothing!
Exception occurred: hi: No symbol "nothing" in current context. (<class 'pwndbg.dbg.Error'>)
For more info invoke `set exception-verbose on` and rerun the command
or debug it by yourself with `set exception-debugger on`
pwndbg> dt struct a
Exception occurred: dt: No symbol "a" in current context. (<class 'pwndbg.dbg.Error'>)
For more info invoke `set exception-verbose on` and rerun the command
or debug it by yourself with `set exception-debugger on`
pwndbg> dt awa vector
Exception occurred: dt: No symbol "vector" in current context. (<class 'pwndbg.dbg.Error'>)
For more info invoke `set exception-verbose on` and rerun the command
or debug it by yourself with `set exception-debugger on`
pwndbg> start
[...]
pwndbg> dt awa a
Exception occurred: dt: Cannot convert value to long. (<class 'pwndbg.dbg.Error'>)
For more info invoke `set exception-verbose on` and rerun the command
or debug it by yourself with `set exception-debugger on`
pwndbg> dt awa vector
Exception occurred: dt: A syntax error in expression, near the end of `vector'. (<class 'pwndbg.dbg.Error'>)
For more info invoke `set exception-verbose on` and rerun the command
or debug it by yourself with `set exception-debugger on`
pwndbg> dt awa awa
Exception occurred: dt: No symbol "awa" in current context. (<class 'pwndbg.dbg.Error'>)
For more info invoke `set exception-verbose on` and rerun the command
or debug it by yourself with `set exception-debugger on`
```
After:
```
pwndbg> hi nothing
usage: hi [-h] [-v] [-s] [-f] addr
hi: error: argument addr: debugger couldn't resolve argument 'nothing': No symbol "nothing" in current context.
pwndbg> dt struct a
usage: dt [-h] typename [address]
dt: error: argument address: debugger couldn't resolve argument 'a': No symbol "a" in current context.
pwndbg> dt awa vector
usage: dt [-h] typename [address]
dt: error: argument address: debugger couldn't resolve argument 'vector': No symbol "vector" in current context.
pwndbg> start
[...]
pwndbg> dt awa a
usage: dt [-h] typename [address]
dt: error: argument address: couldn't convert 'a' (mynumber) to int: Cannot convert value to long.
pwndbg> p a
$1 = {
  i = {0, 1045149306},
  x = 1.2904777690891933e-08,
  d = 1.2904777690891933e-08
}
pwndbg> dt awa vector
usage: dt [-h] typename [address]
dt: error: argument address: debugger couldn't resolve argument 'vector': A syntax error in expression, near the end of `vector'.
pwndbg> dt awa awa
usage: dt [-h] typename [address]
dt: error: argument address: debugger couldn't resolve argument 'awa': No symbol "awa" in current context.
```
I believe this is more clear, as it shows the intended usage of the command and makes debugging the problem easier. For instance it makes it clear that by running `dt struct something`, `something` gets interpreted as the address positional argument. It also makes it clear that at runtime a symbol `a` exists and is of type `mynumber`.

It might be worth looking into subclassing `argparse.ArgumentParser` in the future and overriding the `error` function.

Closes https://github.com/pwndbg/pwndbg/issues/2656