### PR TITLE
add strings.yield_in_page, refactor strings command

### DIFF
--- a/pwndbg/aglib/strings.py
+++ b/pwndbg/aglib/strings.py
@@ -60,7 +60,7 @@ def yield_in_page(page: Page, n=4) -> Iterator[str]:
     """Yields strings of length >= n found in a given vmmap page"""
     try:
         data = pwndbg.aglib.memory.read(addr=page.vaddr, count=page.memsz, partial=True)
-    except:
+    except pwndbg.dbg_mod.Error:
         # E.g. we cannot read [vvar] page even though it has a READ permission
         return
 

--- a/pwndbg/aglib/strings.py
+++ b/pwndbg/aglib/strings.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import re
 import string
-from typing import List
+from typing import Iterator
 
 import pwndbg
 import pwndbg.aglib.memory
@@ -56,9 +56,9 @@ def get(address: int, maxlen: int | None = None, maxread: int | None = None) -> 
     return sz[:maxlen] + "..."
 
 
-def yield_in_page(page: Page, n=4) -> List[str]:
+def yield_in_page(page: Page, n=4) -> Iterator[str]:
     """Yields strings of length >= n found in a given vmmap page"""
-    data = pwndbg.aglib.memory.read(addr=page.vaddr, count=page.memsz)
+    data = pwndbg.aglib.memory.read(addr=page.vaddr, count=page.memsz, partial=True)
 
     for match in re.finditer(rb"[ -~]{%d,}" % n, data):
         decoded_str = match.group().decode("ascii", errors="ignore")

--- a/pwndbg/aglib/strings.py
+++ b/pwndbg/aglib/strings.py
@@ -5,10 +5,13 @@ the debuggee's address space.
 
 from __future__ import annotations
 
+import re
 import string
+from typing import List
 
 import pwndbg
 import pwndbg.aglib.memory
+from pwndbg.lib.memory import Page
 
 length = 15
 
@@ -51,3 +54,12 @@ def get(address: int, maxlen: int | None = None, maxread: int | None = None) -> 
         return sz
 
     return sz[:maxlen] + "..."
+
+
+def yield_in_page(page: Page, n=4) -> List[str]:
+    """Yields strings of length >= n found in a given vmmap page"""
+    data = pwndbg.aglib.memory.read(addr=page.vaddr, count=page.memsz)
+
+    for match in re.finditer(rb"[ -~]{%d,}" % n, data):
+        decoded_str = match.group().decode("ascii", errors="ignore")
+        yield decoded_str

--- a/pwndbg/aglib/strings.py
+++ b/pwndbg/aglib/strings.py
@@ -58,7 +58,11 @@ def get(address: int, maxlen: int | None = None, maxread: int | None = None) -> 
 
 def yield_in_page(page: Page, n=4) -> Iterator[str]:
     """Yields strings of length >= n found in a given vmmap page"""
-    data = pwndbg.aglib.memory.read(addr=page.vaddr, count=page.memsz, partial=True)
+    try:
+        data = pwndbg.aglib.memory.read(addr=page.vaddr, count=page.memsz, partial=True)
+    except:
+        # E.g. we cannot read [vvar] page even though it has a READ permission
+        return
 
     for match in re.finditer(rb"[ -~]{%d,}" % n, data):
         decoded_str = match.group().decode("ascii", errors="ignore")

--- a/pwndbg/commands/strings.py
+++ b/pwndbg/commands/strings.py
@@ -44,4 +44,5 @@ def strings(n: int = 4, page_names: List[str] = [], save_as: str = None):
         for string in pwndbg.aglib.strings.yield_in_page(page, n):
             print(string, file=f)
 
-    f.close()
+    if f:
+        f.close()

--- a/pwndbg/commands/strings.py
+++ b/pwndbg/commands/strings.py
@@ -41,11 +41,7 @@ def strings(n: int = 4, page_names: List[str] = [], save_as: str = None):
     f = open(save_as, "w") if save_as else None
 
     for page in pages:
-        strings_iter = pwndbg.aglib.strings.yield_in_page(page, n)
-
-        if not save_as:
-            for string in strings_iter:
-                print(string, file=f)
-            continue
+        for string in pwndbg.aglib.strings.yield_in_page(page, n):
+            print(string, file=f)
 
     f.close()

--- a/pwndbg/commands/strings.py
+++ b/pwndbg/commands/strings.py
@@ -1,14 +1,12 @@
 from __future__ import annotations
 
 import argparse
-import re
 from typing import List
 
 import pwndbg
 import pwndbg.aglib.memory
 import pwndbg.commands
 from pwndbg.commands import CommandCategory
-from pwndbg.lib.memory import Page
 
 parser = argparse.ArgumentParser(
     description="Extracts and displays ASCII strings from readable memory pages of the debugged process."
@@ -33,30 +31,21 @@ parser.add_argument(
 @pwndbg.commands.ArgparsedCommand(parser, category=CommandCategory.LINUX)
 @pwndbg.commands.OnlyWhenRunning
 def strings(n: int = 4, page_names: List[str] = [], save_as: str = None):
-    # Extract pages with PROT_READ permission
-    readable_pages: List[Page] = [page for page in pwndbg.aglib.vmmap.get() if page.read]
+    # Get only readable pages and those that match the page_names filter
+    pages = (
+        p
+        for p in pwndbg.aglib.vmmap.get()
+        if p.read and ((not page_names) or any(name in p.objfile for name in page_names))
+    )
 
-    for page in readable_pages:
-        if page_names and not any(name in page.objfile for name in page_names):
-            continue  # skip if page does not belong to any of the specified mappings
+    f = open(save_as, "w") if save_as else None
 
-        count = page.memsz
-        start_address = page.vaddr
-
-        try:
-            data = pwndbg.aglib.memory.read(addr=start_address, count=count)
-        except pwndbg.dbg_mod.Error as e:
-            print(f"Skipping inaccessible page at {start_address:#x}: {e}")
-            continue  # skip if access is denied
-
-        # all strings in the `data`
-        strings: List[bytes] = re.findall(rb"[ -~]{%d,}" % n, data)
-        decoded_strings: List[str] = [s.decode("ascii", errors="ignore") for s in strings]
+    for page in pages:
+        strings_iter = pwndbg.aglib.strings.yield_in_page(page, n)
 
         if not save_as:
-            for string in decoded_strings:
-                print(string)
+            for string in strings_iter:
+                print(string, file=f)
             continue
 
-        with open(save_as, "w") as f:
-            f.writelines(string + "\n" for string in decoded_strings)
+    f.close()


### PR DESCRIPTION
This commit adds a `pwndbg.aglib.strings.yield_in_page` function that yields all strings in a given memory page.

It also refactors the `pwndbg.commands.strings` command to use this feature.

<!-- Please make sure to read the testing and linting instructions at https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md before creating a PR -->
