### PR TITLE
Don't print all pwndbg function on startup

### DIFF
--- a/pwndbg/gdblib/prompt.py
+++ b/pwndbg/gdblib/prompt.py
@@ -55,9 +55,9 @@ last_alive_state = False
 def show_hint() -> None:
     hint_lines = (
         f"loaded {len(pwndbg.commands.commands)} pwndbg commands."
-        f" Type {message.notice("pwndbg [filter]")} for a list.",
+        f" Type {message.notice('pwndbg [filter]')} for a list.",
         f"created {len(pwndbg.gdblib.functions.functions)} GDB functions (can be used"
-        f" with print/break). Type {message.notice("help function")} to see them.",
+        f" with print/break). Type {message.notice('help function')} to see them.",
     )
 
     for line in hint_lines:

--- a/pwndbg/gdblib/prompt.py
+++ b/pwndbg/gdblib/prompt.py
@@ -53,14 +53,11 @@ last_alive_state = False
 
 
 def show_hint() -> None:
-    funcs_list_str = ", ".join(
-        message.notice("$" + f.name) for f in pwndbg.gdblib.functions.functions
-    )
-
     hint_lines = (
-        "loaded %i pwndbg commands. Type %s for a list."
-        % (len(pwndbg.commands.commands), message.notice("pwndbg [filter]")),
-        f"created {funcs_list_str} GDB functions (can be used with print/break)",
+        f"loaded {len(pwndbg.commands.commands)} pwndbg commands."
+        f" Type {message.notice("pwndbg [filter]")} for a list.",
+        f"created {len(pwndbg.gdblib.functions.functions)} GDB functions (can be used"
+        f" with print/break). Type {message.notice("help function")} to see them.",
     )
 
     for line in hint_lines:

--- a/tests/gdb-tests/tests/test_loads.py
+++ b/tests/gdb-tests/tests/test_loads.py
@@ -10,7 +10,8 @@ from .utils import run_gdb_with_script
 
 HELLO = [
     "pwndbg: loaded ### pwndbg commands. Type pwndbg [filter] for a list.",
-    "pwndbg: created xxx GDB functions (can be used with print/break)",
+    "pwndbg: created xxx GDB functions (can be used with print/break)."
+    " Type help function to see them.",
 ]
 
 BINARY = tests.binaries.get("div_zero.out")

--- a/tests/gdb-tests/tests/utils.py
+++ b/tests/gdb-tests/tests/utils.py
@@ -61,6 +61,6 @@ def run_gdb_with_script(
 
     # It also shows every single registered function, so we change it to xxx
     # so as to not break this test every time a new function is added
-    output = re.sub(r"created (\$\w+, )*\$\w+ GDB functions", r"created xxx GDB functions", output)
+    output = re.sub(r"created [0-9]+ GDB functions", r"created xxx GDB functions", output)
 
     return output


### PR DESCRIPTION
This is kind of opinionated so let me know what you think, but it seems to me this print was created when there weren't as many functions. The line is kind of long and easily wraps the terminal when the width is small, so this makes it shorter.

Before:
![image](https://github.com/user-attachments/assets/7d9702df-1a96-4ce2-841d-f852abea7a31)
After:
![image](https://github.com/user-attachments/assets/e738382c-cbde-483c-a8fc-ffdc2ede363d)

