### PR TITLE
Build docs in strict mode

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Build site
         run: |
           # --only-group doesn't work with api-autonav (why?)
-          uv run --group docs mkdocs build
+          uv run --group docs mkdocs build --strict
 
   deploy:
     if: github.event_name == 'push' && contains(fromJson('["refs/heads/dev"]'), github.ref)
@@ -41,4 +41,4 @@ jobs:
 
       - name: Deploy site
         run: |
-          uv run --group docs mkdocs gh-deploy --force
+          uv run --group docs mkdocs gh-deploy --strict --force

--- a/pwndbg/aglib/heap/heap.py
+++ b/pwndbg/aglib/heap/heap.py
@@ -17,7 +17,7 @@ class MemoryAllocator:
         """Returns a textual summary of the specified address.
 
         Arguments:
-            address(int): Address of the heap block to summarize.
+            address: Address of the heap block to summarize.
 
         Returns:
             A string.
@@ -28,7 +28,7 @@ class MemoryAllocator:
         """Returns the address of the allocation which contains 'address'.
 
         Arguments:
-            address(int): Address to look up.
+            address: Address to look up.
 
         Returns:
             An integer.

--- a/pwndbg/aglib/memory.py
+++ b/pwndbg/aglib/memory.py
@@ -24,12 +24,12 @@ def read(addr: int, count: int, partial: bool = False) -> bytearray:
     Read memory from the program being debugged.
 
     Arguments:
-        addr(int): Address to read
-        count(int): Number of bytes to read
-        partial(bool): Whether less than ``count`` bytes can be returned
+        addr: Address to read
+        count: Number of bytes to read
+        partial: Whether less than ``count`` bytes can be returned
 
     Returns:
-        :class:`bytearray`: The memory at the specified address,
+        `bytearray` The memory at the specified address,
         or ``None``.
     """
     return pwndbg.dbg.selected_inferior().read_memory(address=addr, size=count, partial=partial)
@@ -42,11 +42,11 @@ def readtype(type: pwndbg.dbg_mod.Type, addr: int) -> int:
     native integer representation of the same.
 
     Arguments:
-        type(pwndbg.dbg_mod.Type): GDB type to read
-        addr(int): Address at which the value to be read resides
+        type: GDB type to read
+        addr: Address at which the value to be read resides
 
     Returns:
-        :class:`int`
+        `int`
     """
     return int(get_typed_pointer_value(type, addr))
 
@@ -57,8 +57,8 @@ def write(addr: int, data: str | bytes | bytearray) -> None:
     Writes data into the memory of the process being debugged.
 
     Arguments:
-        addr(int): Address to write
-        data(str,bytes,bytearray): Data to write
+        addr: Address to write
+        data: Data to write
     """
     if isinstance(data, str):
         data = bytes(data, "utf8")
@@ -72,10 +72,10 @@ def peek(address: int) -> bytearray | None:
     Read one byte from the specified address.
 
     Arguments:
-        address(int): Address to read
+        address: Address to read
 
     Returns:
-        :class:`bytearray`: A single byte of data, or ``None`` if the
+        `bytearray` A single byte of data, or ``None`` if the
         address cannot be read.
     """
     try:
@@ -92,10 +92,10 @@ def is_readable_address(address: int) -> bool:
     Check if the address can be read by GDB.
 
     Arguments:
-        address(int): Address to read
+        address: Address to read
 
     Returns:
-        :class:`bool`: Whether the address is readable.
+        `bool`: Whether the address is readable.
     """
     # We use vmmap to check before `peek()` because accessing memory for embedded targets might be slow and expensive.
     return pwndbg.aglib.vmmap.find(address) is not None and peek(address) is not None
@@ -107,10 +107,10 @@ def poke(address: int) -> bool:
     Checks whether an address is writable.
 
     Arguments:
-        address(int): Address to check
+        address: Address to check
 
     Returns:
-        :class:`bool`: Whether the address is writable.
+        `bool`: Whether the address is writable.
     """
     c = peek(address)
     if c is None:
@@ -134,8 +134,8 @@ def string(addr: int, max: int = 4096) -> bytearray:
     """Reads a null-terminated string from memory.
 
     Arguments:
-        addr(int): Address to read from
-        max(int): Maximum string length (default 4096)
+        addr: Address to read from
+        max: Maximum string length (default 4096)
 
     Returns:
         An empty bytearray, or a NULL-terminated bytearray.

--- a/pwndbg/chain.py
+++ b/pwndbg/chain.py
@@ -41,13 +41,13 @@ def get(
     Recursively dereferences an address. For bare metal, it will stop when the address is not in any of vmmap pages to avoid redundant dereference.
 
     Arguments:
-        address(int): the first address to begin dereferencing
-        limit(int): number of valid pointers
-        offset(int): offset into the address to get the next pointer
-        hard_stop(int): address to stop at
+        address: the first address to begin dereferencing
+        limit: number of valid pointers
+        offset: offset into the address to get the next pointer
+        hard_stop: address to stop at
         hard_end: value to append when hard_stop is reached
-        include_start(bool): whether to include starting address or not
-        safe_linking(bool): whether this chain use safe-linking
+        include_start: whether to include starting address or not
+        safe_linking: whether this chain use safe-linking
 
     Returns:
         A list representing pointers of each ```address``` and reference
@@ -112,14 +112,14 @@ def format(
     of address dereferences into string representation.
 
     Arguments:
-        value(int|list): Either the starting address to be sent to get, or the result of get (a list)
-        limit(int): Number of valid pointers
-        code(bool): Hint that indicates the value may be an instruction
-        offset(int): Offset into the address to get the next pointer
-        hard_stop(int): Value to stop on
+        value: Either the starting address to be sent to get, or the result of get (a list)
+        limit: Number of valid pointers
+        code: Hint that indicates the value may be an instruction
+        offset: Offset into the address to get the next pointer
+        hard_stop: Value to stop on
         hard_end: Value to append when hard_stop is reached: null, value of hard stop, a string.
-        safe_linking(bool): whether this chain use safe-linking
-        enhance_string_len(int): The length of string to display for enhancement of the last pointer
+        safe_linking: whether this chain use safe-linking
+        enhance_string_len: The length of string to display for enhancement of the last pointer
     Returns:
         A string representing pointers of each address and reference
         Strings format: 0x0804a10 —▸ 0x08061000 ◂— 0x41414141

--- a/pwndbg/color/memory.py
+++ b/pwndbg/color/memory.py
@@ -75,9 +75,9 @@ def get(
     Returns a colorized string representing the provided address.
 
     Arguments:
-        address(int | pwndbg.dbg_mod.Value): Address to look up
-        text(str | None): Optional text to use in place of the address in the return value string.
-        prefix(str | None): Optional text to set at beginning in the return value string.
+        address: Address to look up
+        text: Optional text to use in place of the address in the return value string.
+        prefix: Optional text to set at beginning in the return value string.
     """
     address = int(address)
     page = pwndbg.aglib.vmmap.find(address)

--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -207,10 +207,10 @@ def fix(
     """Fix a single command-line argument coming from the CLI.
 
     Arguments:
-        arg(str): Original string representation (e.g. '0', '$rax', '$rax+44')
-        sloppy(bool): If ``arg`` cannot be evaluated, return ``arg``. (default: False)
-        quiet(bool): If an error occurs, suppress it. (default: True)
-        reraise(bool): If an error occurs, raise the exception. (default: False)
+        arg: Original string representation (e.g. '0', '$rax', '$rax+44')
+        sloppy: If ``arg`` cannot be evaluated, return ``arg``. (default: False)
+        quiet: If an error occurs, suppress it. (default: True)
+        reraise: If an error occurs, raise the exception. (default: False)
 
     Returns:
         Ideally a ``Value`` object.  May return a ``str`` if ``sloppy==True``.

--- a/pwndbg/commands/search.py
+++ b/pwndbg/commands/search.py
@@ -26,11 +26,11 @@ if pwndbg.dbg.is_gdblib_available():
 saved: Set[int] = set()
 
 
-def print_search_hit(address) -> None:
+def print_search_hit(address: int) -> None:
     """Prints out a single search hit.
 
     Arguments:
-        address(int): Address to print
+        address: Address to print
     """
     if not address:
         return

--- a/pwndbg/emu/emulator.py
+++ b/pwndbg/emu/emulator.py
@@ -733,16 +733,14 @@ class Emulator:
         debug(DEBUG_MEM_READ, "uc.mem_read(*%r, **%r)", (a, kw))
         return self.uc.mem_read(*a, **kw)
 
-    def until_jump(self, pc=None):
+    def until_jump(self, pc: int = None):
         """
         Emulates instructions starting at the specified address until the
         program counter is set to an address which does not linearly follow
         the previously-emulated instruction.
 
         Arguments:
-            pc(int): Address to start at.  If `None`, uses the current instruction.
-            types(list,set): List of instruction groups to stop at.
-                By default, it stops at all jumps, calls, and returns.
+            pc: Address to start at.  If `None`, uses the current instruction.
 
         Return:
             Returns a tuple containing the address of the jump instruction,

--- a/pwndbg/enhance.py
+++ b/pwndbg/enhance.py
@@ -60,7 +60,7 @@ def enhance(
     value: int,
     code: bool = True,
     safe_linking: bool = False,
-    attempt_dereference=True,
+    attempt_dereference = True,
     enhance_string_len: int = None,
 ) -> str:
     """
@@ -74,10 +74,10 @@ def enhance(
     determine which order to print the fields.
 
     Arguments:
-        value(obj): Value to enhance
-        code(bool): Hint that indicates the value may be an instruction
-        safe_linking(bool): Whether this chain use safe-linking
-        enhance_string_len(int): The length of string to display for enhancement of the last pointer
+        value: Value to enhance
+        code: Hint that indicates the value may be an instruction
+        safe_linking: Whether this chain use safe-linking
+        enhance_string_len: The length of string to display for enhancement of the last pointer
     """
     value = int(value)
 

--- a/pwndbg/enhance.py
+++ b/pwndbg/enhance.py
@@ -60,7 +60,7 @@ def enhance(
     value: int,
     code: bool = True,
     safe_linking: bool = False,
-    attempt_dereference = True,
+    attempt_dereference=True,
     enhance_string_len: int = None,
 ) -> str:
     """

--- a/pwndbg/gdblib/vmmap.py
+++ b/pwndbg/gdblib/vmmap.py
@@ -448,7 +448,7 @@ def info_auxv(skip_exe: bool = False) -> Tuple[pwndbg.lib.memory.Page, ...]:
     it is not dereferenced by `info auxv` and we also don't dereference it.
 
     Arguments:
-        skip_exe(bool): Do not return any mappings that belong to the exe.
+        skip_exe: Do not return any mappings that belong to the exe.
 
     Returns:
         A list of pwndbg.lib.memory.Page objects.

--- a/pwndbg/lib/which.py
+++ b/pwndbg/lib/which.py
@@ -41,16 +41,16 @@ def which(name: str, all: bool = False) -> Set[str] | str | None:
     Works as the system command ``which``; searches $PATH for ``name`` and
     returns a full path if found.
 
-    If `all` is :const:`True` the set of all found locations is returned, else
-    the first occurrence or :const:`None` is returned.
+    If `all` is `True` the set of all found locations is returned, else
+    the first occurrence or `None` is returned.
 
     Arguments:
-      `name` (str): The file to search for.
-      `all` (bool):  Whether to return all locations where `name` was found.
+      name: The file to search for.
+      all:  Whether to return all locations where `name` was found.
 
     Returns:
-      If `all` is :const:`True` the set of all locations where `name` was found,
-      else the first location or :const:`None` if not found.
+      If `all` is `True` the set of all locations where `name` was found,
+      else the first location or `None` if not found.
 
     Example:
       >>> which('sh')

--- a/pwndbg/search.py
+++ b/pwndbg/search.py
@@ -24,16 +24,16 @@ def search(
     """Search inferior memory for a byte sequence.
 
     Arguments:
-        searchfor(bytes): Byte sequence to find
-        mappings(list): List of pwndbg.lib.memory.Page objects to search
+        searchfor: Byte sequence to find
+        mappings: List of pwndbg.lib.memory.Page objects to search
             By default, uses all available mappings.
-        start(int): First address to search, inclusive.
-        end(int): Last address to search, exclusive.
-        step(int): Size of memory region to skip each result
-        aligned(int): Strict byte alignment for search result
-        limit(int): Maximum number of results to return
-        executable(bool): Restrict search to executable pages
-        writable(bool): Restrict search to writable pages
+        start: First address to search, inclusive.
+        end: Last address to search, exclusive.
+        step: Size of memory region to skip each result
+        aligned: Strict byte alignment for search result
+        limit: Maximum number of results to return
+        executable: Restrict search to executable pages
+        writable: Restrict search to writable pages
 
     Yields:
         An iterator on the address matches


### PR DESCRIPTION
Since we are adhering to google style docstrings, we don't need to specify type parameters in the docstring if they are type annotated. Also, mkdocstrings doesn't like recognize this `param(type)` syntax and currently only accepts the more commonly used `param (type)` (with a space) (see https://github.com/mkdocstrings/griffe/issues/375). 