### PR TITLE
Fix read_memory

### DIFF
--- a/pwndbg/dbg/gdb/__init__.py
+++ b/pwndbg/dbg/gdb/__init__.py
@@ -430,54 +430,70 @@ class GDBProcess(pwndbg.dbg_mod.Process):
         pages.sort()
         return GDBMemoryMap(qemu, pages)
 
+    def _find_memory_last_readable(self, start: int, count: int) -> int:
+        end = start + count
+        result = -1
+
+        def _is_readable(addr) -> bool:
+            try:
+                self.read_memory(addr, 1)
+                return True
+            except pwndbg.dbg_mod.Error:
+                return False
+
+        if not _is_readable(start):
+            return result
+
+        while start <= end:
+            mid = (start + end + 1) // 2
+            if _is_readable(mid):
+                result = mid
+                start = mid + 1
+            else:
+                end = mid - 1
+
+        return result
+
     @override
     def read_memory(self, address: int, size: int, partial: bool = False) -> bytearray:
-        result = b""
         count = max(int(size), 0)
         addr = address
 
         try:
             result = gdb.selected_inferior().read_memory(addr, count)
+            return bytearray(result)
         except gdb.error as e:
             if not partial:
                 raise pwndbg.dbg_mod.Error(e)
 
-            message = str(e)
-
-            stop_addr = addr
-            match = re.search(r"Memory at address (\w+) unavailable\.", message)
-            if match:
-                stop_addr = int(match.group(1), 0)
+            if pwndbg.aglib.remote.is_remote():
+                # GDB remote debugging will return the start address as the failed
+                # read address. Try moving back a few pages at a time.
+                stop_addr = self._find_memory_last_readable(addr, count)
+                if stop_addr > 0:
+                    return self.read_memory(addr, stop_addr - addr + 1)
             else:
-                stop_addr = int(message.split()[-1], 0)
+                message = str(e)
 
-            # Handle case of memory read that wraps around the memory space back to 0, where high memory was readable but memory at 0 was not.
-            # Example: 2-byte read at 0xFFFF_FFFF in a 32-bit address space.
-            # GDB returns error: "Cannot access memory at address 0x0"
-            if stop_addr == 0 and stop_addr < addr:
-                # We could read from the top-portion of memory, but not after wrapping around
-                # Because we are doing a partial read, read until the max address
-                return self.read_memory(addr, pwndbg.aglib.arch.ptrmask - addr + 1)
+                stop_addr = addr
+                match = re.search(r"Memory at address (\w+) unavailable\.", message)
+                if match:
+                    stop_addr = int(match.group(1), 0)
+                else:
+                    stop_addr = int(message.split()[-1], 0)
 
-            if stop_addr != addr:
-                return self.read_memory(addr, stop_addr - addr)
+                # Handle case of memory read that wraps around the memory space back to 0, where high memory was readable but memory at 0 was not.
+                # Example: 2-byte read at 0xFFFF_FFFF in a 32-bit address space.
+                # GDB returns error: "Cannot access memory at address 0x0"
+                if stop_addr == 0 and stop_addr < addr:
+                    # We could read from the top-portion of memory, but not after wrapping around
+                    # Because we are doing a partial read, read until the max address
+                    return self.read_memory(addr, pwndbg.aglib.arch.ptrmask - addr + 1)
 
-            # QEMU will return the start address as the failed
-            # read address.  Try moving back a few pages at a time.
-            stop_addr = addr + count
+                if stop_addr > addr:
+                    return self.read_memory(addr, stop_addr - addr)
 
-            # Move the stop address down to the previous page boundary
-            stop_addr &= PAGE_MASK
-            while stop_addr > addr:
-                result = self.read_memory(addr, stop_addr - addr)
-
-                if result:
-                    return bytearray(result)
-
-                # Move down by another page
-                stop_addr -= PAGE_SIZE
-
-        return bytearray(result)
+        raise pwndbg.dbg_mod.Error(f"Cannot access memory at address 0x{address:x}")
 
     @override
     def write_memory(self, address: int, data: bytearray, partial: bool = False) -> int:

--- a/pwndbg/dbg/gdb/__init__.py
+++ b/pwndbg/dbg/gdb/__init__.py
@@ -430,23 +430,23 @@ class GDBProcess(pwndbg.dbg_mod.Process):
         pages.sort()
         return GDBMemoryMap(qemu, pages)
 
+    def _is_memory_readable(self, addr: int) -> bool:
+        try:
+            gdb.selected_inferior().read_memory(addr, 1)
+            return True
+        except gdb.error:
+            return False
+
     def _find_memory_last_readable(self, start: int, count: int) -> int:
         end = start + count
         result = -1
 
-        def _is_readable(addr) -> bool:
-            try:
-                self.read_memory(addr, 1)
-                return True
-            except pwndbg.dbg_mod.Error:
-                return False
-
-        if not _is_readable(start):
+        if not self._is_memory_readable(start):
             return result
 
         while start <= end:
             mid = (start + end + 1) // 2
-            if _is_readable(mid):
+            if self._is_memory_readable(mid):
                 result = mid
                 start = mid + 1
             else:
@@ -466,16 +466,8 @@ class GDBProcess(pwndbg.dbg_mod.Process):
             if not partial:
                 raise pwndbg.dbg_mod.Error(e)
 
-            if pwndbg.aglib.remote.is_remote():
-                # GDB remote debugging will return the start address as the failed
-                # read address. Try moving back a few pages at a time.
-                stop_addr = self._find_memory_last_readable(addr, count)
-                if stop_addr > 0:
-                    return self.read_memory(addr, stop_addr - addr + 1)
-            else:
+            if not pwndbg.aglib.remote.is_remote():
                 message = str(e)
-
-                stop_addr = addr
                 match = re.search(r"Memory at address (\w+) unavailable\.", message)
                 if match:
                     stop_addr = int(match.group(1), 0)
@@ -492,6 +484,18 @@ class GDBProcess(pwndbg.dbg_mod.Process):
 
                 if stop_addr > addr:
                     return self.read_memory(addr, stop_addr - addr)
+            else:
+                # Handle the case of remote debugging, where GDB's remote protocol
+                # returns the start address as the failed read address instead of the stop address.
+                # This is a limitation in how GDB handles the remote protocol, and while it could
+                # be fixed, it currently behaves this way.
+                #
+                # To work around this, we perform a binary search in the `_find_memory_last_readable` method
+                # to find the correct stop address that avoids the failure.
+                #
+                # For local debugging, this issue does not occur, and we proceed with the normal flow.
+                if (stop_addr := self._find_memory_last_readable(addr, count)) > 0:
+                    return self.read_memory(addr, stop_addr - addr + 1)
 
             raise pwndbg.dbg_mod.Error(e)
 

--- a/pwndbg/dbg/gdb/__init__.py
+++ b/pwndbg/dbg/gdb/__init__.py
@@ -493,7 +493,7 @@ class GDBProcess(pwndbg.dbg_mod.Process):
                 if stop_addr > addr:
                     return self.read_memory(addr, stop_addr - addr)
 
-        raise pwndbg.dbg_mod.Error(f"Cannot access memory at address 0x{address:x}")
+            raise pwndbg.dbg_mod.Error(e)
 
     @override
     def write_memory(self, address: int, data: bytearray, partial: bool = False) -> int:

--- a/pwndbg/dbg/lldb/__init__.py
+++ b/pwndbg/dbg/lldb/__init__.py
@@ -939,7 +939,7 @@ class LLDBProcess(pwndbg.dbg_mod.Process):
         e = lldb.SBError()
         buffer = self.process.ReadMemory(address, size, e)
         if buffer:
-            return buffer
+            return bytearray(buffer)
         elif not partial:
             raise pwndbg.dbg_mod.Error(f"could not read {size:#x} bytes: {e}")
 

--- a/tests/qemu-tests/tests/user/test_aarch64.py
+++ b/tests/qemu-tests/tests/user/test_aarch64.py
@@ -6,6 +6,7 @@ from capstone.arm64_const import ARM64_INS_BL
 
 import pwndbg.aglib.disasm
 import pwndbg.aglib.nearpc
+import pwndbg.aglib.stack
 import pwndbg.aglib.symbol
 import pwndbg.dbg
 from pwndbg.aglib.disasm.instruction import InstructionCondition
@@ -463,3 +464,42 @@ def test_aarch64_reference(qemu_start_binary):
     gdb.execute("piebase", to_string=True)
 
     gdb.execute("nextret", to_string=True)
+
+
+def test_memory_read_error_handling(qemu_assembly_run):
+    """
+    This test ensures that memory access errors are correctly handled and partial reads
+    are attempted when possible. Specifically, it tests that the function can handle
+    memory access failures at different address ranges and report the correct result.
+    """
+    qemu_assembly_run(SIMPLE_FUNCTION, "aarch64")
+
+    # Get the stack pointer address
+    stack_end_addr = list(pwndbg.aglib.stack.get().values())[0].end
+
+    result = pwndbg.dbg.selected_inferior().read_memory(stack_end_addr - 0xff, 0xff, partial=False)
+    assert len(result) == 0xff, f"Expected 0xff bytes, but got {len(result)}"
+
+    try:
+        pwndbg.dbg.selected_inferior().read_memory(stack_end_addr - 0xfe, 0xff, partial=False)
+        assert False, "Expected Error due to inaccessible memory address."
+    except pwndbg.dbg_mod.Error as e:
+        pass
+
+    result = pwndbg.dbg.selected_inferior().read_memory(stack_end_addr - 0xff, 0xff, partial=True)
+    assert len(result) == 0xff, f"Expected 0xff bytes, but got {len(result)}"
+
+    result = pwndbg.dbg.selected_inferior().read_memory(stack_end_addr - 0x10, 0xff, partial=True)
+    assert len(result) == 0x10, f"Expected 0x10 bytes, but got {len(result)}"
+
+    result = pwndbg.dbg.selected_inferior().read_memory(stack_end_addr - 0x2, 0xff, partial=True)
+    assert len(result) == 0x2, f"Expected 0x2 bytes, but got {len(result)}"
+
+    result = pwndbg.dbg.selected_inferior().read_memory(stack_end_addr - 0x1, 0xff, partial=True)
+    assert len(result) == 0x1, f"Expected 0x1 byte, but got {len(result)}"
+
+    try:
+        pwndbg.dbg.selected_inferior().read_memory(stack_end_addr - 0x0, 0xff, partial=True)
+        assert False, "Expected Error due to inaccessible memory address."
+    except pwndbg.dbg_mod.Error as e:
+        pass

--- a/tests/qemu-tests/tests/user/test_aarch64.py
+++ b/tests/qemu-tests/tests/user/test_aarch64.py
@@ -474,8 +474,16 @@ def test_memory_read_error_handling(qemu_assembly_run):
     """
     qemu_assembly_run(SIMPLE_FUNCTION, "aarch64")
 
-    # Get the stack pointer address
-    stack_end_addr = list(pwndbg.aglib.stack.get().values())[0].end
+    # Find the first memory page where there is a gap after it
+    stack_end_addr = -1
+    page_prev = None
+    for page in pwndbg.dbg.selected_inferior().vmmap().ranges():
+        if page_prev is not None and page_prev.end != page.start:
+            stack_end_addr = page_prev.end
+            break
+        page_prev = page
+
+    assert stack_end_addr != -1, "Failed to find a memory page followed by a gap"
 
     result = pwndbg.dbg.selected_inferior().read_memory(stack_end_addr - 0xFF, 0xFF, partial=False)
     assert len(result) == 0xFF, f"Expected 0xff bytes, but got {len(result)}"

--- a/tests/qemu-tests/tests/user/test_aarch64.py
+++ b/tests/qemu-tests/tests/user/test_aarch64.py
@@ -477,29 +477,29 @@ def test_memory_read_error_handling(qemu_assembly_run):
     # Get the stack pointer address
     stack_end_addr = list(pwndbg.aglib.stack.get().values())[0].end
 
-    result = pwndbg.dbg.selected_inferior().read_memory(stack_end_addr - 0xff, 0xff, partial=False)
-    assert len(result) == 0xff, f"Expected 0xff bytes, but got {len(result)}"
+    result = pwndbg.dbg.selected_inferior().read_memory(stack_end_addr - 0xFF, 0xFF, partial=False)
+    assert len(result) == 0xFF, f"Expected 0xff bytes, but got {len(result)}"
 
     try:
-        pwndbg.dbg.selected_inferior().read_memory(stack_end_addr - 0xfe, 0xff, partial=False)
+        pwndbg.dbg.selected_inferior().read_memory(stack_end_addr - 0xFE, 0xFF, partial=False)
         assert False, "Expected Error due to inaccessible memory address."
-    except pwndbg.dbg_mod.Error as e:
+    except pwndbg.dbg_mod.Error:
         pass
 
-    result = pwndbg.dbg.selected_inferior().read_memory(stack_end_addr - 0xff, 0xff, partial=True)
-    assert len(result) == 0xff, f"Expected 0xff bytes, but got {len(result)}"
+    result = pwndbg.dbg.selected_inferior().read_memory(stack_end_addr - 0xFF, 0xFF, partial=True)
+    assert len(result) == 0xFF, f"Expected 0xff bytes, but got {len(result)}"
 
-    result = pwndbg.dbg.selected_inferior().read_memory(stack_end_addr - 0x10, 0xff, partial=True)
+    result = pwndbg.dbg.selected_inferior().read_memory(stack_end_addr - 0x10, 0xFF, partial=True)
     assert len(result) == 0x10, f"Expected 0x10 bytes, but got {len(result)}"
 
-    result = pwndbg.dbg.selected_inferior().read_memory(stack_end_addr - 0x2, 0xff, partial=True)
+    result = pwndbg.dbg.selected_inferior().read_memory(stack_end_addr - 0x2, 0xFF, partial=True)
     assert len(result) == 0x2, f"Expected 0x2 bytes, but got {len(result)}"
 
-    result = pwndbg.dbg.selected_inferior().read_memory(stack_end_addr - 0x1, 0xff, partial=True)
+    result = pwndbg.dbg.selected_inferior().read_memory(stack_end_addr - 0x1, 0xFF, partial=True)
     assert len(result) == 0x1, f"Expected 0x1 byte, but got {len(result)}"
 
     try:
-        pwndbg.dbg.selected_inferior().read_memory(stack_end_addr - 0x0, 0xff, partial=True)
+        pwndbg.dbg.selected_inferior().read_memory(stack_end_addr - 0x0, 0xFF, partial=True)
         assert False, "Expected Error due to inaccessible memory address."
-    except pwndbg.dbg_mod.Error as e:
+    except pwndbg.dbg_mod.Error:
         pass


### PR DESCRIPTION
Before:
<img width="562" alt="image" src="https://github.com/user-attachments/assets/70fae681-b582-4485-a43a-a5caf4e67a87" />

After:
```python
pwndbg> ipi

In [1]: pwndbg.dbg.selected_inferior().read_memory(0x1000000000000-0xff, 0xff, True)
Out[1]: bytearray(b'yr900dz34md3p-gdb-15.2/lib -L/nix/store/ibk04bmmyf4rrj139ppyr900dz34md3p-gdb-15.2/lib\x00nativeBuildInputs=\x00__CF_USER_TEXT_ENCODING=0x1F5:0x1D:0x2A\x00name=shell\x00depsHostHostPropagated=\x00/nix/store/4q0wb123xfksdvq23fz3d1qqmm6ncd6p-hello-2.12.1/bin/hello\x00\x00\x00\x00\x00\x00\x00\x00\x00')

In [2]: pwndbg.dbg.selected_inferior().read_memory(0x1000000000000-0x10, 0xff, True)
_is_readable 0x1000000000070 False
_is_readable 0x1000000000030 False
_is_readable 0x1000000000010 False
_is_readable 0x1000000000000 False
_is_readable 0xfffffffffff8 True
_is_readable 0xfffffffffffc True
_is_readable 0xfffffffffffe True
_is_readable 0xffffffffffff True
Out[2]: bytearray(b'n/hello\x00\x00\x00\x00\x00\x00\x00\x00\x00')

In [3]: pwndbg.dbg.selected_inferior().read_memory(0x1000000000000-0x2, 0xff, True)
_is_readable 0x100000000007e False
_is_readable 0x100000000003e False
_is_readable 0x100000000001e False
_is_readable 0x100000000000e False
_is_readable 0x1000000000006 False
_is_readable 0x1000000000002 False
_is_readable 0x1000000000000 False
_is_readable 0xffffffffffff True
Out[3]: bytearray(b'\x00\x00')

In [4]: pwndbg.dbg.selected_inferior().read_memory(0x1000000000000-0x1, 0xff, True)
_is_readable 0x100000000007f False
_is_readable 0x100000000003f False
_is_readable 0x100000000001f False
_is_readable 0x100000000000f False
_is_readable 0x1000000000007 False
_is_readable 0x1000000000003 False
_is_readable 0x1000000000001 False
_is_readable 0x1000000000000 False
_is_readable 0xffffffffffff True
Out[4]: bytearray(b'\x00')

In [5]: pwndbg.dbg.selected_inferior().read_memory(0x1000000000000-0x0, 0xff, True)
---------------------------------------------------------------------------
MemoryError                               Traceback (most recent call last)
File /nix/store/w50mwxpn0ay1yi1928bgidqpkys5xq56-pwndbg/share/pwndbg/pwndbg/dbg/gdb/__init__.py:463, in GDBProcess.read_memory(self, address, size, partial)
    462 try:
--> 463     result = gdb.selected_inferior().read_memory(addr, count)
    464     return bytearray(result)

MemoryError: Cannot access memory at address 0x1000000000000

During handling of the above exception, another exception occurred:

Error                                     Traceback (most recent call last)
Cell In[2], line 1
----> 1 pwndbg.dbg.selected_inferior().read_memory(0x1000000000000-0x0, 0x3, True)

File /nix/store/w50mwxpn0ay1yi1928bgidqpkys5xq56-pwndbg/share/pwndbg/pwndbg/dbg/gdb/__init__.py:496, in GDBProcess.read_memory(self, address, size, partial)
    493     if stop_addr > addr:
    494         return self.read_memory(addr, stop_addr - addr)
--> 496 raise pwndbg.dbg_mod.Error(e)

Error: Cannot access memory at address 0x1000000000000
```