### PR TITLE
portable: fix ipython autocompletion

### DIFF
--- a/nix/portable.nix
+++ b/nix/portable.nix
@@ -178,6 +178,9 @@ let
         # copy extra files
         cp -rf ${lib.getLib pkgs.ncurses}/share/terminfo/ $out/pwndbg/share/
 
+        # fix ipython autocomplete
+        cp -rf ${pwndbgVenv}/lib/${python3.libPrefix}/site-packages/parso/python/*.txt $out/pwndbg/lib/${python3.libPrefix}/site-packages/parso/python/
+
         # fix python "subprocess.py" to use "/bin/sh" and not the nix'ed version, otherwise "gdb-pt-dump" is broken
         sed -i 's@/nix/store/.*/bin/sh@/bin/sh@' $out/pwndbg/lib/${python3.libPrefix}/subprocess.py
 


### PR DESCRIPTION
Portable release had broken ipython autocomplete

<img width="1108" alt="image" src="https://github.com/user-attachments/assets/bfc800d5-1a7d-4b0b-880e-ae5aed770740" />
