### PR TITLE
Fix "set glibc 2.31" which got broken recently

### DIFF
--- a/pwndbg/glibc.py
+++ b/pwndbg/glibc.py
@@ -60,7 +60,7 @@ def set_glibc_version() -> None:
 @pwndbg.aglib.proc.OnlyWhenRunning
 def get_version() -> Tuple[int, ...] | None:
     if glibc_version:
-        version_tuple = tuple(int(i) for i in glibc_version.split('.'))
+        version_tuple = tuple(int(i) for i in glibc_version.split("."))
         return cast(Union[Tuple[int, ...], None], version_tuple)
 
     return _get_version()

--- a/pwndbg/glibc.py
+++ b/pwndbg/glibc.py
@@ -45,9 +45,8 @@ glibc_version = pwndbg.config.add_param(
 
 @pwndbg.config.trigger(glibc_version)
 def set_glibc_version() -> None:
-    ret = re.search(r"(\d+)\.(\d+)", glibc_version.value)
+    ret = re.search(r"^(\d+)\.(\d+)$", glibc_version.value)
     if ret:
-        glibc_version.value = tuple(map(int, ret.groups()))
         return
 
     print(
@@ -60,7 +59,11 @@ def set_glibc_version() -> None:
 
 @pwndbg.aglib.proc.OnlyWhenRunning
 def get_version() -> Tuple[int, ...] | None:
-    return cast(Union[Tuple[int, ...], None], glibc_version) or _get_version()
+    if glibc_version:
+        version_tuple = tuple(int(i) for i in glibc_version.split('.'))
+        return cast(Union[Tuple[int, ...], None], version_tuple)
+
+    return _get_version()
 
 
 @pwndbg.aglib.proc.OnlyWhenRunning

--- a/tests/gdb-tests/tests/test_glibc.py
+++ b/tests/gdb-tests/tests/test_glibc.py
@@ -55,3 +55,20 @@ def test_parsing_info_sharedlibrary_to_find_libc_filename(start_binary, have_deb
         gdb.execute("break break_here")
         gdb.execute("continue")
         assert pwndbg.glibc.get_libc_filename_from_info_sharedlibrary() is None
+
+
+def test_set_glibc_version(start_binary):
+    # Needed for glibc.get_version() as it has @OnlyWhenRunning
+    start_binary(HEAP_MALLOC_CHUNK)
+
+    errmsg = "Invalid GLIBC version:"
+    err = gdb.execute("set glibc 2.31a", to_string=True)
+    assert err.startswith(errmsg)
+
+    err = gdb.execute("set glibc 2.31", to_string=True)
+    assert err == ""
+    assert pwndbg.glibc.get_version() == (2, 31)
+
+    err = gdb.execute("set glibc 2.34", to_string=True)
+    assert err == ""
+    assert pwndbg.glibc.get_version() == (2, 34)


### PR DESCRIPTION
I haven't tracked when it got broken, but we were setting a tuple for a string parameter.

It did not work on 2025.02.19 but worked on 2025.01.20.

I also added a testcase for this behavior now.

<!-- Please make sure to read the testing and linting instructions at https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md before creating a PR -->
