### PR TITLE
Redirect user to vis_heap_chunks help when chunks are ommited

### DIFF
--- a/tests/gdb-tests/tests/heap/test_vis_heap_chunks.py
+++ b/tests/gdb-tests/tests/heap/test_vis_heap_chunks.py
@@ -76,7 +76,9 @@ def test_vis_heap_chunk_command(start_binary):
     gdb.execute("set default-visualize-chunk-number 1")
     assert pwndbg.config.default_visualize_chunk_number == 1
     result = gdb.execute("vis_heap_chunk", to_string=True).splitlines()
-    assert result == expected
+    # No parameters were passed and top isn't reached so help text is shown
+    no_params_help = "Not all chunks were shown, see `vis --help` for more information."
+    assert result == expected + [no_params_help]
     gdb.execute(
         "set default-visualize-chunk-number %d"
         % pwndbg.config.default_visualize_chunk_number.default


### PR DESCRIPTION
I left it as `vis` in the message because it's very nice to know about the shorthand.

![image](https://github.com/user-attachments/assets/9d1e2196-4306-4cf2-b749-a3cfd838c313)
