### PR TITLE
Fix `procinfo` for cross-namespace (root → netns) process attach

### DIFF
--- a/pwndbg/commands/procinfo.py
+++ b/pwndbg/commands/procinfo.py
@@ -80,13 +80,6 @@ def tcp(tid: int):
 
 
 def tcp6(tid: int):
-    # For reference, see:
-    # https://www.kernel.org/doc/Documentation/networking/proc_net_tcp.txt
-    """
-    It will first list all listening TCP sockets, and next list all established
-    TCP connections. A typical entry of /proc/net/tcp would look like this (split
-    up into 3 parts because of the length of the line):
-    """
     data = pwndbg.aglib.file.get(f"/proc/{tid}/net/tcp6").decode()
     return pwndbg.lib.net.tcp6(data)
 

--- a/pwndbg/commands/procinfo.py
+++ b/pwndbg/commands/procinfo.py
@@ -67,7 +67,7 @@ capabilities = {
 }
 
 
-def tcp():
+def tcp(tid: int):
     # For reference, see:
     # https://www.kernel.org/doc/Documentation/networking/proc_net_tcp.txt
     """
@@ -75,20 +75,32 @@ def tcp():
     TCP connections. A typical entry of /proc/net/tcp would look like this (split
     up into 3 parts because of the length of the line):
     """
-    data = pwndbg.aglib.file.get("/proc/net/tcp").decode()
+    data = pwndbg.aglib.file.get(f"/proc/{tid}/net/tcp").decode()
     return pwndbg.lib.net.tcp(data)
 
 
-def unix():
+def tcp6(tid: int):
+    # For reference, see:
+    # https://www.kernel.org/doc/Documentation/networking/proc_net_tcp.txt
+    """
+    It will first list all listening TCP sockets, and next list all established
+    TCP connections. A typical entry of /proc/net/tcp would look like this (split
+    up into 3 parts because of the length of the line):
+    """
+    data = pwndbg.aglib.file.get(f"/proc/{tid}/net/tcp6").decode()
+    return pwndbg.lib.net.tcp6(data)
+
+
+def unix(tid: int):
     # We use errors=ignore because of https://github.com/pwndbg/pwndbg/issues/1544
     # TODO/FIXME: this may not be the best solution because we may end up with
     # invalid UDS data. Can this be a problem?
-    data = pwndbg.aglib.file.get("/proc/net/unix").decode(errors="ignore")
+    data = pwndbg.aglib.file.get(f"/proc/{tid}/net/unix").decode(errors="ignore")
     return pwndbg.lib.net.unix(data)
 
 
-def netlink():
-    data = pwndbg.aglib.file.get("/proc/net/netlink").decode()
+def netlink(tid: int):
+    data = pwndbg.aglib.file.get(f"/proc/{tid}/net/netlink").decode()
     return pwndbg.lib.net.netlink(data)
 
 

--- a/pwndbg/commands/procinfo.py
+++ b/pwndbg/commands/procinfo.py
@@ -215,7 +215,7 @@ class Process:
         socket = "socket:["
         result = []
 
-        functions = [tcp, unix, netlink]
+        functions = [tcp, tcp6, unix, netlink]
 
         for fd, path in fds.items():
             if socket not in path:
@@ -225,7 +225,7 @@ class Process:
             inode = int(inode)
 
             for func in functions:
-                for x in func():
+                for x in func(self.tid):
                     if x.inode == inode:
                         x.fd = fd
                         result.append(x)

--- a/pwndbg/lib/net.py
+++ b/pwndbg/lib/net.py
@@ -27,6 +27,13 @@ TCP_STATUSES = {
 }
 
 
+def format_host_port(ip, port):
+    if ':' in ip and not ip.startswith('['):
+        return f'[{ip}]:{port}'
+    else:
+        return f'{ip}:{port}'
+
+
 class inode:
     inode: int | None = None
 
@@ -45,7 +52,7 @@ class Connection(inode):
 
     def __str__(self) -> str:
         return (
-            f"{self.family} {self.lhost}:{self.lport} => {self.rhost}:{self.rport} ({self.status})"
+            f"{self.family} {format_host_port(self.lhost, self.lport)} => {format_host_port(self.rhost, self.rport)} ({self.status})"
         )
 
     def __repr__(self) -> str:

--- a/pwndbg/lib/net.py
+++ b/pwndbg/lib/net.py
@@ -67,7 +67,7 @@ class UnixSocket(inode):
         return f"UnixSocket({self})"
 
 
-def tcp(data: str) -> List[Connection]:
+def _tcp_parser(data: str, ip_family: socket.AddressFamily) -> List[Connection]:
     # For reference, see:
     # https://www.kernel.org/doc/Documentation/networking/proc_net_tcp.txt
     """
@@ -127,7 +127,7 @@ def tcp(data: str) -> List[Connection]:
             if pwndbg.aglib.arch.endian == "little":
                 host = host[::-1]
 
-            host = socket.inet_ntop(socket.AF_INET, host)
+            host = socket.inet_ntop(ip_family, host)
             port = int(port, 16)
             return host, port
 
@@ -143,80 +143,12 @@ def tcp(data: str) -> List[Connection]:
     return result
 
 
+def tcp(data: str) -> List[Connection]:
+    return _tcp_parser(data, socket.AF_INET)
+
+
 def tcp6(data: str) -> List[Connection]:
-    # For reference, see:
-    # https://www.kernel.org/doc/Documentation/networking/proc_net_tcp.txt
-    """
-    It will first list all listening TCP sockets, and next list all established
-    TCP connections. A typical entry of /proc/net/tcp would look like this (split
-    up into 3 parts because of the length of the line):
-    """
-    if not data:
-        return []
-
-    result: List[Connection] = []
-    for line in data.splitlines()[1:]:
-        fields = line.split()
-        """
-           46: 010310AC:9C4C 030310AC:1770 01
-           |      |      |      |      |   |--> connection state
-           |      |      |      |      |------> remote TCP port number
-           |      |      |      |-------------> remote IPv4 address
-           |      |      |--------------------> local TCP port number
-           |      |---------------------------> local IPv4 address
-           |----------------------------------> number of entry
-        """
-        local = fields[1]
-        remote = fields[2]
-        status = fields[3]
-        """
-           00000150:00000000 01:00000019 00000000
-              |        |     |     |       |--> number of unrecovered RTO timeouts
-              |        |     |     |----------> number of jiffies until timer expires
-              |        |     |----------------> timer_active (see below)
-              |        |----------------------> receive-queue
-              |-------------------------------> transmit-queue
-        """
-        """
-           1000        0 54165785 4 cd1e6040 25 4 27 3 -1
-            |          |    |     |    |     |  | |  | |--> slow start size threshold,
-            |          |    |     |    |     |  | |  |      or -1 if the threshold
-            |          |    |     |    |     |  | |  |      is >= 0xFFFF
-            |          |    |     |    |     |  | |  |----> sending congestion window
-            |          |    |     |    |     |  | |-------> (ack.quick<<1)|ack.pingpong
-            |          |    |     |    |     |  |---------> Predicted tick of soft clock
-            |          |    |     |    |     |              (delayed ACK control data)
-            |          |    |     |    |     |------------> retransmit timeout
-            |          |    |     |    |------------------> location of socket in memory
-            |          |    |     |-----------------------> socket reference count
-            |          |    |-----------------------------> inode
-            |          |----------------------------------> unanswered 0-window probes
-            |---------------------------------------------> uid
-        """
-        inode = fields[9]
-
-        # Actually extract the useful data
-        def split_hist_port(hostport: str):
-            host, port = hostport.split(":")
-            host = binascii.unhexlify(host)
-
-            if pwndbg.aglib.arch.endian == "little":
-                host = host[::-1]
-
-            host = socket.inet_ntop(socket.AF_INET6, host)
-            port = int(port, 16)
-            return host, port
-
-        c = Connection()
-        c.rhost, c.rport = split_hist_port(remote)
-        c.lhost, c.lport = split_hist_port(local)
-        c.inode = int(inode)
-        c.status = TCP_STATUSES.get(status, "unknown")
-        c.family = "tcp6"
-
-        result.append(c)
-
-    return result
+    return _tcp_parser(data, socket.AF_INET6)
 
 
 def unix(data: str) -> List[UnixSocket]:
@@ -272,7 +204,7 @@ NETLINK_TYPES = {
 
 class Netlink(inode):
     eth: int = 0
-    pid: int | None = None
+    portid: int | None = None
 
     def __str__(self) -> str:
         return NETLINK_TYPES.get(self.eth, "(unknown netlink)")
@@ -292,7 +224,7 @@ def netlink(data: str) -> List[Netlink]:
 
         n = Netlink()
         n.eth = int(fields[1])
-        n.pid = int(fields[2])
+        n.portid = int(fields[2])  # 'Pid' in Netlink context refers to Port ID, not Process ID
         n.inode = int(fields[9])
         result.append(n)
 

--- a/pwndbg/lib/net.py
+++ b/pwndbg/lib/net.py
@@ -28,10 +28,10 @@ TCP_STATUSES = {
 
 
 def format_host_port(ip, port):
-    if ':' in ip and not ip.startswith('['):
-        return f'[{ip}]:{port}'
+    if ":" in ip and not ip.startswith("["):
+        return f"[{ip}]:{port}"
     else:
-        return f'{ip}:{port}'
+        return f"{ip}:{port}"
 
 
 class inode:
@@ -51,9 +51,7 @@ class Connection(inode):
     family: str | None = None
 
     def __str__(self) -> str:
-        return (
-            f"{self.family} {format_host_port(self.lhost, self.lport)} => {format_host_port(self.rhost, self.rport)} ({self.status})"
-        )
+        return f"{self.family} {format_host_port(self.lhost, self.lport)} => {format_host_port(self.rhost, self.rport)} ({self.status})"
 
     def __repr__(self) -> str:
         return f'Connection("{self}")'

--- a/pwndbg/lib/net.py
+++ b/pwndbg/lib/net.py
@@ -138,6 +138,82 @@ def tcp(data: str) -> List[Connection]:
     return result
 
 
+def tcp6(data: str) -> List[Connection]:
+    # For reference, see:
+    # https://www.kernel.org/doc/Documentation/networking/proc_net_tcp.txt
+    """
+    It will first list all listening TCP sockets, and next list all established
+    TCP connections. A typical entry of /proc/net/tcp would look like this (split
+    up into 3 parts because of the length of the line):
+    """
+    if not data:
+        return []
+
+    result: List[Connection] = []
+    for line in data.splitlines()[1:]:
+        fields = line.split()
+        """
+           46: 010310AC:9C4C 030310AC:1770 01
+           |      |      |      |      |   |--> connection state
+           |      |      |      |      |------> remote TCP port number
+           |      |      |      |-------------> remote IPv4 address
+           |      |      |--------------------> local TCP port number
+           |      |---------------------------> local IPv4 address
+           |----------------------------------> number of entry
+        """
+        local = fields[1]
+        remote = fields[2]
+        status = fields[3]
+        """
+           00000150:00000000 01:00000019 00000000
+              |        |     |     |       |--> number of unrecovered RTO timeouts
+              |        |     |     |----------> number of jiffies until timer expires
+              |        |     |----------------> timer_active (see below)
+              |        |----------------------> receive-queue
+              |-------------------------------> transmit-queue
+        """
+        """
+           1000        0 54165785 4 cd1e6040 25 4 27 3 -1
+            |          |    |     |    |     |  | |  | |--> slow start size threshold,
+            |          |    |     |    |     |  | |  |      or -1 if the threshold
+            |          |    |     |    |     |  | |  |      is >= 0xFFFF
+            |          |    |     |    |     |  | |  |----> sending congestion window
+            |          |    |     |    |     |  | |-------> (ack.quick<<1)|ack.pingpong
+            |          |    |     |    |     |  |---------> Predicted tick of soft clock
+            |          |    |     |    |     |              (delayed ACK control data)
+            |          |    |     |    |     |------------> retransmit timeout
+            |          |    |     |    |------------------> location of socket in memory
+            |          |    |     |-----------------------> socket reference count
+            |          |    |-----------------------------> inode
+            |          |----------------------------------> unanswered 0-window probes
+            |---------------------------------------------> uid
+        """
+        inode = fields[9]
+
+        # Actually extract the useful data
+        def split_hist_port(hostport: str):
+            host, port = hostport.split(":")
+            host = binascii.unhexlify(host)
+
+            if pwndbg.aglib.arch.endian == "little":
+                host = host[::-1]
+
+            host = socket.inet_ntop(socket.AF_INET6, host)
+            port = int(port, 16)
+            return host, port
+
+        c = Connection()
+        c.rhost, c.rport = split_hist_port(remote)
+        c.lhost, c.lport = split_hist_port(local)
+        c.inode = int(inode)
+        c.status = TCP_STATUSES.get(status, "unknown")
+        c.family = "tcp6"
+
+        result.append(c)
+
+    return result
+
+
 def unix(data: str) -> List[UnixSocket]:
     if not data:
         return []

--- a/pwndbg/lib/net.py
+++ b/pwndbg/lib/net.py
@@ -127,15 +127,15 @@ def _tcp_parser(data: str, ip_family: socket.AddressFamily) -> List[Connection]:
 
             if pwndbg.aglib.arch.endian == "little":
                 if ip_family == socket.AF_INET:
-                    words = struct.unpack('<1I', host)
-                    host = struct.pack('>1I', *words)
+                    words = struct.unpack("<1I", host)
+                    host = struct.pack(">1I", *words)
                 elif ip_family == socket.AF_INET6:
                     # The kernel outputs the IPv6 address as 4 little-endian 32-bit chunks.
                     # This behavior is specific to little-endian kernels, such as x86.
                     # On a big-endian kernel, the byte order would differ.
                     # Reference: https://github.com/torvalds/linux/blob/a7c428ee8f59f171a3b57474f2bd5cee0ef1e036/net/ipv6/tcp_ipv6.c#L2153
-                    words = struct.unpack('<4I', host)
-                    host = struct.pack('>4I', *words)
+                    words = struct.unpack("<4I", host)
+                    host = struct.pack(">4I", *words)
 
             host = socket.inet_ntop(ip_family, host)
             port = int(port, 16)

--- a/pwndbg/lib/net.py
+++ b/pwndbg/lib/net.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import binascii
 import socket
+import struct
 from typing import List
 
 import pwndbg.aglib.arch
@@ -125,7 +126,16 @@ def _tcp_parser(data: str, ip_family: socket.AddressFamily) -> List[Connection]:
             host = binascii.unhexlify(host)
 
             if pwndbg.aglib.arch.endian == "little":
-                host = host[::-1]
+                if ip_family == socket.AF_INET:
+                    words = struct.unpack('<1I', host)
+                    host = struct.pack('>1I', *words)
+                elif ip_family == socket.AF_INET6:
+                    # The kernel outputs the IPv6 address as 4 little-endian 32-bit chunks.
+                    # This behavior is specific to little-endian kernels, such as x86.
+                    # On a big-endian kernel, the byte order would differ.
+                    # Reference: https://github.com/torvalds/linux/blob/a7c428ee8f59f171a3b57474f2bd5cee0ef1e036/net/ipv6/tcp_ipv6.c#L2153
+                    words = struct.unpack('<4I', host)
+                    host = struct.pack('>4I', *words)
 
             host = socket.inet_ntop(ip_family, host)
             port = int(port, 16)

--- a/tests/gdb-tests/tests/binaries/reference-binary-net.c
+++ b/tests/gdb-tests/tests/binaries/reference-binary-net.c
@@ -1,37 +1,73 @@
 #include <arpa/inet.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include <unistd.h>
-
-#define PORT 31337
 
 void break_here() {};
 
+int parse_ip_port(const char* ip_str, int port, struct sockaddr_storage* out_addr, socklen_t* out_len) {
+    if (port <= 0 || port > 65535) {
+        fprintf(stderr, "Error: Invalid port number. Provide a value between 1 and 65535.\n");
+        return -1;
+    }
+
+    memset(out_addr, 0, sizeof(*out_addr));
+    if (strchr(ip_str, ':') != NULL) {
+        // IPv6
+        struct sockaddr_in6* addr6 = (struct sockaddr_in6*)out_addr;
+        addr6->sin6_family = AF_INET6;
+        addr6->sin6_port = htons(port);
+        if (inet_pton(AF_INET6, ip_str, &addr6->sin6_addr) <= 0) {
+            perror("inet_pton (IPv6)");
+            return -1;
+        }
+        *out_len = sizeof(struct sockaddr_in6);
+        return AF_INET6;
+    } else {
+        // IPv4
+        struct sockaddr_in* addr4 = (struct sockaddr_in*)out_addr;
+        addr4->sin_family = AF_INET;
+        addr4->sin_port = htons(port);
+        if (inet_pton(AF_INET, ip_str, &addr4->sin_addr) <= 0) {
+            perror("inet_pton (IPv4)");
+            return -1;
+        }
+        *out_len = sizeof(struct sockaddr_in);
+        return AF_INET;
+    }
+}
+
 int main(int argc, char const* argv[]) {
+    if (argc != 3) {
+        fprintf(stderr, "Usage: %s <ip> <port>\n", argv[0]);
+        return -1;
+    }
+    const char* ip_str = argv[1];
+    int port = atoi(argv[2]);
+
     puts("Hello World");
 
-    int sock = 0, client_fd;
-    struct sockaddr_in serv_addr;
+    int sock;
+    struct sockaddr_storage serv_addr;
+    socklen_t addr_len;
+    int family = parse_ip_port(ip_str, port, &serv_addr, &addr_len);
+    if (family < 0) {
+        return -1;
+    }
 
-    if ((sock = socket(AF_INET, SOCK_STREAM, 0)) < 0) {
+    if ((sock = socket(family, SOCK_STREAM, 0)) < 0) {
         perror("socket");
         return -1;
     }
 
-    serv_addr.sin_family = AF_INET;
-    serv_addr.sin_port = htons(PORT);
-
-    if (inet_pton(AF_INET, "127.0.0.1", &serv_addr.sin_addr) <= 0) {
-        perror("inet_pton");
-        return -1;
-    }
-
-    if ((client_fd = connect(sock, (struct sockaddr*)&serv_addr, sizeof(serv_addr))) < 0) {
+    if (connect(sock, (struct sockaddr*)&serv_addr, addr_len) < 0) {
         perror("connect");
         return -1;
     }
 
     break_here();
 
-    close(client_fd);
+    close(sock);
     return 0;
 }

--- a/tests/gdb-tests/tests/test_command_procinfo.py
+++ b/tests/gdb-tests/tests/test_command_procinfo.py
@@ -5,6 +5,7 @@ import threading
 import time
 
 import gdb
+import pytest
 
 import pwndbg.aglib.proc
 import tests
@@ -13,12 +14,17 @@ REFERENCE_BINARY_NET = tests.binaries.get("reference-binary-net.out")
 
 
 class TCPServerThread(threading.Thread):
-    def __init__(self):
+    def __init__(self, *, ip: str, port: int):
         super().__init__(daemon=True)
-        self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        self.sock.bind(("127.0.0.1", 31337))
+        self.sock = socket.socket(
+            socket.AF_INET6 if ":" in ip else socket.AF_INET, socket.SOCK_STREAM
+        )
+        self.sock.bind((ip, port))
         self.port = self.sock.getsockname()[1]
         self.sock.listen(1)
+
+    def stop(self):
+        self.sock.close()
 
     def run(self):
         try:
@@ -30,12 +36,13 @@ class TCPServerThread(threading.Thread):
             pass  # Socket closed
 
 
-def test_command_procinfo(start_binary):
-    start_binary(REFERENCE_BINARY_NET)
-
+@pytest.mark.parametrize("ip_connect", ["127.0.0.1", "::1"])
+def test_command_procinfo_net(start_binary, ip_connect):
     # Listen tcp server
-    server = TCPServerThread()
+    server = TCPServerThread(ip=ip_connect, port=0)
     server.start()
+
+    start_binary(REFERENCE_BINARY_NET, ip_connect, str(server.port))
 
     bin_path = pwndbg.aglib.proc.exe
     pid = str(pwndbg.aglib.proc.pid)
@@ -48,10 +55,14 @@ def test_command_procinfo(start_binary):
 
     assert bin_path in res_list[0]
     assert pid in res_list[3]
-    assert f"127.0.0.1:{server.port}" in result
+
+    if ":" in ip_connect:
+        assert f"[{ip_connect}]:{server.port}" in result
+    else:
+        assert f"{ip_connect}:{server.port}" in result
 
     # Close tcp server
-    server.sock.close()
+    server.stop()
 
 
 def test_command_procinfo_before_binary_start():


### PR DESCRIPTION
This change adds support for displaying the correct `procinfo` when attaching from the root namespace to a process in a network namespace.

Before: 
<img width="507" alt="image" src="https://github.com/user-attachments/assets/0aacadde-75aa-457a-adbf-7d984a83c92d" />

After:
<img width="492" alt="image" src="https://github.com/user-attachments/assets/249aa9c1-a806-4883-95a3-756425e9d74c" />

