### PR TITLE
fixed knft_dump and disable kernel_vmmap_via_page_tables under Darwin

### DIFF
--- a/pwndbg/aglib/kernel/vmmap.py
+++ b/pwndbg/aglib/kernel/vmmap.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import sys
 import random
 import string
 import subprocess
@@ -112,6 +113,10 @@ class QemuMachine(Machine):
 @pwndbg.lib.cache.cache_until("stop")
 def kernel_vmmap_via_page_tables() -> Tuple[pwndbg.lib.memory.Page, ...]:
     if not pwndbg.aglib.qemu.is_qemu_kernel():
+        return ()
+
+    if sys.platform != "linux":
+        # QemuMachine requires access to /proc/{qemu-pid}/mem, which is only available on Linux
         return ()
 
     try:

--- a/pwndbg/aglib/kernel/vmmap.py
+++ b/pwndbg/aglib/kernel/vmmap.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import os
-import sys
 import random
 import string
 import subprocess
+import sys
 import tempfile
 from typing import List
 from typing import Tuple

--- a/pwndbg/commands/knft.py
+++ b/pwndbg/commands/knft.py
@@ -19,7 +19,7 @@ def parse_nft_family(s: str) -> int:
 parser = argparse.ArgumentParser(
     description="Dump all nftables: tables, chains, rules, expressions"
 )
-parser.add_argument("nsid", type=int, nargs='?', help="Network Namespace ID")
+parser.add_argument("nsid", type=int, nargs="?", help="Network Namespace ID")
 
 
 @pwndbg.commands.ArgparsedCommand(parser, category=CommandCategory.KERNEL)

--- a/pwndbg/commands/knft.py
+++ b/pwndbg/commands/knft.py
@@ -19,7 +19,7 @@ def parse_nft_family(s: str) -> int:
 parser = argparse.ArgumentParser(
     description="Dump all nftables: tables, chains, rules, expressions"
 )
-parser.add_argument("nsid", type=int, help="Network Namespace ID")
+parser.add_argument("nsid", type=int, nargs='?', help="Network Namespace ID")
 
 
 @pwndbg.commands.ArgparsedCommand(parser, category=CommandCategory.KERNEL)


### PR DESCRIPTION
fixes:
- knft_dump positional argument should be optional
- disable kernel_vmmap_via_page_tables under darwin
