### PR TITLE
Add remote file retrieval module for debugging remote processes

### DIFF
--- a/pwndbg/aglib/file.py
+++ b/pwndbg/aglib/file.py
@@ -104,8 +104,9 @@ def get_file(path: str, try_local_path: bool = False) -> str:
         try:
             pwndbg.dbg.selected_inferior().download_remote_file(path, local_path)
         except pwndbg.dbg_mod.Error as e:
-            # This module originally raised this as an OSError.
+            # This module originally raised this as an OSError
             raise OSError(e)
+
     else:
         raise OSError(f"get_file('{local_path}') is not supported for your target", errno.ENODEV)
 


### PR DESCRIPTION
@OBarronCS   #2946

Adds support for retrieving remote files during debugging, enabling easier inspection of binaries and core dumps in remote debugging sessions.

![image](https://github.com/user-attachments/assets/5c819747-fee8-48b1-aa45-2be6c0d08943)

