### PR TITLE
Switch to using `pwnlib` constants for flags.

### DIFF
--- a/pwndbg/lib/functions.py
+++ b/pwndbg/lib/functions.py
@@ -4,6 +4,9 @@ from collections.abc import Mapping
 from typing import List
 from typing import NamedTuple
 
+from pwnlib import constants
+from pwnlib.constants.constant import Constant
+
 
 class Function(NamedTuple):
     type: str
@@ -16,12 +19,7 @@ class Argument(NamedTuple):
     type: str
     derefcnt: int
     name: str
-    flags: tuple[Flag, ...] | None = None
-
-
-class Flag(NamedTuple):
-    value: int
-    name: str
+    flags: tuple[Constant, ...] | None = None
 
 
 class LazyFunctions(Mapping[str, Function]):
@@ -46,7 +44,16 @@ class LazyFunctions(Mapping[str, Function]):
 functions = LazyFunctions()
 
 
-def format_flags_argument(flags: tuple[Flag, ...], value: int):
+def resolve_constants(*names: str) -> tuple[Constant, ...]:
+    resolved: List[Constant] = []
+    for name in names:
+        constant = getattr(constants, name, None)
+        if constant is not None:
+            resolved.append(constant)
+    return tuple(resolved)
+
+
+def format_flags_argument(flags: tuple[Constant, ...], value: int):
     original_value: int = value
     flag_names: List[str] = []
 
@@ -57,9 +64,9 @@ def format_flags_argument(flags: tuple[Flag, ...], value: int):
     # descending popcount, this loop will output more specific
     # flags.
     for flag in flags:
-        if (value & flag.value) == flag.value:
-            flag_names.append(flag.name)
-            value = value & ~flag.value
+        if (value & int(flag)) == int(flag):
+            flag_names.append(str(flag))
+            value = value & ~int(flag)
 
     # If none of the known flags matched the value, just
     # format the value as a normal hex integer.

--- a/pwndbg/lib/functions_data.py
+++ b/pwndbg/lib/functions_data.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 from pwndbg.lib.functions import Argument
-from pwndbg.lib.functions import Flag
 from pwndbg.lib.functions import Function
+from pwndbg.lib.functions import resolve_constants
 
 
 def load_functions():
@@ -28484,12 +28484,12 @@ _functions = {
                 type="int",
                 derefcnt=0,
                 name="flags",
-                flags=(
-                    Flag(value=0x03, name="MAP_SHARED_VALIDATE"),
-                    Flag(value=0x01, name="MAP_SHARED"),
-                    Flag(value=0x02, name="MAP_PRIVATE"),
-                    Flag(value=0x20, name="MAP_ANONYMOUS"),
-                    Flag(value=0x10, name="MAP_FIXED"),
+                flags=resolve_constants(
+                    "MAP_SHARED_VALIDATE",
+                    "MAP_SHARED",
+                    "MAP_PRIVATE",
+                    "MAP_ANONYMOUS",
+                    "MAP_FIXED",
                 ),
             ),
             Argument(type="int", derefcnt=0, name="fd"),

--- a/tests/unit-tests/test_functions.py
+++ b/tests/unit-tests/test_functions.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from pwndbg.lib.functions import Flag
+from pwnlib.constants.constant import Constant
+
 from pwndbg.lib.functions import format_flags_argument
 from pwndbg.lib.functions import functions
 from pwndbg.lib.functions_data import _functions
@@ -21,9 +22,9 @@ def test_functions_lookup_does_not_exist():
 def test_format_flags_not_found():
     # None of the known flags are found in the value.
     flags = (
-        Flag(value=0x01, name="FLAG_1"),
-        Flag(value=0x02, name="FLAG_2"),
-        Flag(value=0x08, name="FLAG_8"),
+        Constant("FLAG_1", 0x01),
+        Constant("FLAG_2", 0x02),
+        Constant("FLAG_8", 0x08),
     )
     formatted = "0x4"
     assert format_flags_argument(flags, 0x4) == formatted
@@ -31,10 +32,10 @@ def test_format_flags_not_found():
 
 def test_format_flags_found():
     flags = (
-        Flag(value=0x03, name="FLAG_3"),
-        Flag(value=0x01, name="FLAG_1"),
-        Flag(value=0x02, name="FLAG_2"),
-        Flag(value=0x08, name="FLAG_8"),
+        Constant("FLAG_3", 0x03),
+        Constant("FLAG_1", 0x01),
+        Constant("FLAG_2", 0x02),
+        Constant("FLAG_8", 0x08),
     )
     formatted = "0xf (FLAG_3|FLAG_8|0x4)"
     assert format_flags_argument(flags, 0xF) == formatted


### PR DESCRIPTION
PR #2740 added initial support for formatting flag arguments to `dumpargs`. However, the flag values were hard-coded and might not have been correct on certain platforms and architectures. @patryk4815 and @OBarronCS made me aware of `pwnlib`, which already exposes these constants through a Python library, and which is already used elsewhere in this project.

Switching the flags to use `pwnlib` constants directly avoids some repetition, and also makes this code more portable.