### PR TITLE
Fix update dependencies function in gdbinit.py

### DIFF
--- a/gdbinit.py
+++ b/gdbinit.py
@@ -80,7 +80,7 @@ def update_deps(src_root: Path, venv_path: Path) -> None:
         logging.debug("No stored hash found")
 
     # If the hashes don't match, update the dependencies
-    if current_hash != stored_hash:
+    if current_hash == stored_hash:
         return
 
     print("Detected outdated Pwndbg dependencies (uv.lock). Updating.")


### PR DESCRIPTION
Fix gdbinit.py packages-out-of-date detection. Looks like there was a small equality check error, a flipped `==` vs `!=`

It is now the same as lldbinit.py
https://github.com/pwndbg/pwndbg/blob/9eab50b2f07c579023e022db1166a23c55d2c753/lldbinit.py#L62-L65