### PR TITLE
Prefer relative paths for vmmap output

### DIFF
--- a/pwndbg/aglib/vmmap.py
+++ b/pwndbg/aglib/vmmap.py
@@ -7,6 +7,12 @@ import pwndbg.aglib.vmmap_custom
 import pwndbg.lib.cache
 import pwndbg.lib.memory
 
+pwndbg.config.add_param(
+    "vmmap-prefer-relpaths",
+    True,
+    "show relative paths by default in vmmap",
+    param_class=pwndbg.lib.config.PARAM_BOOLEAN,
+)
 
 @pwndbg.lib.cache.cache_until("start", "stop")
 def get() -> Tuple[pwndbg.lib.memory.Page, ...]:

--- a/pwndbg/aglib/vmmap.py
+++ b/pwndbg/aglib/vmmap.py
@@ -14,6 +14,7 @@ pwndbg.config.add_param(
     param_class=pwndbg.lib.config.PARAM_BOOLEAN,
 )
 
+
 @pwndbg.lib.cache.cache_until("start", "stop")
 def get() -> Tuple[pwndbg.lib.memory.Page, ...]:
     return tuple(pwndbg.dbg.selected_inferior().vmmap().ranges())

--- a/pwndbg/commands/vmmap.py
+++ b/pwndbg/commands/vmmap.py
@@ -46,9 +46,10 @@ def print_vmmap_table_header() -> None:
     """
     Prints the table header for the vmmap command.
     """
-    prefer_relpaths = 'on' if pwndbg.config.vmmap_prefer_relpaths else 'off'
+    prefer_relpaths = "on" if pwndbg.config.vmmap_prefer_relpaths else "off"
+    width = 2 + 2 * pwndbg.aglib.arch.ptrsize
     print(
-        f"{'Start':>{2 + 2 * pwndbg.aglib.arch.ptrsize}} {'End':>{2 + 2 * pwndbg.aglib.arch.ptrsize}} {'Perm'} {'Size':>8} {'Offset':>6} "
+        f"{'Start':>{width}} {'End':>{width}} {'Perm'} {'Size':>8} {'Offset':>6} "
         f"{'File'} (set vmmap_prefer_relpaths {prefer_relpaths})"
     )
 

--- a/pwndbg/commands/vmmap.py
+++ b/pwndbg/commands/vmmap.py
@@ -46,8 +46,10 @@ def print_vmmap_table_header() -> None:
     """
     Prints the table header for the vmmap command.
     """
+    prefer_relpaths = 'on' if pwndbg.config.vmmap_prefer_relpaths else 'off'
     print(
-        f"{'Start':>{2 + 2 * pwndbg.aglib.arch.ptrsize}} {'End':>{2 + 2 * pwndbg.aglib.arch.ptrsize}} {'Perm'} {'Size':>8} {'Offset':>6} {'File'}"
+        f"{'Start':>{2 + 2 * pwndbg.aglib.arch.ptrsize}} {'End':>{2 + 2 * pwndbg.aglib.arch.ptrsize}} {'Perm'} {'Size':>8} {'Offset':>6} "
+        f"{'File'} (set vmmap_prefer_relpaths {prefer_relpaths})"
     )
 
 

--- a/pwndbg/lib/memory.py
+++ b/pwndbg/lib/memory.py
@@ -141,8 +141,11 @@ class Page:
 
     def __str__(self) -> str:
         from os.path import relpath
-        rel = relpath(self.objfile)
-        objfile = self.objfile if rel.startswith('../../') else rel
+        if pwndbg.config.vmmap_prefer_relpaths:
+            rel = relpath(self.objfile)
+            objfile = self.objfile if rel.startswith('../../') else rel
+        else:
+            objfile = self.objfile
         return f"{self.vaddr:#{2 + 2 * pwndbg.aglib.arch.ptrsize}x} {self.vaddr + self.memsz:#{2 + 2 * pwndbg.aglib.arch.ptrsize}x} {self.permstr} {self.memsz:8x} {self.offset:6x} {objfile or ''}"
 
     def __repr__(self) -> str:

--- a/pwndbg/lib/memory.py
+++ b/pwndbg/lib/memory.py
@@ -5,6 +5,7 @@ Reading, writing, and describing memory.
 from __future__ import annotations
 
 import os
+from os.path import relpath
 
 import pwndbg.aglib.arch
 
@@ -140,13 +141,14 @@ class Page:
         )
 
     def __str__(self) -> str:
-        from os.path import relpath
         if pwndbg.config.vmmap_prefer_relpaths:
             rel = relpath(self.objfile)
-            objfile = self.objfile if rel.startswith('../../') else rel
+            # Files from the /usr (for example libc) should use the absolute paths
+            objfile = self.objfile if rel.startswith("../../") else rel
         else:
             objfile = self.objfile
-        return f"{self.vaddr:#{2 + 2 * pwndbg.aglib.arch.ptrsize}x} {self.vaddr + self.memsz:#{2 + 2 * pwndbg.aglib.arch.ptrsize}x} {self.permstr} {self.memsz:8x} {self.offset:6x} {objfile or ''}"
+        width = 2 + 2 * pwndbg.aglib.arch.ptrsize
+        return f"{self.vaddr:#{width}x} {self.vaddr + self.memsz:#{width}x} {self.permstr} {self.memsz:8x} {self.offset:6x} {objfile or ''}"
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self.__str__()!r})"

--- a/pwndbg/lib/memory.py
+++ b/pwndbg/lib/memory.py
@@ -140,7 +140,10 @@ class Page:
         )
 
     def __str__(self) -> str:
-        return f"{self.vaddr:#{2 + 2 * pwndbg.aglib.arch.ptrsize}x} {self.vaddr + self.memsz:#{2 + 2 * pwndbg.aglib.arch.ptrsize}x} {self.permstr} {self.memsz:8x} {self.offset:6x} {self.objfile or ''}"
+        from os.path import relpath
+        rel = relpath(self.objfile)
+        objfile = self.objfile if rel.startswith('../../') else rel
+        return f"{self.vaddr:#{2 + 2 * pwndbg.aglib.arch.ptrsize}x} {self.vaddr + self.memsz:#{2 + 2 * pwndbg.aglib.arch.ptrsize}x} {self.permstr} {self.memsz:8x} {self.offset:6x} {objfile or ''}"
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self.__str__()!r})"

--- a/pwndbg/lib/memory.py
+++ b/pwndbg/lib/memory.py
@@ -143,7 +143,8 @@ class Page:
     def __str__(self) -> str:
         if pwndbg.config.vmmap_prefer_relpaths:
             rel = relpath(self.objfile)
-            # Files from the /usr (for example libc) should use the absolute paths
+            # Prefer absolute paths for system files (for example libc) since
+            # `os.path.relpath` returns longer relative paths with no clear benefits.
             objfile = self.objfile if rel.startswith("../../") else rel
         else:
             objfile = self.objfile

--- a/tests/gdb-tests/tests/test_command_vmmap.py
+++ b/tests/gdb-tests/tests/test_command_vmmap.py
@@ -74,6 +74,7 @@ def test_command_vmmap_on_coredump_on_crash_simple_binary(start_binary, unload_f
 
     expected_maps = get_proc_maps()
 
+    gdb.execute("set vmmap-prefer-relpaths off")
     vmmaps = gdb.execute("vmmap", to_string=True).splitlines()
 
     # Basic asserts


### PR DESCRIPTION
Closes #2802

This also adds a new configuration `vmmap-prefer-relpaths` (True by default) to control whether to fallback to use absolute paths.

Tested locally:
```gdb
pwndbg> show vmmap-prefer-relpaths 
Show relative paths by default in vmmap is 'on'.
pwndbg> pipe vmmap  | head -n5
LEGEND: STACK | HEAP | CODE | DATA | WX | RODATA
             Start                End Perm     Size Offset File (set vmmap_prefer_relpaths on)
          0x400000           0x401000 r--p     1000      0 binary
          0x401000           0x402000 r-xp     1000   1000 binary
          0x402000           0x403000 r--p     1000   2000 binary
pwndbg> set vmmap-prefer-relpaths off
Set show relative paths by default in vmmap to 'off'.
pwndbg> pipe vmmap  | head -n5
LEGEND: STACK | HEAP | CODE | DATA | WX | RODATA
             Start                End Perm     Size Offset File (set vmmap_prefer_relpaths off)
          0x400000           0x401000 r--p     1000      0 /home/lzutao/ctfs/2025/swamp/pwn/buffer/binary
          0x401000           0x402000 r-xp     1000   1000 /home/lzutao/ctfs/2025/swamp/pwn/buffer/binary
          0x402000           0x403000 r--p     1000   2000 /home/lzutao/ctfs/2025/swamp/pwn/buffer/binary
```