### PR TITLE
empty context-sections

### DIFF
--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -702,14 +702,13 @@ def context(subcontext=None, enabled=None) -> None:
         subcontext = []
     args = subcontext
 
-    if len(args) == 0:
-        args = config_context_sections.split()
-
     # Inform when sections set to be empty
     sections = pwndbg.config.context_sections.split()
     if not sections:
         print(message.warn("Sections set to be empty."))
-        return
+    
+    if len(args) == 0:
+        args = config_context_sections.split()
 
     sections = []
     if args:

--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -705,7 +705,7 @@ def context(subcontext=None, enabled=None) -> None:
     # Inform when sections set to be empty
     sections = pwndbg.config.context_sections.split()
     if not sections:
-        print(message.warn("Sections set to be empty."))
+        print(message.warn("Context sections are empty. You can set context-sections to the following values: args, regs, disasm, stack, backtrace, code, expressions, ghidra, heap_tracker, threads, last_signal"))
     
     if len(args) == 0:
         args = config_context_sections.split()

--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -705,6 +705,12 @@ def context(subcontext=None, enabled=None) -> None:
     if len(args) == 0:
         args = config_context_sections.split()
 
+    # Inform when sections set to be empty
+    sections = pwndbg.config.context_sections.split()
+    if not sections:
+        print(message.warn("Sections set to be empty."))
+        return
+
     sections = []
     if args:
         if selected_history_index is None:
@@ -715,7 +721,7 @@ def context(subcontext=None, enabled=None) -> None:
             sections.append(("legend", lambda *args, **kwargs: [M.legend() + history_status]))
 
     sections += [(arg, context_sections.get(arg[0], None)) for arg in args]
-
+        
     result = defaultdict(list)
     result_settings: DefaultDict[str, Dict[Any, Any]] = defaultdict(dict)
     for section, func in sections:


### PR DESCRIPTION
When context sections are set empty, ctx command gives a warning.
