### PR TITLE
Argument display fixes

### DIFF
--- a/pwndbg/arguments.py
+++ b/pwndbg/arguments.py
@@ -159,6 +159,8 @@ def arguments(abi: pwndbg.lib.abi.ABI | None = None):
         yield argname(i, abi), argument(i, abi)
 
 
+# When an argument is named one of these in Linux syscalls/glibc, it refers to a file descriptor
+# Search for strings containing "fd" in https://chromium.googlesource.com/chromiumos/docs/+/master/constants/syscalls.md
 FILE_DESCRIPTOR_ARG_NAMES = {
     "fd",
     "in_fd",

--- a/pwndbg/arguments.py
+++ b/pwndbg/arguments.py
@@ -26,12 +26,13 @@ import pwndbg.lib.funcparser
 import pwndbg.lib.functions
 from pwndbg.aglib.disasm.instruction import PwndbgInstruction
 from pwndbg.aglib.nearpc import c as N
+from pwndbg.lib.functions import format_flags_argument
 
 
 def get(instruction: PwndbgInstruction) -> List[Tuple[pwndbg.lib.functions.Argument, int]]:
     """
     Returns an array containing the arguments to the current function,
-    if $pc is a 'call', 'bl', or 'jalr' type instruction.
+    if $pc is a function call or syscall instruction.
 
     Otherwise, returns None.
     """
@@ -158,14 +159,34 @@ def arguments(abi: pwndbg.lib.abi.ABI | None = None):
         yield argname(i, abi), argument(i, abi)
 
 
+FILE_DESCRIPTOR_ARG_NAMES = {
+    "fd",
+    "in_fd",
+    "out_fd",
+    "fdin",
+    "fdout",
+    "oldfd",
+    "fildes",
+    "newfd",
+    "epfd",
+    "dfd",
+    "dirfd",
+    "mountdirfd",
+}
+
+
 def format_args(instruction: PwndbgInstruction) -> List[str]:
     result = []
     for arg, value in get(instruction):
         code = arg.type != "char"
-        pretty = pwndbg.chain.format(value, code=code)
+        pretty = (
+            pwndbg.chain.format(value, code=code)
+            if not arg.flags
+            else format_flags_argument(arg.flags, value)
+        )
 
         # Enhance args display
-        if arg.name == "fd" and isinstance(value, int):
+        if arg.name in FILE_DESCRIPTOR_ARG_NAMES and isinstance(value, int):
             # Cannot find PID of the QEMU program: perhaps it is in a different pid namespace or we have no permission to read the QEMU process' /proc/$pid/fd/$fd file.
             pid = pwndbg.aglib.proc.pid
             if pid is not None:

--- a/pwndbg/commands/dumpargs.py
+++ b/pwndbg/commands/dumpargs.py
@@ -38,12 +38,10 @@ def call_args() -> List[str]:
     """
 
     # Get arguments and add spacing
-    results = [
+    return [
         f"        {arg}"
         for arg in pwndbg.arguments.format_args(pwndbg.aglib.disasm.disassembly.one())
     ]
-
-    return results
 
 
 def all_args() -> List[str]:

--- a/pwndbg/commands/dumpargs.py
+++ b/pwndbg/commands/dumpargs.py
@@ -10,7 +10,6 @@ import pwndbg.chain
 import pwndbg.commands
 import pwndbg.commands.telescope
 from pwndbg.commands import CommandCategory
-from pwndbg.lib.functions import format_flags_argument
 
 parser = argparse.ArgumentParser(description="Prints determined arguments for call instruction.")
 parser.add_argument("-f", "--force", action="store_true", help="Force displaying of all arguments.")
@@ -34,18 +33,15 @@ def call_args() -> List[str]:
     """
     Returns list of resolved call argument strings for display.
     Attempts to resolve the target and determine the number of arguments.
-    Should be used only when being on a call instruction.
-    """
-    results: List[str] = []
 
-    for arg, value in pwndbg.arguments.get(pwndbg.aglib.disasm.disassembly.one()):
-        code = arg.type != "char"
-        pretty = (
-            pwndbg.chain.format(value, code=code)
-            if not arg.flags
-            else format_flags_argument(arg.flags, value)
-        )
-        results.append("        %-10s %s" % (arg.name + ":", pretty))
+    Return empty list if PC is not on a call or syscall instruction.
+    """
+
+    # Get arguments and add spacing
+    results = [
+        f"        {arg}"
+        for arg in pwndbg.arguments.format_args(pwndbg.aglib.disasm.disassembly.one())
+    ]
 
     return results
 


### PR DESCRIPTION
1. If we detect the argument as a file descriptor, we enhance it with the underlying filename. Previously, it looked for the parameter name `fd` - this adds a couple other names that refer to file descriptors as found in this syscall guide: https://syscalls.mebeim.net/?table=x86/64/x64/v6.6

![image](https://github.com/user-attachments/assets/0bb2709b-bf21-4747-99ab-c39ca07a6cc1)

2. Show bitflag argument constant names in context (previously only shown in `dumpargs`) - referring to the `flags` argument in this example
![image](https://github.com/user-attachments/assets/658abc06-7abd-4f71-8fb8-562d3f4037d2)
