### PR TITLE
tests.sh: print glibc version via ldd

### DIFF
--- a/tests.sh
+++ b/tests.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# Print ldd and so glibc version
+echo "Running ldd to see ldd and so glibc version"
+ldd --version
+
 # Run integration tests
 (cd tests && python3 tests.py $@)
 exit_code=$?


### PR DESCRIPTION
Add printing of ldd (glibc) version before running tests.

This may help diagnose some CI tests issues at times.