### PR TITLE
Add telescope-frame-print-retaddr and telescope-frame-print-retaddr

### DIFF
--- a/pwndbg/commands/telescope.py
+++ b/pwndbg/commands/telescope.py
@@ -43,6 +43,12 @@ print_framepointer_offset = pwndbg.config.add_param(
     True,
     "print offset to framepointer for each address, if sufficiently small",
 )
+print_retaddr_in_frame = pwndbg.config.add_param(
+    "telescope-frame-print-retaddr", True, "print one pointer past the stack frame"
+)
+dont_skip_registers = pwndbg.config.add_param(
+    "telescope-dont-skip-registers", True, "don't skip a repeated line if a registers points to it"
+)
 
 offset_separator = theme.add_param(
     "telescope-offset-separator", "│", "offset separator of the telescope command"
@@ -148,6 +154,7 @@ def telescope(
 
         address = sp
         count = int((bp - sp) / ptrsize) + 1
+        count += 1 if print_retaddr_in_frame else 0
 
     # Allow invocation of "telescope a b" to dump all bytes from A to B
     if int(address) <= int(count):
@@ -250,7 +257,11 @@ def telescope(
         # Buffer repeating values.
         if skip_repeating_values:
             value = pwndbg.aglib.memory.pvoid(addr)
-            if last == value and addr != input_address:
+            if (
+                last == value
+                and addr != input_address
+                and (not dont_skip_registers or not regs[addr])
+            ):
                 collapse_buffer.append(line)
                 continue
             collapse_repeating_values()
@@ -270,8 +281,7 @@ def telescope(
 
 def regs_or_frame_offset(addr: int, bp: int | None, regs: Dict[int, str], longest_regs: int) -> str:
     # bp only set if print_framepointer_offset=True
-    # len(regs[addr]) == 1 if no registers pointer to address
-    if bp is None or len(regs[addr]) > 1 or not -0xFFF <= addr - bp <= 0xFFF:
+    if bp is None or regs[addr] or not -0xFFF <= addr - bp <= 0xFFF:
         return " " + T.register(regs[addr].ljust(longest_regs))
     else:
         # If offset to frame pointer as hex fits in hex 3 digits, print it

--- a/tests/gdb-tests/tests/test_command_telescope.py
+++ b/tests/gdb-tests/tests/test_command_telescope.py
@@ -123,7 +123,7 @@ def test_command_telescope_frame(start_binary):
     result_lines = result_str.strip().split("\n")
 
     assert rsp in result_lines[0]
-    assert rbp in result_lines[-1]
+    assert rbp in result_lines[-2]
 
 
 def test_command_telescope_frame_bp_below_sp(start_binary):


### PR DESCRIPTION
configuration options to telescope.

This changes the default behaviour for both cases because that's my personal preference, but feel free to disagree :9 

![image](https://github.com/user-attachments/assets/9b00107f-d6d3-4be2-b40d-2905e2c23fdc)
![image](https://github.com/user-attachments/assets/0d0fe664-bc35-44f4-af3e-49cc1ce02da2)
