### PR TITLE
Disable pwnlib update detection

### DIFF
--- a/pwndbg/dbg/gdb/__init__.py
+++ b/pwndbg/dbg/gdb/__init__.py
@@ -1294,6 +1294,9 @@ def _gdb_event_class_from_event_type(ty: pwndbg.dbg_mod.EventType) -> Any:
 class GDB(pwndbg.dbg_mod.Debugger):
     @override
     def setup(self):
+        import pwnlib
+        pwnlib.update.disabled = True
+
         from pwndbg.commands import load_commands
 
         load_gdblib()

--- a/pwndbg/dbg/gdb/__init__.py
+++ b/pwndbg/dbg/gdb/__init__.py
@@ -1294,7 +1294,7 @@ def _gdb_event_class_from_event_type(ty: pwndbg.dbg_mod.EventType) -> Any:
 class GDB(pwndbg.dbg_mod.Debugger):
     @override
     def setup(self):
-        import pwnlib
+        import pwnlib.update
         pwnlib.update.disabled = True
 
         from pwndbg.commands import load_commands

--- a/pwndbg/dbg/gdb/__init__.py
+++ b/pwndbg/dbg/gdb/__init__.py
@@ -1295,6 +1295,7 @@ class GDB(pwndbg.dbg_mod.Debugger):
     @override
     def setup(self):
         import pwnlib.update
+
         pwnlib.update.disabled = True
 
         from pwndbg.commands import load_commands

--- a/pwndbg/dbg/lldb/__init__.py
+++ b/pwndbg/dbg/lldb/__init__.py
@@ -1752,6 +1752,7 @@ class LLDB(pwndbg.dbg_mod.Debugger):
     @override
     def setup(self, *args, **kwargs):
         import pwnlib.update
+
         pwnlib.update.disabled = True
 
         self.exec_states = []

--- a/pwndbg/dbg/lldb/__init__.py
+++ b/pwndbg/dbg/lldb/__init__.py
@@ -1751,6 +1751,9 @@ class LLDB(pwndbg.dbg_mod.Debugger):
 
     @override
     def setup(self, *args, **kwargs):
+        import pwnlib
+        pwnlib.update.disabled = True
+
         self.exec_states = []
         self.event_handlers = {}
         self.controllers = []

--- a/pwndbg/dbg/lldb/__init__.py
+++ b/pwndbg/dbg/lldb/__init__.py
@@ -1751,7 +1751,7 @@ class LLDB(pwndbg.dbg_mod.Debugger):
 
     @override
     def setup(self, *args, **kwargs):
-        import pwnlib
+        import pwnlib.update
         pwnlib.update.disabled = True
 
         self.exec_states = []


### PR DESCRIPTION
Before there was this message, but it is useless in our portable release.
User can't update pwntools.
<img width="1147" alt="image" src="https://github.com/user-attachments/assets/083d5c3c-f1ac-426d-b791-f28ce7d52c43" />
