### PR TITLE
Fix remote procinfo errors & remote xinfo

### DIFF
--- a/pwndbg/commands/xinfo.py
+++ b/pwndbg/commands/xinfo.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import argparse
-import os
 
 import pwndbg
 import pwndbg.aglib.arch
@@ -13,6 +12,7 @@ import pwndbg.color.memory as M
 import pwndbg.commands
 import pwndbg.wrappers
 from pwndbg.commands import CommandCategory
+from pwndbg.lib.memory import Page
 
 parser = argparse.ArgumentParser(
     description="Shows offsets of the specified address from various useful locations."
@@ -26,7 +26,7 @@ def print_line(name, addr, first, second, op, width=20) -> None:
     )
 
 
-def xinfo_stack(page, addr) -> None:
+def xinfo_stack(page: Page, addr: int) -> None:
     # If it's a stack address, print offsets to top and bottom of stack, as
     # well as offsets to current stack and base pointer (if used by debuggee)
 
@@ -55,15 +55,11 @@ def xinfo_stack(page, addr) -> None:
             print_line("Next Stack Canary", addr, nxt, nxt - addr, "-")
 
 
-def xinfo_mmap_file(page, addr) -> None:
+def xinfo_mmap_file(page: Page, addr: int) -> None:
     # If it's an address pointing into a memory mapped file, print offsets
     # to beginning of file in memory and on disk
 
     file_name = page.objfile
-    # Check if the file exists on the local system, as we may be attached to a gdb-server or qemu.
-    # Even so, the file might exist locally, if we are doing `target remote localhost:1234`
-    if not os.path.exists(file_name):
-        return None
 
     objpages = filter(lambda p: p.objfile == file_name, pwndbg.aglib.vmmap.get())
     first = sorted(objpages, key=lambda p: p.vaddr)[0]
@@ -100,7 +96,7 @@ def xinfo_mmap_file(page, addr) -> None:
             print_line(sec["x_name"], addr, sec["sh_addr"], addr - sec["sh_addr"], "+")
 
 
-def xinfo_default(page, addr) -> None:
+def xinfo_default(page: Page, addr: int) -> None:
     # Just print the distance to the beginning of the mapping
     print_line("Mapped Area", addr, page.vaddr, addr - page.vaddr, "+")
 

--- a/pwndbg/dbg/gdb/__init__.py
+++ b/pwndbg/dbg/gdb/__init__.py
@@ -596,16 +596,15 @@ class GDBProcess(pwndbg.dbg_mod.Process):
         import pwndbg.aglib.file
 
         if pwndbg.aglib.file.is_vfile_qemu_user_bug():
-            try:
-                with open(local_path, "wb") as fp:
+            with open(local_path, "wb") as fp:
+                try:
                     for data in pwndbg.aglib.file.vfile_readfile(remote_path):
                         fp.write(data)
-                return
-            except OSError as e:
-                raise pwndbg.dbg_mod.Error(
-                    "Could not download remote file %r:\nError: %s" % (remote_path, str(e))
-                )
-
+                    return
+                except OSError as e:
+                    raise pwndbg.dbg_mod.Error(
+                        "Could not download remote file %r:\nError: %s" % (remote_path, str(e))
+                    )
         try:
             error = gdb.execute(f'remote get "{remote_path}" "{local_path}"', to_string=True)
         except gdb.error as e:

--- a/pwndbg/dbg/gdb/__init__.py
+++ b/pwndbg/dbg/gdb/__init__.py
@@ -596,10 +596,15 @@ class GDBProcess(pwndbg.dbg_mod.Process):
         import pwndbg.aglib.file
 
         if pwndbg.aglib.file.is_vfile_qemu_user_bug():
-            with open(local_path, "wb") as fp:
-                for data in pwndbg.aglib.file.vfile_readfile(remote_path):
-                    fp.write(data)
-            return
+            try:
+                with open(local_path, "wb") as fp:
+                    for data in pwndbg.aglib.file.vfile_readfile(remote_path):
+                        fp.write(data)
+                return
+            except OSError as e:
+                raise pwndbg.dbg_mod.Error(
+                    "Could not download remote file %r:\nError: %s" % (remote_path, str(e))
+                )
 
         try:
             error = gdb.execute(f'remote get "{remote_path}" "{local_path}"', to_string=True)

--- a/pwndbg/lib/memory.py
+++ b/pwndbg/lib/memory.py
@@ -59,6 +59,12 @@ class Page:
     flags = 0  #: Flags set by the ELF file, see PF_X, PF_R, PF_W
     offset = 0  #: Offset into the original ELF file that the data is loaded from
     objfile = ""  #: Path to the ELF on disk
+    """
+    Possible non-empty values of `objfile`:
+    - Contains square brackets "[]" if it's not a memory mapped file.
+        Examples: [stack], [vsyscall], [heap], [vdso]
+    - A path to a file, such as `/usr/lib/libc.so.6`
+    """
 
     def __init__(self, start: int, size: int, flags: int, offset: int, objfile: str = "") -> None:
         self.vaddr = start


### PR DESCRIPTION
This provides a fix to #2615. The `procinfo` commands attempts to read SELinux attributes from a `/proc`, and reading that file ( `/proc/%PID/task/$TID/attr/current`) sometimes fails (you can reproduce locally with ` cat /proc/$$/attr/current`). There's some discussion of this behavior here - https://serverfault.com/questions/895946/cant-read-from-proc-self-attr-current-but-permissions-are-0666.

This adds a try-catch block around that code so that `procinfo` continues if the file cannot be read.


#### Fix to `xinfo`

This also reverts a previous change that prevents `xinfo` from producing full information when inspecting an address in a memory mapped file while debugging with qemu - https://github.com/pwndbg/pwndbg/commit/914110b8a3cfa7ebaa304c1288efe45151284a7c. After the commit linked here, the codebase has added changes so that we can get files from qemu processes, so we can now produce some elf and offset information about the address in question.

Before:
![image](https://github.com/user-attachments/assets/072f3818-216e-4928-af71-e845a1a61e1c)

After:

![image](https://github.com/user-attachments/assets/c49f5dfb-c62c-4b76-8066-7eb5122b1e46)
