### PR TITLE
GDB: Allow partial read of memory that wraps around address space boundary

### DIFF
--- a/pwndbg/dbg/gdb/__init__.py
+++ b/pwndbg/dbg/gdb/__init__.py
@@ -451,6 +451,14 @@ class GDBProcess(pwndbg.dbg_mod.Process):
             else:
                 stop_addr = int(message.split()[-1], 0)
 
+            # Handle case of memory read that wraps around the memory space back to 0, where high memory was readable but memory at 0 was not.
+            # Example: 2-byte read at 0xFFFF_FFFF in a 32-bit address space.
+            # GDB returns error: "Cannot access memory at address 0x0"
+            if stop_addr == 0 and stop_addr < addr:
+                # We could read from the top-portion of memory, but not after wrapping around
+                # Because we are doing a partial read, read until the max address
+                return self.read_memory(addr, pwndbg.aglib.arch.ptrmask - addr)
+
             if stop_addr != addr:
                 return self.read_memory(addr, stop_addr - addr)
 

--- a/pwndbg/dbg/gdb/__init__.py
+++ b/pwndbg/dbg/gdb/__init__.py
@@ -457,7 +457,7 @@ class GDBProcess(pwndbg.dbg_mod.Process):
             if stop_addr == 0 and stop_addr < addr:
                 # We could read from the top-portion of memory, but not after wrapping around
                 # Because we are doing a partial read, read until the max address
-                return self.read_memory(addr, pwndbg.aglib.arch.ptrmask - addr)
+                return self.read_memory(addr, pwndbg.aglib.arch.ptrmask - addr + 1)
 
             if stop_addr != addr:
                 return self.read_memory(addr, stop_addr - addr)


### PR DESCRIPTION
This fixes #2792, which is a crash under a very specific scenario when reading memory.

The crash occurs when the very top-page in memory is memory mapped (in 32-bit, this would be `0xFFFF_F000` to `0xFFFF_FFFF`) and the memory at the first page in memory, address starting at `0`, is not mapped. Then, we attempt to do a memory read that crosses the boundary back to 0, such as a 2-byte read from `0xFFFF_FFFF`.

The GDB memory read handler missed this edge case (when partial=True was passed to the function). Now, if this scenario occurs, we will do a partial read until the max address (0xFFFF_FFFF).
