### PR TITLE
TUI: fix gdb version crash

### DIFF
--- a/pwndbg/gdblib/tui/context.py
+++ b/pwndbg/gdblib/tui/context.py
@@ -13,6 +13,7 @@ from pwndbg.commands.context import context
 from pwndbg.commands.context import context_sections
 from pwndbg.commands.context import contextoutput
 from pwndbg.commands.context import resetcontextoutput
+from pwndbg.gdblib import gdb_version
 
 
 class ContextTUIWindow:
@@ -200,7 +201,7 @@ class ContextTUIWindow:
     # It resets other styling attributes like bold too but it's better
     # than having wrong colors.
     # https://github.com/pwndbg/pwndbg/issues/2654
-    if tuple(map(int, gdb.VERSION.split(".")[:2])) < (16, 3):
+    if gdb_version < (16, 3):
         ___ansi_substr = _ansi_substr
         _ansi_substr = (
             lambda *a, **kw: ContextTUIWindow.___ansi_substr(*a, **kw)


### PR DESCRIPTION
<img width="808" alt="image" src="https://github.com/user-attachments/assets/0e829ebf-6a67-45f5-a9d1-4ded3989770b" />

```
Fish — 18:42
Has anyone else had issues with "-1" appended on RPM version names? I worked around it but unless I did something strange I imagine others have this problem.

File "/home//Git/pwndbg/pwndbg/gdblib/tui/context.py", line 203, in ContextTUIWindow
    if tuple(map(int, gdb.VERSION.split(".")[:2])) < (16, 3):
       ~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: invalid literal for int() with base 10: '3-1'
```