### PR TITLE
fix f string not working on older versions of python

### DIFF
--- a/pwndbg/commands/version.py
+++ b/pwndbg/commands/version.py
@@ -51,9 +51,10 @@ def debugger_version():
 
 
 def all_versions():
+    py_version = sys.version.replace("\n", " ")
     return (
         f"Pwndbg:   {pwndbg.__version__}",
-        f"Python:   {sys.version.replace('\n', ' ')}",
+        f"Python:   {py_version}",
         debugger_version(),
         f"Capstone: {module_version('capstone')}",
         f"Unicorn:  {module_version('unicorn')}",


### PR DESCRIPTION
f strings containing backslashes are not supported in python 3.10.12, this is an easy fix