### PR TITLE
Add test for mixed case handling in hex2ptr_common

### DIFF
--- a/tests/unit-tests/test_hex2ptr.py
+++ b/tests/unit-tests/test_hex2ptr.py
@@ -22,5 +22,5 @@ def test_hex2ptr_common_invalid_hex():
 
 def test_hex2ptr_common_mixed_case():
     """Test that hex2ptr_common correctly handles mixed case hex strings."""
-    assert hex2ptr_common("aB cD eF 12") == 0x12EFCDAb
+    assert hex2ptr_common("aB cD eF 12") == 0x12EFCDAB
     assert hex2ptr_common("FfFf") == 0xFFFF

--- a/tests/unit-tests/test_hex2ptr.py
+++ b/tests/unit-tests/test_hex2ptr.py
@@ -18,3 +18,9 @@ def test_hex2ptr_common_invalid_hex():
     # Test for invalid hex characters
     with pytest.raises(ValueError, match="Invalid hex string"):
         hex2ptr_common("zz zz zz")
+
+
+def test_hex2ptr_common_mixed_case():
+    """Test that hex2ptr_common correctly handles mixed case hex strings."""
+    assert hex2ptr_common("aB cD eF 12") == 0x12EFCDAb
+    assert hex2ptr_common("FfFf") == 0xFFFF


### PR DESCRIPTION
Added a test case to check that hex2ptr_mmon handles hex strings with mixed uppercase and lowercase letters. 