### PR TITLE
Cleanup configurable parameters

### DIFF
--- a/pwndbg/aglib/disasm/arch.py
+++ b/pwndbg/aglib/disasm/arch.py
@@ -35,9 +35,7 @@ if TYPE_CHECKING:
 pwndbg.config.add_param(
     "emulate",
     "on",
-    """
-Unicorn emulation of code from the current PC register
-""",
+    "unicorn emulation of code from the current PC register",
     help_docstring="""\
 emulate can be:
 off             - no emulation is performed
@@ -56,26 +54,21 @@ Emulation requires >1GB RAM being available on the system and ability to allocat
 pwndbg.config.add_param(
     "disasm-annotations",
     True,
-    """
-Display annotations for instructions to provide context on operands and results
-""",
+    "display annotations for instructions",
 )
 
 pwndbg.config.add_param(
     "emulate-annotations",
     True,
-    """
-Unicorn emulation for register and memory value annotations on instructions
-""",
+    "unicorn emulation for instruction annotations",
+    help_docstring="Refers to register and memory value annotations.",
 )
 
 # If this is false, emulation is only used for the current instruction (if emulate-annotations is enabled)
 pwndbg.config.add_param(
     "emulate-future-annotations",
     True,
-    """
-Unicorn emulation to annotate instructions after the current program counter
-""",
+    "unicorn emulation for future instruction's annotations",
 )
 
 # Effects future instructions, as past ones have already been cached and reflect the process state at the time
@@ -85,13 +78,13 @@ pwndbg.config.add_param("disasm-telescope-depth", 3, "Depth of telescope for dis
 pwndbg.config.add_param(
     "disasm-telescope-string-length",
     50,
-    "Number of characters in strings to display in disasm annotations",
+    "the number of characters in strings to display in disasm annotations",
 )
 
 pwndbg.config.add_param(
     "disasm-inline-symbols",
     True,
-    "Enable replacing constant operands with their symbol in the disassembly",
+    "replacing constant operands with their symbol in the disassembly",
 )
 
 

--- a/pwndbg/aglib/heap/__init__.py
+++ b/pwndbg/aglib/heap/__init__.py
@@ -55,8 +55,11 @@ heap_chain_limit = add_heap_param(
 heap_corruption_check_limit = add_heap_param(
     "heap-corruption-check-limit",
     64,
-    "amount of chunks to traverse (forwards and backwards) for the bin corruption check",
+    "amount of chunks to traverse for the bin corruption check",
     param_class=pwndbg.lib.config.PARAM_UINTEGER,
+    help_docstring="""
+The bins are traversed both forwards and backwards.
+""",
 )
 
 resolve_heap_via_heuristic = add_heap_param(

--- a/pwndbg/aglib/stack.py
+++ b/pwndbg/aglib/stack.py
@@ -24,7 +24,7 @@ import pwndbg.lib.memory
 auto_explore = pwndbg.config.add_param(
     "auto-explore-stack",
     "warn",
-    "Enable or disable stack exploration; it may be really slow.",
+    "stack exploration; it may be really slow.",
     param_class=pwndbg.lib.config.PARAM_ENUM,
     enum_sequence=["warn", "yes", "no"],
 )

--- a/pwndbg/aglib/vmmap_custom.py
+++ b/pwndbg/aglib/vmmap_custom.py
@@ -24,9 +24,12 @@ custom_pages: List[pwndbg.lib.memory.Page] = []
 auto_explore = pwndbg.config.add_param(
     "auto-explore-pages",
     "warn",
-    "whether to try to infer page permissions when memory maps missing (can cause errors)",
+    "whether to try to infer page permissions when memory maps are missing",
     param_class=pwndbg.lib.config.PARAM_ENUM,
     enum_sequence=["yes", "warn", "no"],
+    help_docstring="""
+This command can cause errors.
+""",
 )
 
 

--- a/pwndbg/auxv.py
+++ b/pwndbg/auxv.py
@@ -28,7 +28,7 @@ if pwndbg.dbg.is_gdblib_available():
 auto_explore = pwndbg.config.add_param(
     "auto-explore-auxv",
     "warn",
-    "Enable or disable stack exploration for AUXV information; it may be really slow.",
+    "stack exploration for AUXV information; it may be really slow.",
     param_class=pwndbg.lib.config.PARAM_ENUM,
     enum_sequence=["warn", "yes", "no"],
 )

--- a/pwndbg/color/hexdump.py
+++ b/pwndbg/color/hexdump.py
@@ -28,8 +28,8 @@ config_separator = theme.add_color_param(
 config_highlight_group_lsb = theme.add_param(
     "hexdump-highlight-group-lsb",
     "underline",
-    "highlight LSB of each group. Applies only if hexdump-use-big-endian"
-    " actually changes byte order.",
+    "highlight LSB of each group",
+    help_docstring="Applies only if hexdump-use-big-endian actually changes byte order.",
 )
 
 

--- a/pwndbg/color/syntax_highlight.py
+++ b/pwndbg/color/syntax_highlight.py
@@ -17,11 +17,11 @@ from pwndbg.color import disable_colors
 from pwndbg.color import message
 from pwndbg.color import theme
 
-pwndbg.config.add_param("syntax-highlight", True, "Source code / assembly syntax highlight")
+pwndbg.config.add_param("syntax-highlight", True, "source code / assembly syntax highlight")
 style = theme.add_param(
     "syntax-highlight-style",
     "monokai",
-    "Source code / assembly syntax highlight stylename of pygments module",
+    "source code / assembly syntax highlight stylename of pygments module",
 )
 
 formatter = pygments.formatters.Terminal256Formatter(style=str(style))

--- a/pwndbg/color/theme.py
+++ b/pwndbg/color/theme.py
@@ -10,8 +10,17 @@ class ColorParameter(Parameter):
     pass
 
 
-def add_param(name: str, default: Any, set_show_doc: str, color_param: bool = False) -> Parameter:
-    return config.add_param(name, default, set_show_doc, scope="theme")
+def add_param(
+    name: str,
+    default: Any,
+    set_show_doc: str,
+    color_param: bool = False,
+    *,
+    help_docstring: str = "",
+) -> Parameter:
+    return config.add_param(
+        name, default, set_show_doc, scope="theme", help_docstring=help_docstring
+    )
 
 
 def add_color_param(name: str, default: Any, set_show_doc: str) -> Parameter:

--- a/pwndbg/commands/ai.py
+++ b/pwndbg/commands/ai.py
@@ -29,17 +29,19 @@ from pwndbg.commands import CommandCategory
 pwndbg.config.add_param(
     "ai-openai-api-key",
     "",
-    "OpenAI API key (will default to OPENAI_API_KEY environment variable if not set)",
+    "OpenAI API key",
+    help_docstring="Will default to OPENAI_API_KEY environment variable if not set.",
 )
 pwndbg.config.add_param(
     "ai-anthropic-api-key",
     "",
-    "Anthropic API key (will default to ANTHROPIC_API_KEY environment variable if not set)",
+    "Anthropic API key",
+    help_docstring="Defaults to ANTHROPIC_API_KEY environment variable if not set.",
 )
 pwndbg.config.add_param(
     "ai-history-size",
     3,
-    "maximum number of successive questions and answers to maintain in the prompt for the ai command",
+    "maximum number of questions and answers to maintain in ai command's prompt",
 )
 pwndbg.config.add_param(
     "ai-stack-depth", 16, "rows of stack context to include in the prompt for the ai command"
@@ -47,17 +49,20 @@ pwndbg.config.add_param(
 pwndbg.config.add_param(
     "ai-model",
     "gpt-3.5-turbo",  # the new conversational model
-    "the name of the OpenAI large language model to query (see <https://platform.openai.com/docs/models> for details)",
+    "the name of the OpenAI large language model to query",
+    help_docstring="See <https://platform.openai.com/docs/models> for details.",
 )
 pwndbg.config.add_param(
     "ai-temperature",
     0,
-    "the temperature specification for the LLM query (this controls the degree of randomness in the response -- see <https://beta.openai.com/docs/api-reference/parameters> for details)",
+    "the temperature specification for the LLM query",
+    help_docstring="This controls the degree of randomness in the response -- see <https://beta.openai.com/docs/api-reference/parameters> for details.",
 )
 pwndbg.config.add_param(
     "ai-max-tokens",
     100,
-    "the maximum number of tokens to return in the response (see <https://beta.openai.com/docs/api-reference/parameters> for details)",
+    "the maximum number of tokens to return in the response",
+    help_docstring="See <https://beta.openai.com/docs/api-reference/parameters> for details.",
 )
 pwndbg.config.add_param(
     "ai-show-usage",

--- a/pwndbg/commands/ai.py
+++ b/pwndbg/commands/ai.py
@@ -41,7 +41,7 @@ pwndbg.config.add_param(
 pwndbg.config.add_param(
     "ai-history-size",
     3,
-    "maximum number of questions and answers to maintain in ai command's prompt",
+    "maximum number of questions and answers to keep in the prompt",
 )
 pwndbg.config.add_param(
     "ai-stack-depth", 16, "rows of stack context to include in the prompt for the ai command"

--- a/pwndbg/commands/attachp.py
+++ b/pwndbg/commands/attachp.py
@@ -24,7 +24,9 @@ _OPTIONS = [_NONE, _OLDEST, _NEWEST, _ASK]
 pwndbg.config.add_param(
     "attachp-resolution-method",
     _ASK,
-    f'how to determine the process to attach when multiple candidates exists ("{_OLDEST}", "{_NEWEST}", "{_NONE}" or "{_ASK}"(default))',
+    "how to determine the process to attach when multiple candidates exists",
+    param_class=pwndbg.lib.config.PARAM_ENUM,
+    enum_sequence=_OPTIONS,
 )
 
 parser = argparse.ArgumentParser(
@@ -180,14 +182,6 @@ def attachp(target, no_truncate, retry, exact, all, user=None) -> None:
 
             if len(pids) > 1:
                 method = pwndbg.config.attachp_resolution_method
-
-                if method not in _OPTIONS:
-                    print(
-                        message.warn(
-                            f'Invalid value for `attachp-resolution-method` config. Fallback to default value("{_ASK}").'
-                        )
-                    )
-                    method = _ASK
 
                 try:
                     ps_output = check_output(

--- a/pwndbg/commands/config.py
+++ b/pwndbg/commands/config.py
@@ -26,7 +26,7 @@ def print_row(
     set_show_doc: str,
     ljust_optname: int,
     ljust_doc: int,
-    empty_space: int = 6,
+    empty_space: int = 2,
 ):
     name = ljust_colored(name, ljust_optname + empty_space)
     set_show_doc = ljust_colored(set_show_doc, ljust_doc + empty_space)

--- a/pwndbg/commands/config.py
+++ b/pwndbg/commands/config.py
@@ -96,17 +96,12 @@ def display_config(filter_pattern: str, scope: str, has_file_command: bool = Tru
 
         print_row(v.name, value, default, v.set_show_doc, longest_optname, longest_doc)
 
-    print(hint(f"You can set config variable with `set <{scope}-var> <value>`"))
-    print(
-        hint(
-            f"You can see more information about a config variable with `help set <{scope}-var> <value>`"
-        )
-    )
+    print(hint(f"You can set a {scope} variable with `set <{scope}-var> <value>`, and read more about it with `help set <{scope}-var>`."))
     if has_file_command:
         print(
             hint(
-                f"You can generate configuration file using `{scope}file` "
-                "- then put it in your .gdbinit after initializing pwndbg"
+                f"You can generate a configuration file using `{scope}file` "
+                "- then put it in your .gdbinit after initializing pwndbg."
             )
         )
 

--- a/pwndbg/commands/config.py
+++ b/pwndbg/commands/config.py
@@ -29,7 +29,7 @@ def print_row(
     empty_space: int = 6,
 ):
     name = ljust_colored(name, ljust_optname + empty_space)
-    set_show_doc = ljust_colored(set_show_doc , ljust_doc + empty_space)
+    set_show_doc = ljust_colored(set_show_doc, ljust_doc + empty_space)
     defval = extend_value_with_default(value, default)
     result = f"{name} {set_show_doc} {defval} "
     print(result)
@@ -78,9 +78,7 @@ def display_config(filter_pattern: str, scope: str, has_file_command: bool = Tru
         return
 
     longest_optname = max(map(len, (v.name for v in values)))
-    longest_doc = max(
-        map(len, (v.set_show_doc for v in values))
-    )
+    longest_doc = max(map(len, (v.set_show_doc for v in values)))
 
     header = print_row("Name", "Value", "Default", "Documentation", longest_optname, longest_doc)
     print("-" * len(header))

--- a/pwndbg/commands/config.py
+++ b/pwndbg/commands/config.py
@@ -79,8 +79,7 @@ def display_config(filter_pattern: str, scope: str, has_file_command: bool = Tru
 
     longest_optname = max(map(len, (v.name for v in values)))
     longest_value = max(
-        # We use `repr` here so the string values will be in quotes
-        map(len, (extend_value_with_default(repr(v.value), repr(v.default)) for v in values))
+        map(len, (extend_value_with_default(v.pretty(), v.pretty_default()) for v in values))
     )
 
     header = print_row("Name", "Value", "Default", "Documentation", longest_optname, longest_value)
@@ -93,13 +92,9 @@ def display_config(filter_pattern: str, scope: str, has_file_command: bool = Tru
 
             value = generateColorFunction(v.value)(v.value)
             default = generateColorFunction(v.default)(v.default)
-        elif isinstance(v.value, bool):
-            # Display 'on' or 'off' - same as GDB parameter display
-            value = "on" if v.value else "off"
-            default = "on" if v.default else "off"
         else:
-            value = repr(v.value)
-            default = repr(v.default)
+            value = v.pretty()
+            default = v.pretty_default()
 
         print_row(v.name, value, default, v.set_show_doc, longest_optname, longest_value)
 

--- a/pwndbg/commands/config.py
+++ b/pwndbg/commands/config.py
@@ -96,7 +96,11 @@ def display_config(filter_pattern: str, scope: str, has_file_command: bool = Tru
 
         print_row(v.name, value, default, v.set_show_doc, longest_optname, longest_doc)
 
-    print(hint(f"You can set a {scope} variable with `set <{scope}-var> <value>`, and read more about it with `help set <{scope}-var>`."))
+    print(
+        hint(
+            f"You can set a {scope} variable with `set <{scope}-var> <value>`, and read more about it with `help set <{scope}-var>`."
+        )
+    )
     if has_file_command:
         print(
             hint(

--- a/pwndbg/commands/config.py
+++ b/pwndbg/commands/config.py
@@ -99,6 +99,11 @@ def display_config(filter_pattern: str, scope: str, has_file_command: bool = Tru
         print_row(v.name, value, default, v.set_show_doc, longest_optname, longest_value)
 
     print(hint(f"You can set config variable with `set <{scope}-var> <value>`"))
+    print(
+        hint(
+            f"You can see more information about a config variable with `help set <{scope}-var> <value>`"
+        )
+    )
     if has_file_command:
         print(
             hint(

--- a/pwndbg/commands/config.py
+++ b/pwndbg/commands/config.py
@@ -25,13 +25,13 @@ def print_row(
     default: str,
     set_show_doc: str,
     ljust_optname: int,
-    ljust_value: int,
+    ljust_doc: int,
     empty_space: int = 6,
 ):
     name = ljust_colored(name, ljust_optname + empty_space)
+    set_show_doc = ljust_colored(set_show_doc , ljust_doc + empty_space)
     defval = extend_value_with_default(value, default)
-    defval = ljust_colored(defval, ljust_value + empty_space)
-    result = f"{name} {defval} {set_show_doc}"
+    result = f"{name} {set_show_doc} {defval} "
     print(result)
     return result
 
@@ -78,11 +78,11 @@ def display_config(filter_pattern: str, scope: str, has_file_command: bool = Tru
         return
 
     longest_optname = max(map(len, (v.name for v in values)))
-    longest_value = max(
-        map(len, (extend_value_with_default(v.pretty(), v.pretty_default()) for v in values))
+    longest_doc = max(
+        map(len, (v.set_show_doc for v in values))
     )
 
-    header = print_row("Name", "Value", "Default", "Documentation", longest_optname, longest_value)
+    header = print_row("Name", "Value", "Default", "Documentation", longest_optname, longest_doc)
     print("-" * len(header))
 
     for v in sorted(values):
@@ -96,7 +96,7 @@ def display_config(filter_pattern: str, scope: str, has_file_command: bool = Tru
             value = v.pretty()
             default = v.pretty_default()
 
-        print_row(v.name, value, default, v.set_show_doc, longest_optname, longest_value)
+        print_row(v.name, value, default, v.set_show_doc, longest_optname, longest_doc)
 
     print(hint(f"You can set config variable with `set <{scope}-var> <value>`"))
     print(

--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -96,7 +96,8 @@ config_reserve_lines = pwndbg.config.add_param(
     "if-ctx-fits",
     "when to reserve lines after the prompt to reduce context shake",
     help_docstring="""
-The "if-ctx-fits" setting only reserves lines if the whole context would still fit vertically in the current terminal window. It doesn't take into account line-wrapping due to insufficient terminal width.
+The "if-ctx-fits" setting only reserves lines if the whole context would still fit vertically in the current terminal window.
+It doesn't take into account line-wrapping due to insufficient terminal width.
 """,  # TODO: maybe it could take into account line-wrapping?
     param_class=pwndbg.lib.config.PARAM_ENUM,
     enum_sequence=["never", "if-ctx-fits", "always"],

--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -94,9 +94,9 @@ def clear_screen(out=sys.stdout) -> None:
 config_reserve_lines = pwndbg.config.add_param(
     "context-reserve-lines",
     "if-ctx-fits",
-    'when to reserve lines after the prompt to reduce context shake ("never", "if-ctx-fits"(default), "always")',
-    help_docstring="""\
-The "if-ctx-fits" setting only reserves lines if the whole context would still fit vertically in the current terminal window. Note that it doesn't take into account line-wrapping due to insufficient terminal width.
+    "when to reserve lines after the prompt to reduce context shake",
+    help_docstring="""
+The "if-ctx-fits" setting only reserves lines if the whole context would still fit vertically in the current terminal window. It doesn't take into account line-wrapping due to insufficient terminal width.
 """,  # TODO: maybe it could take into account line-wrapping?
     param_class=pwndbg.lib.config.PARAM_ENUM,
     enum_sequence=["never", "if-ctx-fits", "always"],
@@ -626,7 +626,10 @@ def context_expressions(target=sys.stdout, with_banner=True, width=None):
 config_context_ghidra = pwndbg.config.add_param(
     "context-ghidra",
     "never",
-    "when to try to decompile the current function with ghidra (slow and requires radare2/r2pipe or rizin/rzpipe) (valid values: always, never, if-no-source)",
+    "when to try to decompile the current function with ghidra",
+    help_docstring="Doing this is slow and requires radare2/r2pipe or rizin/rzpipe.",
+    param_class=pwndbg.lib.config.PARAM_ENUM,
+    enum_sequence=["always", "never", "if-no-source"],
 )
 
 

--- a/pwndbg/commands/hexdump.py
+++ b/pwndbg/commands/hexdump.py
@@ -23,7 +23,7 @@ pwndbg.config.add_param(
 pwndbg.config.add_param(
     "hexdump-group-use-big-endian",
     False,
-    "whether to use big-endian within each group of bytes in hexdump command",
+    "use big-endian within each group of bytes in hexdump command",
     help_docstring="When `on`, use big-endian within each group of bytes. Only applies to raw bytes, not the ASCII part. "
     "See also hexdump-highlight-group-lsb.",
 )

--- a/pwndbg/commands/hexdump.py
+++ b/pwndbg/commands/hexdump.py
@@ -17,7 +17,8 @@ pwndbg.config.add_param("hexdump-bytes", 64, "number of bytes printed by hexdump
 pwndbg.config.add_param(
     "hexdump-group-width",
     -1,
-    "number of bytes grouped in hexdump command (If -1, the architecture's pointer size is used)",
+    "number of bytes grouped in hexdump command",
+    help_docstring="If -1, the architecture's pointer size is used.",
 )
 pwndbg.config.add_param(
     "hexdump-group-use-big-endian",

--- a/pwndbg/commands/ptmalloc2.py
+++ b/pwndbg/commands/ptmalloc2.py
@@ -948,7 +948,7 @@ pwndbg.config.add_param(
 pwndbg.config.add_param(
     "default-visualize-chunk-number",
     10,
-    "default number of chunks to visualize (default is 10)",
+    "default number of chunks to visualize",
 )
 
 parser = argparse.ArgumentParser(

--- a/pwndbg/commands/telescope.py
+++ b/pwndbg/commands/telescope.py
@@ -34,7 +34,7 @@ skip_repeating_values = pwndbg.config.add_param(
     "whether to skip repeating values of the telescope command",
 )
 skip_repeating_values_minimum = pwndbg.config.add_param(
-    "telescope-skip-repeating-val-minimum",
+    "telescope-skip-repeating-val-min",
     3,
     "minimum amount of repeated values before skipping lines",
 )

--- a/pwndbg/dbg/lldb/pset.py
+++ b/pwndbg/dbg/lldb/pset.py
@@ -73,7 +73,7 @@ def parse_value(param: pwndbg.lib.config.Parameter, expression: str) -> Any:
             raise InvalidParse("expected an integer value")
     elif param_class == cfg.PARAM_ENUM:
         if expression not in param.enum_sequence:
-            names = ", ".join([f"'{name}'" for name in param.enum_sequence])
+            names = ", ".join([f'"{name}"' for name in param.enum_sequence])
             raise InvalidParse(f"expected one of {names}")
         return expression
     elif param_class == cfg.PARAM_OPTIONAL_FILENAME:

--- a/pwndbg/dbg/lldb/pset.py
+++ b/pwndbg/dbg/lldb/pset.py
@@ -73,7 +73,7 @@ def parse_value(param: pwndbg.lib.config.Parameter, expression: str) -> Any:
             raise InvalidParse("expected an integer value")
     elif param_class == cfg.PARAM_ENUM:
         if expression not in param.enum_sequence:
-            names = ", ".join([f'"{name}"' for name in param.enum_sequence])
+            names = ", ".join([f"'{name}'" for name in param.enum_sequence])
             raise InvalidParse(f"expected one of {names}")
         return expression
     elif param_class == cfg.PARAM_OPTIONAL_FILENAME:

--- a/pwndbg/exception.py
+++ b/pwndbg/exception.py
@@ -37,7 +37,7 @@ def print_exception(exception_msg) -> None:
 verbose = config.add_param(
     "exception-verbose",
     False,
-    "whether to print a full stacktrace for exceptions raised in Pwndbg commands",
+    "print a full stacktrace for exceptions raised in pwndbg commands",
 )
 debug = config.add_param(
     "exception-debugger", False, "whether to debug exceptions raised in Pwndbg commands"

--- a/pwndbg/gdblib/events.py
+++ b/pwndbg/gdblib/events.py
@@ -30,7 +30,8 @@ debug = config.add_param("debug-events", False, "display internal event debuggin
 gdb_workaround_stop_event = config.add_param(
     "gdb-workaround-stop-event",
     0,
-    """Enable asynchronous stop events as a workaround to improve 'commands' functionality.
+    "asynchronous stop events to improve 'commands' functionality.",
+    help_docstring="""
 Note: This may cause unexpected behavior with pwndbg or gdb.execute.
 
 Values:

--- a/pwndbg/ghidra.py
+++ b/pwndbg/ghidra.py
@@ -16,7 +16,11 @@ if pwndbg.dbg.is_gdblib_available():
 from pwndbg.color import message
 
 r2decompiler = pwndbg.config.add_param(
-    "r2decompiler", "radare2", "framework that your ghidra plugin installed (radare2/rizin)"
+    "r2decompiler",
+    "radare2",
+    "framework that your ghidra plugin installed",
+    param_class=pwndbg.lib.config.PARAM_ENUM,
+    enum_sequence=["radare2", "rizin"],
 )
 
 
@@ -48,13 +52,12 @@ def decompile(func=None):
             # Outputs for example: pdc\npdg
             if "pdg" not in r2.cmd("LD").split("\n"):
                 raise Exception("radare2 plugin r2ghidra must be installed and available from r2")
-        elif r2decompiler == "rizin":
+        else:
+            assert r2decompiler == "rizin"
             r2 = pwndbg.rizin.rzpipe()
             # Lc -> list core plugins
             if "ghidra" not in r2.cmd("Lc"):
                 raise Exception("rizin plugin rzghidra must be installed and available from rz")
-        else:
-            raise Exception(f"{r2decompiler} not support. Plz select from (radare2/rizin)")
     except ImportError:
         raise Exception("r2pipe or rzpipe not available, but required for r2/rz->ghidra bridge")
 

--- a/pwndbg/glibc.py
+++ b/pwndbg/glibc.py
@@ -34,7 +34,7 @@ T = TypeVar("T")
 safe_lnk = pwndbg.config.add_param(
     "safe-linking",
     None,
-    "whether glibc use safe-linking (on/off/auto)",
+    "whether glibc uses safe-linking",
     param_class=pwndbg.lib.config.PARAM_AUTO_BOOLEAN,
 )
 

--- a/pwndbg/integration/__init__.py
+++ b/pwndbg/integration/__init__.py
@@ -77,13 +77,13 @@ symbol_lookup = pwndbg.config.add_param(
 smart_enhance = pwndbg.config.add_param(
     "integration-smart-enhance",
     True,
-    "whether to use integration to determine when to disassemble during enhancing",
+    "use integration to determine when to disassemble during enhancing",
 )
 
 function_lookup = pwndbg.config.add_param(
     "integration-function-lookup",
     True,
-    "whether to use integration to look up function type signatures",
+    "use integration to look up function type signatures",
 )
 
 

--- a/pwndbg/integration/__init__.py
+++ b/pwndbg/integration/__init__.py
@@ -77,7 +77,7 @@ symbol_lookup = pwndbg.config.add_param(
 smart_enhance = pwndbg.config.add_param(
     "integration-smart-enhance",
     True,
-    "whether to use integration to determine if code should be disassembled during enhancing",
+    "whether to use integration to determine when to disassemble during enhancing",
 )
 
 function_lookup = pwndbg.config.add_param(

--- a/pwndbg/integration/binja.py
+++ b/pwndbg/integration/binja.py
@@ -383,7 +383,8 @@ themes["light"] = LightTheme
 style = theme.add_param(
     "bn-decomp-style",
     "dark",
-    f"Decompilation highlight theme for Binary Ninja (valid values are {', '.join(themes.keys())})",
+    "decompilation highlight theme for Binary Ninja",
+    help_docstring=f"Valid values: {', '.join(themes.keys())})",
 )
 
 

--- a/pwndbg/lib/config.py
+++ b/pwndbg/lib/config.py
@@ -2,7 +2,13 @@ from __future__ import annotations
 
 from collections import defaultdict
 from functools import total_ordering
-from typing import Any, Callable, DefaultDict, Dict, List, Sequence, TypeVar
+from typing import Any
+from typing import Callable
+from typing import DefaultDict
+from typing import Dict
+from typing import List
+from typing import Sequence
+from typing import TypeVar
 
 T = TypeVar("T")
 
@@ -70,7 +76,9 @@ class Parameter:
         self.help_docstring += "\n\nDefault: " + self.pretty_default()
         # Show valid values if they aren't obvious
         if param_class == PARAM_ENUM:
-            self.help_docstring += "\nValid values: " + ", ".join([f"'{name}'" for name in enum_sequence]) + "."
+            self.help_docstring += (
+                "\nValid values: " + ", ".join([f'"{name}"' for name in enum_sequence]) + "."
+            )
         if param_class == PARAM_AUTO_BOOLEAN:
             self.help_docstring += "\nValid values: on, off, auto."
 
@@ -205,9 +213,9 @@ class Config:
     ) -> Parameter:
         # Dictionary keys are going to have underscores, so we can't allow them here
         assert "_" not in name
-        # assert len(set_show_doc) <= 80 and "Config set_show_doc too long, use the help_docstring parameter."
+        assert len(set_show_doc) <= 80 and "Config set_show_doc too long, use the help_docstring parameter."
         if param_class == PARAM_ENUM or enum_sequence:
-            assert(param_class == PARAM_ENUM and enum_sequence)
+            assert param_class == PARAM_ENUM and enum_sequence
 
         p = Parameter(
             name,

--- a/pwndbg/lib/config.py
+++ b/pwndbg/lib/config.py
@@ -213,7 +213,10 @@ class Config:
     ) -> Parameter:
         # Dictionary keys are going to have underscores, so we can't allow them here
         assert "_" not in name
-        assert len(set_show_doc) <= 80 and "Config set_show_doc too long, use the help_docstring parameter."
+        assert (
+            len(set_show_doc) <= 80
+            and "Config set_show_doc too long, use the help_docstring parameter."
+        )
         if param_class == PARAM_ENUM or enum_sequence:
             assert param_class == PARAM_ENUM and enum_sequence
 

--- a/pwndbg/lib/config.py
+++ b/pwndbg/lib/config.py
@@ -213,8 +213,9 @@ class Config:
     ) -> Parameter:
         # Dictionary keys are going to have underscores, so we can't allow them here
         assert "_" not in name
+        assert len(name) <= 32 and "Config name too long."
         assert (
-            len(set_show_doc) <= 80
+            len(set_show_doc) <= 70
             and "Config set_show_doc too long, use the help_docstring parameter."
         )
         if param_class == PARAM_ENUM or enum_sequence:

--- a/pwndbg/lib/config.py
+++ b/pwndbg/lib/config.py
@@ -77,7 +77,7 @@ class Parameter:
         # Show valid values if they aren't obvious
         if param_class == PARAM_ENUM:
             self.help_docstring += (
-                "\nValid values: " + ", ".join([f'"{name}"' for name in enum_sequence]) + "."
+                "\nValid values: " + ", ".join([f"'{name}'" for name in enum_sequence]) + "."
             )
         if param_class == PARAM_AUTO_BOOLEAN:
             self.help_docstring += "\nValid values: on, off, auto."

--- a/pwndbg/lib/config.py
+++ b/pwndbg/lib/config.py
@@ -124,7 +124,7 @@ class Parameter:
             else:
                 return "on" if val else "off"
         elif self.param_class == PARAM_STRING or self.param_class == PARAM_ENUM:
-            return '"' + val + '"'
+            return "'" + val + "'"
         else:
             return str(val)
 

--- a/pwndbg/lib/config.py
+++ b/pwndbg/lib/config.py
@@ -2,13 +2,7 @@ from __future__ import annotations
 
 from collections import defaultdict
 from functools import total_ordering
-from typing import Any
-from typing import Callable
-from typing import DefaultDict
-from typing import Dict
-from typing import List
-from typing import Sequence
-from typing import TypeVar
+from typing import Any, Callable, DefaultDict, Dict, List, Sequence, TypeVar
 
 T = TypeVar("T")
 
@@ -61,6 +55,10 @@ class Parameter:
         enum_sequence: Sequence[str] | None = None,
         scope: str = "config",
     ) -> None:
+        self.name = name
+        self.default = default
+        self._value = default
+        self.param_class = param_class or PARAM_CLASSES[type(default)]
         # Note: `set_show_doc` should be a noun phrase, e.g. "the value of the foo"
         # The `set_doc` will be "Set the value of the foo."
         # The `show_doc` will be "Show the value of the foo."
@@ -68,10 +66,14 @@ class Parameter:
         # `get_show_string()` will return "Show the value of the foo."
         self.set_show_doc = set_show_doc.strip()
         self.help_docstring = help_docstring.strip()
-        self.name = name
-        self.default = default
-        self._value = default
-        self.param_class = param_class or PARAM_CLASSES[type(default)]
+        # Show the default value in the parameter help
+        self.help_docstring += "\n\nDefault: " + self.pretty_default()
+        # Show valid values if they aren't obvious
+        if param_class == PARAM_ENUM:
+            self.help_docstring += "\nValid values: " + ", ".join([f"'{name}'" for name in enum_sequence]) + "."
+        if param_class == PARAM_AUTO_BOOLEAN:
+            self.help_docstring += "\nValid values: on, off, auto."
+
         self.enum_sequence = enum_sequence
         self.scope = scope
         self.update_listeners: List[Callable[[Any], None]] = []
@@ -103,6 +105,26 @@ class Parameter:
 
     def __getattr__(self, name: str):
         return getattr(self.value, name)
+
+    def pretty_val(self, val: Any) -> str:
+        """Convert a value this object could contain to its pretty string representation."""
+        if self.param_class == PARAM_BOOLEAN:
+            return "on" if val else "off"
+        elif self.param_class == PARAM_AUTO_BOOLEAN:
+            if val is None:
+                return "auto"
+            else:
+                return "on" if val else "off"
+        elif self.param_class == PARAM_STRING or self.param_class == PARAM_ENUM:
+            return '"' + val + '"'
+        else:
+            return str(val)
+
+    def pretty(self) -> str:
+        return self.pretty_val(self.value)
+
+    def pretty_default(self) -> str:
+        return self.pretty_val(self.default)
 
     # Casting
     def __int__(self) -> int:
@@ -183,6 +205,9 @@ class Config:
     ) -> Parameter:
         # Dictionary keys are going to have underscores, so we can't allow them here
         assert "_" not in name
+        # assert len(set_show_doc) <= 80 and "Config set_show_doc too long, use the help_docstring parameter."
+        if param_class == PARAM_ENUM or enum_sequence:
+            assert(param_class == PARAM_ENUM and enum_sequence)
 
         p = Parameter(
             name,

--- a/tests/gdb-tests/tests/test_command_config.py
+++ b/tests/gdb-tests/tests/test_command_config.py
@@ -20,13 +20,13 @@ def test_config():
 def test_config_filtering():
     out = gdb.execute("config context-disasm-lines", to_string=True).splitlines()
 
-    assert re.match(r"Name\s+Value\s+\(Default\)\s+Documentation", out[0])
+    assert re.match(r"Name\s+Documentation\s+Value\s+\(Default\)", out[0])
     assert re.match(r"-+", out[1])
     assert re.match(
-        r"context-disasm-lines\s+10\s+number of additional lines to print in the disasm context",
+        r"context-disasm-lines\s+number of additional lines to print in the disasm context\s+10",
         out[2],
     )
-    assert out[3] == "You can set config variable with `set <config-var> <value>`"
+    assert out[3] == "You can set a config variable with `set <config-var> <value>`, and read more about it with `help set <config-var>`."
     assert (
         out[4]
         == "You can generate configuration file using `configfile` - then put it in your .gdbinit after initializing pwndbg"

--- a/tests/gdb-tests/tests/test_command_config.py
+++ b/tests/gdb-tests/tests/test_command_config.py
@@ -26,10 +26,13 @@ def test_config_filtering():
         r"context-disasm-lines\s+number of additional lines to print in the disasm context\s+10",
         out[2],
     )
-    assert out[3] == "You can set a config variable with `set <config-var> <value>`, and read more about it with `help set <config-var>`."
+    assert (
+        out[3]
+        == "You can set a config variable with `set <config-var> <value>`, and read more about it with `help set <config-var>`."
+    )
     assert (
         out[4]
-        == "You can generate configuration file using `configfile` - then put it in your .gdbinit after initializing pwndbg"
+        == "You can generate a configuration file using `configfile` - then put it in your .gdbinit after initializing pwndbg."
     )
 
 

--- a/tests/gdb-tests/tests/test_gdblib_parameter.py
+++ b/tests/gdb-tests/tests/test_gdblib_parameter.py
@@ -97,11 +97,13 @@ def test_gdb_parameter_default_value_works(start_binary, params):
         assert gdb.parameter(param_name) == default_value
     assert param.value == default_value
 
+    # help_docstring is modified inside the Parameter constructor
+
     out = gdb.execute(f"help show {param_name}", to_string=True)
-    assert out == f"Show {set_show_doc}.\n{help_docstring}\n"
+    assert out == f"Show {set_show_doc}.\n{param.help_docstring}\n"
     assert (
         gdb.execute(f"help set {param_name}", to_string=True)
-        == f"Set {set_show_doc}.\n{help_docstring}\n"
+        == f"Set {set_show_doc}.\n{param.help_docstring}\n"
     )
 
     # TODO/FIXME: Is there a way to unregister a GDB parameter defined in Python?


### PR DESCRIPTION
+ Short descriptions cant be more than 70 characters anymore. Config names can't be more than 32 characters anymore.
+ Default values are printed with the help.
+ For enums and autobool, the valid values are printed with the help
+ Replaced the `repr(v.value)` thingy with a bit more robust function for visualizing parameter values

Before:
![image](https://github.com/user-attachments/assets/f36e3feb-b55d-4bf7-ad3b-4bffa3a9473d)
![image](https://github.com/user-attachments/assets/53f2d09f-e273-47d9-a791-b3d13807501e)
![image](https://github.com/user-attachments/assets/d21fe338-d1d7-4392-a223-7ffc18cc4e62)

After:
![image](https://github.com/user-attachments/assets/0e265ff9-9a4c-46eb-8bad-026a66089458)
![image](https://github.com/user-attachments/assets/fa0b0829-7a87-4b7b-9ce0-3bf60b85e80c)
![image](https://github.com/user-attachments/assets/9e48b750-b96c-4d89-b249-644859c65499)

