### PR TITLE
Add Ctrl+C cancellation support to `ProcessController.run_coroutine`

### DIFF
--- a/pwndbg/dbg/lldb/repl/__init__.py
+++ b/pwndbg/dbg/lldb/repl/__init__.py
@@ -261,6 +261,7 @@ def run(
     # Set ourselves up to respond to SIGINT by interrupting the process if it is
     # running, and doing nothing otherwise.
     def handle_sigint(_sig, _frame):
+        driver.cancel()
         if driver.has_process():
             driver.interrupt()
             print()

--- a/pwndbg/dbg/lldb/repl/proc.py
+++ b/pwndbg/dbg/lldb/repl/proc.py
@@ -71,6 +71,7 @@ class ProcessDriver:
     listener: lldb.SBListener
     debug: bool
     eh: EventHandler
+    cancellation_requested: bool
 
     def __init__(self, event_handler: EventHandler, debug=False):
         self.io = None
@@ -78,6 +79,7 @@ class ProcessDriver:
         self.listener = None
         self.debug = debug
         self.eh = event_handler
+        self.cancellation_requested = False
 
     def has_process(self) -> bool:
         """
@@ -92,7 +94,31 @@ class ProcessDriver:
         """
         return self.process is not None
 
+    def cancel(self) -> None:
+        """
+        Request that a currently ongoing operation be cancelled.
+        """
+        self.cancellation_requested = True
+
+    def _should_cancel(self) -> bool:
+        """
+        Checks whether a cancellation has been requested, and clears cancellation state.
+        """
+        should = self.cancellation_requested
+        self._clear_cancel()
+
+        return should
+
+    def _clear_cancel(self) -> None:
+        """
+        Clears cancellation state.
+        """
+        self.cancellation_requested = False
+
     def interrupt(self) -> None:
+        """
+        Interrupts the currently running process.
+        """
         assert self.has_process(), "called interrupt() on a driver with no process"
         self.process.SendAsyncInterrupt()
 
@@ -287,7 +313,12 @@ class ProcessDriver:
         """
         assert self.has_process(), "called run_coroutine() on a driver with no process"
         exception: Exception | None = None
+        self._clear_cancel()
         while True:
+            if self._should_cancel():
+                # We were requested to cancel the execution controller.
+                exception = CancelledError()
+
             try:
                 if exception is None:
                     step = coroutine.send(None)


### PR DESCRIPTION
This PR is intended to add full cancellation support for `ExecutionController`-based commands.

Currently, Pwndbg only supports cancellation of those commands through LLDB's `SBProcess::SendAsyncInterrupt`, and, while that is usually fine if the execution controller mostly uses `ExecutionController.continue`, #2794 has shown that it is not sufficient for commands such as `stepsyscall`, which use `ExecutionController.single_step`, instead.

This PR adds a mechanism to `ProcessController` that allows it to be notified about external cancellation requests, and code that polls this mechanism during the `run_coroutine` loop, as well as code in the Pwndbg CLI that triggers it on Ctrl+C.

It is important to note that this PR chooses to not change the fact that `ProcessController.run_coroutine` allows execution controllers to override cancellation requests. If an execution controller chooses to catch `CancelledError`, `run_coroutine` will still not stop, even if the cancellation source is the user. This is a choice that is easy to change, however, if it's more desirable that user-requested cancellations be mandatory.