### PR TITLE
add auto trigger homebrew release

### DIFF
--- a/.github/workflows/trigger-homebrew-release.yml
+++ b/.github/workflows/trigger-homebrew-release.yml
@@ -1,0 +1,17 @@
+name: Trigger Homebrew Release
+on:
+  release:
+    types: [released]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send
+        run: |
+          curl -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.HOMEBREW_TRIGGER_TOKEN }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/pwndbg/homebrew-tap/dispatches \
+            -d '{"event_type":"pwndbg_release","client_payload":{"version":"${{ github.event.release.tag_name }}"}}'


### PR DESCRIPTION
When a new release is published on [pwndbg/pwndbg](https://github.com/pwndbg/pwndbg), it triggers this workflow in the [homebrew-tap](https://github.com/pwndbg/homebrew-tap) repo.

This automates the release process for both pwndbg-gdb and pwndbg-lldb, ensuring the tap stays up to date with no manual intervention.

Homebrew workflow here: https://github.com/pwndbg/homebrew-tap/blob/main/.github/workflows/update.yml

secrets.HOMEBREW_TRIGGER_TOKEN need only this permission and single repo `pwndbg/homebrew-tap`:
<img width="634" alt="image" src="https://github.com/user-attachments/assets/28edfbcc-9e19-434a-b797-85c5e86cb046" />

