### PR TITLE
Fix .gdbinit for portable pwndbg

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -75,8 +75,6 @@ or
 ./pwndbg/bin/pwndbg-lldb
 ```
 depending on which version you installed. You may add the appropriate file to your shell's PATH.
-!!! warning ".gdbinit doesn't work for portable release"
-    If you're running `./pwndbg/bin/pwndbg` from the portable release, it is a known limitation that pwndbg settings in your `.gdbinit` won't work (see [issue #2774](https://github.com/pwndbg/pwndbg/issues/2774)). Also, make sure not to source pwndbg in your gdbinit as it already happens automatically for portable releases (if this is the first time you're installing pwndbg, you don't need to worry about this).
 
 ## Installing from source
 See the relevant section in DEVELOPING.md: [with GDB](https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md#install-from-source-gdb), [with LLDB](https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md#install-from-source-lldb).

--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -78,7 +78,7 @@ in
         jemalloc-static
         pyEnv
         (pkgs.writeShellScriptBin "pwndbg" ''
-          exec ${lib.getBin pkgs.gdb}/bin/gdb --quiet --command="$REPO_ROOT/gdbinit.py" $@
+          exec ${lib.getBin pkgs.gdb}/bin/gdb --quiet --nx --init-command="$REPO_ROOT/gdbinit.py" $@
         '')
       ]
       ++ pkgs.lib.optionals isLLDB [

--- a/nix/pwndbg.nix
+++ b/nix/pwndbg.nix
@@ -119,7 +119,7 @@ let
 
               touch $out/share/pwndbg/.skip-venv
               makeWrapper ${gdb}/bin/gdb $out/bin/${pwndbgName} \
-                --add-flags "--quiet --early-init-eval-command=\"set auto-load safe-path /\" --command=$out/share/pwndbg/gdbinit.py"
+                --add-flags "--quiet --nx --init-command=$out/share/pwndbg/gdbinit.py"
             ''
         );
 

--- a/nix/pyenv.nix
+++ b/nix/pyenv.nix
@@ -68,6 +68,7 @@ let
     "types-tabulate"
     "types-pygments"
     "types-docutils"
+    "types-psutil"
     "types-gdb"
     "types-setuptools"
     "cryptography"

--- a/pwndbg/dbg/gdb/__init__.py
+++ b/pwndbg/dbg/gdb/__init__.py
@@ -4,6 +4,7 @@ import re
 from asyncio import CancelledError
 from contextlib import contextmanager
 from contextlib import nullcontext
+from pathlib import Path
 from typing import Any
 from typing import Coroutine
 from typing import Generator
@@ -1302,6 +1303,56 @@ def _gdb_event_class_from_event_type(ty: pwndbg.dbg_mod.EventType) -> Any:
 
 
 class GDB(pwndbg.dbg_mod.Debugger):
+    def _disable_gdbinit_loading(self) -> Tuple[bool, bool, bool]:
+        import os
+
+        import psutil
+
+        disable_home_gdbinit = 0
+        disable_any_gdbinit = 0
+        proc = psutil.Process(os.getpid())
+        for arg in proc.cmdline():
+            if arg in ("-nh", "--nh"):
+                disable_home_gdbinit += 1
+            elif arg in ("-nx", "--nx", "-n", "--n"):
+                disable_any_gdbinit += 1
+
+        if disable_any_gdbinit == 0:
+            # The `--nx` option is added only in pwndbg-portable mode.
+            # This check allows using OLD syntax, eg: `source /path/to/pwndbg/gdbinit.py`, from ~/.gdbinit
+            return True, True, True
+
+        disable_local = not gdb.parameter("auto-load local-gdbinit")
+        return disable_any_gdbinit >= 2, disable_home_gdbinit >= 1, disable_local
+
+    def _load_gdbinit(self):
+        # Emulate how `gdb` loads `.gdbinit` files (home and local)
+        disable_any, disable_home, disable_local = self._disable_gdbinit_loading()
+        if disable_any:
+            return
+
+        home_file = Path("~/.gdbinit").expanduser().resolve()
+        local_file = Path("./.gdbinit").resolve()
+
+        def safe_source(file_path: str):
+            try:
+                gdb.execute(f"source {file_path}", to_string=True)
+            except gdb.error as e:
+                print(e)
+
+        is_home_loaded = False
+        if not disable_home and home_file.exists():
+            safe_source("~/.gdbinit")
+            is_home_loaded = True
+
+        should_load_local = (
+            not disable_local
+            and local_file.exists()
+            and not (is_home_loaded and home_file.samefile(local_file))
+        )
+        if should_load_local:
+            safe_source("./.gdbinit")
+
     @override
     def setup(self):
         import pwnlib.update
@@ -1324,6 +1375,7 @@ class GDB(pwndbg.dbg_mod.Debugger):
         prompt.set_prompt()
 
         pre_commands = """
+        set auto-load safe-path /
         set confirm off
         set verbose off
         set pagination off
@@ -1399,6 +1451,8 @@ class GDB(pwndbg.dbg_mod.Debugger):
         prompt.show_hint()
 
         from pwndbg.dbg.gdb import debug_sym
+
+        self._load_gdbinit()
 
     @override
     def add_command(

--- a/pwndbg/dbg/gdb/__init__.py
+++ b/pwndbg/dbg/gdb/__init__.py
@@ -1335,7 +1335,7 @@ class GDB(pwndbg.dbg_mod.Debugger):
         home_file = Path("~/.gdbinit").expanduser().resolve()
         local_file = Path("./.gdbinit").resolve()
 
-        def safe_source(file_path: str):
+        def load_source(file_path: str):
             try:
                 gdb.execute(f"source {file_path}", to_string=True)
             except gdb.error as e:
@@ -1343,7 +1343,7 @@ class GDB(pwndbg.dbg_mod.Debugger):
 
         is_home_loaded = False
         if not disable_home and home_file.exists():
-            safe_source("~/.gdbinit")
+            load_source("~/.gdbinit")
             is_home_loaded = True
 
         disable_local = not gdb.parameter("auto-load local-gdbinit")
@@ -1353,7 +1353,7 @@ class GDB(pwndbg.dbg_mod.Debugger):
             and not (is_home_loaded and home_file.samefile(local_file))
         )
         if should_load_local:
-            safe_source("./.gdbinit")
+            load_source("./.gdbinit")
 
     @override
     def setup(self):

--- a/pwndbg/dbg/gdb/__init__.py
+++ b/pwndbg/dbg/gdb/__init__.py
@@ -1303,7 +1303,7 @@ def _gdb_event_class_from_event_type(ty: pwndbg.dbg_mod.EventType) -> Any:
 
 
 class GDB(pwndbg.dbg_mod.Debugger):
-    def _disable_gdbinit_loading(self) -> Tuple[bool, bool, bool]:
+    def _disable_gdbinit_loading(self) -> Tuple[bool, bool]:
         import os
 
         import psutil
@@ -1322,14 +1322,13 @@ class GDB(pwndbg.dbg_mod.Debugger):
         if disable_any_gdbinit == 0:
             # The `--nx` option is added only in pwndbg-portable mode.
             # This check allows using OLD syntax, eg: `source /path/to/pwndbg/gdbinit.py`, from ~/.gdbinit
-            return True, True, True
+            return True, True
 
-        disable_local = not gdb.parameter("auto-load local-gdbinit")
-        return disable_any_gdbinit >= 2, disable_home_gdbinit >= 1, disable_local
+        return disable_any_gdbinit >= 2, disable_home_gdbinit >= 1
 
     def _load_gdbinit(self):
         # Emulate how `gdb` loads `.gdbinit` files (home and local)
-        disable_any, disable_home, disable_local = self._disable_gdbinit_loading()
+        disable_any, disable_home = self._disable_gdbinit_loading()
         if disable_any:
             return
 
@@ -1347,6 +1346,7 @@ class GDB(pwndbg.dbg_mod.Debugger):
             safe_source("~/.gdbinit")
             is_home_loaded = True
 
+        disable_local = not gdb.parameter("auto-load local-gdbinit")
         should_load_local = (
             not disable_local
             and local_file.exists()

--- a/pwndbg/dbg/gdb/__init__.py
+++ b/pwndbg/dbg/gdb/__init__.py
@@ -1312,7 +1312,9 @@ class GDB(pwndbg.dbg_mod.Debugger):
         disable_any_gdbinit = 0
         proc = psutil.Process(os.getpid())
         for arg in proc.cmdline():
-            if arg in ("-nh", "--nh"):
+            if arg in ("-args", "--args"):
+                break
+            elif arg in ("-nh", "--nh"):
                 disable_home_gdbinit += 1
             elif arg in ("-nx", "--nx", "-n", "--n"):
                 disable_any_gdbinit += 1

--- a/pwndbg/dbg/gdb/__init__.py
+++ b/pwndbg/dbg/gdb/__init__.py
@@ -1314,7 +1314,7 @@ class GDB(pwndbg.dbg_mod.Debugger):
         for arg in proc.cmdline():
             if arg in ("-args", "--args"):
                 break
-            elif arg in ("-nh", "--nh"):
+            if arg in ("-nh", "--nh"):
                 disable_home_gdbinit += 1
             elif arg in ("-nx", "--nx", "-n", "--n"):
                 disable_any_gdbinit += 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dev = [
     "types-requests>=2.31.0.20240406,<3",
     "types-tabulate>=0.9.0.20240106,<0.10",
     "types-gdb>=12.1.4.20240704,<13",
+    "types-psutil>=6.1.0.20241221,<7",
 ]
 lint = [
     # Newer mypy has more types to fix. Please fix types in the future.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "pycparser~=2.22",
     "pyelftools>=0.29,<0.30",
     "pygments>=2.18.0,<3",
+    "psutil>=6.1.1,<7",
     # Optional? only for 'ipi' command
     "ipython>=8.27.0,<9",
     # Optional? only for 'ropgadget' command

--- a/uv.lock
+++ b/uv.lock
@@ -1220,6 +1220,7 @@ lldb = [
 dev = [
     { name = "sortedcontainers-stubs" },
     { name = "types-gdb" },
+    { name = "types-psutil" },
     { name = "types-pygments" },
     { name = "types-requests" },
     { name = "types-tabulate" },
@@ -1277,6 +1278,7 @@ provides-extras = ["lldb", "gdb"]
 dev = [
     { name = "sortedcontainers-stubs", specifier = ">=2.4.2,<3" },
     { name = "types-gdb", specifier = ">=12.1.4.20240704,<13" },
+    { name = "types-psutil", specifier = ">=6.1.0.20241221,<7" },
     { name = "types-pygments", specifier = ">=2.17.0.20240310,<3" },
     { name = "types-requests", specifier = ">=2.31.0.20240406,<3" },
     { name = "types-tabulate", specifier = ">=0.9.0.20240106,<0.10" },
@@ -1826,6 +1828,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/62/e2/fecd2092bc4c516d095aa3315f3fbb7de64ce200aceed4bb92807a16cc4d/types-gdb-12.1.4.20240704.tar.gz", hash = "sha256:0b537f6acf8339e82dc92388aad057a30c83d89105cd820cf5dc948d6debce10", size = 11819 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/27/d4/48df589370499dd5c1011a5351f74ac69b296030fe84d732c37083ce6b4f/types_gdb-12.1.4.20240704-py3-none-any.whl", hash = "sha256:da273ebf395ded84ea12745ef70d0c1560694c26b6d9c04575d500a74929fed1", size = 12067 },
+]
+
+[[package]]
+name = "types-psutil"
+version = "6.1.0.20241221"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/44/8c/5f82cd554cc5bb79d137f082e4c9f8d22e85c8c08dabee4971d422a9abdd/types_psutil-6.1.0.20241221.tar.gz", hash = "sha256:600f5a36bd5e0eb8887f0e3f3ff2cf154d90690ad8123c8a707bba4ab94d3185", size = 20035 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/8f/eda6f25fe59e683b875108f520dfaf683dd45aed59051ec55b9470d869b7/types_psutil-6.1.0.20241221-py3-none-any.whl", hash = "sha256:8498dbe13285a9ba7d4b2fa934c569cc380efc74e3dacdb34ae16d2cdf389ec3", size = 23361 },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1195,6 +1195,7 @@ source = { editable = "." }
 dependencies = [
     { name = "capstone" },
     { name = "ipython" },
+    { name = "psutil" },
     { name = "pt" },
     { name = "pwntools" },
     { name = "pycparser" },
@@ -1255,6 +1256,7 @@ requires-dist = [
     { name = "capstone", specifier = "==6.0.0a4" },
     { name = "gnureadline", marker = "sys_platform != 'win32' and extra == 'lldb'", specifier = ">=8.2.10,<9" },
     { name = "ipython", specifier = ">=8.27.0,<9" },
+    { name = "psutil", specifier = ">=6.1.1,<7" },
     { name = "pt", git = "https://github.com/martinradev/gdb-pt-dump?rev=50227bda0b6332e94027f811a15879588de6d5cb" },
     { name = "pwntools", specifier = ">=4.14.0,<5" },
     { name = "pycparser", specifier = "~=2.22" },


### PR DESCRIPTION
**Closes**: 
- #2774 
- #2887 

**Changes**:
- GDB now starts with the `--nx` option to prevent automatic loading of any `.gdbinit` files.
- On startup, we manually load `.gdbinit` files following logic similar to GDB's native behavior.
- Replaced the `--command=gdbinit.py` option with `--init-command=gdbinit.py`, since `init-command` runs before the inferior is started.

**Before:**
- GDB would automatically load `.gdbinit` (both home and local) **before** pwndbg was initialized.

**After:**
- GDB does **not** load any `.gdbinit` files (due to `--nx`).
- Instead, pwndbg implements its own logic to load `.gdbinit` files in the same order and manner as GDB.

**Implications:**
- This change allows `.gdbinit` files (e.g., user configurations) to be loaded **after** pwndbg is fully initialized.
- It also enables disabling or overriding default pwndbg settings (like `set follow-fork-mode child`) **only in pwndbg-portable mode** 

**Question:**
Should we allow users to override default settings (e.g., `set follow-fork-mode child`)?
Previously, this was not possible because GDB loaded `.gdbinit` before pwndbg.  
Now, with pwndbg handling `.gdbinit` loading (in portable mode), such overrides are possible — but only in pwndbg-portable
