### PR TITLE
Fix #2674: context out when splitting window

### DIFF
--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -674,9 +674,7 @@ def context(subcontext=None, enabled=None) -> None:
         with target as out:
             if result_settings[target].get("clearing", config_clear_screen) and lines:
                 clear_screen(out)
-            out.write("\n".join(lines))
-            if out is sys.stdout:
-                out.write("\n")
+            out.writelines(line + "\n" for line in lines)
             out.flush()
 
 


### PR DESCRIPTION
This commit fixes #2674. A bug in `commands.context` implementation where we printed out the banner without a newline when context was forwarded to separate terminals.

This commit also refactors the `context` function a bit to simplify it.

As a result, when the context is supposed to not print anything the `history_handle_unchanged_contents` will not be called.

<!-- Please make sure to read the testing and linting instructions at https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md before creating a PR -->
