### PR TITLE
Native Apple Silicon GDB :)

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -25,6 +25,7 @@ jobs:
           ubuntu-latest,  # x86_64-linux
           ubuntu-24.04-arm,  # aarch64-linux
           macos-13,  # x86_64-darwin
+          macos-15,  # aarch64-darwin
         ]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -88,11 +88,8 @@ jobs:
         ]
         attribute: [
           pwndbg-lldb-portable-tarball,
+          pwndbg-gdb-portable-tarball,
         ]
-        include:
-          # gdb is only supported on macos x86_64
-          - os: macos-13  # x86_64-darwin
-            attribute: pwndbg-gdb-portable-tarball
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     steps:

--- a/flake.nix
+++ b/flake.nix
@@ -226,7 +226,7 @@
         // (crossDrvs system)
         // (portableDrvs system)
         // (tarballDrv system)
-        // (pwndbg_gdb_drvs (if (system == "aarch64-darwin") then "x86_64-darwin" else system))
+        // (pwndbg_gdb_drvs system)
         // (pwndbg_lldb_drvs system)
       );
 

--- a/nix/overlay/gdb.nix
+++ b/nix/overlay/gdb.nix
@@ -8,7 +8,17 @@ let
 
   drv =
     if !isCross then
-      prev.pwndbg_gdb
+      prev.pwndbg_gdb.overrideAttrs (
+        old:
+        prev.lib.optionalAttrs (prev.stdenv.targetPlatform.isDarwin && prev.stdenv.targetPlatform.isAarch64)
+          {
+            configureFlags = [
+              "--target=arm-none-eabi"
+            ] ++ old.configureFlags;
+            configurePlatforms = [ ];
+            meta.badPlatforms = [ ];
+          }
+      )
     else
       (prev.pwndbg_gdb.override { pythonSupport = true; }).overrideAttrs (old: {
         patches = (old.patches or [ ]) ++ [


### PR DESCRIPTION
Add portable native GDB multi-arch for Apple Silicon :)

Still it is not possible to debug aarch64-darwin binaries via GDB.
But GDB is useful as a frontend for remote debugging.