### PR TITLE
exec_shellcode: add steps=N argument to prevent deadlocks

### DIFF
--- a/pwndbg/aglib/shellcode.py
+++ b/pwndbg/aglib/shellcode.py
@@ -68,7 +68,7 @@ async def exec_syscall(
 
 @contextlib.asynccontextmanager
 async def exec_shellcode(
-    ec: ExecutionController, blob, restore_context=True, disable_breakpoints=False
+    ec: ExecutionController, blob, restore_context=True, disable_breakpoints=False, steps=0
 ):
     """
     Tries executing the given blob of machine code in the current context of the
@@ -87,6 +87,13 @@ async def exec_shellcode(
     the caller must be careful to inject code that will (1) terminate and (2)
     not cause the inferior to misbehave. Otherwise, it is fairly easy to crash
     or currupt the memory in the inferior.
+
+    The `steps` argument may help in certain contexts like when running `exec_shellcode`
+    during Linux kernel debugging. When steps is bigger than 0, we use `stepi {steps}`
+    instead of `continue` command. This prevents Linux kernel from interrupting
+    the thread during shellcode execution with IRQ, which can cause deadlocks.
+    Care must be taken to provide proper `steps` value that execute all instructions
+    of the shellcode.
     """
 
     register_set = pwndbg.lib.regs.reg_sets[pwndbg.aglib.arch.name]
@@ -123,30 +130,41 @@ async def exec_shellcode(
         would_skip_context = pwndbg.gdblib.prompt.context_shown
 
     # Execute.
-    target_address = starting_address + len(blob)
-    with pwndbg.dbg.selected_inferior().break_at(
-        BreakpointLocation(target_address), internal=True
-    ) as bp:
-        while True:
-            try:
-                await ec.cont(bp)
-                break
-            except CancelledError:
-                if disable_breakpoints:
-                    # We probably hit another breakpoint, but in this mode we're
-                    # supposed to ignore any breakpoints that aren't the one we put
-                    # at the end of the range, so just retry.
-                    continue
+    if steps == 0:
+        target_address = starting_address + len(blob)
+        with pwndbg.dbg.selected_inferior().break_at(
+            BreakpointLocation(target_address), internal=True
+        ) as bp:
+            while True:
+                try:
+                    await ec.cont(bp)
+                    break
+                except CancelledError:
+                    if disable_breakpoints:
+                        # We probably hit another breakpoint, but in this mode we're
+                        # supposed to ignore any breakpoints that aren't the one we put
+                        # at the end of the range, so just retry.
+                        continue
 
-                # We hit an external break, and we haven't been told to ignore it.
-                raise
+                    # We hit an external break, and we haven't been told to ignore it.
+                    raise
+    else:
+        # Note: This is a workaround: we should probably fix it one day
+        # Read the docstring 'Safety' note for more info.
+        try:
+            await ec.single_steps(steps)
+        except CancelledError:
+            print(f"exec_shellcode error: attempted to execute {steps} instruction but failed")
+            print("- reverting code and saved registers state")
+            print("- however, some state may have been corrupted by executed instructions")
 
     # Restore the state of the context skip.
     if pwndbg.dbg.is_gdblib_available():
         pwndbg.gdblib.prompt.context_shown = would_skip_context
 
     # Make sure we're in the right place.
-    assert pwndbg.aglib.regs.pc == target_address
+    if steps == 0:
+        assert pwndbg.aglib.regs.pc == target_address
 
     try:
         # Give the caller a chance to collect information from the environment

--- a/pwndbg/commands/msr.py
+++ b/pwndbg/commands/msr.py
@@ -59,7 +59,7 @@ def parse_range(msr_range: str, arch: str) -> Optional[Tuple[int, int]]:
 def x86_msr_read(msr: int) -> None:
     async def ctrl(ec: pwndbg.dbg_mod.ExecutionController):
         sc = pwnlib.asm.asm(f"mov ecx, {msr}; rdmsr")
-        async with pwndbg.aglib.shellcode.exec_shellcode(ec, sc):
+        async with pwndbg.aglib.shellcode.exec_shellcode(ec, sc, steps=2):
             edx = int(pwndbg.aglib.regs["edx"]) << 32
             eax = int(pwndbg.aglib.regs["eax"])
             ret = edx + eax
@@ -73,7 +73,7 @@ def x86_msr_write(msr: int, write_value: int) -> None:
         eax = write_value & 0xFFFFFFFF
         edx = write_value >> 32
         sc = pwnlib.asm.asm(f"mov ecx, {msr}; mov eax, {eax}; mov edx, {edx}; wrmsr")
-        async with pwndbg.aglib.shellcode.exec_shellcode(ec, sc):
+        async with pwndbg.aglib.shellcode.exec_shellcode(ec, sc, steps=4):
             return
 
     pwndbg.dbg.selected_inferior().dispatch_execution_controller(ctrl)

--- a/pwndbg/dbg/__init__.py
+++ b/pwndbg/dbg/__init__.py
@@ -302,6 +302,21 @@ class MemoryMap:
 
 
 class ExecutionController:
+    async def single_steps(self, steps: int) -> None:
+        """
+        Steps N times.
+
+        Throws `CancelledError` if a breakpoint or watchpoint is hit, the program
+        exits, or if any other unexpected event that diverts execution happens
+        while fulfulling the step.
+
+        Debuggers may specialize the implementation to perform this operation
+        faster.
+        """
+        while steps > 0:
+            await self.single_step()
+            steps -= 1
+
     def single_step(self) -> Awaitable[None]:
         """
         Steps to the next instruction.

--- a/pwndbg/dbg/gdb/__init__.py
+++ b/pwndbg/dbg/gdb/__init__.py
@@ -984,13 +984,6 @@ class GDBProcess(pwndbg.dbg_mod.Process):
 
 class GDBExecutionController(pwndbg.dbg_mod.ExecutionController):
     @override
-    async def single_steps(self, steps: int):
-        gdb.execute(f"si {steps}")
-
-        if "It stopped after being stepped" not in gdb.execute("info program", to_string=True):
-            raise CancelledError()
-
-    @override
     async def single_step(self):
         gdb.execute("si")
 

--- a/pwndbg/dbg/gdb/__init__.py
+++ b/pwndbg/dbg/gdb/__init__.py
@@ -984,6 +984,13 @@ class GDBProcess(pwndbg.dbg_mod.Process):
 
 class GDBExecutionController(pwndbg.dbg_mod.ExecutionController):
     @override
+    async def single_steps(self, steps: int):
+        gdb.execute(f"si {steps}")
+
+        if "It stopped after being stepped" not in gdb.execute("info program", to_string=True):
+            raise CancelledError()
+
+    @override
     async def single_step(self):
         gdb.execute("si")
 


### PR DESCRIPTION
This adds a `steps=N` argument for `pwndbg.aglib.shellcode.exec_shellcode`. When this is passed, the underlying debugger will perform `stepi` N times instead of `continue`.

This helps prevent deadlocks e.g. when using `exec_shellcode` in Linux kernel since `stepi N` is not interrupted by IRQ while `continue` can be.

Of course this has its own issues, but I am not sure of a better solution for now (and we can't just do `stepi 1000` until we hit an expected PC address or something, because there may be loops).

<!--
    Please make sure to read the linting and testing instructions at
    https://pwndbg.re/pwndbg/dev/contributing/ before creating a PR.
-->
