### PR TITLE
CI workflows: disable Arch Linux temporarily

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        images: [ubuntu22.04, ubuntu24.04, debian12, archlinux]
+        images: [ubuntu22.04, ubuntu24.04, debian12] # archlinux - tests fail on arch, see #2796
 
     runs-on: ubuntu-latest
     timeout-minutes: 30


### PR DESCRIPTION
This disables the docker builds of Arch Linux that run tests on CI temporarily until someone fixes it. This is tracked by #2796.

<!-- Please make sure to read the testing and linting instructions at https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md before creating a PR -->
