### PR TITLE
Cleanup installation instructions

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -1,4 +1,6 @@
 - [Development Basics](#development-basics)
+  - [Install from source GDB](#install-from-source-gdb)
+  - [Install from source LLDB](#install-from-source-lldb)
   - [Environment setup](#environment-setup)
     - [Development using Nix](#development-using-nix)
   - [Testing](#testing)
@@ -25,6 +27,60 @@
   - [Creating small cross-architecture programs](#creating-small-cross-architecture-programs)
 
 # Development Basics
+
+## Install from source GDB
+Installation from source is straightforward:
+```shell
+git clone https://github.com/pwndbg/pwndbg
+cd pwndbg
+./setup.sh
+```
+
+Pwndbg is supported on Ubuntu 22.04, and 24.04 with GDB 12.1 and later. We do not test
+on any older versions of Ubuntu, so `pwndbg` may not work on these versions.
+- For Ubuntu 20.04 use the [2024.08.29 release](https://github.com/pwndbg/pwndbg/releases/tag/2024.08.29)
+- For Ubuntu 18.04 use the [2023.07.17: ubuntu18.04-final release](https://github.com/pwndbg/pwndbg/releases/tag/2023.07.17)
+
+We may accept pull requests fixing issues in older versions on a case by case basis,
+please discuss this with us on [Discord][discord] first. You can also always checkout
+an older version of `pwndbg` from around the time the Ubuntu version you're interested
+in was still supported by Canonical, or you can attempt to build a newer version of GDB from source.
+
+Other Linux distributions are also supported via `setup.sh`, including:
+
+* Debian-based OSes (via apt-get)
+* Fedora and Red Hat (via dnf)
+* Clear (via swiped)
+* OpenSUSE LEAP (via zypper)
+* Arch and Manjaro (via community AUR packages)
+* Void (via xbps)
+* Gentoo (via emerge)
+
+If you use any Linux distribution other than Ubuntu, we recommend using the [latest available GDB](https://www.gnu.org/software/gdb/download/) built from source. You can build it as:
+```
+cd <gdb-sources-dir>
+mkdir build && cd build
+sudo apt install libgmp-dev libmpfr-dev libreadline-dev texinfo  # required by build
+../configure --disable-nls --disable-werror --with-system-readline --with-python=`which python3` --with-system-gdbinit=/etc/gdb/gdbinit --enable-targets=all
+make -j $(nproc)
+```
+
+## Install from source LLDB
+```shell
+git clone https://github.com/pwndbg/pwndbg
+cd pwndbg
+
+apt install -y lldb-19 liblldb-19-dev python3 python3-venv 
+export PATH=/usr/lib/llvm-19/bin/:$PATH
+export LLDB_DEBUGSERVER_PATH=/usr/lib/llvm-19/bin/lldb-server
+
+python3 -m venv -- .venv
+./.venv/bin/pip install uv
+./.venv/bin/uv sync --extra lldb
+
+./.venv/bin/python3 ./pwndbg-lldb.py
+```
+This will work only for ubuntu 24.04
 
 ## Environment setup
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Pwndbg ensures a consistent experience across both, so switching between them is
 ### Installing Pwndbg-LLDB
 * Install via curl/sh (Linux/macOS)
 ```
-curl -qsL 'https://install.pwndbg.re' | /bin/sh -s -- -t pwndbg-lldb
+curl -qsL 'https://install.pwndbg.re' | sh -s -- -t pwndbg-lldb
 ```
 * Install via Homebrew (macOS)
 ```
@@ -98,7 +98,7 @@ pwndbg-lldb ./your-binary
 ### Installing Pwndbg-GDB
 * Install via curl/sh (Linux/macOS)
 ```
-curl -qsL 'https://install.pwndbg.re' | /bin/sh -s -- -t pwndbg-gdb
+curl -qsL 'https://install.pwndbg.re' | sh -s -- -t pwndbg-gdb
 ```
 * Install via Homebrew (macOS)
 ```

--- a/README.md
+++ b/README.md
@@ -79,38 +79,7 @@ Pwndbg ensures a consistent experience across both, so switching between them is
 
 ## How?
 
-### Installing Pwndbg-LLDB
-* Install via curl/sh (Linux/macOS)
-```
-curl -qsL 'https://install.pwndbg.re' | sh -s -- -t pwndbg-lldb
-```
-* Install via Homebrew (macOS)
-```
-brew install pwndbg/tap/pwndbg-lldb
-```
-* Install via the Nix package manager (Linux/macOS):
-```shell
-nix shell github:pwndbg/pwndbg#pwndbg-lldb
-pwndbg-lldb ./your-binary
-```
-* [Install from source](https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md#install-from-source-lldb)
-
-### Installing Pwndbg-GDB
-* Install via curl/sh (Linux/macOS)
-```
-curl -qsL 'https://install.pwndbg.re' | sh -s -- -t pwndbg-gdb
-```
-* Install via Homebrew (macOS)
-```
-brew install pwndbg/tap/pwndbg-gdb
-```
-* Install via the Nix package manager (Linux/macOS)
-```shell
-nix shell github:pwndbg/pwndbg
-pwndbg ./your-binary
-```
-* [Install via your distro’s package manager (apt, yum, dnf, apk, pacman)](https://pwndbg.re/pwndbg/latest/setup/#download-the-portable-version)
-* [Install from source](https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md#install-from-source-gdb)
+See [installation instructions](https://pwndbg.re/pwndbg/latest/setup).
 
 ## What can I do with that?
 

--- a/README.md
+++ b/README.md
@@ -79,130 +79,37 @@ Pwndbg ensures a consistent experience across both, so switching between them is
 
 ## How?
 
-For a portable version with no external dependencies, scroll down for the [Portable Installation](#portable-installation) section.
-
-### Installing LLDB
-
-* Install via the Nix package manager (you can use Nix on any distribution):
+### Installing Pwndbg-LLDB
+* Install via curl/sh (Linux/macOS)
+```
+curl -qsL 'https://install.pwndbg.re' | /bin/sh -s -- -t pwndbg-lldb
+```
+* Install via Homebrew (macOS)
+```
+brew install pwndbg/tap/pwndbg-lldb
+```
+* Install via the Nix package manager (Linux/macOS):
 ```shell
 nix shell github:pwndbg/pwndbg#pwndbg-lldb
 pwndbg-lldb ./your-binary
 ```
-* Or download portable version with no external dependencies, scroll down for the [Portable Installation](#portable-installation) section
-* ~~Or install from source, instructions below.~~ (not supported)
+* Install from source [go here](https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md#install-from-source-lldb)
 
-### Installing GDB
-
-* Install via the Nix package manager (you can use Nix on any distribution):
+### Installing Pwndbg-GDB
+* Install via curl/sh (Linux/macOS)
+```
+curl -qsL 'https://install.pwndbg.re' | /bin/sh -s -- -t pwndbg-gdb
+```
+* Install via Homebrew (macOS)
+```
+brew install pwndbg/tap/pwndbg-gdb
+```
+* Install via the Nix package manager (Linux/macOS)
 ```shell
 nix shell github:pwndbg/pwndbg
 pwndbg ./your-binary
 ```
-* Or download portable version with no external dependencies, scroll down for the [Portable Installation](#portable-installation) section
-
-* Or install from source, instructions below.
-<details>
-  <summary>Click here to expand instructions</summary>
-
-Installation from source is straightforward:
-```shell
-git clone https://github.com/pwndbg/pwndbg
-cd pwndbg
-./setup.sh
-```
-
-Pwndbg is supported on Ubuntu 22.04, and 24.04 with GDB 12.1 and later. We do not test
-on any older versions of Ubuntu, so `pwndbg` may not work on these versions.
-- For Ubuntu 20.04 use the [2024.08.29 release](https://github.com/pwndbg/pwndbg/releases/tag/2024.08.29)
-- For Ubuntu 18.04 use the [2023.07.17: ubuntu18.04-final release](https://github.com/pwndbg/pwndbg/releases/tag/2023.07.17)
-
-We may accept pull requests fixing issues in older versions on a case by case basis,
-please discuss this with us on [Discord][discord] first. You can also always checkout
-an older version of `pwndbg` from around the time the Ubuntu version you're interested
-in was still supported by Canonical, or you can attempt to build a newer version of GDB from source.
-
-Other Linux distributions are also supported via `setup.sh`, including:
-
-* Debian-based OSes (via apt-get)
-* Fedora and Red Hat (via dnf)
-* Clear (via swiped)
-* OpenSUSE LEAP (via zypper)
-* Arch and Manjaro (via community AUR packages)
-* Void (via xbps)
-* Gentoo (via emerge)
-
-If you use any Linux distribution other than Ubuntu, we recommend using the [latest available GDB](https://www.gnu.org/software/gdb/download/) built from source. You can build it as:
-```
-cd <gdb-sources-dir>
-mkdir build && cd build
-sudo apt install libgmp-dev libmpfr-dev libreadline-dev texinfo  # required by build
-../configure --disable-nls --disable-werror --with-system-readline --with-python=`which python3` --with-system-gdbinit=/etc/gdb/gdbinit --enable-targets=all
-make -j7
-```
-</details>
-
-## Portable Installation:
-
-The portable version includes all necessary dependencies and should work without the need to install additional packages.
-
-### Download the Portable Version:
-
-Download the portable version from the [Pwndbg releases page](https://github.com/pwndbg/pwndbg/releases) by selecting the desired version.
-
-**Note:** For LLDB, only the tarball version is available.
-
-Make sure to select the correct file for your operating system and architecture:
-- **Linux (x86_64, armv7l, aarch64, riscv64):**
-  - `pwndbg_2025.04.18_amd64.tar.xz` (x86_64 for GDB)
-  - `pwndbg_2025.04.18_armv7.tar.xz` (armv7l for GDB)
-  - `pwndbg_2025.04.18_arm64.tar.xz` (aarch64 for GDB)
-  - `pwndbg_2025.04.18_riscv64.tar.xz` (riscv64 for GDB)
-  - `pwndbg-lldb_2025.04.18_amd64.tar.xz` (x86_64 for LLDB)
-  - `pwndbg-lldb_2025.04.18_armv7.tar.xz` (armv7l for LLDB)
-  - `pwndbg-lldb_2025.04.18_arm64.tar.xz` (aarch64 for LLDB)
-  - `pwndbg-lldb_2025.04.18_riscv64.tar.xz` (riscv64 for LLDB)
-
-- **macOS (amd64, arm64):**
-  - `pwndbg-lldb_2025.04.18_macos_amd64.tar.xz` (macOS, Intel/AMD CPUs, for LLDB)
-  - `pwndbg-lldb_2025.04.18_macos_arm64.tar.xz` (macOS, Apple Silicon/M1/M2/M*, for LLDB)
-  - `pwndbg_2025.04.18_macos_amd64.tar.xz` (macOS, Intel/AMD CPUs for GDB)
-  - `pwndbg_2025.04.18_macos_amd64.tar.xz` (macOS, Apple Silicon/M1/M2/M*, for GDB via **Rosseta emulation**)
-
-
-#### Instructions:
-- Portable tarball:
-```shell
-tar -v -xf ./pwndbg_2025.04.18_amd64.tar.xz
-# ./pwndbg/bin/pwndbg
-# or ./pwndbg/bin/pwndbg-lldb
-```
-- Installation on RPM-based Systems (CentOS/Alma/Rocky/RHEL):
-```shell
-dnf install ./pwndbg-2025.04.18.x86_64.rpm
-# pwndbg
-# and/or pwndbg-lldb
-```
-
-- Installation on DEB-based Systems (Debian/Ubuntu/Kali):
-```shell
-apt install ./pwndbg_2025.04.18_amd64.deb
-# pwndbg
-# and/or pwndbg-lldb
-```
-
-- Installation on Alpine:
-```shell
-apk add --allow-untrusted ./pwndbg_2025.04.18_x86_64.apk
-# pwndbg
-# and/or pwndbg-lldb
-```
-
-- Installation on Arch Linux:
-```shell
-pacman -U ./pwndbg-2025.04.18-1-x86_64.pkg.tar.zst
-# pwndbg
-# and/or pwndbg-lldb
-```
+* Install from source [go here](https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md#install-from-source-gdb)
 
 ## What can I do with that?
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ brew install pwndbg/tap/pwndbg-lldb
 nix shell github:pwndbg/pwndbg#pwndbg-lldb
 pwndbg-lldb ./your-binary
 ```
-* Install from source [go here](https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md#install-from-source-lldb)
+* [Install from source](https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md#install-from-source-lldb)
 
 ### Installing Pwndbg-GDB
 * Install via curl/sh (Linux/macOS)
@@ -109,7 +109,8 @@ brew install pwndbg/tap/pwndbg-gdb
 nix shell github:pwndbg/pwndbg
 pwndbg ./your-binary
 ```
-* Install from source [go here](https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md#install-from-source-gdb)
+* [Install via your distro’s package manager (apt, yum, dnf, apk, pacman)](https://pwndbg.re/pwndbg/latest/setup/#download-the-portable-version)
+* [Install from source](https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md#install-from-source-gdb)
 
 ## What can I do with that?
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -8,7 +8,7 @@ hide:
 ### Installing Pwndbg-LLDB
 * Install via curl/sh (Linux/macOS)
 ```
-curl -qsL 'https://install.pwndbg.re' | /bin/sh -s -- -t pwndbg-lldb
+curl -qsL 'https://install.pwndbg.re' | sh -s -- -t pwndbg-lldb
 ```
 * Install via Homebrew (macOS)
 ```
@@ -24,7 +24,7 @@ pwndbg-lldb ./your-binary
 ### Installing Pwndbg-GDB
 * Install via curl/sh (Linux/macOS)
 ```
-curl -qsL 'https://install.pwndbg.re' | /bin/sh -s -- -t pwndbg-gdb
+curl -qsL 'https://install.pwndbg.re' | sh -s -- -t pwndbg-gdb
 ```
 * Install via Homebrew (macOS)
 ```

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -35,9 +35,10 @@ brew install pwndbg/tap/pwndbg-gdb
 nix shell github:pwndbg/pwndbg
 pwndbg ./your-binary
 ```
-* Install from source [go here](https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md#install-from-source-gdb)
+* [Install via your distro’s package manager (apt, yum, dnf, apk, pacman)](https://pwndbg.re/pwndbg/latest/setup/#download-the-portable-version)
+* [Install from source](https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md#install-from-source-gdb)
 
-### Download the Distro/Portable Version:
+### Download the Portable Version:
 
 > [!TIP]
 > Download the proper version from the [Pwndbg releases page](https://github.com/pwndbg/pwndbg/releases).

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -5,76 +5,78 @@ hide:
 
 # Setup
 
-### Installing Pwndbg-LLDB
-* Install via curl/sh (Linux/macOS)
-```
-curl -qsL 'https://install.pwndbg.re' | sh -s -- -t pwndbg-lldb
-```
-* Install via Homebrew (macOS)
-```
-brew install pwndbg/tap/pwndbg-lldb
-```
-* Install via the Nix package manager (Linux/macOS):
-```shell
-nix shell github:pwndbg/pwndbg#pwndbg-lldb
-pwndbg-lldb ./your-binary
-```
-* Install from source [go here](https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md#install-from-source-lldb)
+There are multiple ways to install pwndbg, depending on whether you want to use it [for GDB](#installing-pwndbg-for-gdb), [for LLDB](#installing-pwndbg-for-lldb), use a [portable release](#download-the-portable-version), or install it [from source](#installing-from-source).
 
-### Installing Pwndbg-GDB
-* Install via curl/sh (Linux/macOS)
-```
+## Installing pwndbg for GDB
+Install via curl/sh (Linux/macOS)
+```{.bash .copy}
 curl -qsL 'https://install.pwndbg.re' | sh -s -- -t pwndbg-gdb
 ```
-* Install via Homebrew (macOS)
-```
+Install via Homebrew (macOS)
+```{.bash .copy}
 brew install pwndbg/tap/pwndbg-gdb
 ```
-* Install via the Nix package manager (Linux/macOS)
-```shell
+Install via the Nix package manager (Linux/macOS)
+```{.bash .copy}
 nix shell github:pwndbg/pwndbg
-pwndbg ./your-binary
 ```
-* [Install via your distro’s package manager (apt, yum, dnf, apk, pacman)](https://pwndbg.re/pwndbg/latest/setup/#download-the-portable-version)
-* [Install from source](https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md#install-from-source-gdb)
+### Through package manager
+When installing for GDB, you may also download a package to install through your package manager of choice. Download the package from the [releases page](https://github.com/pwndbg/pwndbg/releases) and pick the appropriate download from the second table.
 
-### Download the Portable Version:
 
-> [!TIP]
-> Download the proper version from the [Pwndbg releases page](https://github.com/pwndbg/pwndbg/releases).
-> Choose the appropriate version for your system architecture.
-
-### Installation Pwndbg-GDB on RPM-based Systems (CentOS/Alma/Rocky/RHEL):
-
-```shell
+RPM-based Systems (CentOS/Alma/Rocky/RHEL):
+```{.bash .copy}
 dnf install ./pwndbg-2025.04.18.x86_64.rpm
-# pwndbg
 ```
-
-### Installation Pwndbg-GDB on DEB-based Systems (Debian/Ubuntu/Kali):
-
-```shell
+DEB-based Systems (Debian/Ubuntu/Kali):
+```{.bash .copy}
 apt install ./pwndbg_2025.04.18_amd64.deb
-# pwndbg
 ```
-
-### Installation Pwndbg-GDB on Alpine:
-
-```shell
+Alpine:
+```{.bash .copy}
 apk add --allow-untrusted ./pwndbg_2025.04.18_x86_64.apk
-# pwndbg
 ```
-
-### Installation Pwndbg-GDB on Arch Linux:
-
-```shell
+Arch Linux:
+```{.bash .copy}
 pacman -U ./pwndbg-2025.04.18-1-x86_64.pkg.tar.zst
-# pwndbg
 ```
 
-### Generic Linux Installation:
-
-```shell
-tar -v -xf ./pwndbg_2025.04.18_x86_64-portable.tar.xz
-# ./pwndbg/bin/pwndbg
+## Installing pwndbg for LLDB
+These installation methods provide the
+```{.bash .copy}
+pwndbg-lldb ./your-binary
 ```
+command.
+
+Install via curl/sh (Linux/macOS)
+```{.bash .copy}
+curl -qsL 'https://install.pwndbg.re' | sh -s -- -t pwndbg-lldb
+```
+Install via Homebrew (macOS)
+```{.bash .copy}
+brew install pwndbg/tap/pwndbg-lldb
+```
+Install via the Nix package manager (Linux/macOS):
+```{.bash .copy}
+nix shell github:pwndbg/pwndbg#pwndbg-lldb
+```
+
+## Download the Portable Version
+You can download a portable release with all batteries included on the [pwndbg releases page](https://github.com/pwndbg/pwndbg/releases). There are seperate releases for GDB and LLDB. Use the first table to pick the appropriate download for your system architecture. You can then unpack the archive with:
+```{.bash .copy}
+tar -v -xf <archive-name>
+```
+And run pwndbg with
+```bash
+./pwndbg/bin/pwndbg
+```
+or
+```
+./pwndbg/bin/pwndbg-lldb
+```
+depending on which version you installed. You may add the appropriate file to your shell's PATH.
+!!! warning ".gdbinit doesn't work for portable release"
+    If you're running `./pwndbg/bin/pwndbg` from the portable release, it is a known limitation that pwndbg settings in your `.gdbinit` won't work (see [issue #2774](https://github.com/pwndbg/pwndbg/issues/2774)). Also, make sure not to source pwndbg in your gdbinit as it already happens automatically for portable releases (if this is the first time you're installing pwndbg, you don't need to worry about this).
+
+## Installing from source
+See the relevant section in DEVELOPING.md: [for GDB](https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md#install-from-source-gdb), [for LLDB](https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md#install-from-source-lldb).

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -5,9 +5,9 @@ hide:
 
 # Setup
 
-There are multiple ways to install pwndbg, depending on whether you want to use it [for GDB](#installing-pwndbg-for-gdb), [for LLDB](#installing-pwndbg-for-lldb), use a [portable release](#download-the-portable-version), or install it [from source](#installing-from-source).
+There are multiple ways to install pwndbg, depending on whether you want to use it [with GDB](#installing-pwndbg-gdb), [with LLDB](#installing-pwndbg-lldb), use a [portable release](#download-the-portable-version), or install it [from source](#installing-from-source).
 
-## Installing pwndbg for GDB
+## Installing pwndbg-gdb
 Install via curl/sh (Linux/macOS)
 ```{.bash .copy}
 curl -qsL 'https://install.pwndbg.re' | sh -s -- -t pwndbg-gdb
@@ -21,7 +21,7 @@ Install via the Nix package manager (Linux/macOS)
 nix shell github:pwndbg/pwndbg
 ```
 ### Through package manager
-When installing for GDB, you may also download a package to install through your package manager of choice. Download the package from the [releases page](https://github.com/pwndbg/pwndbg/releases) and pick the appropriate download from the second table.
+When installing with GDB, you may also download a package to install through your package manager of choice. Download the package from the [releases page](https://github.com/pwndbg/pwndbg/releases) and pick the appropriate download from the second table.
 
 
 RPM-based Systems (CentOS/Alma/Rocky/RHEL):
@@ -41,7 +41,7 @@ Arch Linux:
 pacman -U ./pwndbg-2025.04.18-1-x86_64.pkg.tar.zst
 ```
 
-## Installing pwndbg for LLDB
+## Installing pwndbg-lldb
 These installation methods provide the
 ```{.bash .copy}
 pwndbg-lldb ./your-binary
@@ -62,7 +62,7 @@ nix shell github:pwndbg/pwndbg#pwndbg-lldb
 ```
 
 ## Download the Portable Version
-You can download a portable release with all batteries included on the [pwndbg releases page](https://github.com/pwndbg/pwndbg/releases). There are seperate releases for GDB and LLDB. Use the first table to pick the appropriate download for your system architecture. You can then unpack the archive with:
+You can download a portable release on the [pwndbg releases page](https://github.com/pwndbg/pwndbg/releases). There are seperate releases for GDB and LLDB. Use the first table to pick the appropriate download for your system architecture. You can then unpack the archive with:
 ```{.bash .copy}
 tar -v -xf <archive-name>
 ```
@@ -79,4 +79,4 @@ depending on which version you installed. You may add the appropriate file to yo
     If you're running `./pwndbg/bin/pwndbg` from the portable release, it is a known limitation that pwndbg settings in your `.gdbinit` won't work (see [issue #2774](https://github.com/pwndbg/pwndbg/issues/2774)). Also, make sure not to source pwndbg in your gdbinit as it already happens automatically for portable releases (if this is the first time you're installing pwndbg, you don't need to worry about this).
 
 ## Installing from source
-See the relevant section in DEVELOPING.md: [for GDB](https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md#install-from-source-gdb), [for LLDB](https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md#install-from-source-lldb).
+See the relevant section in DEVELOPING.md: [with GDB](https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md#install-from-source-gdb), [with LLDB](https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md#install-from-source-lldb).

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -5,73 +5,67 @@ hide:
 
 # Setup
 
-## Quick start
-Installation from source is straightforward:
-
-```shell
-git clone https://github.com/pwndbg/pwndbg
-cd pwndbg
-./setup.sh
+### Installing Pwndbg-LLDB
+* Install via curl/sh (Linux/macOS)
 ```
-## Install on Linux distributions
-Nix package manager (you can use Nix on any distribution):
+curl -qsL 'https://install.pwndbg.re' | /bin/sh -s -- -t pwndbg-lldb
+```
+* Install via Homebrew (macOS)
+```
+brew install pwndbg/tap/pwndbg-lldb
+```
+* Install via the Nix package manager (Linux/macOS):
+```shell
+nix shell github:pwndbg/pwndbg#pwndbg-lldb
+pwndbg-lldb ./your-binary
+```
+* Install from source [go here](https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md#install-from-source-lldb)
+
+### Installing Pwndbg-GDB
+* Install via curl/sh (Linux/macOS)
+```
+curl -qsL 'https://install.pwndbg.re' | /bin/sh -s -- -t pwndbg-gdb
+```
+* Install via Homebrew (macOS)
+```
+brew install pwndbg/tap/pwndbg-gdb
+```
+* Install via the Nix package manager (Linux/macOS)
 ```shell
 nix shell github:pwndbg/pwndbg
 pwndbg ./your-binary
 ```
+* Install from source [go here](https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md#install-from-source-gdb)
 
-Pwndbg is supported on Ubuntu 22.04, and 24.04 with GDB 12.1 and later. We do not test on any older versions of Ubuntu, so `pwndbg` may not work on these versions (for Ubuntu 18.04 use the [2023.07.17: ubuntu18.04-final release](https://github.com/pwndbg/pwndbg/releases/tag/2023.07.17)). We may accept pull requests fixing issues in older versions on a case by case basis, please discuss this with us on [Discord](https://discord.gg/x47DssnGwm) first. You can also always checkout an older version of `pwndbg` from around the time the Ubuntu version you're interested in was still supported by Canonical, or you can attempt to build a newer version of GDB from source.
+### Download the Distro/Portable Version:
 
-Other Linux distributions are also supported via `setup.sh`, including:
+> Remember!
+> 
+> Download the proper version from the [Pwndbg releases page](https://github.com/pwndbg/pwndbg/releases).
+> Choose the appropriate version for your system architecture.
 
-* Debian-based OSes (via apt-get)
-* Fedora and Red Hat (via dnf)
-* Clear (via swiped)
-* OpenSUSE LEAP (via zypper)
-* Arch and Manjaro (via community AUR packages)
-* Void (via xbps)
-* Gentoo (via emerge)
-
-If you use any Linux distribution other than Ubuntu, we recommend using the [latest available GDB](https://www.gnu.org/software/gdb/download/) built from source. You can build it as:
-```
-cd <gdb-sources-dir>
-mkdir build
-cd build
-../configure --disable-nls --disable-werror --with-system-readline --with-python=`which python3` --with-system-gdbinit=/etc/gdb/gdbinit --enable-targets=all
-make -j7
-```
-
-## Portable Installation from package
-
-The portable version includes all necessary dependencies and should work without the need to install additional packages.
-
-### Download the Portable Version:
-
-Download the portable version from the [Pwndbg releases page](https://github.com/pwndbg/pwndbg/releases) by selecting the desired version.
-Choose the appropriate version for your system architecture (x86_64, armv7l, aarch64, riscv64).
-
-### Installation on RPM-based Systems (CentOS/Alma/Rocky/RHEL):
+### Installation Pwndbg-GDB on RPM-based Systems (CentOS/Alma/Rocky/RHEL):
 
 ```shell
 dnf install ./pwndbg-2025.04.18.x86_64.rpm
 # pwndbg
 ```
 
-### Installation on DEB-based Systems (Debian/Ubuntu/Kali):
+### Installation Pwndbg-GDB on DEB-based Systems (Debian/Ubuntu/Kali):
 
 ```shell
 apt install ./pwndbg_2025.04.18_amd64.deb
 # pwndbg
 ```
 
-### Installation on Alpine:
+### Installation Pwndbg-GDB on Alpine:
 
 ```shell
 apk add --allow-untrusted ./pwndbg_2025.04.18_x86_64.apk
 # pwndbg
 ```
 
-### Installation on Arch Linux:
+### Installation Pwndbg-GDB on Arch Linux:
 
 ```shell
 pacman -U ./pwndbg-2025.04.18-1-x86_64.pkg.tar.zst
@@ -81,6 +75,6 @@ pacman -U ./pwndbg-2025.04.18-1-x86_64.pkg.tar.zst
 ### Generic Linux Installation:
 
 ```shell
-tar -v -xf ./pwndbg_2025.04.18_amd64.tar.xz
+tar -v -xf ./pwndbg_2025.04.18_x86_64-portable.tar.xz
 # ./pwndbg/bin/pwndbg
 ```

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -39,8 +39,7 @@ pwndbg ./your-binary
 
 ### Download the Distro/Portable Version:
 
-> Remember!
-> 
+> [!TIP]
 > Download the proper version from the [Pwndbg releases page](https://github.com/pwndbg/pwndbg/releases).
 > Choose the appropriate version for your system architecture.
 


### PR DESCRIPTION
changes:
- add instruction how to install pwndbg for LLDB only on ubuntu24.04
- remove all install instruction from README.md
- move section "Install from source GDB" from README.md to DEVELOPING.md 

thanks @k4lizen for help with documentation
