### PR TITLE
Sync gdb.Parameter when config.Parameter changes

### DIFF
--- a/pwndbg/gdblib/config.py
+++ b/pwndbg/gdblib/config.py
@@ -53,6 +53,7 @@ class Parameter(gdb.Parameter):
         self.init_super(param)
         self.param = param
         self.value = param.value
+        self.param.add_update_listener(self.on_change)
 
     def init_super(self, param: pwndbg.lib.config.Parameter) -> None:
         """Initializes the super class for GDB >= 9"""
@@ -66,6 +67,12 @@ class Parameter(gdb.Parameter):
             )
             return
         super().__init__(param.name, gdb.COMMAND_SUPPORT, c)
+
+    def on_change(self, value: Any) -> None:
+        """Called when the value of the pwndbg.lib.config.Parameter changes
+        Transfer the value to the GDB parameter to keep them in sync.
+        """
+        self.value = value
 
     @property
     def native_value(self):

--- a/pwndbg/lib/config.py
+++ b/pwndbg/lib/config.py
@@ -70,10 +70,24 @@ class Parameter:
         self.help_docstring = help_docstring.strip()
         self.name = name
         self.default = default
-        self.value = default
+        self._value = default
         self.param_class = param_class or PARAM_CLASSES[type(default)]
         self.enum_sequence = enum_sequence
         self.scope = scope
+        self.update_listeners: List[Callable[[Any], None]] = []
+
+    def add_update_listener(self, listener: Callable[[Any], None]) -> None:
+        self.update_listeners.append(listener)
+
+    @property
+    def value(self) -> Any:
+        return self._value
+
+    @value.setter
+    def value(self, value: Any) -> None:
+        self._value = value
+        for listener in self.update_listeners:
+            listener(value)
 
     @property
     def is_changed(self) -> bool:


### PR DESCRIPTION
Set the parameter in gdb to the new value when the abstraction in pwndbg.lib.config.Parameter changes. This makes sure other commands accessing the value in gdb like "show <parameter>" display the correct value.

Changes of the gdb.Parameter value with `set param_name value` were already transferred to the config.Parameter in the [`Parameter.get_set_string`](https://sourceware.org/gdb/current/onlinedocs/gdb.html/Parameters-In-Python.html) callback, but changes to the `pwndbg.config.param_name.value`  in code wouldn't be propagated to the `gdb.Parameter`.

Fixes #2744