### PR TITLE
Fix format failure due to gdb.Value

### DIFF
--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -1247,7 +1247,7 @@ def save_signal(signal) -> None:
             else:
                 try:
                     si_addr = gdb.parse_and_eval("$_siginfo._sifields._sigfault.si_addr")
-                    msg += f" (fault address {(si_addr or 0):#x})"
+                    msg += f" (fault address {(int(si_addr) or 0):#x})"
                 except gdb.error:
                     pass
         result.append(message.signal(msg))

--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -1247,7 +1247,7 @@ def save_signal(signal) -> None:
             else:
                 try:
                     si_addr = gdb.parse_and_eval("$_siginfo._sifields._sigfault.si_addr")
-                    msg += f" (fault address {(int(si_addr) or 0):#x})"
+                    msg += f" (fault address {int(si_addr):#x})"
                 except gdb.error:
                     pass
         result.append(message.signal(msg))


### PR DESCRIPTION
```
Program received signal SIGSEGV, Segmentation fault.
0xffffffffcd4010b0 in ?? ()
Traceback (most recent call last):
  File "/pwndbg/pwndbg/commands/context.py", line 1250, in save_signal
    msg += f" (fault address {(si_addr or 0):#x})"
                             ^^^^^^^^^^^^^^^^^^^
TypeError: unsupported format string passed to gdb.Value.__format__
```