### PR TITLE
Context display fix involving unknown syscall ABI's + MIPS Disassembly CapstoneV6 Hotfix

### DIFF
--- a/pwndbg/aglib/disasm/arch.py
+++ b/pwndbg/aglib/disasm/arch.py
@@ -604,7 +604,11 @@ class DisassemblyAssistant:
 
         Elements of the tuple will be None to indicate it's not a syscall
         """
-        return (pwndbg.aglib.arch.name, pwndbg.lib.abi.ABI.syscall().syscall_register)
+        try:
+            abi = pwndbg.lib.abi.ABI.syscall()
+        except KeyError:
+            return (None, None)
+        return (pwndbg.aglib.arch.name, abi.syscall_register)
 
     def _enhance_conditional(self, instruction: PwndbgInstruction, emu: Emulator) -> None:
         """

--- a/pwndbg/aglib/disasm/disassembly.py
+++ b/pwndbg/aglib/disasm/disassembly.py
@@ -499,6 +499,11 @@ def near(
                     emu.valid = False
 
                 split_insn = one(insn.address + insn.size, None, put_cache=True)
+
+                # There might not be a valid instruction at the branch delay slot
+                if split_insn is None:
+                    break
+
                 insns.append(split_insn)
 
                 # Manually make the backtracing cache correct

--- a/pwndbg/aglib/disasm/disassembly.py
+++ b/pwndbg/aglib/disasm/disassembly.py
@@ -181,12 +181,35 @@ def get_disassembler(address):
     elif pwndbg.aglib.arch.name == "i8086":
         extra = CS_MODE_16
 
-    elif (
-        pwndbg.aglib.arch.name == "mips"
-        and pwndbg.dbg.is_gdblib_available()
-        and "isa32r6" in gdb.newest_frame().architecture().name()
-    ):
-        extra = CS_MODE_MIPS32R6
+    elif pwndbg.aglib.arch.name == "mips":
+        if pwndbg.dbg.is_gdblib_available():
+            # Example: "mips:isa64r2"
+            raw_arch_name = gdb.newest_frame().architecture().name()
+
+            if "isa32r2" in raw_arch_name:
+                extra = CS_MODE_MIPS32R2
+            elif "isa32r3" in raw_arch_name:
+                extra = CS_MODE_MIPS32R3
+            elif "isa32r5" in raw_arch_name:
+                extra = CS_MODE_MIPS32R5
+            elif "isa32r6" in raw_arch_name:
+                extra = CS_MODE_MIPS32R6
+            elif "isa64r2" in raw_arch_name:
+                extra = CS_MODE_MIPS64R2
+            elif "isa64r3" in raw_arch_name:
+                extra = CS_MODE_MIPS64R3
+            elif "isa64r5" in raw_arch_name:
+                extra = CS_MODE_MIPS64R5
+            elif "isa64r6" in raw_arch_name:
+                extra = CS_MODE_MIPS64R6
+            elif "micromips" in raw_arch_name:
+                extra = CS_MODE_MICRO
+            elif "mips5" in raw_arch_name:
+                extra = CS_MODE_MIPS5
+            elif pwndbg.aglib.arch.ptrsize == 64:
+                extra = CS_MODE_MIPS64
+            else:
+                extra = CS_MODE_MIPS32
 
     elif pwndbg.aglib.arch.name == "rv32":
         extra = CS_MODE_RISCV32 | CS_MODE_RISCVC  # novermin

--- a/pwndbg/arguments.py
+++ b/pwndbg/arguments.py
@@ -60,7 +60,10 @@ def get(instruction: PwndbgInstruction) -> List[Tuple[pwndbg.lib.functions.Argum
     elif CS_GRP_INT in instruction.groups:
         # Get the syscall number and name
         name = instruction.syscall_name
-        abi = pwndbg.lib.abi.ABI.syscall()
+        try:
+            abi = pwndbg.lib.abi.ABI.syscall()
+        except KeyError:
+            return []
         target = None
 
         if name is None:


### PR DESCRIPTION
1. Adds a try/catch block to a place that fetches the syscall ABI, which might return a KeyError - this results in a crash when encountering a syscall instruction in the disasm context view for an arch where the syscall ABI is not defined.
- This is fixed in #2771, but before that is merged I wanted to get a fix in

2. We just updated to Capstone V6, which changed how to specify the disassembler mode for MIPS - now, we have to be much more precise about the specific ABI version being used. Adds a quick check to select the correct constant to pass to Capstone to correctly disassemble instructions. 