### PR TITLE
test.sh: implement profiling with cProfile

### DIFF
--- a/tests.sh
+++ b/tests.sh
@@ -5,6 +5,32 @@ echo "Running ldd to see ldd and so glibc version"
 ldd --version
 
 # Run integration tests
-(cd tests && python3 tests.py $@)
+PROFILE=0
+ARGS=()
+
+
+for arg in "$@"; do
+    if [ "$arg" = "--profile" ]; then
+        PROFILE=1
+    else
+        ARGS+=("$arg")
+    fi
+done
+
+# Run integration tests with profile flag 
+if [ "$PROFILE" -eq 1 ]; then
+    (cd tests && python3 -m cProfile -o profile.stats tests.py "${ARGS[@]}")
+    # Generate a readable report
+    (cd tests && python3 -c '
+import pstats
+from pstats import SortKey
+p = pstats.Stats("profile.stats")
+p.sort_stats(SortKey.TIME).print_stats(30)
+    ')
+else
+    # Run tests normally.
+    (cd tests && python3 tests.py "${ARGS[@]}")
+fi
+
 exit_code=$?
 exit $exit_code


### PR DESCRIPTION

Resolves #2486

This PR introduces a `--profile` flag to `tests.sh`, enabling performance profiling of integration tests using Python’s `cProfile`. When profiling is enabled, the script generates both a raw profiling data file (`profile.stats`) and an immediate human-readable report.

#### **Changes Made**

- **Added `--profile` Flag Support:**
    
    - If `--profile` is provided, the tests run under `cProfile`.
    - If omitted, the tests run normally.
- **Profiling Data Capture:**
    
    - Profiling results are saved to `tests/profile.stats`.
- **Automated Report Generation:**
    
    - After profiling, a summary report is printed using Python’s `pstats` module.
    - The report:
        - Sorts results by execution time.
        - Displays the top 30 most time-consuming functions.
#### **Usage**

- **Run Tests Normally:**
    
    `./tests.sh`
    
- **Run Tests with Profiling:**

    `./tests.sh --profile`