### PR TITLE
Highlight breakpoints in `nearpc` output

### DIFF
--- a/pwndbg/aglib/nearpc.py
+++ b/pwndbg/aglib/nearpc.py
@@ -36,6 +36,7 @@ c = ColorConfig(
         ColorParamSpec("symbol", "normal", "color for nearpc command (symbol)"),
         ColorParamSpec("address", "normal", "color for nearpc command (address)"),
         ColorParamSpec("prefix", "none", "color for nearpc command (prefix marker)"),
+        ColorParamSpec("breakpoint", "red", "color for nearpc command (breakpoint marker)"),
         ColorParamSpec("syscall-name", "red", "color for nearpc command (resolved syscall name)"),
         ColorParamSpec("argument", "bold", "color for nearpc command (target argument)"),
         ColorParamSpec(
@@ -57,7 +58,11 @@ nearpc_branch_marker_contiguous = pwndbg.color.theme.add_param(
     "contiguous branch marker line for nearpc command",
 )
 pwndbg.color.theme.add_param("highlight-pc", True, "whether to highlight the current instruction")
+pwndbg.color.theme.add_param("highlight-breakpoints", True, "whether to highlight breakpoints")
 pwndbg.color.theme.add_param("nearpc-prefix", "►", "prefix marker for nearpc command")
+pwndbg.color.theme.add_param(
+    "nearpc-breakpoint-prefix", "b+", "breakpoint marker for nearpc command"
+)
 pwndbg.config.add_param("left-pad-disasm", True, "whether to left-pad disassembly")
 nearpc_lines = pwndbg.config.add_param(
     "nearpc-lines", 10, "number of additional lines to print for the nearpc command"
@@ -168,11 +173,14 @@ def nearpc(
 
     assembly_strings = D.instructions_and_padding(instructions)
 
+    breakpoint_locations = pwndbg.dbg.breakpoint_locations()
+
     # Print out each instruction
     for i, (address_str, symbol, instr, asm) in enumerate(
         zip(addresses, symbols, instructions, assembly_strings)
     ):
         prefix_sign = pwndbg.config.nearpc_prefix
+        breakpoint_sign = pwndbg.config.nearpc_breakpoint_prefix
 
         # Show prefix only on the specified address and don't show it while in repeat-mode
         # or when showing current instruction for the second time
@@ -180,11 +188,21 @@ def nearpc(
         prefix = " %s" % (prefix_sign if show_prefix else " " * len(prefix_sign))
         prefix = c.prefix(prefix)
 
+        is_breakpoint = not show_prefix and instr.address in breakpoint_locations
+        # If the instruction is not the current instruction and a breakpoint,
+        # show the breakpoint sign
+        if is_breakpoint:
+            prefix = c.breakpoint(breakpoint_sign.ljust(len(prefix_sign)))
+
+        # If this instruction is a breakpoint and not the current pc, highlight it.
+        if is_breakpoint and pwndbg.config.highlight_breakpoints:
+            address_str = c.breakpoint(address_str)
+            symbol = c.breakpoint(symbol)
         # Colorize address and symbol if not highlighted
         # symbol is fetched from gdb and it can be e.g. '<main+8>'
         # In case there are duplicate instances of an instruction (tight loop),
         # ones that the instruction pointer is not at stick out a little, to indicate the repetition
-        if not pwndbg.config.highlight_pc or instr.address != pc or repeat:
+        elif not pwndbg.config.highlight_pc or instr.address != pc or repeat:
             address_str = c.address(address_str)
             symbol = c.symbol(symbol)
         elif pwndbg.config.highlight_pc and i == index_of_pc:

--- a/pwndbg/aglib/nearpc.py
+++ b/pwndbg/aglib/nearpc.py
@@ -192,11 +192,11 @@ def nearpc(
         elif instr.address in breakpoint_locations:
             # If the instruction is not the current instruction and a breakpoint,
             # show the breakpoint sign
-            prefix = breakpoint_sign.ljust(len(prefix_sign))
+            prefix = breakpoint_sign.ljust(len(prefix_sign) + 1)
             prefix = c.breakpoint(prefix)
             is_breakpoint = True
         else:
-            prefix = " " * len(prefix_sign)
+            prefix = " " * (len(prefix_sign) + 1)
             prefix = c.prefix(prefix)
 
         # If this instruction is a breakpoint and not the current pc, highlight it.

--- a/pwndbg/aglib/nearpc.py
+++ b/pwndbg/aglib/nearpc.py
@@ -175,24 +175,29 @@ def nearpc(
 
     breakpoint_locations = pwndbg.dbg.breakpoint_locations()
 
+    prefix_sign = pwndbg.config.nearpc_prefix
+    breakpoint_sign = pwndbg.config.nearpc_breakpoint_prefix
+
     # Print out each instruction
     for i, (address_str, symbol, instr, asm) in enumerate(
         zip(addresses, symbols, instructions, assembly_strings)
     ):
-        prefix_sign = pwndbg.config.nearpc_prefix
-        breakpoint_sign = pwndbg.config.nearpc_breakpoint_prefix
-
         # Show prefix only on the specified address and don't show it while in repeat-mode
         # or when showing current instruction for the second time
         show_prefix = instr.address == pc and not repeat and i == index_of_pc
-        prefix = " %s" % (prefix_sign if show_prefix else " " * len(prefix_sign))
-        prefix = c.prefix(prefix)
-
-        is_breakpoint = not show_prefix and instr.address in breakpoint_locations
-        # If the instruction is not the current instruction and a breakpoint,
-        # show the breakpoint sign
-        if is_breakpoint:
-            prefix = c.breakpoint(breakpoint_sign.ljust(len(prefix_sign)))
+        is_breakpoint = False
+        if show_prefix:
+            prefix = f" {prefix_sign}"
+            prefix = c.prefix(prefix)
+        elif instr.address in breakpoint_locations:
+            # If the instruction is not the current instruction and a breakpoint,
+            # show the breakpoint sign
+            prefix = breakpoint_sign.ljust(len(prefix_sign))
+            prefix = c.breakpoint(prefix)
+            is_breakpoint = True
+        else:
+            prefix = " " * len(prefix_sign)
+            prefix = c.prefix(prefix)
 
         # If this instruction is a breakpoint and not the current pc, highlight it.
         if is_breakpoint and pwndbg.config.highlight_breakpoints:

--- a/pwndbg/aglib/nearpc.py
+++ b/pwndbg/aglib/nearpc.py
@@ -176,7 +176,14 @@ def nearpc(
     breakpoint_locations = pwndbg.dbg.breakpoint_locations()
 
     prefix_sign = pwndbg.config.nearpc_prefix
+    current_insn_prefix = f" {prefix_sign}"
+    current_insn_prefix = c.prefix(current_insn_prefix)
+    default_prefix = " " * (len(prefix_sign) + 1)
+    default_prefix = c.prefix(default_prefix)
+
     breakpoint_sign = pwndbg.config.nearpc_breakpoint_prefix
+    breakpoint_prefix = breakpoint_sign.ljust(len(prefix_sign) + 1)
+    breakpoint_prefix = c.breakpoint(breakpoint_prefix)
 
     # Print out each instruction
     for i, (address_str, symbol, instr, asm) in enumerate(
@@ -187,17 +194,14 @@ def nearpc(
         show_prefix = instr.address == pc and not repeat and i == index_of_pc
         is_breakpoint = False
         if show_prefix:
-            prefix = f" {prefix_sign}"
-            prefix = c.prefix(prefix)
+            prefix = current_insn_prefix
         elif instr.address in breakpoint_locations:
             # If the instruction is not the current instruction and a breakpoint,
             # show the breakpoint sign
-            prefix = breakpoint_sign.ljust(len(prefix_sign) + 1)
-            prefix = c.breakpoint(prefix)
+            prefix = breakpoint_prefix
             is_breakpoint = True
         else:
-            prefix = " " * (len(prefix_sign) + 1)
-            prefix = c.prefix(prefix)
+            prefix = default_prefix
 
         # If this instruction is a breakpoint and not the current pc, highlight it.
         if is_breakpoint and pwndbg.config.highlight_breakpoints:

--- a/pwndbg/dbg/__init__.py
+++ b/pwndbg/dbg/__init__.py
@@ -142,6 +142,13 @@ class BreakpointLocation:
     def __init__(self, address: int):
         self.address = address
 
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, BreakpointLocation):
+            return self.address == other.address
+        if isinstance(other, int):
+            return self.address == other
+        return False
+
 
 class WatchpointLocation:
     """
@@ -1142,6 +1149,13 @@ class Debugger:
         """
         Whether breakpoint or watchpoint creation through `break_at` is
         supported during breakpoint stop handlers.
+        """
+        raise NotImplementedError()
+
+    def breakpoint_locations(self) -> List[BreakpointLocation]:
+        """
+        Returns a list of all breakpoint locations that are currently
+        installed and enabled in the focused process.
         """
         raise NotImplementedError()
 

--- a/pwndbg/dbg/gdb/__init__.py
+++ b/pwndbg/dbg/gdb/__init__.py
@@ -1550,6 +1550,36 @@ class GDB(pwndbg.dbg_mod.Debugger):
         return False
 
     @override
+    def breakpoint_locations(self) -> List[pwndbg.dbg_mod.BreakpointLocation]:
+        bps = gdb.breakpoints()
+        locations: List[pwndbg.dbg_mod.BreakpointLocation] = []
+        for bp in bps:
+            if (
+                bp.is_valid()
+                and bp.enabled
+                and bp.type in (gdb.BP_BREAKPOINT, gdb.BP_HARDWARE_BREAKPOINT)
+                and bp.visible
+            ):
+                # GDB 13.1+
+                if hasattr(bp, "locations"):
+                    for location in bp.locations:
+                        locations.append(pwndbg.dbg_mod.BreakpointLocation(location.address))
+                else:
+                    # Num     Type           Disp Enb Address            What
+                    # 1       breakpoint     keep y   0x00007ffff7e90840 in __GI___libc_read at ../sysdeps/unix/sysv/linux/read.c:26
+                    bp_locations = gdb.execute(
+                        f"info breakpoint {bp.number}", to_string=True
+                    ).split("\n")
+                    for line in bp_locations:
+                        try:
+                            address = int(line.split()[4], 16)
+                            locations.append(pwndbg.dbg_mod.BreakpointLocation(address))
+                        except (IndexError, ValueError):
+                            # Ignore lines that don't have an address.
+                            pass
+        return locations
+
+    @override
     def name(self) -> pwndbg.dbg_mod.DebuggerType:
         return pwndbg.dbg_mod.DebuggerType.GDB
 

--- a/pwndbg/dbg/lldb/__init__.py
+++ b/pwndbg/dbg/lldb/__init__.py
@@ -2040,7 +2040,7 @@ class LLDB(pwndbg.dbg_mod.Debugger):
         for bp in bps:
             if bp.IsValid() and bp.IsEnabled():
                 for location in bp.locations:
-                    locations.append(location.GetAddress())
+                    locations.append(location.GetAddress().GetLoadAddress(inferior.target))
         return locations
 
     @override

--- a/pwndbg/dbg/lldb/__init__.py
+++ b/pwndbg/dbg/lldb/__init__.py
@@ -2030,6 +2030,20 @@ class LLDB(pwndbg.dbg_mod.Debugger):
         return True
 
     @override
+    def breakpoint_locations(self) -> List[pwndbg.dbg_mod.BreakpointLocation]:
+        inferior: LLDBProcess = self.selected_inferior()
+        if inferior is None:
+            return []
+
+        bps: List[lldb.SBBreakpoint] = inferior.target.breakpoints
+        locations: List[pwndbg.dbg_mod.BreakpointLocation] = []
+        for bp in bps:
+            if bp.IsValid() and bp.IsEnabled():
+                for location in bp.locations:
+                    locations.append(location.GetAddress())
+        return locations
+
+    @override
     def name(self) -> pwndbg.dbg_mod.DebuggerType:
         return pwndbg.dbg_mod.DebuggerType.LLDB
 

--- a/tests/gdb-tests/tests/test_nearpc.py
+++ b/tests/gdb-tests/tests/test_nearpc.py
@@ -208,6 +208,7 @@ def test_nearpc_highlight_breakpoint(start_binary):
 
     gdb.execute("stepi")
     dis = gdb.execute("nearpc", to_string=True)
+    # When we stop on a breakpoint, we only highlight it (and not show the "b+" marker)
     expected = (
         "   0x400080 <_start>       mov    eax, 0                 EAX => 0\n"
         " ► 0x400085 <_start+5>     mov    edi, 0x1337            EDI => 0x1337\n"

--- a/tests/gdb-tests/tests/test_nearpc.py
+++ b/tests/gdb-tests/tests/test_nearpc.py
@@ -184,3 +184,126 @@ def test_nearpc_opcode_invalid_config():
         )
     except gdb.error as e:
         assert expected == str(e)
+
+
+def test_nearpc_highlight_breakpoint(start_binary):
+    start_binary(SYSCALLS_BINARY)
+    gdb.execute("break *_start+5")
+    gdb.execute("break *_start+22")
+    dis = gdb.execute("nearpc", to_string=True)
+    expected = (
+        " ► 0x400080 <_start>       mov    eax, 0                 EAX => 0\n"
+        "b+ 0x400085 <_start+5>     mov    edi, 0x1337            EDI => 0x1337\n"
+        "   0x40008a <_start+10>    mov    esi, 0xdeadbeef        ESI => 0xdeadbeef\n"
+        "   0x40008f <_start+15>    mov    ecx, 0x10              ECX => 0x10\n"
+        "   0x400094 <_start+20>    syscall \n"
+        "b+ 0x400096 <_start+22>    mov    eax, 0xa               EAX => 0xa\n"
+        "   0x40009b <_start+27>    int    0x80\n"
+        "   0x40009d                add    byte ptr [rax], al\n"
+        "   0x40009f                add    byte ptr [rax], al\n"
+        "   0x4000a1                add    byte ptr [rax], al\n"
+        "   0x4000a3                add    byte ptr [rax], al\n"
+    )
+    assert dis == expected
+
+    gdb.execute("stepi")
+    dis = gdb.execute("nearpc", to_string=True)
+    expected = (
+        "   0x400080 <_start>       mov    eax, 0                 EAX => 0\n"
+        " ► 0x400085 <_start+5>     mov    edi, 0x1337            EDI => 0x1337\n"
+        "   0x40008a <_start+10>    mov    esi, 0xdeadbeef        ESI => 0xdeadbeef\n"
+        "   0x40008f <_start+15>    mov    ecx, 0x10              ECX => 0x10\n"
+        "   0x400094 <_start+20>    syscall \n"
+        "b+ 0x400096 <_start+22>    mov    eax, 0xa               EAX => 0xa\n"
+        "   0x40009b <_start+27>    int    0x80\n"
+        "   0x40009d                add    byte ptr [rax], al\n"
+        "   0x40009f                add    byte ptr [rax], al\n"
+        "   0x4000a1                add    byte ptr [rax], al\n"
+        "   0x4000a3                add    byte ptr [rax], al\n"
+    )
+    assert dis == expected
+
+    gdb.execute("stepi")
+    dis = gdb.execute("nearpc", to_string=True)
+    expected = (
+        "   0x400080 <_start>       mov    eax, 0                 EAX => 0\n"
+        "b+ 0x400085 <_start+5>     mov    edi, 0x1337            EDI => 0x1337\n"
+        " ► 0x40008a <_start+10>    mov    esi, 0xdeadbeef        ESI => 0xdeadbeef\n"
+        "   0x40008f <_start+15>    mov    ecx, 0x10              ECX => 0x10\n"
+        "   0x400094 <_start+20>    syscall \n"
+        "b+ 0x400096 <_start+22>    mov    eax, 0xa               EAX => 0xa\n"
+        "   0x40009b <_start+27>    int    0x80\n"
+        "   0x40009d                add    byte ptr [rax], al\n"
+        "   0x40009f                add    byte ptr [rax], al\n"
+        "   0x4000a1                add    byte ptr [rax], al\n"
+        "   0x4000a3                add    byte ptr [rax], al\n"
+    )
+    assert dis == expected
+
+    gdb.execute("disable breakpoint 1")
+    dis = gdb.execute("nearpc", to_string=True)
+    expected = (
+        "   0x400080 <_start>       mov    eax, 0                 EAX => 0\n"
+        "   0x400085 <_start+5>     mov    edi, 0x1337            EDI => 0x1337\n"
+        " ► 0x40008a <_start+10>    mov    esi, 0xdeadbeef        ESI => 0xdeadbeef\n"
+        "   0x40008f <_start+15>    mov    ecx, 0x10              ECX => 0x10\n"
+        "   0x400094 <_start+20>    syscall \n"
+        "b+ 0x400096 <_start+22>    mov    eax, 0xa               EAX => 0xa\n"
+        "   0x40009b <_start+27>    int    0x80\n"
+        "   0x40009d                add    byte ptr [rax], al\n"
+        "   0x40009f                add    byte ptr [rax], al\n"
+        "   0x4000a1                add    byte ptr [rax], al\n"
+        "   0x4000a3                add    byte ptr [rax], al\n"
+    )
+    assert dis == expected
+
+    gdb.execute("enable breakpoint 1")
+    dis = gdb.execute("nearpc", to_string=True)
+    expected = (
+        "   0x400080 <_start>       mov    eax, 0                 EAX => 0\n"
+        "b+ 0x400085 <_start+5>     mov    edi, 0x1337            EDI => 0x1337\n"
+        " ► 0x40008a <_start+10>    mov    esi, 0xdeadbeef        ESI => 0xdeadbeef\n"
+        "   0x40008f <_start+15>    mov    ecx, 0x10              ECX => 0x10\n"
+        "   0x400094 <_start+20>    syscall \n"
+        "b+ 0x400096 <_start+22>    mov    eax, 0xa               EAX => 0xa\n"
+        "   0x40009b <_start+27>    int    0x80\n"
+        "   0x40009d                add    byte ptr [rax], al\n"
+        "   0x40009f                add    byte ptr [rax], al\n"
+        "   0x4000a1                add    byte ptr [rax], al\n"
+        "   0x4000a3                add    byte ptr [rax], al\n"
+    )
+    assert dis == expected
+
+    gdb.execute("delete breakpoint 1")
+    dis = gdb.execute("nearpc", to_string=True)
+    expected = (
+        "   0x400080 <_start>       mov    eax, 0                 EAX => 0\n"
+        "   0x400085 <_start+5>     mov    edi, 0x1337            EDI => 0x1337\n"
+        " ► 0x40008a <_start+10>    mov    esi, 0xdeadbeef        ESI => 0xdeadbeef\n"
+        "   0x40008f <_start+15>    mov    ecx, 0x10              ECX => 0x10\n"
+        "   0x400094 <_start+20>    syscall \n"
+        "b+ 0x400096 <_start+22>    mov    eax, 0xa               EAX => 0xa\n"
+        "   0x40009b <_start+27>    int    0x80\n"
+        "   0x40009d                add    byte ptr [rax], al\n"
+        "   0x40009f                add    byte ptr [rax], al\n"
+        "   0x4000a1                add    byte ptr [rax], al\n"
+        "   0x4000a3                add    byte ptr [rax], al\n"
+    )
+    assert dis == expected
+
+    gdb.execute("delete breakpoint 2")
+    dis = gdb.execute("nearpc", to_string=True)
+    expected = (
+        "   0x400080 <_start>       mov    eax, 0                 EAX => 0\n"
+        "   0x400085 <_start+5>     mov    edi, 0x1337            EDI => 0x1337\n"
+        " ► 0x40008a <_start+10>    mov    esi, 0xdeadbeef        ESI => 0xdeadbeef\n"
+        "   0x40008f <_start+15>    mov    ecx, 0x10              ECX => 0x10\n"
+        "   0x400094 <_start+20>    syscall \n"
+        "   0x400096 <_start+22>    mov    eax, 0xa               EAX => 0xa\n"
+        "   0x40009b <_start+27>    int    0x80\n"
+        "   0x40009d                add    byte ptr [rax], al\n"
+        "   0x40009f                add    byte ptr [rax], al\n"
+        "   0x4000a1                add    byte ptr [rax], al\n"
+        "   0x4000a3                add    byte ptr [rax], al\n"
+    )
+    assert dis == expected


### PR DESCRIPTION
Add visual indication for breakpoints in the `nearpc` output. Addresses in the disassembly which have an active breakpoint attached to them are prefixed using by `b+` and highlighted in red by default.

This can be configured using the new `highlight-breakpoints`, `nearpc-breakpoint`, and `nearpc-breakpoint-color` theme config options.

~~I only did proper tests on gdb, sorry.~~ Are there benchmarks to see if this slows `nearpc` down too bad?

Fixes #2783

![grafik](https://github.com/user-attachments/assets/37e9a13b-2550-4893-ab31-769fd57d8a05)
![grafik](https://github.com/user-attachments/assets/6f06ef0c-7c86-4313-b159-cd4f878cfd21)
