### PR TITLE
Refactor callstack to use yield instead of returning list (#2837)

### DIFF
--- a/profiling/benchmark_vis_heap_chunks/gdbscript.py
+++ b/profiling/benchmark_vis_heap_chunks/gdbscript.py
@@ -1,4 +1,5 @@
-import gdb, pwndbg
+import gdb 
+import pwndbg
 
 pwndbg.profiling.profiler.start()
 result = gdb.execute("vis 2000", to_string=True)

--- a/pwndbg/aglib/stack.py
+++ b/pwndbg/aglib/stack.py
@@ -8,7 +8,6 @@ binaries do things to remap the stack (e.g. pwnies' postit).
 from __future__ import annotations
 
 from typing import Dict
-from typing import List
 
 import pwndbg
 import pwndbg.aglib.elf
@@ -176,16 +175,13 @@ def _fetch_via_exploration() -> Dict[int, pwndbg.lib.memory.Page]:
     return stacks
 
 
-def callstack() -> List[int]:
+def callstack():
     """
     Return the address of the return address for the current frame.
     """
     frame = pwndbg.dbg.selected_frame()
-    addresses = []
     while frame:
         addr = frame.pc()
         if pwndbg.aglib.memory.is_readable_address(addr):
-            addresses.append(addr)
+            yield addr
         frame = frame.parent()
-
-    return addresses

--- a/pwndbg/dbg/lldb/__init__.py
+++ b/pwndbg/dbg/lldb/__init__.py
@@ -1758,7 +1758,7 @@ class LLDB(pwndbg.dbg_mod.Debugger):
 
         import pwndbg
 
-        self.suspended_events = {a: False for a in pwndbg.dbg_mod.EventType}
+        self.suspended_events = dict.fromkeys(pwndbg.dbg_mod.EventType, False)
 
         debugger: lldb.SBDebugger = args[0]
         assert (

--- a/tests/gdb-tests/tests/test_callstack.py
+++ b/tests/gdb-tests/tests/test_callstack.py
@@ -14,7 +14,7 @@ def test_callstack_readable(start_binary):
     gdb.execute("b break_here")
     gdb.execute("r")
 
-    addresses = pwndbg.aglib.stack.callstack()
+    addresses = list(pwndbg.aglib.stack.callstack())
 
     assert len(addresses) > 0
     assert all(pwndbg.aglib.memory.is_readable_address(address) for address in addresses)

--- a/tests/qemu-tests/tests/system/test_callstack.py
+++ b/tests/qemu-tests/tests/system/test_callstack.py
@@ -5,7 +5,7 @@ import pwndbg.aglib.stack
 
 
 def test_callstack_readable():
-    addresses = pwndbg.aglib.stack.callstack()
+    addresses = list(pwndbg.aglib.stack.callstack())
 
     assert len(addresses) > 0
     assert all(pwndbg.aglib.memory.is_readable_address(address) for address in addresses)


### PR DESCRIPTION
Refactored the callstack function to use a generator (yield) instead of returning a full list. This helps reduce memory usage and allows more efficient iteration over frames.

Details
Replaced list appending with yield in pwndbg/aglib/stack.py

Updated relevant tests:

tests/gdb-tests/tests/test_callstack.py

tests/qemu-tests/tests/system/test_callstack.py

Related Issue
Closes #2837


<!-- Please make sure to read the testing and linting instructions at https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md before creating a PR -->
