### PR TITLE
Fix config display

### DIFF
--- a/pwndbg/commands/config.py
+++ b/pwndbg/commands/config.py
@@ -95,8 +95,8 @@ def display_config(filter_pattern: str, scope: str, has_file_command: bool = Tru
             default = generateColorFunction(v.default)(v.default)
         elif isinstance(v.value, bool):
             # Display 'on' or 'off' - same as GDB parameter display
-            value = 'on' if v.value else 'off'
-            default = 'on' if v.default else 'off'
+            value = "on" if v.value else "off"
+            default = "on" if v.default else "off"
         else:
             value = repr(v.value)
             default = repr(v.default)

--- a/pwndbg/commands/config.py
+++ b/pwndbg/commands/config.py
@@ -77,14 +77,14 @@ def display_config(filter_pattern: str, scope: str, has_file_command: bool = Tru
         print(hint(f'No {scope} parameter found with filter "{filter_pattern}"'))
         return
 
-    longest_optname = max(map(len, [v.name for v in values]))
+    longest_optname = max(map(len, (v.name for v in values)))
     longest_value = max(
         # We use `repr` here so the string values will be in quotes
-        map(len, [extend_value_with_default(repr(v.value), repr(v.default)) for v in values])
+        map(len, (extend_value_with_default(repr(v.value), repr(v.default)) for v in values))
     )
 
     header = print_row("Name", "Value", "Default", "Documentation", longest_optname, longest_value)
-    print("-" * (len(header)))
+    print("-" * len(header))
 
     for v in sorted(values):
         if isinstance(v, pwndbg.color.theme.ColorParameter):

--- a/pwndbg/commands/config.py
+++ b/pwndbg/commands/config.py
@@ -93,6 +93,10 @@ def display_config(filter_pattern: str, scope: str, has_file_command: bool = Tru
 
             value = generateColorFunction(v.value)(v.value)
             default = generateColorFunction(v.default)(v.default)
+        elif isinstance(v.value, bool):
+            # Display 'on' or 'off' - same as GDB parameter display
+            value = 'on' if v.value else 'off'
+            default = 'on' if v.default else 'off'
         else:
             value = repr(v.value)
             default = repr(v.default)


### PR DESCRIPTION
Fixes #2748: a bug/bad UX where `config` command displayed the boolean parameter values as `True` or `False` while setting them with `set <param> <value>` requires passing `on` or `off`.

This PR makes it so that the `on` or `off` is shown instead.