### PR TITLE
Make Binary Ninja integration not dependent on IDA integration to work

### DIFF
--- a/pwndbg/integration/binja.py
+++ b/pwndbg/integration/binja.py
@@ -48,6 +48,9 @@ from pwndbg.dbg import StopPoint
 from pwndbg.lib.functions import Argument
 from pwndbg.lib.functions import Function
 
+xmlrpc.client.MAXINT = 10**100  # type: ignore[misc]
+xmlrpc.client.MININT = -(10**100)  # type: ignore[misc]
+
 bn_rpc_host = pwndbg.config.add_param(
     "bn-rpc-host", "127.0.0.1", "Binary Ninja XML-RPC server host"
 )

--- a/pwndbg/integration/binja.py
+++ b/pwndbg/integration/binja.py
@@ -189,17 +189,11 @@ def can_connect() -> bool:
 
 
 def l2r(addr: int) -> int:
-    exe = pwndbg.aglib.elf.exe()
-    if not exe:
-        raise Exception("Can't find EXE base")
     result = (addr - pwndbg.aglib.proc.binary_base_addr + base()) & pwndbg.aglib.arch.ptrmask
     return result
 
 
 def r2l(addr: int) -> int:
-    exe = pwndbg.aglib.elf.exe()
-    if not exe:
-        raise Exception("Can't find EXE base")
     result = (addr - base() + pwndbg.aglib.proc.binary_base_addr) & pwndbg.aglib.arch.ptrmask
     return result
 

--- a/pwndbg/integration/binja.py
+++ b/pwndbg/integration/binja.py
@@ -48,9 +48,6 @@ from pwndbg.dbg import StopPoint
 from pwndbg.lib.functions import Argument
 from pwndbg.lib.functions import Function
 
-xmlrpc.client.MAXINT = 10**100  # type: ignore[misc]
-xmlrpc.client.MININT = -(10**100)  # type: ignore[misc]
-
 bn_rpc_host = pwndbg.config.add_param(
     "bn-rpc-host", "127.0.0.1", "Binary Ninja XML-RPC server host"
 )
@@ -89,6 +86,9 @@ def init_bn_rpc_client() -> None:
 
     if pwndbg.integration.provider_name.value != "binja":
         return
+
+    xmlrpc.client.MAXINT = 10**100  # type: ignore[misc]
+    xmlrpc.client.MININT = -(10**100)  # type: ignore[misc]
 
     now = time.time()
     if _bn is None and (now - _bn_last_connection_check) < int(bn_timeout) + 5:

--- a/pwndbg/integration/ida.py
+++ b/pwndbg/integration/ida.py
@@ -42,7 +42,8 @@ ida_rpc_host = pwndbg.config.add_param("ida-rpc-host", "127.0.0.1", "ida xmlrpc 
 ida_rpc_port = pwndbg.config.add_param("ida-rpc-port", 31337, "ida xmlrpc server port")
 ida_timeout = pwndbg.config.add_param("ida-timeout", 2, "time to wait for ida xmlrpc in seconds")
 
-xmlrpc.client.Marshaller.dispatch[int] = lambda _, v, w: w("<value><i8>%d</i8></value>" % v)
+xmlrpc.client.MAXINT = 10**100  # type: ignore[misc]
+xmlrpc.client.MININT = -(10**100)  # type: ignore[misc]
 
 
 _ida: xmlrpc.client.ServerProxy | None = None

--- a/pwndbg/integration/ida.py
+++ b/pwndbg/integration/ida.py
@@ -42,9 +42,6 @@ ida_rpc_host = pwndbg.config.add_param("ida-rpc-host", "127.0.0.1", "ida xmlrpc 
 ida_rpc_port = pwndbg.config.add_param("ida-rpc-port", 31337, "ida xmlrpc server port")
 ida_timeout = pwndbg.config.add_param("ida-timeout", 2, "time to wait for ida xmlrpc in seconds")
 
-xmlrpc.client.MAXINT = 10**100  # type: ignore[misc]
-xmlrpc.client.MININT = -(10**100)  # type: ignore[misc]
-
 
 _ida: xmlrpc.client.ServerProxy | None = None
 
@@ -65,6 +62,9 @@ def init_ida_rpc_client() -> None:
 
     if pwndbg.integration.provider_name.value != "ida":
         return
+
+    xmlrpc.client.MAXINT = 10**100  # type: ignore[misc]
+    xmlrpc.client.MININT = -(10**100)  # type: ignore[misc]
 
     now = time.time()
     if _ida is None and (now - _ida_last_connection_check) < int(ida_timeout) + 5:


### PR DESCRIPTION
The current binja integration depends on the IDA integration to inject a custom int marshaller into the xmlrpc client, which can cause the binja integration to error if the IDA integration doesn't get run. This PR makes it so both integrations will inject a large `MAXINT` and `MININT` so that they're not dependent on each other.
