### PR TITLE
Fix bad colors in TUI output - part 2

### DIFF
--- a/pwndbg/gdblib/tui/context.py
+++ b/pwndbg/gdblib/tui/context.py
@@ -202,6 +202,7 @@ class ContextTUIWindow:
             )
             .replace("\x1b[39m", "\x1b[0m")
             .replace("\x1b[49m", "\x1b[0m")
+            .replace("\x1b[39;49m", "\x1b[0m")
         )
 
 


### PR DESCRIPTION
pygments emits a sequence resetting both the foreground and background color at the same time using one sequence `\x1b[39;49m`.

Replace that one too. If pygments generates other escape sequences with 39 or 49 included we'll have to think of a smarter way to strip those commands.

Refs #2654 #2764