### PR TITLE
Only apply TUI color workaround for gdb < 16.3

### DIFF
--- a/pwndbg/gdblib/tui/context.py
+++ b/pwndbg/gdblib/tui/context.py
@@ -186,28 +186,28 @@ class ContextTUIWindow:
                 colored_end_idx += 1
                 char_count += 1
             colored_idx += 1
-        output = (
+        return (
             ansi_escape_before_start
             + line[colored_start_idx:colored_end_idx]
             + ansi_escape_after_end
         )
 
-        # Workaround for display bug in GDB TUI ANSI escape sequence translation.
-        # Only resetting the foreground or background colors results in
-        # generating wrong colors in the TUI.
-        # The workaround is to avoid the sequences that only reset the colors
-        # and replace them with a full reset sequence.
-        # It resets other styling attributes like bold too but it's better
-        # than having wrong colors.
-        # https://github.com/pwndbg/pwndbg/issues/2654
-        gdb_version = tuple(map(int, gdb.VERSION.split(".")[:2]))
-        if gdb_version < (16, 3):
-            return (
-                output.replace("\x1b[39m", "\x1b[0m")
-                .replace("\x1b[49m", "\x1b[0m")
-                .replace("\x1b[39;49m", "\x1b[0m")
-            )
-        return output
+    # Workaround for display bug in GDB TUI ANSI escape sequence translation.
+    # Only resetting the foreground or background colors results in
+    # generating wrong colors in the TUI.
+    # The workaround is to avoid the sequences that only reset the colors
+    # and replace them with a full reset sequence.
+    # It resets other styling attributes like bold too but it's better
+    # than having wrong colors.
+    # https://github.com/pwndbg/pwndbg/issues/2654
+    if tuple(map(int, gdb.VERSION.split(".")[:2])) < (16, 3):
+        ___ansi_substr = _ansi_substr
+        _ansi_substr = (
+            lambda *a, **kw: ContextTUIWindow.___ansi_substr(*a, **kw)
+            .replace("\x1b[39m", "\x1b[0m")
+            .replace("\x1b[49m", "\x1b[0m")
+            .replace("\x1b[39;49m", "\x1b[0m")
+        )
 
 
 if hasattr(gdb, "register_window_type"):

--- a/pwndbg/gdblib/tui/context.py
+++ b/pwndbg/gdblib/tui/context.py
@@ -186,24 +186,28 @@ class ContextTUIWindow:
                 colored_end_idx += 1
                 char_count += 1
             colored_idx += 1
-        return (
-            (
-                ansi_escape_before_start
-                + line[colored_start_idx:colored_end_idx]
-                + ansi_escape_after_end
-                # Workaround for display bug in GDB TUI ANSI escape sequence translation.
-                # Only resetting the foreground or background colors results in
-                # generating wrong colors in the TUI.
-                # The workaround is to avoid the sequences that only reset the colors
-                # and replace them with a full reset sequence.
-                # It resets other styling attributes like bold too but it's better
-                # than having wrong colors.
-                # https://github.com/pwndbg/pwndbg/issues/2654
-            )
-            .replace("\x1b[39m", "\x1b[0m")
-            .replace("\x1b[49m", "\x1b[0m")
-            .replace("\x1b[39;49m", "\x1b[0m")
+        output = (
+            ansi_escape_before_start
+            + line[colored_start_idx:colored_end_idx]
+            + ansi_escape_after_end
         )
+
+        # Workaround for display bug in GDB TUI ANSI escape sequence translation.
+        # Only resetting the foreground or background colors results in
+        # generating wrong colors in the TUI.
+        # The workaround is to avoid the sequences that only reset the colors
+        # and replace them with a full reset sequence.
+        # It resets other styling attributes like bold too but it's better
+        # than having wrong colors.
+        # https://github.com/pwndbg/pwndbg/issues/2654
+        gdb_version = tuple(map(int, gdb.VERSION.split(".")[:2]))
+        if gdb_version < (16, 3):
+            return (
+                output.replace("\x1b[39m", "\x1b[0m")
+                .replace("\x1b[49m", "\x1b[0m")
+                .replace("\x1b[39;49m", "\x1b[0m")
+            )
+        return output
 
 
 if hasattr(gdb, "register_window_type"):


### PR DESCRIPTION
The fix was backported to GDB 16.3, it was fixed in a larger patchset in GDB 17 already.

https://lists.gnu.org/archive/html/info-gnu/2025-04/msg00014.html
 * PR tui/32797 (Escape sequences to only reset foreground or background color
to default fail)

Fixes #2654