### PR TITLE
PLT command - search all .plt.* sections

### DIFF
--- a/docs/commands/index.md
+++ b/docs/commands/index.md
@@ -103,7 +103,7 @@
 -  [linkmap](linux_libc_elf/linkmap.md) - Show the state of the Link Map
 -  [onegadget](linux_libc_elf/onegadget.md) - Find gadgets which single-handedly give code execution.
 -  [piebase](linux_libc_elf/piebase.md) - Calculate VA of RVA from PIE base.
--  [plt](linux_libc_elf/plt.md) - Prints any symbols found in the .plt section if it exists.
+-  [plt](linux_libc_elf/plt.md) - Prints any symbols found in Procedure Linkage Table sections if any exist.
 -  [strings](linux_libc_elf/strings.md) - Extracts and displays ASCII strings from readable memory pages of the debugged process.
 -  [threads](linux_libc_elf/threads.md) - List all threads belonging to the selected inferior.
 -  [tls](linux_libc_elf/tls.md) - Print out base address of the current Thread Local Storage (TLS).

--- a/docs/commands/linux_libc_elf/plt.md
+++ b/docs/commands/linux_libc_elf/plt.md
@@ -5,19 +5,13 @@
 
 # plt
 
-## Description
-
-
-Prints any symbols found in Procedure Linkage Table sections if any exist.
-## Usage
-
 
 ```text
 usage: plt [-h]
 
 ```
 
-Prints any symbols found in the .plt section if it exists.
+Prints any symbols found in Procedure Linkage Table sections if any exist.
 ### Optional arguments
 
 |Short|Long|Help|

--- a/docs/commands/linux_libc_elf/plt.md
+++ b/docs/commands/linux_libc_elf/plt.md
@@ -5,6 +5,12 @@
 
 # plt
 
+## Description
+
+
+Prints any symbols found in Procedure Linkage Table sections if any exist.
+## Usage
+
 
 ```text
 usage: plt [-h]

--- a/pwndbg/commands/elf.py
+++ b/pwndbg/commands/elf.py
@@ -47,12 +47,12 @@ def gotplt() -> None:
 
 PLT_SECTION_NAMES = (".plt", ".plt.sec", ".plt.got", ".plt.bnd")
 
+
 @pwndbg.commands.Command(
     "Prints any symbols found in the .plt section if it exists.", category=CommandCategory.LINUX
 )
 @pwndbg.commands.OnlyWithFile
 def plt() -> None:
-
     local_path = pwndbg.aglib.file.get_proc_exe_file()
 
     bin_base_addr = 0
@@ -68,7 +68,7 @@ def plt() -> None:
 
         for section_name in PLT_SECTION_NAMES:
             section = elffile.get_section_by_name(section_name)
-            
+
             if section:
                 start = section["sh_addr"]
                 size = section["sh_size"]
@@ -97,7 +97,7 @@ def plt() -> None:
                     print(hex(int(addr)) + ": " + symbol)
 
     if not found:
-        print(message.error(f"No .plt.* sections found"))
+        print(message.error("No .plt.* sections found"))
 
 
 def get_section_bounds(section_name: str):
@@ -116,14 +116,12 @@ def get_section_bounds(section_name: str):
         return (start, start + size)
 
 
-def print_symbols_in_section(section_name, filter_text=""):
-    """
-    Return True if any symbols were found
-    """
+def print_symbols_in_section(section_name, filter_text="") -> None:
     start, end = get_section_bounds(section_name)
 
     if start is None:
         print(message.error(f"Could not find section {section_name}"))
+        return
 
     # If we started the binary and it has PIE, rebase it
     if pwndbg.aglib.proc.alive:
@@ -135,7 +133,7 @@ def print_symbols_in_section(section_name, filter_text=""):
             end += bin_base_addr
 
     print(message.notice(f"Section {section_name} {start:#x}-{end:#x}:"))
-    
+
     symbols = get_symbols_in_region(start, end, filter_text)
 
     if not symbols:

--- a/pwndbg/commands/elf.py
+++ b/pwndbg/commands/elf.py
@@ -91,7 +91,7 @@ def plt() -> None:
     # Sort by the start address so we print from lowest to highest
     sections_found.sort(key=lambda x: x[1])
 
-    for name, start, end in sections_found:
+    for section_name, start, end in sections_found:
         symbols = get_symbols_in_region(start, end, "@plt")
 
         print(message.notice(f"Section {section_name} {start:#x}-{end:#x}:"))

--- a/pwndbg/commands/elf.py
+++ b/pwndbg/commands/elf.py
@@ -94,7 +94,7 @@ def plt() -> None:
     for section_name, start, end in sections_found:
         symbols = get_symbols_in_region(start, end, "@plt")
 
-        print(message.notice(f"Section {section_name} {start:#x}-{end:#x}:"))
+        print(message.notice(f"Section {section_name} {start:#x} - {end:#x}:"))
 
         if not symbols:
             print(message.error(f"No symbols found in section {section_name}"))

--- a/pwndbg/commands/elf.py
+++ b/pwndbg/commands/elf.py
@@ -52,7 +52,8 @@ PLT_SECTION_NAMES = (".plt", ".plt.sec", ".plt.got", ".plt.bnd")
 
 
 @pwndbg.commands.Command(
-    "Prints any symbols found in Procedure Linkage Table sections if any exist.", category=CommandCategory.LINUX
+    "Prints any symbols found in Procedure Linkage Table sections if any exist.",
+    category=CommandCategory.LINUX,
 )
 @pwndbg.commands.OnlyWithFile
 def plt() -> None:

--- a/pwndbg/commands/elf.py
+++ b/pwndbg/commands/elf.py
@@ -75,8 +75,6 @@ def plt() -> None:
 
                 if start is None:
                     continue
-                    # print(message.error(f"Could not find section {section_name}"))
-                    # return False
 
                 found = True
                 end = start + size

--- a/pwndbg/commands/elf.py
+++ b/pwndbg/commands/elf.py
@@ -51,7 +51,9 @@ def gotplt() -> None:
 @pwndbg.commands.OnlyWithFile
 def plt() -> None:
     found = print_symbols_in_section(".plt", "@plt")
-    print_symbols_in_section(".plt.sec", "@plt", silent_if_empty=found)
+    found |= print_symbols_in_section(".plt.sec", "@plt", silent_if_empty=found)
+    found |= print_symbols_in_section(".plt.got", "@plt", silent_if_empty=found)
+    print_symbols_in_section(".plt.bnd", "@plt", silent_if_empty=found)
 
 
 def get_section_bounds(section_name):

--- a/pwndbg/commands/elf.py
+++ b/pwndbg/commands/elf.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from typing import List
+from typing import Tuple
+
 from elftools.elf.elffile import ELFFile
 
 import pwndbg.commands
@@ -47,7 +50,8 @@ def gotplt() -> None:
 )
 @pwndbg.commands.OnlyWithFile
 def plt() -> None:
-    print_symbols_in_section(".plt", "@plt")
+    found = print_symbols_in_section(".plt", "@plt")
+    print_symbols_in_section(".plt.sec", "@plt", silent_if_empty=found)
 
 
 def get_section_bounds(section_name):
@@ -66,12 +70,16 @@ def get_section_bounds(section_name):
         return (start, start + size)
 
 
-def print_symbols_in_section(section_name, filter_text="") -> None:
+def print_symbols_in_section(section_name, filter_text="", silent_if_empty=False) -> bool:
+    """
+    Return True if any symbols were found
+    """
     start, end = get_section_bounds(section_name)
 
     if start is None:
-        print(message.error(f"Could not find section {section_name}"))
-        return
+        if not silent_if_empty:
+            print(message.error(f"Could not find section {section_name}"))
+        return False
 
     # If we started the binary and it has PIE, rebase it
     if pwndbg.aglib.proc.alive:
@@ -82,9 +90,12 @@ def print_symbols_in_section(section_name, filter_text="") -> None:
             start += bin_base_addr
             end += bin_base_addr
 
-    print(message.notice(f"Section {section_name} {start:#x}-{end:#x}:"))
-
     symbols = get_symbols_in_region(start, end, filter_text)
+
+    if len(symbols) == 0 and silent_if_empty:
+        return False
+
+    print(message.notice(f"Section {section_name} {start:#x}-{end:#x}:"))
 
     if not symbols:
         print(message.error(f"No symbols found in section {section_name}"))
@@ -92,9 +103,11 @@ def print_symbols_in_section(section_name, filter_text="") -> None:
     for symbol, addr in symbols:
         print(hex(int(addr)) + ": " + symbol)
 
+    return len(symbols) > 0
 
-def get_symbols_in_region(start, end, filter_text=""):
-    symbols = []
+
+def get_symbols_in_region(start: int, end: int, filter_text="") -> List[Tuple[str, int]]:
+    symbols: List[Tuple[str, int]] = []
     ptr_size = pwndbg.aglib.typeinfo.pvoid.sizeof
     addr = start
     while addr < end:

--- a/pwndbg/commands/elf.py
+++ b/pwndbg/commands/elf.py
@@ -45,6 +45,9 @@ def gotplt() -> None:
     print_symbols_in_section(".got.plt", "@got.plt")
 
 
+# These are all the section names associated with PLTs.
+# .plt.sec and .plt.bnd are associated with control flow transfer integrity.
+# These are derived from this list that GDB recognizes: https://github.com/bminor/binutils-gdb/blob/38d726a24c1a85abdb606e7ab6cefad17872aad7/bfd/elf64-x86-64.c#L5775-L5780
 PLT_SECTION_NAMES = (".plt", ".plt.sec", ".plt.got", ".plt.bnd")
 
 
@@ -60,8 +63,8 @@ def plt() -> None:
     if pwndbg.aglib.proc.alive:
         bin_base_addr = pwndbg.aglib.proc.binary_base_addr
 
-    # If at least one .plt.* section was found
-    found = False
+    # List of (Section name, start_addr, end_addr)
+    sections_found: List[Tuple[str, int, int]] = []
 
     with open(local_path, "rb") as f:
         elffile = ELFFile(f)
@@ -70,13 +73,12 @@ def plt() -> None:
             section = elffile.get_section_by_name(section_name)
 
             if section:
-                start = section["sh_addr"]
-                size = section["sh_size"]
+                start: int = section["sh_addr"]
+                size: int = section["sh_size"]
 
                 if start is None:
                     continue
 
-                found = True
                 end = start + size
 
                 # Rebase the start and end addresses if needed
@@ -84,17 +86,26 @@ def plt() -> None:
                     start += bin_base_addr
                     end += bin_base_addr
 
-                symbols = get_symbols_in_region(start, end, "@plt")
+                sections_found.append((section_name, start, end))
 
-                print(message.notice(f"Section {section_name} {start:#x}-{end:#x}:"))
+    # Sort by the start address so we print from lowest to highest
+    sections_found.sort(key=lambda x: x[1])
 
-                if not symbols:
-                    print(message.error(f"No symbols found in section {section_name}"))
+    for name, start, end in sections_found:
+        symbols = get_symbols_in_region(start, end, "@plt")
 
-                for symbol, addr in symbols:
-                    print(hex(int(addr)) + ": " + symbol)
+        print(message.notice(f"Section {section_name} {start:#x}-{end:#x}:"))
 
-    if not found:
+        if not symbols:
+            print(message.error(f"No symbols found in section {section_name}"))
+
+        stuff: List[Tuple[int, str]] = []
+
+        for symbol, addr in symbols:
+            stuff.append((addr, symbol))
+            print(hex(int(addr)) + ": " + symbol)
+
+    if len(sections_found) == 0:
         print(message.error("No .plt.* sections found"))
 
 

--- a/pwndbg/commands/elf.py
+++ b/pwndbg/commands/elf.py
@@ -45,18 +45,62 @@ def gotplt() -> None:
     print_symbols_in_section(".got.plt", "@got.plt")
 
 
+PLT_SECTION_NAMES = (".plt", ".plt.sec", ".plt.got", ".plt.bnd")
+
 @pwndbg.commands.Command(
     "Prints any symbols found in the .plt section if it exists.", category=CommandCategory.LINUX
 )
 @pwndbg.commands.OnlyWithFile
 def plt() -> None:
-    found = print_symbols_in_section(".plt", "@plt")
-    found |= print_symbols_in_section(".plt.sec", "@plt", silent_if_empty=found)
-    found |= print_symbols_in_section(".plt.got", "@plt", silent_if_empty=found)
-    print_symbols_in_section(".plt.bnd", "@plt", silent_if_empty=found)
+
+    local_path = pwndbg.aglib.file.get_proc_exe_file()
+
+    bin_base_addr = 0
+    # If we started the binary and it has PIE, rebase it
+    if pwndbg.aglib.proc.alive:
+        bin_base_addr = pwndbg.aglib.proc.binary_base_addr
+
+    # If at least one .plt.* section was found
+    found = False
+
+    with open(local_path, "rb") as f:
+        elffile = ELFFile(f)
+
+        for section_name in PLT_SECTION_NAMES:
+            section = elffile.get_section_by_name(section_name)
+            
+            if section:
+                start = section["sh_addr"]
+                size = section["sh_size"]
+
+                if start is None:
+                    continue
+                    # print(message.error(f"Could not find section {section_name}"))
+                    # return False
+
+                found = True
+                end = start + size
+
+                # Rebase the start and end addresses if needed
+                if start < bin_base_addr:
+                    start += bin_base_addr
+                    end += bin_base_addr
+
+                symbols = get_symbols_in_region(start, end, "@plt")
+
+                print(message.notice(f"Section {section_name} {start:#x}-{end:#x}:"))
+
+                if not symbols:
+                    print(message.error(f"No symbols found in section {section_name}"))
+
+                for symbol, addr in symbols:
+                    print(hex(int(addr)) + ": " + symbol)
+
+    if not found:
+        print(message.error(f"No .plt.* sections found"))
 
 
-def get_section_bounds(section_name):
+def get_section_bounds(section_name: str):
     local_path = pwndbg.aglib.file.get_proc_exe_file()
 
     with open(local_path, "rb") as f:
@@ -72,16 +116,14 @@ def get_section_bounds(section_name):
         return (start, start + size)
 
 
-def print_symbols_in_section(section_name, filter_text="", silent_if_empty=False) -> bool:
+def print_symbols_in_section(section_name, filter_text=""):
     """
     Return True if any symbols were found
     """
     start, end = get_section_bounds(section_name)
 
     if start is None:
-        if not silent_if_empty:
-            print(message.error(f"Could not find section {section_name}"))
-        return False
+        print(message.error(f"Could not find section {section_name}"))
 
     # If we started the binary and it has PIE, rebase it
     if pwndbg.aglib.proc.alive:
@@ -92,20 +134,15 @@ def print_symbols_in_section(section_name, filter_text="", silent_if_empty=False
             start += bin_base_addr
             end += bin_base_addr
 
-    symbols = get_symbols_in_region(start, end, filter_text)
-
-    if len(symbols) == 0 and silent_if_empty:
-        return False
-
     print(message.notice(f"Section {section_name} {start:#x}-{end:#x}:"))
+    
+    symbols = get_symbols_in_region(start, end, filter_text)
 
     if not symbols:
         print(message.error(f"No symbols found in section {section_name}"))
 
     for symbol, addr in symbols:
         print(hex(int(addr)) + ": " + symbol)
-
-    return len(symbols) > 0
 
 
 def get_symbols_in_region(start: int, end: int, filter_text="") -> List[Tuple[str, int]]:

--- a/pwndbg/commands/elf.py
+++ b/pwndbg/commands/elf.py
@@ -52,7 +52,7 @@ PLT_SECTION_NAMES = (".plt", ".plt.sec", ".plt.got", ".plt.bnd")
 
 
 @pwndbg.commands.Command(
-    "Prints any symbols found in the .plt section if it exists.", category=CommandCategory.LINUX
+    "Prints any symbols found in Procedure Linkage Table sections if any exist.", category=CommandCategory.LINUX
 )
 @pwndbg.commands.OnlyWithFile
 def plt() -> None:

--- a/tests/gdb-tests/tests/test_commands_elf.py
+++ b/tests/gdb-tests/tests/test_commands_elf.py
@@ -18,7 +18,7 @@ def test_commands_plt_gotplt_got_when_no_sections(start_binary):
     start_binary(NO_SECTS_BINARY)
 
     # elf.py commands
-    assert gdb.execute("plt", to_string=True) == "Could not find section .plt\n"
+    assert gdb.execute("plt", to_string=True) == "No .plt.* sections found\n"
     assert gdb.execute("gotplt", to_string=True) == "Could not find section .got.plt\n"
 
     # got.py command

--- a/tests/gdb-tests/tests/test_commands_elf.py
+++ b/tests/gdb-tests/tests/test_commands_elf.py
@@ -40,7 +40,7 @@ def test_command_plt(binary_name, is_pie):
     out = gdb.execute("plt", to_string=True).splitlines()
 
     assert len(out) == 2
-    assert re.match(r"Section \.plt 0x[0-9a-f]+-0x[0-9a-f]+:", out[0])
+    assert re.match(r"Section \.plt 0x[0-9a-f]+ - 0x[0-9a-f]+:", out[0])
     assert re.match(r"0x[0-9a-f]+: puts@plt", out[1])
 
     gdb.execute("starti")
@@ -53,7 +53,7 @@ def test_command_plt(binary_name, is_pie):
         assert out == out2
 
     assert len(out2) == 2
-    assert re.match(r"Section \.plt 0x[0-9a-f]+-0x[0-9a-f]+:", out2[0])
+    assert re.match(r"Section \.plt 0x[0-9a-f]+ - 0x[0-9a-f]+:", out2[0])
     assert re.match(r"0x[0-9a-f]+: puts@plt", out2[1])
 
 


### PR DESCRIPTION
Binaries compiled with the `-fcf-protection` emit a `.plt.sec` section, which functions identically to `.plt` but the instructions include control flow integrity tracking, such as the `endbr64` instruction in x86.

Example:
![image](https://github.com/user-attachments/assets/38d4eee9-99a3-42c6-85bd-eae9d74fc788)

Based on this blog post, looks like the new section was introduced due to the plt stub size increasing with the new instructions, so the structure no longer fit in the old format
https://maskray.me/blog/2021-09-19-all-about-procedure-linkage-table#:~:text=add%20a%20new%20section%20.plt.sec

In this PR, the `plt` command now searches the `.plt.sec` section in addition to the `.plt` section.

![image](https://github.com/user-attachments/assets/fd903e76-05e3-453e-9076-f92ed4224368)

If no .plt.sec section is found but .plt is found, it doesn't print about .plt.sec: 
![image](https://github.com/user-attachments/assets/26c1cc20-ef5d-4aa6-9937-3b2c301bbb11)

If neither are found, it prints this:
![image](https://github.com/user-attachments/assets/b10870bc-b907-4da8-810e-409ae53d090a)

