### PR TITLE
Remove support for GDB <= 9.x

### DIFF
--- a/pwndbg/dbg/gdb/__init__.py
+++ b/pwndbg/dbg/gdb/__init__.py
@@ -1331,10 +1331,6 @@ class GDB(pwndbg.dbg_mod.Debugger):
         handle SIGSEGV stop   print nopass
         """.strip()
 
-        # See https://github.com/pwndbg/pwndbg/issues/808
-        if gdb_version[0] <= 9:
-            pre_commands += "\nset remote search-memory-packet off"
-
         for line in pre_commands.strip().splitlines():
             gdb.execute(line)
 


### PR DESCRIPTION
Removing a fix for GDBs <= 9.x which are not needed anymore as we only support GDB 12+.

<img width="646" alt="image" src="https://github.com/user-attachments/assets/d1f769f1-aeba-4b3b-8d71-052ecd00d752" />
