### PR TITLE
fix printing stdout when sourcing .gdbinit

### DIFF
--- a/pwndbg/dbg/gdb/__init__.py
+++ b/pwndbg/dbg/gdb/__init__.py
@@ -1337,7 +1337,7 @@ class GDB(pwndbg.dbg_mod.Debugger):
 
         def load_source(file_path: str):
             try:
-                gdb.execute(f"source {file_path}", to_string=True)
+                gdb.execute(f"source {file_path}")
             except gdb.error as e:
                 print(e)
 


### PR DESCRIPTION
Before:
<img width="806" alt="image" src="https://github.com/user-attachments/assets/6ab41f90-8a1a-48e4-870f-514ab1c5e1a9" />

After:
<img width="793" alt="image" src="https://github.com/user-attachments/assets/ef9668b2-9b8d-4680-9b63-1c978bfb5e12" />
