### PR TITLE
Simplify local testing inside Docker environment

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -74,6 +74,8 @@ docker compose run --rm --build ubuntu24.04-mount ./unit-tests.sh
 
 This comes in handy particularly for cross-architecture tests because the Docker environment has all the cross-compilers installed. The active `pwndbg` directory is mounted, preventing the need for a full rebuild whenever you update the codebase.
 
+Remove the `-mount` if you want the tests to run from a clean slate (no files mounted, meaning all binaries are recompiled each time).
+
 ## Writing Tests
 
 Each test is a Python function that runs inside of an isolated GDB session. 

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -69,7 +69,7 @@ To run the tests in the same environment as the testing CI/CD, you can use the f
 # General test suite
 docker compose run --rm --build ubuntu24.04-mount ./tests.sh
 # Cross-architecture tests
-docker compose run --rm --build ubuntu24.04-mount ./unit-tests.sh
+docker compose run --rm --build ubuntu24.04-mount ./qemu-tests.sh
 ```
 
 This comes in handy particularly for cross-architecture tests because the Docker environment has all the cross-compilers installed. The active `pwndbg` directory is mounted, preventing the need for a full rebuild whenever you update the codebase.

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -74,7 +74,7 @@ docker compose run --rm --build ubuntu24.04-mount ./unit-tests.sh
 
 This comes in handy particularly for cross-architecture tests because the Docker environment has all the cross-compilers installed. The active `pwndbg` directory is mounted, preventing the need for a full rebuild whenever you update the codebase.
 
-Remove the `-mount` if you want the tests to run from a clean slate (no files mounted, meaning all binaries are recompiled each time).
+Remove the `-mount` if you want the tests to run from a clean slate (no files are mounted, meaning all binaries are recompiled each time).
 
 ## Writing Tests
 

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -63,6 +63,17 @@ To run these tests, run [`./tests.sh`](./tests.sh). You can filter the tests to 
 
 To invoke cross-architecture tests, use `./qemu-tests.sh`, and to run unit tests, use `./unit-tests.sh`
 
+To run the tests in the same environment as the testing CI/CD, you can use the following Docker command.
+
+```sh
+# General test suite
+docker compose run --rm --build ubuntu24.04-mount ./tests.sh
+# Cross-architecture tests
+docker compose run --rm --build ubuntu24.04-mount ./unit-tests.sh
+```
+
+This comes in handy particularly for cross-architecture tests because the Docker environment has all the cross-compilers installed. The active `pwndbg` directory is mounted, preventing the need for a full rebuild whenever you update the codebase.
+
 ## Writing Tests
 
 Each test is a Python function that runs inside of an isolated GDB session. 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@
 #
 
 ARG image=mcr.microsoft.com/devcontainers/base:jammy
-FROM $image
+FROM $image AS base
 
 WORKDIR /pwndbg
 
@@ -44,6 +44,8 @@ RUN ./setup-dev.sh
 
 # Cleanup dummy files
 RUN rm README.md && rm -rf pwndbg
+
+FROM base AS full
 
 ADD . /pwndbg/
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
   base: &base-spec
     build: .
@@ -28,6 +27,16 @@ services:
       args:
         image: ubuntu:24.04
 
+  ubuntu24.04-mount:
+    <<: *base-spec
+    build:
+      context: .
+      target: base
+      dockerfile: Dockerfile
+      args:
+        image: ubuntu:24.04
+    volumes:
+      - .:/pwndbg
 
   debian12:
     <<: *base-spec


### PR DESCRIPTION
This PR makes a small change to the Dockerfile+Docker compose file to make it easier to run the tests locally.

Many of the tests are dependent on the environment (libc version dependencies as well as the entire cross-architecture test suite relying on cross compilers being installed), and this makes it a little easier to locally run the tests in the same environment as CI/CD.

You can run:
```sh
docker compose run --rm --build ubuntu24.04-mount ./qemu-tests.sh
```
The ./pwndbg directory is mounted, and by adding a new "stage" to the Dockerfile, we can avoid a rebuild of the image when changing files, making it easier to run the tests. 