### PR TITLE
Add special handling for `version` in LLDB Pwndbg

### DIFF
--- a/pwndbg/commands/version.py
+++ b/pwndbg/commands/version.py
@@ -100,7 +100,7 @@ def version_impl() -> None:
     print("\n".join(map(message.system, all_versions())))
 
 
-if not pwndbg.dbg.name() == "lldb":
+if pwndbg.dbg.name() != "lldb":
     # In LLDB, this command is implemented as part of the Pwndbg CLI.
     @pwndbg.commands.ArgparsedCommand(
         "Displays Pwndbg and its important deps versions.", category=CommandCategory.PWNDBG

--- a/pwndbg/commands/version.py
+++ b/pwndbg/commands/version.py
@@ -93,11 +93,20 @@ def get_terminal_size():
     return f"Terminal width: {width_info}, height: {height_info}\n"
 
 
-@pwndbg.commands.ArgparsedCommand(
-    "Displays Pwndbg and its important deps versions.", category=CommandCategory.PWNDBG
-)
-def version() -> None:
+def version_impl() -> None:
+    """
+    Implementation of the `version` command.
+    """
     print("\n".join(map(message.system, all_versions())))
+
+
+if not pwndbg.dbg.name() == "lldb":
+    # In LLDB, this command is implemented as part of the Pwndbg CLI.
+    @pwndbg.commands.ArgparsedCommand(
+        "Displays Pwndbg and its important deps versions.", category=CommandCategory.PWNDBG
+    )
+    def version() -> None:
+        version_impl()
 
 
 bugreport_parser = argparse.ArgumentParser(description="Generate a bug report.")

--- a/pwndbg/dbg/__init__.py
+++ b/pwndbg/dbg/__init__.py
@@ -1134,6 +1134,12 @@ class Debugger:
     # removed or replaced as the porting work continues.
     #
 
+    def name(self) -> Literal["lldb", "gdb"]:
+        """
+        The name of the current debugger.
+        """
+        raise NotImplementedError()
+
     # We'd like to be able to gate some imports off during porting. This aids in
     # that.
     def is_gdblib_available(self) -> bool:

--- a/pwndbg/dbg/gdb/__init__.py
+++ b/pwndbg/dbg/gdb/__init__.py
@@ -1550,6 +1550,10 @@ class GDB(pwndbg.dbg_mod.Debugger):
         return False
 
     @override
+    def name(self) -> Literal["gdb", "lldb"]:
+        return "gdb"
+
+    @override
     def x86_disassembly_flavor(self) -> Literal["att", "intel"]:
         try:
             flavor = gdb.execute("show disassembly-flavor", to_string=True).lower().split('"')[1]

--- a/pwndbg/dbg/lldb/__init__.py
+++ b/pwndbg/dbg/lldb/__init__.py
@@ -2030,6 +2030,10 @@ class LLDB(pwndbg.dbg_mod.Debugger):
         return True
 
     @override
+    def name(self) -> Literal["lldb", "gdb"]:
+        return "lldb"
+
+    @override
     def x86_disassembly_flavor(self) -> Literal["att", "intel"]:
         # Example:
         # (lldb) settings show target.x86-disassembly-flavor

--- a/pwndbg/dbg/lldb/repl/__init__.py
+++ b/pwndbg/dbg/lldb/repl/__init__.py
@@ -366,11 +366,17 @@ def exec_repl_command(
         )
         return True
 
+    # Not allowed to have this be a regular command, because of LLDB.
+    if "version".startswith(line) and line.startswith("ve"):
+        pwndbg.commands.version.version_impl()
+        print()
+        # Don't return. We want the LLDB command to also run.
+
     # There are interactive commands that `SBDebugger.HandleCommand` will
     # silently ignore. We have to implement them manually, here.
-    if "quit".startswith(line) and line.startswith("quit"):
+    if "quit".startswith(line) and line.startswith("q"):
         return False
-    if "exit".startswith(line) and line.startswith("exit"):
+    if "exit".startswith(line) and line.startswith("exi"):
         return False
 
     # `script` is a little weird. Unlike with the other commands we're


### PR DESCRIPTION
Fixes: #2800

`version` is another Pwndbg command that has to alias an LLDB command. This PR adds it to the LLDB Pwndbg CLI, in the same way we handle `set`. This PR also introduces a name component to `pwndbg.dbg.Debugger`, as a means to distinguish between debuggers that's more specific than `is_gdblib_available`, and uses it to gate off installing `version` as a regular command when running under LLDB.

Currently, doing these overrides manually for Pwndbg commands is probably fine, because there's all in all like two of them. But if there end up being more commands like this, we should find a better, more structured way to do it.