### PR TITLE
set xmlrpc.client.MAXINT and MININT to support larger integers

### DIFF
--- a/pwndbg/integration/ida.py
+++ b/pwndbg/integration/ida.py
@@ -45,6 +45,10 @@ ida_timeout = pwndbg.config.add_param("ida-timeout", 2, "time to wait for ida xm
 
 _ida: xmlrpc.client.ServerProxy | None = None
 
+# Patch to avoid OverflowError for large integers
+xmlrpc.client.MAXINT = 10**100
+xmlrpc.client.MININT = -(10**100)
+
 # to avoid printing the same exception multiple times, we store the last exception here
 _ida_last_exception = None
 


### PR DESCRIPTION
The XML-RPC library in Python by default only supports integers within 32-bit signed int range. This patch overrides that limit so large integers (like addresses or offsets from IDA) won't throw `OverflowError`.


