### PR TITLE
Rename all occurrences of .arch.current to .arch.name

### DIFF
--- a/pwndbg/aglib/arch.py
+++ b/pwndbg/aglib/arch.py
@@ -15,11 +15,11 @@ def read_thumb_bit() -> int | None:
 
     Return None if the Thumb bit is not relevent to the current architecture
     """
-    if pwndbg.aglib.arch.current == "arm":
+    if pwndbg.aglib.arch.name == "arm":
         # When program initially starts, cpsr may not be readable
         if (cpsr := pwndbg.aglib.regs.cpsr) is not None:
             return (cpsr >> 5) & 1
-    elif pwndbg.aglib.arch.current == "armcm":
+    elif pwndbg.aglib.arch.name == "armcm":
         # ARM Cortex-M procesors only suport Thumb mode. However, there is still a bit
         # that represents the Thumb mode (which is currently architecturally defined to be 1)
         if (xpsr := pwndbg.aglib.regs.xpsr) is not None:

--- a/pwndbg/aglib/disasm/__init__.py
+++ b/pwndbg/aglib/disasm/__init__.py
@@ -146,46 +146,46 @@ def get_disassembler_cached(arch, ptrsize: int, endian, extra=None):
 
 
 def get_disassembler(address):
-    if pwndbg.aglib.arch.current == "armcm":
+    if pwndbg.aglib.arch.name == "armcm":
         thumb_mode = emulated_arm_mode_cache[address]
         if thumb_mode is None:
             thumb_mode = pwndbg.aglib.regs.xpsr & (1 << 24)
         # novermin
         extra = (CS_MODE_MCLASS | CS_MODE_THUMB) if thumb_mode else CS_MODE_MCLASS
 
-    elif pwndbg.aglib.arch.current in ("arm", "aarch64"):
+    elif pwndbg.aglib.arch.name in ("arm", "aarch64"):
         thumb_mode = emulated_arm_mode_cache[address]
         if thumb_mode is None:
             thumb_mode = pwndbg.aglib.regs.cpsr & (1 << 5)
         extra = CS_MODE_THUMB if thumb_mode else CS_MODE_ARM
 
-    elif pwndbg.aglib.arch.current == "sparc":
+    elif pwndbg.aglib.arch.name == "sparc":
         if pwndbg.dbg.is_gdblib_available() and "v9" in gdb.newest_frame().architecture().name():
             extra = CS_MODE_V9
         else:
             # The ptrsize base modes cause capstone.CsError: Invalid mode (CS_ERR_MODE)
             extra = 0
 
-    elif pwndbg.aglib.arch.current == "i8086":
+    elif pwndbg.aglib.arch.name == "i8086":
         extra = CS_MODE_16
 
     elif (
-        pwndbg.aglib.arch.current == "mips"
+        pwndbg.aglib.arch.name == "mips"
         and pwndbg.dbg.is_gdblib_available()
         and "isa32r6" in gdb.newest_frame().architecture().name()
     ):
         extra = CS_MODE_MIPS32R6
 
-    elif pwndbg.aglib.arch.current == "rv32":
+    elif pwndbg.aglib.arch.name == "rv32":
         extra = CS_MODE_RISCV32 | CS_MODE_RISCVC  # novermin
-    elif pwndbg.aglib.arch.current == "rv64":
+    elif pwndbg.aglib.arch.name == "rv64":
         extra = CS_MODE_RISCV64 | CS_MODE_RISCVC  # novermin
 
     else:
         extra = None
 
     return get_disassembler_cached(
-        pwndbg.aglib.arch.current, pwndbg.aglib.arch.ptrsize, pwndbg.aglib.arch.endian, extra
+        pwndbg.aglib.arch.name, pwndbg.aglib.arch.ptrsize, pwndbg.aglib.arch.endian, extra
     )
 
 
@@ -205,11 +205,11 @@ def get_one_instruction(
         if cached is not None:
             return cached
 
-    if pwndbg.aglib.arch.current not in CapstoneArch:
+    if pwndbg.aglib.arch.name not in CapstoneArch:
         return ManualPwndbgInstruction(address)
 
     md = get_disassembler(address)
-    size = VariableInstructionSizeMax.get(pwndbg.aglib.arch.current, 4)
+    size = VariableInstructionSizeMax.get(pwndbg.aglib.arch.name, 4)
     data = pwndbg.aglib.memory.read(address, size, partial=True)
     for ins in md.disasm(bytes(data), address, 1):
         pwn_ins: PwndbgInstruction = PwndbgInstructionImpl(ins)
@@ -377,7 +377,7 @@ def near(
     pc = pwndbg.aglib.regs.pc
 
     # Some architecture aren't emulated yet
-    if not pwndbg.emu or pwndbg.aglib.arch.current not in pwndbg.emu.emulator.arch_to_UC:
+    if not pwndbg.emu or pwndbg.aglib.arch.name not in pwndbg.emu.emulator.arch_to_UC:
         emulate = False
 
     emu: pwndbg.emu.emulator.Emulator = None

--- a/pwndbg/aglib/disasm/arch.py
+++ b/pwndbg/aglib/disasm/arch.py
@@ -172,7 +172,7 @@ class DisassemblyAssistant:
 
     @staticmethod
     def for_current_arch() -> DisassemblyAssistant:
-        return DisassemblyAssistant.assistants.get(pwndbg.aglib.arch.current, None)
+        return DisassemblyAssistant.assistants.get(pwndbg.aglib.arch.name, None)
 
     # Mutates the "instruction" object
     @staticmethod
@@ -218,7 +218,7 @@ class DisassemblyAssistant:
                 emu = jump_emu = None
 
         enhancer: DisassemblyAssistant = DisassemblyAssistant.assistants.get(
-            pwndbg.aglib.arch.current, generic_assistant
+            pwndbg.aglib.arch.name, generic_assistant
         )
 
         # Don't disable emulation yet, as we can use it to read the syscall register

--- a/pwndbg/aglib/heap/ptmalloc.py
+++ b/pwndbg/aglib/heap/ptmalloc.py
@@ -1114,7 +1114,7 @@ class GlibcMemoryAllocator(pwndbg.aglib.heap.heap.MemoryAllocator, Generic[TheTy
     @pwndbg.lib.cache.cache_until("objfile")
     def malloc_alignment(self) -> int:
         """Corresponds to MALLOC_ALIGNMENT in glibc malloc.c"""
-        if pwndbg.aglib.arch.current == "i386" and pwndbg.glibc.get_version() >= (2, 26):
+        if pwndbg.aglib.arch.name == "i386" and pwndbg.glibc.get_version() >= (2, 26):
             # i386 will override it to 16 when GLIBC version >= 2.26
             # See https://elixir.bootlin.com/glibc/glibc-2.26/source/sysdeps/i386/malloc-alignment.h#L22
             return 16

--- a/pwndbg/aglib/kernel/vmmap.py
+++ b/pwndbg/aglib/kernel/vmmap.py
@@ -135,7 +135,7 @@ def kernel_vmmap_via_page_tables() -> Tuple[pwndbg.lib.memory.Page, ...]:
         )
         return ()
 
-    arch = pwndbg.aglib.arch.current
+    arch = pwndbg.aglib.arch.name
     if arch == "aarch64":
         arch_backend = PT_Aarch64_Backend(machine_backend)
     elif arch == "i386":
@@ -292,7 +292,7 @@ def kernel_vmmap() -> Tuple[pwndbg.lib.memory.Page, ...]:
     if not pwndbg.aglib.qemu.is_qemu_kernel():
         return ()
 
-    if pwndbg.aglib.arch.current not in (
+    if pwndbg.aglib.arch.name not in (
         "i386",
         "x86-64",
         "aarch64",

--- a/pwndbg/aglib/shellcode.py
+++ b/pwndbg/aglib/shellcode.py
@@ -32,7 +32,7 @@ def _get_syscall_return_value():
     just returned.
     """
 
-    register_set = pwndbg.lib.regs.reg_sets[pwndbg.aglib.arch.current]
+    register_set = pwndbg.lib.regs.reg_sets[pwndbg.aglib.arch.name]
     # FIXME: `retval` is syscall abi? or sysv abi?
     return pwndbg.aglib.regs[register_set.retval]
 
@@ -89,7 +89,7 @@ async def exec_shellcode(
     or currupt the memory in the inferior.
     """
 
-    register_set = pwndbg.lib.regs.reg_sets[pwndbg.aglib.arch.current]
+    register_set = pwndbg.lib.regs.reg_sets[pwndbg.aglib.arch.name]
     preserve_set = register_set.gpr + register_set.args + (register_set.pc, register_set.stack)
 
     registers = {reg: pwndbg.aglib.regs[reg] for reg in preserve_set}

--- a/pwndbg/aglib/tls.py
+++ b/pwndbg/aglib/tls.py
@@ -37,7 +37,7 @@ def find_address_with_pthread_self() -> int:
     the pthread_self() function. The returned address points to the `struct tcbhead_t`,
     which serves as the header for TLS and thread-specific metadata.
     """
-    if pwndbg.aglib.arch.current not in ("x86-64", "i386", "arm", "aarch64"):
+    if pwndbg.aglib.arch.name not in ("x86-64", "i386", "arm", "aarch64"):
         return 0
 
     result = __call_pthread_self()
@@ -53,7 +53,7 @@ def find_address_with_pthread_self() -> int:
     # For i386 and x86-64, the return value of the pthread_self() is the address of TLS, because the value is self reference of the TLS: https://elixir.bootlin.com/glibc/glibc-2.37/source/nptl/pthread_create.c#L671
     # But for arm, the implementation of THREAD_SELF is different, we need to add sizeof(struct pthread) to the result to get the address of TLS.
 
-    if pwndbg.aglib.arch.current in ("arm", "aarch64"):
+    if pwndbg.aglib.arch.name in ("arm", "aarch64"):
         pthread_type = pwndbg.aglib.typeinfo.load("struct pthread")
         if pthread_type is None:
             # Type 'pthread' not found
@@ -69,14 +69,14 @@ def find_address_with_register() -> int:
     a CPU register. The returned address points to the `struct tcbhead_t`, which is the
     entry point for TLS and thread-specific metadata.
     """
-    if pwndbg.aglib.arch.current == "x86-64":
+    if pwndbg.aglib.arch.name == "x86-64":
         return int(pwndbg.aglib.regs.fsbase)
-    elif pwndbg.aglib.arch.current == "i386":
+    elif pwndbg.aglib.arch.name == "i386":
         return int(pwndbg.aglib.regs.gsbase)
-    elif pwndbg.aglib.arch.current == "aarch64":
+    elif pwndbg.aglib.arch.name == "aarch64":
         # FIXME: cleanup/remove `TPIDR_EL0` register, it was renamed to `tpidr` since GDB13+
         return int(pwndbg.aglib.regs.tpidr or pwndbg.aglib.regs.TPIDR_EL0 or 0)
-    elif pwndbg.aglib.arch.current == "arm":
+    elif pwndbg.aglib.arch.name == "arm":
         # TODO: linux ptrace for 64bit kernel?
         # In FreeBSD tls is under `tpidruro` register.
         # In Linux, the `tpidruro` register isn't available via ptrace in the 32-bit

--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -908,10 +908,10 @@ def context_disasm(target=sys.stdout, with_banner=True, width=None):
     thumb_mode_str = get_thumb_mode_string()
     if thumb_mode_str is not None:
         info = " / {} / {} mode / set emulate {}".format(
-            pwndbg.aglib.arch.current, thumb_mode_str, pwndbg.config.emulate
+            pwndbg.aglib.arch.name, thumb_mode_str, pwndbg.config.emulate
         )
     else:
-        info = " / {} / set emulate {}".format(pwndbg.aglib.arch.current, pwndbg.config.emulate)
+        info = " / {} / set emulate {}".format(pwndbg.aglib.arch.name, pwndbg.config.emulate)
     banner = [pwndbg.ui.banner("disasm", target=target, width=width, extra=info)]
 
     # If we didn't disassemble backward, try to make sure

--- a/pwndbg/commands/hijack_fd.py
+++ b/pwndbg/commands/hijack_fd.py
@@ -31,7 +31,7 @@ class ShellcodeRegs(NamedTuple):
 
 
 def get_shellcode_regs() -> ShellcodeRegs:
-    register_set = pwndbg.lib.regs.reg_sets[pwndbg.aglib.arch.current]
+    register_set = pwndbg.lib.regs.reg_sets[pwndbg.aglib.arch.name]
     syscall_abi = pwndbg.lib.abi.ABI.syscall()
 
     # pickup free register what is not used for syscall abi
@@ -44,7 +44,7 @@ def get_shellcode_regs() -> ShellcodeRegs:
     )
     assert (
         newfd_reg is not None
-    ), f"architecture {pwndbg.aglib.arch.current} don't have unused register..."
+    ), f"architecture {pwndbg.aglib.arch.name} don't have unused register..."
 
     return ShellcodeRegs(newfd_reg, register_set.retval, register_set.stack)
 

--- a/pwndbg/commands/version.py
+++ b/pwndbg/commands/version.py
@@ -63,7 +63,7 @@ def all_versions():
 
 
 def get_target_arch():
-    arch_info = pwndbg.aglib.arch.current
+    arch_info = pwndbg.aglib.arch.name
     target = f"Target Arch: {arch_info}\n"
 
     if pwndbg.dbg.is_gdblib_available():

--- a/pwndbg/emu/emulator.py
+++ b/pwndbg/emu/emulator.py
@@ -210,7 +210,7 @@ class InstructionExecutedResult(NamedTuple):
 # with a copy of the current processor state.
 class Emulator:
     def __init__(self) -> None:
-        self.arch = pwndbg.aglib.arch.current
+        self.arch = pwndbg.aglib.arch.name
 
         if self.arch not in arch_to_UC:
             raise NotImplementedError(f"Cannot emulate code for {self.arch}")
@@ -582,7 +582,7 @@ class Emulator:
         """
         Retrieve the mode used by Unicorn for the current architecture.
         """
-        arch = pwndbg.aglib.arch.current
+        arch = pwndbg.aglib.arch.name
         mode = 0
 
         if arch == "armcm":

--- a/pwndbg/gdblib/shellcode.py
+++ b/pwndbg/gdblib/shellcode.py
@@ -27,7 +27,7 @@ def _get_syscall_return_value():
     just returned.
     """
 
-    register_set = pwndbg.lib.regs.reg_sets[pwndbg.aglib.arch.current]
+    register_set = pwndbg.lib.regs.reg_sets[pwndbg.aglib.arch.name]
     return pwndbg.aglib.regs[register_set.retval]
 
 
@@ -79,7 +79,7 @@ def exec_shellcode(blob, restore_context=True, capture=None, disable_breakpoints
     or currupt the memory in the inferior.
     """
 
-    register_set = pwndbg.lib.regs.reg_sets[pwndbg.aglib.arch.current]
+    register_set = pwndbg.lib.regs.reg_sets[pwndbg.aglib.arch.name]
     preserve_set = register_set.gpr + register_set.args + (register_set.pc, register_set.stack)
 
     registers = {reg: pwndbg.aglib.regs[reg] for reg in preserve_set}

--- a/pwndbg/lib/arch.py
+++ b/pwndbg/lib/arch.py
@@ -64,10 +64,6 @@ class Arch:
         endian: Literal["little", "big"],
     ) -> None:
         self.name = arch_name
-        # TODO: `current` is the old name for the arch name, and it's now an
-        # alias for `name`. It's used throughout the codebase, do we want to
-        # migrate these uses to `name`?
-        self.current = self.name
         self.ptrsize = ptrsize
         self.ptrmask = (1 << 8 * ptrsize) - 1
         self.endian = endian


### PR DESCRIPTION
Some places in the codebase refer to the architecture name via `pwndbg.aglib.arch.current`, while others use `pwndbg.aglib.arch.name`. This PR consolidates all of these references to use `.arch.name`.