### PR TITLE
Use nixfmt-tree instead of calling the nixfmt-rfc-style directly

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -248,6 +248,6 @@
           isLLDB = true;
         }
       );
-      formatter = forAllSystems (system: pkgsBySystem.${system}.nixfmt-rfc-style);
+      formatter = forAllSystems (system: pkgsBySystem.${system}.nixfmt-tree);
     };
 }


### PR DESCRIPTION
as of nix 2.25.0, `nix fmt` will not automatically recurse through nix files so `nixfmt-rfc-style` will format from stdin instead.

see: https://github.com/NixOS/nix/pull/11438

this issue https://github.com/NixOS/nixfmt/issues/273 recommends that we use `nixfmt-tree` which calls `treefmt` in the backend with a minimal configuration for nix

<!-- Please make sure to read the testing and linting instructions at https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md before creating a PR -->
