### PR TITLE
Test that gdb and argparse give the same help message

### DIFF
--- a/pwndbg/commands/ida.py
+++ b/pwndbg/commands/ida.py
@@ -69,7 +69,7 @@ parser.add_argument(
 )
 
 
-@pwndbg.commands.Command(parser, category=CommandCategory.MISC)
+@pwndbg.commands.Command(parser, category=CommandCategory.MISC, aliases=["do", "dow"])
 @pwndbg.commands.OnlyWhenRunning
 def down(n=1) -> None:
     """

--- a/pwndbg/commands/ida.py
+++ b/pwndbg/commands/ida.py
@@ -70,7 +70,9 @@ parser.add_argument(
 
 
 # Since we are redefining a gdb command, we also redefine the original aliases.
-# This is both for consistency and to pass the test_consistent_help test - see #2961.
+# These aliases ("do", "dow") are necessary to ensure consistency in the help system
+# and to pass the test_consistent_help test, which verifies that all commands and their
+# aliases are documented correctly. See issue #2961 for more details.
 @pwndbg.commands.Command(parser, category=CommandCategory.MISC, aliases=["do", "dow"])
 @pwndbg.commands.OnlyWhenRunning
 def down(n=1) -> None:

--- a/pwndbg/commands/ida.py
+++ b/pwndbg/commands/ida.py
@@ -69,6 +69,8 @@ parser.add_argument(
 )
 
 
+# Since we are redefining a gdb command, we also redefine the original aliases.
+# This is both for consistency and to pass the test_consistent_help test - see #2961.
 @pwndbg.commands.Command(parser, category=CommandCategory.MISC, aliases=["do", "dow"])
 @pwndbg.commands.OnlyWhenRunning
 def down(n=1) -> None:

--- a/tests/gdb-tests/tests/test_consistent_help.py
+++ b/tests/gdb-tests/tests/test_consistent_help.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import gdb
+
+import pwndbg
+
+
+def test_consistent_help():
+    """
+    Tests that the help printed by gdb (via `help cmd`) is
+    the exact same as the help printed by argparse (via `cmd -h`).
+    """
+
+    for cmd in pwndbg.commands.commands:
+        name = cmd.command_name
+        gdb_out = gdb.execute(f"help {name}", to_string=True)
+        argparse_out = gdb.execute(f"{name} -h", to_string=True)
+
+        assert gdb_out == argparse_out

--- a/tests/gdb-tests/tests/test_consistent_help.py
+++ b/tests/gdb-tests/tests/test_consistent_help.py
@@ -16,4 +16,5 @@ def test_consistent_help():
         gdb_out = gdb.execute(f"help {name}", to_string=True)
         argparse_out = gdb.execute(f"{name} -h", to_string=True)
 
-        assert gdb_out == argparse_out
+        # I would rather not strip, but gdb is inconsistent between versions.
+        assert gdb_out.rstrip() == argparse_out.rstrip()

--- a/tests/gdb-tests/tests/test_misc.py
+++ b/tests/gdb-tests/tests/test_misc.py
@@ -11,6 +11,7 @@ STACK_COMMANDS = [
         "Context",
         "Print out the current register, instruction, and stack context.",
     ),
+    # The aliases 'do' and 'dow' were added to support the help consistency test.
     ("down", ["do", "dow"], "Misc", "Select and print stack frame called by this one."),
     ("retaddr", [], "Stack", "Print out the stack addresses that contain return addresses."),
     ("stack", [], "Stack", "Dereferences on stack data with specified count and offset."),

--- a/tests/gdb-tests/tests/test_misc.py
+++ b/tests/gdb-tests/tests/test_misc.py
@@ -11,7 +11,7 @@ STACK_COMMANDS = [
         "Context",
         "Print out the current register, instruction, and stack context.",
     ),
-    ("down", [], "Misc", "Select and print stack frame called by this one."),
+    ("down", ["do", "dow"], "Misc", "Select and print stack frame called by this one."),
     ("retaddr", [], "Stack", "Print out the stack addresses that contain return addresses."),
     ("stack", [], "Stack", "Dereferences on stack data with specified count and offset."),
     ("up", [], "Misc", "Select and print stack frame that called this one."),


### PR DESCRIPTION
If I don't alias `down` like I did:
![image](https://github.com/user-attachments/assets/c544d73f-971e-49f8-835d-8d84a0eb0573)
