### PR TITLE
Clean up glibc version printed in ./tests.sh

### DIFF
--- a/tests.sh
+++ b/tests.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 
-# Print ldd and so glibc version
-echo "Running ldd to see ldd and so glibc version"
-ldd --version
+# Use ldd to fetch the glibc version.
+# Can help with diagnosing CI issues.
+glibc_version=$(ldd --version | sed -n '1s/([^)]*)//g; s/.* \([0-9]\+\.[0-9]\+\)$/\1/p')
+echo "glibc version: $glibc_version"
 
 # Run integration tests
 (cd tests && python3 tests.py $@)


### PR DESCRIPTION
Before:
```bash
~> ./tests.sh
Running ldd to see ldd and so glibc version
ldd (GNU libc) 2.41
Copyright (C) 2024 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
Written by Roland McGrath and Ulrich Drepper.
ZIGPATH set to ~/pwndbg/.zig
make: Nothing to be done for 'all'.

Running tests in parallel
```
After:
```bash
~> ./tests.sh
glibc version: 2.41
ZIGPATH set to ~/pwndbg/.zig
make: Nothing to be done for 'all'.

Running tests in parallel
```