### PR TITLE
Moving the check condition of hexdump invalid addresses

### DIFF
--- a/pwndbg/commands/hexdump.py
+++ b/pwndbg/commands/hexdump.py
@@ -77,9 +77,6 @@ def hexdump(address, count=pwndbg.config.hexdump_bytes) -> None:
         hexdump.offset = 0
 
     address = int(address)
-    if not pwndbg.aglib.memory.peek(address):
-        print("Could not read memory at specified address")
-        return
     if address > pwndbg.aglib.arch.ptrmask:
         new_address = address & pwndbg.aglib.arch.ptrmask
         print(
@@ -88,6 +85,10 @@ def hexdump(address, count=pwndbg.config.hexdump_bytes) -> None:
             new_address,
         )
         address = new_address
+
+    if not pwndbg.aglib.memory.peek(address):
+        print("Could not read memory at specified address")
+        return
 
     count = max(int(count), 0)
 


### PR DESCRIPTION
Move the check of invalid addresses to after the `if address > pwndbg.aglib.arch.ptrmask:` check

This is a fix of PR #2833