### PR TITLE
fix: adjust to `rr`'s vFile reply

### DIFF
--- a/pwndbg/aglib/file.py
+++ b/pwndbg/aglib/file.py
@@ -173,8 +173,8 @@ def _vfile_check_response(response: bytes):
     if response.startswith(b"F") and b"," in response:
         resp_status, resp_data = response[1:].split(b",", 1)  # Skip "F"
         if int(resp_status) != -1:
-            raise NotImplementedError(f"Unknown response status {resp_status}")
-        errno = int(resp_data.decode(), 10 if is_vfile_qemu_user_bug() else 16)
+            raise NotImplementedError(f"Unknown response status {resp_status!r}")
+        errno = int(resp_data.split(b";", 1)[0].decode(), 10 if is_vfile_qemu_user_bug() else 16)
         raise OSError(errno, "Error")
 
 

--- a/pwndbg/aglib/file.py
+++ b/pwndbg/aglib/file.py
@@ -170,12 +170,14 @@ def is_vfile_qemu_user_bug() -> bool:
 def _vfile_check_response(response: bytes):
     if len(response) == 0:
         raise NotImplementedError("Not supported")
-    if response.startswith(b"F") and b"," in response:
-        resp_status, resp_data = response[1:].split(b",", 1)  # Skip "F"
-        if int(resp_status) != -1:
-            raise NotImplementedError(f"Unknown response status {resp_status!r}")
-        errno = int(resp_data.split(b";", 1)[0].decode(), 10 if is_vfile_qemu_user_bug() else 16)
-        raise OSError(errno, "Error")
+    # F result [,errno] [;attachment]; strip attachment first, skip if no errno
+    result_errno = response.split(b";", 1)[0]
+    if result_errno.startswith(b"F") and b"," in result_errno:
+        result, errno = result_errno[1:].split(b",", 1)  # Skip "F"
+        if int(result.split(b";", 1)[0]) != -1:
+            raise NotImplementedError(f"Unknown response status {result!r}")
+        err = int(errno, 10 if is_vfile_qemu_user_bug() else 16)
+        raise OSError(err, "Error")
 
 
 def vfile_readlink(pathname: str | bytes) -> bytes:

--- a/pwndbg/aglib/file.py
+++ b/pwndbg/aglib/file.py
@@ -170,8 +170,11 @@ def is_vfile_qemu_user_bug() -> bool:
 def _vfile_check_response(response: bytes):
     if len(response) == 0:
         raise NotImplementedError("Not supported")
-    if response.startswith(b"F-1,"):
-        errno = int(response[4:].decode(), 10 if is_vfile_qemu_user_bug() else 16)
+    if response.startswith(b"F") and b"," in response:
+        resp_status, resp_data = response[1:].split(b",", 1)  # Skip "F"
+        if int(resp_status) != -1:
+            raise NotImplementedError(f"Unknown response status {resp_status}")
+        errno = int(resp_data.decode(), 10 if is_vfile_qemu_user_bug() else 16)
         raise OSError(errno, "Error")
 
 

--- a/pwndbg/aglib/file.py
+++ b/pwndbg/aglib/file.py
@@ -174,7 +174,7 @@ def _vfile_check_response(response: bytes):
     result_errno = response.split(b";", 1)[0]
     if result_errno.startswith(b"F") and b"," in result_errno:
         result, errno = result_errno[1:].split(b",", 1)  # Skip "F"
-        if int(result.split(b";", 1)[0]) != -1:
+        if int(result) != -1:
             raise NotImplementedError(f"Unknown response status {result!r}")
         err = int(errno, 10 if is_vfile_qemu_user_bug() else 16)
         raise OSError(err, "Error")


### PR DESCRIPTION
`rr replay` use `"F-01,2"` to indicate a vFile error while pwndbg detects `"F-1,"`. Patch the code to process some cases like `rr`.

As this piece of code is run when displaying context, it's critical to fix it. pwndbg tries to cache `/proc/$tid/maps` which utilize vFile to grab it.