### PR TITLE
Remove hidden call to __len__ in register lookup

### DIFF
--- a/pwndbg/aglib/regs.py
+++ b/pwndbg/aglib/regs.py
@@ -52,7 +52,8 @@ def get_register(
 
     regs = regs_in_frame(frame)
 
-    return regs.by_name(name) or regs.by_name(name.upper())
+    value = regs.by_name(name)
+    return value if value is not None else regs.by_name(name.upper())
 
 
 @pwndbg.aglib.proc.OnlyWhenQemuKernel


### PR DESCRIPTION
The return statement of the `get_register` function did 
```python
return regs.by_name(frame) or regs.by_name(name.upper())
```
The `or` is meant to check if the left side is `None`. However, even if it is a `Value` object, Python will try to coerce it into a boolean, in this case calling the objects `__len__` method to see if it returns 0 (which it never will). Changing the lines here removes this hidden function call, slightly speeding up register fetches.

https://github.com/pwndbg/pwndbg/blob/dca2e3f9539e7eb2d579b4f3a81f1daef9bf5dbd/pwndbg/dbg/gdb/__init__.py#L1275-L1281