### PR TITLE
Set cyclic default size to 4

### DIFF
--- a/pwndbg/commands/cyclic.py
+++ b/pwndbg/commands/cyclic.py
@@ -26,8 +26,9 @@ parser.add_argument(
     "-n",
     "--length",
     metavar="length",
+    default=4,
     type=int,
-    help="Size of the unique subsequences (defaults to the pointer size for the current arch)",
+    help="Size of the unique subsequences",
 )
 
 
@@ -69,7 +70,11 @@ def cyclic_cmd(alphabet, length: Optional[int], lookup, count=100, filename="") 
         lookup = pwndbg.commands.fix(lookup, sloppy=True)
 
         if isinstance(lookup, (pwndbg.dbg_mod.Value, int)):
-            lookup = int(lookup).to_bytes(length, pwndbg.aglib.arch.endian)
+            try:
+                lookup = int(lookup).to_bytes(length, pwndbg.aglib.arch.endian)
+            except OverflowError:
+                lookup = int(lookup).to_bytes(pwndbg.aglib.arch.ptrsize, pwndbg.aglib.arch.endian)
+                lookup = lookup[:length]
         elif isinstance(lookup, str):
             lookup = bytes(lookup, "utf-8")
 


### PR DESCRIPTION
If the value is too large to fit in a 4-byte type, a pointer type is tried and the result is cut to fit. This is consistent with Pwntools behaviour, and follows the principle of least surprise.

Ref. Gallopsled/pwntools#2573
Fixes #2812 