### PR TITLE
FEAT: Rebase addresses in elfsections command #2958

### DIFF
--- a/pwndbg/commands/elf.py
+++ b/pwndbg/commands/elf.py
@@ -9,13 +9,24 @@ import pwndbg.commands
 from pwndbg.color import message
 from pwndbg.commands import CommandCategory
 
+from pwnlib.elf import ELF # for PIE check
+import pwndbg.aglib.vmmap # for address mapping
 
 @pwndbg.commands.Command(
     "Prints the section mappings contained in the ELF header.", category=CommandCategory.LINUX
 )
 @pwndbg.commands.OnlyWithFile
-def elfsections() -> None:
+def elfsections() -> None:    
     local_path = pwndbg.aglib.file.get_proc_exe_file()
+
+    # IF PIE is set and binary is in execution, save relocation base address.
+    pie_relocation = False
+    if pwndbg.aglib.proc.alive and ELF(local_path).pie:
+        for mapping in pwndbg.aglib.vmmap.get():
+            if mapping.objfile == local_path:
+                pie_relocation = True
+                base_addr = mapping.start
+                break
 
     with open(local_path, "rb") as f:
         elffile = ELFFile(f)
@@ -32,8 +43,17 @@ def elfsections() -> None:
 
         sections.sort()
 
+        # Header
+        print('ADDRESS', end='\t\t')
+        if pie_relocation:
+            print('RELOCATED', end='\t\t\t')
+        print(' SECTION')
+
         for start, end, name in sections:
-            print(f"{start:#x} - {end:#x} ", name)
+            print(f"{start:#x} - {end:#x}", end='\t')
+            if pie_relocation:
+                print(f"{start + base_addr:#x} - {end + base_addr:#x}", end='\t')
+            print(name)
 
 
 @pwndbg.commands.Command(

--- a/pwndbg/commands/elf.py
+++ b/pwndbg/commands/elf.py
@@ -4,19 +4,19 @@ from typing import List
 from typing import Tuple
 
 from elftools.elf.elffile import ELFFile
+from pwnlib.elf import ELF  # for PIE check
 
+import pwndbg.aglib.vmmap  # for address mapping
 import pwndbg.commands
 from pwndbg.color import message
 from pwndbg.commands import CommandCategory
 
-from pwnlib.elf import ELF # for PIE check
-import pwndbg.aglib.vmmap # for address mapping
 
 @pwndbg.commands.Command(
     "Prints the section mappings contained in the ELF header.", category=CommandCategory.LINUX
 )
 @pwndbg.commands.OnlyWithFile
-def elfsections() -> None:    
+def elfsections() -> None:
     local_path = pwndbg.aglib.file.get_proc_exe_file()
 
     # IF PIE is set and binary is in execution, save relocation base address.
@@ -44,15 +44,15 @@ def elfsections() -> None:
         sections.sort()
 
         # Header
-        print('ADDRESS', end='\t\t')
+        print("ADDRESS", end="\t\t")
         if pie_relocation:
-            print('RELOCATED', end='\t\t\t')
-        print(' SECTION')
+            print("RELOCATED", end="\t\t\t")
+        print(" SECTION")
 
         for start, end, name in sections:
-            print(f"{start:#x} - {end:#x}", end='\t')
+            print(f"{start:#x} - {end:#x}", end="\t")
             if pie_relocation:
-                print(f"{start + base_addr:#x} - {end + base_addr:#x}", end='\t')
+                print(f"{start + base_addr:#x} - {end + base_addr:#x}", end="\t")
             print(name)
 
 

--- a/pwndbg/commands/elf.py
+++ b/pwndbg/commands/elf.py
@@ -5,6 +5,7 @@ from typing import Tuple
 
 from elftools.elf.elffile import ELFFile
 from pwnlib.elf import ELF  # for PIE check
+from tabulate import tabulate
 
 import pwndbg.aglib.vmmap  # for address mapping
 import pwndbg.commands
@@ -19,41 +20,37 @@ from pwndbg.commands import CommandCategory
 def elfsections() -> None:
     local_path = pwndbg.aglib.file.get_proc_exe_file()
 
-    # IF PIE is set and binary is in execution, save relocation base address.
-    pie_relocation = False
+    # If PIE is set and binary is in execution, get the relocation base address
+    base_addr = 0
     if pwndbg.aglib.proc.alive and ELF(local_path).pie:
-        for mapping in pwndbg.aglib.vmmap.get():
-            if mapping.objfile == local_path:
-                pie_relocation = True
-                base_addr = mapping.start
-                break
+        base_addr = next(
+            (p.start for p in pwndbg.aglib.vmmap.get() if p.objfile == pwndbg.aglib.proc.exe),
+            0,
+        )
 
     with open(local_path, "rb") as f:
         elffile = ELFFile(f)
         sections = []
         for section in elffile.iter_sections():
             start = section["sh_addr"]
-
-            # Don't print sections that aren't mapped into memory
             if start == 0:
                 continue
-
             size = section["sh_size"]
-            sections.append((start, start + size, section.name))
+            end = start + size
+            row = [f"{start:#x} - {end:#x}"]
+            if base_addr != 0:
+                relocated_start = start + base_addr
+                relocated_end = end + base_addr
+                row.append(f"{relocated_start:#x} - {relocated_end:#x}")
+            row.append(section.name)
+            sections.append(row)
 
-        sections.sort()
+    headers = ["ADDRESS"]
+    if base_addr != 0:
+        headers.append("RELOCATED")
+    headers.append("SECTION")
 
-        # Header
-        print("ADDRESS", end="\t\t")
-        if pie_relocation:
-            print("RELOCATED", end="\t\t\t")
-        print(" SECTION")
-
-        for start, end, name in sections:
-            print(f"{start:#x} - {end:#x}", end="\t")
-            if pie_relocation:
-                print(f"{start + base_addr:#x} - {end + base_addr:#x}", end="\t")
-            print(name)
+    print(tabulate(sections, headers=headers))
 
 
 @pwndbg.commands.Command(

--- a/tests/gdb-tests/tests/test_commands_elf.py
+++ b/tests/gdb-tests/tests/test_commands_elf.py
@@ -286,13 +286,12 @@ def test_command_elf_with_relocation_address_if_pie(binary_name, is_pie):
     # Check if every address returned is correct
     if is_pie:
         elf_sections = []
-        for line in elf_output[1:]:  # skip header
+        for line in elf_output[2:]:  # skip header
             parts = line.split()
-            if len(parts) >= 5:
-                section = parts[6]
-                start_rel = int(parts[3], 16)
-                end_rel = int(parts[5], 16)
-                elf_sections.append((section, start_rel, end_rel))
+            section = parts[6]
+            start_rel = int(parts[3], 16)
+            end_rel = int(parts[5], 16)
+            elf_sections.append((section, start_rel, end_rel))
 
         # 3. Execute `info files`
         info_output = gdb.execute("info files", to_string=True).splitlines()

--- a/tests/gdb-tests/tests/test_commands_elf.py
+++ b/tests/gdb-tests/tests/test_commands_elf.py
@@ -260,3 +260,58 @@ def test_command_got_for_target_binary_and_loaded_library(binary_name):
         r"GOT protection: (?:Partial|Full) RELRO \| Found 0 GOT entries passing the filter", out[10]
     )
     assert len(out) == 11
+
+
+@pytest.mark.parametrize(
+    "binary_name,is_pie", ((PIE_BINARY_WITH_PLT, True), (NOPIE_BINARY_WITH_PLT, False), (NOPIE_I386_BINARY_WITH_PLT, True))
+)
+def test_command_elf_with_relocation_address_if_pie(binary_name, is_pie):
+    binary = tests.binaries.get(binary_name)
+    gdb.execute(f"file {binary}")
+    binary_path = str(Path.cwd() / binary)
+
+    try:
+        gdb.execute("starti")
+    except gdb.error:
+        pytest.skip("Test not supported on this platform.")
+
+    elf_output = gdb.execute("elf", to_string=True).splitlines()
+    
+    assert ("RELOCATED" in elf_output[0]) == is_pie
+
+    # Check if every address returned is correct
+    if is_pie:
+        elf_sections = []
+        for line in elf_output[1:]:  # skip header
+            parts = line.split()
+            if len(parts) >= 5:
+                section = parts[6]
+                start_rel = int(parts[3], 16)
+                end_rel = int(parts[5], 16)
+                elf_sections.append((section, start_rel, end_rel))
+
+        # 3. Execute `info files`
+        info_output = gdb.execute("info files", to_string=True).splitlines()
+
+        # 4. Retrieve addresses
+        info_sections = []
+        for line in info_output[8:]:
+            match = re.match(r"\s*0x([0-9a-f]+) - 0x([0-9a-f]+) is (.+)", line)
+            if match:
+                start = int(match.group(1), 16)
+                end = int(match.group(2), 16)
+                section = match.group(3).strip()
+                info_sections.append((section, start, end))
+
+        # 5. Build dictionaries for comparison
+        elf_map = {name: (start, end) for name, start, end in elf_sections}
+        info_map = {name: (start, end) for name, start, end in info_sections}
+
+        common_sections = set(elf_map.keys()) & set(info_map.keys())
+
+        assert common_sections
+
+        for section in sorted(common_sections):
+            elf_start, elf_end = elf_map[section]
+            info_start, info_end = info_map[section]
+            assert elf_start == info_start and elf_end == info_end

--- a/tests/gdb-tests/tests/test_commands_elf.py
+++ b/tests/gdb-tests/tests/test_commands_elf.py
@@ -263,12 +263,16 @@ def test_command_got_for_target_binary_and_loaded_library(binary_name):
 
 
 @pytest.mark.parametrize(
-    "binary_name,is_pie", ((PIE_BINARY_WITH_PLT, True), (NOPIE_BINARY_WITH_PLT, False), (NOPIE_I386_BINARY_WITH_PLT, True))
+    "binary_name,is_pie",
+    (
+        (PIE_BINARY_WITH_PLT, True),
+        (NOPIE_BINARY_WITH_PLT, False),
+        (NOPIE_I386_BINARY_WITH_PLT, True),
+    ),
 )
 def test_command_elf_with_relocation_address_if_pie(binary_name, is_pie):
     binary = tests.binaries.get(binary_name)
     gdb.execute(f"file {binary}")
-    binary_path = str(Path.cwd() / binary)
 
     try:
         gdb.execute("starti")
@@ -276,7 +280,7 @@ def test_command_elf_with_relocation_address_if_pie(binary_name, is_pie):
         pytest.skip("Test not supported on this platform.")
 
     elf_output = gdb.execute("elf", to_string=True).splitlines()
-    
+
     assert ("RELOCATED" in elf_output[0]) == is_pie
 
     # Check if every address returned is correct


### PR DESCRIPTION
This PR adds support for displaying relocated section addresses in the elf command, as requested in issue [#2958](https://github.com/pwndbg/pwndbg/issues/2958).

This is actually the first time I contribute to an open-source project, I hope I correctly followed the guidelines. Here is what I've done:
Changes:
1. Show relocated address ranges when the binary is PIE and currently running
2. Relocation base address is extracted via `pwndbg.gdblib.vmmap`
3. Output format updated with an additional RELOCATED column
4. Includes tests to validate against `info files` section addresses
Testing:
1. Verified manually with PIE and non-PIE binaries
2. Added automated test using pytest, passes via ./tests.sh