### PR TITLE
AArch64 kernel mode address handling fix

### DIFF
--- a/pwndbg/aglib/disasm/aarch64.py
+++ b/pwndbg/aglib/disasm/aarch64.py
@@ -281,7 +281,7 @@ class DisassemblyAssistant(pwndbg.aglib.disasm.arch.DisassemblyAssistant):
     def _handle_adrp(self, instruction: PwndbgInstruction, emu: Emulator) -> None:
         result_operand, right = instruction.operands
         if result_operand.str and right.before_value is not None:
-            address = right.before_value
+            address = right.before_value & pwndbg.aglib.arch.ptrmask
 
             TELESCOPE_DEPTH = max(0, int(pwndbg.config.disasm_telescope_depth))
 
@@ -348,7 +348,9 @@ class DisassemblyAssistant(pwndbg.aglib.disasm.arch.DisassemblyAssistant):
 
         if len(instruction.operands) > 0:
             # For all AArch64 branches, the target is either an immediate or a register and is the last operand
-            return instruction.operands[-1].before_value
+            if (val := instruction.operands[-1].before_value) is not None:
+                return val & pwndbg.aglib.arch.ptrmask
+            return None
         elif instruction.id == ARM64_INS_RET:
             # If this is a ret WITHOUT an operand, it means we should read from the LR/x30 register
             return super()._read_register_name(instruction, "lr", emu)

--- a/pwndbg/aglib/disasm/arch.py
+++ b/pwndbg/aglib/disasm/arch.py
@@ -691,7 +691,7 @@ class DisassemblyAssistant:
         if instruction.target is None:
             instruction.target = instruction.next
 
-        if instruction.has_jump_target:
+        if instruction.has_jump_target and instruction.target >= 0:
             # Only bother doing the symbol lookup if this is a jump
             instruction.target_string = MemoryColor.get_address_or_symbol(instruction.target)
 

--- a/pwndbg/emu/emulator.py
+++ b/pwndbg/emu/emulator.py
@@ -190,6 +190,7 @@ BANNED_INSTRUCTIONS = {
     "mips": {C.mips.MIPS_INS_RDHWR},
     "arm": ARM_BANNED_INSTRUCTIONS,
     "armcm": ARM_BANNED_INSTRUCTIONS,
+    "aarch64": {C.arm64.ARM64_INS_MRS},
 }
 
 # https://github.com/unicorn-engine/unicorn/issues/550


### PR DESCRIPTION
This PR fixes #2787, a crash when debugging an AArch64 kernel-mode program.

What follows is an explanation of the bug:

The underlying bug relates to how the Capstone disassembler exposes the values of immediate operands, and the interaction of a design decision in Capstone with the high addresses present in the kernel virtual address space.

The `.imm` types of immediate operands on 64-bit architectures are stored as 64-bit signed integers in Capstone internals.

(example of x86 .imm code)
https://github.com/capstone-engine/capstone/blob/6461ed0843a677f0b689488132ce73d2083ca11e/include/capstone/x86.h#L278-L284

However, semantically, the number sometimes represents an unsigned value, such as in the case of an address.

For convenience, on certain instructions, Capstone adds the address of the instruction with the immediate operand, such as in branch instructions, and `adrp` in AArch64. As an example, if you have `bl 0x1000`, and the instruction is at address `0xffff_ffff_0000_0000`, then the `.imm` takes on the value of `0xffff_ffff_0000_1000`, because this is what will be placed in the instruction pointer. Since kernel mode addresses start at high addresses, when interpreted as a signed-value, it is negative. This PR adds a missing masking operation to convert it to a signed value.



