### PR TITLE
Check if the address is valid when using hexdump

### DIFF
--- a/pwndbg/commands/hexdump.py
+++ b/pwndbg/commands/hexdump.py
@@ -77,6 +77,9 @@ def hexdump(address, count=pwndbg.config.hexdump_bytes) -> None:
         hexdump.offset = 0
 
     address = int(address)
+    if not pwndbg.aglib.memory.peek(address):
+        print("Could not read memory at specified address")
+        return
     if address > pwndbg.aglib.arch.ptrmask:
         new_address = address & pwndbg.aglib.arch.ptrmask
         print(

--- a/tests/gdb-tests/tests/test_hexdump.py
+++ b/tests/gdb-tests/tests/test_hexdump.py
@@ -21,7 +21,7 @@ def run_tests(stack, use_big_endian, expected):
 
     # Test empty hexdump
     result = gdb.execute("hexdump 0", to_string=True)
-    assert result == "+0000 0x000000  \n"
+    assert result == "Could not read memory at specified address\n"
 
     results = []
     # TODO: Repetition is not working in tests


### PR DESCRIPTION
I used the same approach telescope uses to check if the address is valid by peeking at it.
There is also a change at the test that checks an empty hexdump

Closes #2832 