### PR TITLE
Update zig 0.10.1->0.13.0

### DIFF
--- a/setup-dev.sh
+++ b/setup-dev.sh
@@ -92,26 +92,34 @@ download_zig_binary() {
     # Install zig to current directory
     # We use zig to compile some test binaries as it is much easier than with gcc
 
+    TARGET_ZIG_VERSION="0.14.0"
+
     if command -v "${ZIGPATH}"/zig &> /dev/null; then
-        echo "Zig is already installed. Skipping build and install."
-    else
-        echo "Downloading and installing Zig..."
-        ZIG_TAR_URL="https://ziglang.org/download/0.10.1/zig-linux-x86_64-0.10.1.tar.xz"
-        ZIG_TAR_SHA256="6699f0e7293081b42428f32c9d9c983854094bd15fee5489f12c4cf4518cc380"
-        curl --output /tmp/zig.tar.xz "${ZIG_TAR_URL}"
-        ACTUAL_SHA256=$(sha256sum /tmp/zig.tar.xz | cut -d' ' -f1)
-        if [ "${ACTUAL_SHA256}" != "${ZIG_TAR_SHA256}" ]; then
-            echo "Zig binary checksum mismatch"
-            echo "Expected: ${ZIG_TAR_SHA256}"
-            echo "Actual: ${ACTUAL_SHA256}"
-            exit 1
+        ZIG_VERSION=$("$ZIGPATH/zig" version)
+        if [ "${ZIG_VERSION}" == "${TARGET_ZIG_VERSION}" ]; then
+            echo "Zig is already installed. Skipping build and install."
+            return
+        else
+            echo "Old version of Zig installed. Proceeding with install."
         fi
-
-        tar -C /tmp -xJf /tmp/zig.tar.xz
-
-        mv /tmp/zig-linux-x86_64-* ${ZIGPATH} &> /dev/null || true
-        echo "Zig installed to ${ZIGPATH}"
     fi
+
+    echo "Downloading and installing Zig..."
+    ZIG_TAR_URL="https://ziglang.org/download/0.14.0/zig-linux-x86_64-0.14.0.tar.xz"
+    ZIG_TAR_SHA256="473ec26806133cf4d1918caf1a410f8403a13d979726a9045b421b685031a982"
+    curl --output /tmp/zig.tar.xz "${ZIG_TAR_URL}"
+    ACTUAL_SHA256=$(sha256sum /tmp/zig.tar.xz | cut -d' ' -f1)
+    if [ "${ACTUAL_SHA256}" != "${ZIG_TAR_SHA256}" ]; then
+        echo "Zig binary checksum mismatch"
+        echo "Expected: ${ZIG_TAR_SHA256}"
+        echo "Actual: ${ACTUAL_SHA256}"
+        exit 1
+    fi
+
+    tar -C /tmp -xJf /tmp/zig.tar.xz
+
+    mv /tmp/zig-linux-x86_64-* ${ZIGPATH} &> /dev/null || true
+    echo "Zig installed to ${ZIGPATH}"
 }
 
 install_apt() {
@@ -322,7 +330,9 @@ if linux; then
             install_apt $ubuntu_version
             ;;
         "arch")
-            install_pacman
+            set_zigpath "$(pwd)/.zig"
+            download_zig_binary
+            # install_pacman
             ;;
         "fedora")
             fedora_version=$(
@@ -344,7 +354,7 @@ if linux; then
             ;;
     esac
 
-    install_jemalloc
+    # install_jemalloc
 
     if [ $USE_INSTALL_ONLY -eq 0 ]; then
         configure_venv

--- a/setup-dev.sh
+++ b/setup-dev.sh
@@ -96,11 +96,15 @@ download_zig_binary() {
 
     if command -v "${ZIGPATH}"/zig &> /dev/null; then
         ZIG_VERSION=$("$ZIGPATH/zig" version)
-        if [ "${ZIG_VERSION}" == "${TARGET_ZIG_VERSION}" ]; then
+
+        echo "${TARGET_ZIG_VERSION}"
+
+        if [ "${ZIG_VERSION}" = "${TARGET_ZIG_VERSION}" ]; then
+
             echo "Zig is already installed. Skipping build and install."
             return
         else
-            echo "Old version of Zig installed. Proceeding with install."
+            echo "Old version of Zig installed (${ZIG_VERSION}). Installing version ${TARGET_ZIG_VERSION}."
         fi
     fi
 
@@ -117,6 +121,9 @@ download_zig_binary() {
     fi
 
     tar -C /tmp -xJf /tmp/zig.tar.xz
+
+    # Delete previous installation
+    rm -rf "${ZIGPATH}"
 
     mv /tmp/zig-linux-x86_64-* ${ZIGPATH} &> /dev/null || true
     echo "Zig installed to ${ZIGPATH}"
@@ -330,9 +337,7 @@ if linux; then
             install_apt $ubuntu_version
             ;;
         "arch")
-            set_zigpath "$(pwd)/.zig"
-            download_zig_binary
-            # install_pacman
+            install_pacman
             ;;
         "fedora")
             fedora_version=$(
@@ -354,7 +359,7 @@ if linux; then
             ;;
     esac
 
-    # install_jemalloc
+    install_jemalloc
 
     if [ $USE_INSTALL_ONLY -eq 0 ]; then
         configure_venv

--- a/setup-dev.sh
+++ b/setup-dev.sh
@@ -97,10 +97,7 @@ download_zig_binary() {
     if command -v "${ZIGPATH}"/zig &> /dev/null; then
         ZIG_VERSION=$("$ZIGPATH/zig" version)
 
-        echo "${TARGET_ZIG_VERSION}"
-
         if [ "${ZIG_VERSION}" = "${TARGET_ZIG_VERSION}" ]; then
-
             echo "Zig is already installed. Skipping build and install."
             return
         else

--- a/setup-dev.sh
+++ b/setup-dev.sh
@@ -92,7 +92,9 @@ download_zig_binary() {
     # Install zig to current directory
     # We use zig to compile some test binaries as it is much easier than with gcc
 
-    TARGET_ZIG_VERSION="0.14.0"
+    TARGET_ZIG_VERSION="0.13.0"
+    ZIG_TAR_URL="https://ziglang.org/download/0.13.0/zig-linux-x86_64-0.13.0.tar.xz"
+    ZIG_TAR_SHA256="d45312e61ebcc48032b77bc4cf7fd6915c11fa16e4aad116b66c9468211230ea"
 
     if command -v "${ZIGPATH}"/zig &> /dev/null; then
         ZIG_VERSION=$("$ZIGPATH/zig" version)
@@ -106,8 +108,6 @@ download_zig_binary() {
     fi
 
     echo "Downloading and installing Zig..."
-    ZIG_TAR_URL="https://ziglang.org/download/0.14.0/zig-linux-x86_64-0.14.0.tar.xz"
-    ZIG_TAR_SHA256="473ec26806133cf4d1918caf1a410f8403a13d979726a9045b421b685031a982"
     curl --output /tmp/zig.tar.xz "${ZIG_TAR_URL}"
     ACTUAL_SHA256=$(sha256sum /tmp/zig.tar.xz | cut -d' ' -f1)
     if [ "${ACTUAL_SHA256}" != "${ZIG_TAR_SHA256}" ]; then

--- a/tests/gdb-tests/tests/binaries/makefile
+++ b/tests/gdb-tests/tests/binaries/makefile
@@ -120,7 +120,7 @@ tls.i386.out: tls.i386.c
 	@echo "[+] Building tls.i386.c"
 	${ZIGCC} \
 	${CFLAGS} \
-	-target i386-linux-gnu \
+	-target x86-linux-gnu \
 	-o tls.i386.out tls.i386.c
 
 issue_1565.out: issue_1565.c
@@ -132,7 +132,7 @@ initialized_heap_i386_big.out: initialized_heap.c
 	@echo "[+] Building initialized_heap_i386_big.out"
 	${ZIGCC} \
 	${CFLAGS} \
-	-target i386-linux-gnu \
+	-target x86-linux-gnu \
 	-o initialized_heap_i386_big.out initialized_heap.c
 
 # TODO: Link against a specific GLIBC version.
@@ -154,7 +154,7 @@ onegadget.i386.out: onegadget.c
 	@echo "[+] Building onegadget.i386.out"
 	${ZIGCC} \
 	${CFLAGS} \
-	-target i386-linux-gnu \
+	-target x86-linux-gnu \
 	-o onegadget.i386.out onegadget.c
 
 clean :
@@ -175,7 +175,7 @@ reference_bin_nopie.out: reference-binary.c
 
 reference_bin_nopie.i386.out: reference-binary.c
 	@echo "[+] Building reference_bin_nopie.i386.out"
-	${ZIGCC} -fpie -target i386-linux-gnu -o reference_bin_nopie.i386.out reference-binary.c
+	${ZIGCC} -fpie -target x86-linux-gnu -o reference_bin_nopie.i386.out reference-binary.c
 
 symbol_1600_and_752.out: symbol_1600_and_752.cpp
 	${CXX} -O0 -ggdb -Wno-pmf-conversions symbol_1600_and_752.cpp -o symbol_1600_and_752.out


### PR DESCRIPTION
This updates zig to 0.14.0 in the setup-dev.sh install script. The newer versions of Zig have better support for cross architecture compilation.