### PR TITLE
Cleanup dt.py, don't print typedefs to primitives

### DIFF
--- a/pwndbg/aglib/dt.py
+++ b/pwndbg/aglib/dt.py
@@ -51,15 +51,14 @@ def dt(
         t = pwndbg.aglib.typeinfo.load(name)
 
     if not t:
-        return ""
+        return "Type not found."
 
     # If it's not a struct (e.g. int or char*), bail
-    if t.code not in (
+    if t.strip_typedefs().code not in (
         pwndbg.dbg_mod.TypeCode.STRUCT,
-        pwndbg.dbg_mod.TypeCode.TYPEDEF,
         pwndbg.dbg_mod.TypeCode.UNION,
     ):
-        return f"Not a structure: {t}"
+        return f"Not a structure: {t.strip_typedefs().name_to_human_readable}"
 
     # If an address was specified, create a Value of the
     # specified type at that address.
@@ -72,20 +71,7 @@ def dt(
         header = f"{header} @ {hex(int(obj.address))}"
     rv.append(header)
 
-    if t.strip_typedefs().code == pwndbg.dbg_mod.TypeCode.ARRAY:
-        return "Arrays not supported yet"
-
-    if t.strip_typedefs().code not in (
-        pwndbg.dbg_mod.TypeCode.STRUCT,
-        pwndbg.dbg_mod.TypeCode.UNION,
-    ):
-        newobj = obj
-        if not newobj:
-            newobj = pwndbg.dbg.selected_inferior().create_value(0, t)
-
-        iter_fields = [(field.name, field) for field in newobj.type.fields()]
-    else:
-        iter_fields = [(field.name, field) for field in t.fields()]
+    iter_fields = [(field.name, field) for field in t.fields()]
 
     for field_name, field in iter_fields:
         # Offset into the parent structure
@@ -98,17 +84,20 @@ def dt(
             pwndbg.dbg_mod.TypeCode.STRUCT,
             pwndbg.dbg_mod.TypeCode.UNION,
         ):
-            obj_value = obj[field_name]
-            if ftype.code == pwndbg.dbg_mod.TypeCode.INT:
-                extra = hex(int(obj_value))
-            elif (
-                ftype.code in (pwndbg.dbg_mod.TypeCode.POINTER, pwndbg.dbg_mod.TypeCode.ARRAY)
-                and ftype.target() == pwndbg.aglib.typeinfo.uchar
-            ):
-                data = pwndbg.aglib.memory.read(int(obj_value.address), ftype.sizeof)
-                extra = " ".join("%02x" % b for b in data)
-            else:
-                extra = obj_value.value_to_human_readable()
+            try:
+                obj_value = obj[field_name]
+                if ftype.code == pwndbg.dbg_mod.TypeCode.INT:
+                    extra = hex(int(obj_value))
+                elif (
+                    ftype.code in (pwndbg.dbg_mod.TypeCode.POINTER, pwndbg.dbg_mod.TypeCode.ARRAY)
+                    and ftype.target() == pwndbg.aglib.typeinfo.uchar
+                ):
+                    data = pwndbg.aglib.memory.read(int(obj_value.address), ftype.sizeof)
+                    extra = " ".join("%02x" % b for b in data)
+                else:
+                    extra = obj_value.value_to_human_readable()
+            except pwndbg.dbg_mod.Error as e:
+                return f"{e}\nIs the provided address near a page boundry?"
 
         # Adjust trailing lines in 'extra' to line up
         # This is necessary when there are nested structures.

--- a/pwndbg/commands/dt.py
+++ b/pwndbg/commands/dt.py
@@ -4,9 +4,7 @@ import argparse
 
 import pwndbg
 import pwndbg.aglib.dt
-import pwndbg.aglib.vmmap
-import pwndbg.color
-import pwndbg.commands
+from pwndbg.color import message
 
 parser = argparse.ArgumentParser(
     formatter_class=argparse.RawTextHelpFormatter,
@@ -16,20 +14,25 @@ parser = argparse.ArgumentParser(
     Optionally overlay that information at an address.
     """,
 )
-parser.add_argument("typename", type=str, help="The name of the structure being dumped.")
+parser.add_argument(
+    "typename",
+    type=str,
+    help='The name of the structure being dumped. Use quotes if the type contains spaces (e.g. "struct malloc_state").',
+)
 parser.add_argument(
     "address", type=int, nargs="?", default=None, help="The address of the structure."
 )
 
 
 @pwndbg.commands.ArgparsedCommand(parser)
-def dt(typename: str, address: int | pwndbg.dbg_mod.Value | None = None) -> None:
+def dt(typename: str, address: int | None = None) -> None:
     """
     Dump out information on a type (e.g. ucontext_t).
 
     Optionally overlay that information at an address.
     """
-    if address is not None:
-        address = pwndbg.commands.fix(str(address))
+    if address is not None and not pwndbg.aglib.memory.is_readable_address(address):
+        print(message.error("The provided address is not readable."))
+        return
 
     print(pwndbg.aglib.dt.dt(typename, addr=address))


### PR DESCRIPTION
Long ago, `dt` refused to print types that aren't structs/unions, but was fine with printing types which are typedefs to non-structs/unions. This was a peculiar design decision. Printing primitive types is not too difficult, but then why refuse to do it when they are not typedefs? At some point while this file was refactored, this logic stopped working. It originally had `t = {name: obj or gdb.Value(0).cast(t)}`, wasn't iterating over `TypeField`'s etc.

Removing this wrong logic; it needs to be implemented quite differently if it is at all wanted. With this PR the resolved type of a typedef is seen in its error message anyway.

Assume `typedef int myint;`

Before:
```
pwndbg> dt std::nullptr_t
'dt': Dump out information on a type (e.g. ucontext_t).

    Optionally overlay that information at an address.
Exception occurred: dt: Type is not a structure, union, enum, or function type. (<class 'TypeError'>)
For more info invoke `set exception-verbose on` and rerun the command
or debug it by yourself with `set exception-debugger on`
pwndbg> dt 'struct malloc_state' 0x1337
Exception occurred: dt: Cannot access memory at address 0x1337 (<class 'pwndbg.dbg.Error'>)
For more info invoke `set exception-verbose on` and rerun the command
or debug it by yourself with `set exception-debugger on`
pwndbg> dt 'struct malloc_state' 0x7fffffffeff0
Exception occurred: dt: Cannot access memory at address 0x7ffffffff000 (<class 'pwndbg.dbg.Error'>)
For more info invoke `set exception-verbose on` and rerun the command
or debug it by yourself with `set exception-debugger on`
pwndbg> dt myint
'dt': Dump out information on a type (e.g. ucontext_t).

    Optionally overlay that information at an address.
Exception occurred: dt: Type is not a structure, union, enum, or function type. (<class 'TypeError'>)
For more info invoke `set exception-verbose on` and rerun the command
or debug it by yourself with `set exception-debugger on`
pwndbg> dt nonexistanttype

pwndbg> 
```

After:
```
pwndbg> dt std::nullptr_t
Not a structure: decltype(nullptr)
pwndbg> dt 'struct malloc_state' 0x1337
The provided address is not readable.
pwndbg> dt 'struct malloc_state' 0x7fffffffeff0
Cannot access memory at address 0x7ffffffff000
Is the provided address near a page boundry?
pwndbg> dt myint
Not a structure: int
pwndbg> dt nonexistanttype
Type not found.
pwndbg>
```

Closes https://github.com/pwndbg/pwndbg/issues/2655 , https://github.com/pwndbg/pwndbg/issues/2657 .