### PR TITLE
add libcinfo command

### DIFF
--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -750,6 +750,7 @@ def load_commands() -> None:
     import pwndbg.commands.knft
     import pwndbg.commands.kversion
     import pwndbg.commands.leakfind
+    import pwndbg.commands.libcinfo
     import pwndbg.commands.linkmap
     import pwndbg.commands.memoize
     import pwndbg.commands.misc

--- a/pwndbg/commands/libcinfo.py
+++ b/pwndbg/commands/libcinfo.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import pwndbg.commands
+import pwndbg.glibc
+from pwndbg.commands import CommandCategory
+
+
+@pwndbg.commands.ArgparsedCommand(
+    "Show libc version and link to its sources", category=CommandCategory.LINUX
+)
+@pwndbg.commands.OnlyWhenRunning
+def libcinfo():
+    glibc_version = pwndbg.glibc.get_version()
+
+    if glibc_version:
+        glibc_version = ".".join(map(str, glibc_version))
+        print(f"libc version: {glibc_version}")
+        print(f"libc source link: https://ftp.gnu.org/gnu/libc/glibc-{glibc_version}.tar.gz")
+        return
+
+    print("Could not determine libc version.")


### PR DESCRIPTION
This command shows libc version of currently debugged binary and link to its sources.

Currently it only supports glibc and shows link to raw/pure gnu.org glibc sources. Meaning, it does not handle custom/patched glibc versions that may be there on Ubuntu etc.

In the future this command could support other libcs (like musl used by Alpine) or/and display the binary build_id and maybe a link to libcdb.

<!-- Please make sure to read the testing and linting instructions at https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md before creating a PR -->
