### PR TITLE
Strip preceeding and trailing newlines in TUI output

### DIFF
--- a/pwndbg/gdblib/tui/context.py
+++ b/pwndbg/gdblib/tui/context.py
@@ -133,7 +133,7 @@ class ContextTUIWindow:
     def _receive_context_output(self, data: str):
         if not self._verify_enabled_state():
             return
-        self._lines = data.split("\n")
+        self._lines = data.strip("\n").split("\n")
         self._blank_line_lengths = [
             len(self._ansi_escape_regex.sub("", line)) for line in self._lines
         ]


### PR DESCRIPTION
#2767 adds a newline before the actual content of context sections. The layout leaves room for only one line for the legend section. The prepended newline caused the legend section to show up empty by default in TUI mode.