### PR TITLE
fix knft for py3.10

### DIFF
--- a/pwndbg/aglib/kernel/nftables.py
+++ b/pwndbg/aglib/kernel/nftables.py
@@ -117,7 +117,8 @@ class Expr:
 
     def print(self, print_nested: bool = True):
         expr_name = self.expr_name
-        print(f'{expr_name} @ 0x{int(self._addr['data'].address):x}')
+        addr = int(self._addr["data"].address)
+        print(f'{expr_name} @ 0x{addr:x}')
 
         if not print_nested:
             return

--- a/pwndbg/aglib/kernel/nftables.py
+++ b/pwndbg/aglib/kernel/nftables.py
@@ -118,7 +118,7 @@ class Expr:
     def print(self, print_nested: bool = True):
         expr_name = self.expr_name
         addr = int(self._addr["data"].address)
-        print(f'{expr_name} @ 0x{addr:x}')
+        print(f"{expr_name} @ 0x{addr:x}")
 
         if not print_nested:
             return


### PR DESCRIPTION
```
  File "/pwndbg/pwndbg/aglib/kernel/nftables.py", line 120
    print(f'{expr_name} @ 0x{int(self._addr['data'].address):x}')
                                             ^^^^
SyntaxError: f-string: unmatched '['
```
xd