### PR TITLE
hint users about libthread_db configuration if arena not found

### DIFF
--- a/pwndbg/commands/ptmalloc2.py
+++ b/pwndbg/commands/ptmalloc2.py
@@ -144,6 +144,12 @@ def print_no_arena_found_error(tid=None) -> None:
             f"No arena found for thread {message.hint(tid)} (the thread hasn't performed any allocations)."
         )
     )
+    print(
+        message.hint(
+            "Use `set libthread-db-search-path <path>` if the path contains a compatible libthread_db.\n"
+            "Then rerun the program."
+        )
+    )
 
 
 def print_no_tcache_bins_found_error(tid: int | None = None) -> None:

--- a/pwndbg/commands/ptmalloc2.py
+++ b/pwndbg/commands/ptmalloc2.py
@@ -144,12 +144,13 @@ def print_no_arena_found_error(tid=None) -> None:
             f"No arena found for thread {message.hint(tid)} (the thread hasn't performed any allocations)."
         )
     )
-    print(
-        message.hint(
-            "Use `set libthread-db-search-path <path>` if the path contains a compatible libthread_db.\n"
-            "Then rerun the program."
+    if pwndbg.dbg.name() == pwndbg.dbg_mod.DebuggerType.GDB:
+        print(
+            message.hint(
+                "Use `set libthread-db-search-path <path>` if the path contains a compatible libthread_db.\n"
+                "Then rerun the program."
+            )
         )
-    )
 
 
 def print_no_tcache_bins_found_error(tid: int | None = None) -> None:


### PR DESCRIPTION
Today I encountered an error when trying to view heap chunks while switching between (p)threads. I used `pathelf` to set runpath to my cwd. And pwndbg (or vanilla gdb) cannot use my libthread_db that exists on my cwd. So a little hint about this gdb configuration might help people in the future. 
![image](https://github.com/user-attachments/assets/f5f545d9-e6cb-473c-ae91-60b60ab4d28f)
![image](https://github.com/user-attachments/assets/ec6f04fe-46df-47fc-8647-ae068ed699d5)

Note: gef, however, still is [able to view/get heap](https://github.com/pwndbg/pwndbg/pull/2868#issuecomment-2800068340) chunks while it doesn't use libthread_db. I haven't dug deep to understand what gef does.