### PR TITLE
Configure IDA/Binary Ninja integration server endpoint through environment

### DIFF
--- a/binja_script.py
+++ b/binja_script.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import ctypes
+import os
 import sys
 import threading
 import xmlrpc.client
@@ -20,8 +21,8 @@ xmlrpc.client.MAXINT = 10**100
 xmlrpc.client.MININT = -(10**100)
 
 
-host = "127.0.0.1"
-port = 31337
+host = os.environ.get("PWNDBG_BINJA_SERVER_HOST", "127.0.0.1")
+port = int(os.environ.get("PWNDBG_BINJA_SERVER_PORT", "31337"))
 
 logger = binaryninja.log.Logger(0, "pwndbg-integration")
 

--- a/ida_script.py
+++ b/ida_script.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import datetime
+import os
 import threading
 import xmlrpc.client as xmlclient
 from xml.sax.saxutils import escape
@@ -48,8 +49,8 @@ xmlclient.Marshaller.dispatch[type(1 << 63)] = create_marshaller("<value><i8>%d<
 xmlclient.Marshaller.dispatch[int] = create_marshaller("<value><i8>%d</i8></value>")
 xmlclient.Marshaller.dispatch[idaapi.cfuncptr_t] = create_marshaller(just_to_str=True)
 
-host = "127.0.0.1"
-port = 31337
+host = os.environ.get("PWNDBG_IDA_SERVER_HOST", "127.0.0.1")
+port = int(os.environ.get("PWNDBG_IDA_SERVER_PORT", "31337"))
 
 mutex = threading.Condition()
 


### PR DESCRIPTION
Use the `PWNDBG_[BINJA|IDA]_SERVER_HOST` and `PWNDBG_[BINJA|IDA]_SERVER_PORT` environment variables to specify where the XMLRPC server should listen on.

This allows you to change the host to e.g. "0.0.0.0" to allow connecting from WSL to an IDA/Binja running on Windows without having to touch the scripts everytime.