### PR TITLE
Don't install `docs/` directory into site packages directory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,10 +125,10 @@ builtins-ignorelist = [
 ]
 
 [tool.hatch.build.targets.sdist]
-include = ["pwndbg"]
+include = ["/pwndbg"]
 
 [tool.hatch.build.targets.wheel]
-include = ["pwndbg"]
+include = ["/pwndbg"]
 
 [build-system]
 requires = ["hatchling"]


### PR DESCRIPTION
The current build system configuration installs the `docs/` directory into the target systems `site-packages/` directory (see https://bugs.gentoo.org/954386). This PR ensures only module-code is installed into this location.