### PR TITLE
Fix TUI context sections display after #2743

### DIFF
--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -204,6 +204,9 @@ class CallOutput:
     def write(self, data) -> None:
         self.func(data)
 
+    def writelines(self, lines_iterable) -> None:
+        self.func("".join(lines_iterable))
+
     def flush(self):
         try:
             return self.func.flush()


### PR DESCRIPTION
We're now using `writelines` to output the context data which wasn't implemented
for the CallOutput redirection layer. Add a smoke test for that output redirection.

Refs #2654