### PR TITLE
Fix #2958: Rebase addresses in elfsections command 

### DIFF
--- a/pwndbg/commands/elf.py
+++ b/pwndbg/commands/elf.py
@@ -5,6 +5,8 @@ from typing import Tuple
 
 from elftools.elf.elffile import ELFFile
 
+import pwndbg.aglib
+import pwndbg.aglib.proc
 import pwndbg.commands
 from pwndbg.color import message
 from pwndbg.commands import CommandCategory
@@ -16,6 +18,12 @@ from pwndbg.commands import CommandCategory
 @pwndbg.commands.OnlyWithFile
 def elfsections() -> None:
     local_path = pwndbg.aglib.file.get_proc_exe_file()
+    
+    bin_base_addr = 0
+    
+    # Get the binary base address, for rebase the section address if we need.
+    if pwndbg.aglib.proc.alive:
+        bin_base_addr = pwndbg.aglib.proc.binary_base_addr
 
     with open(local_path, "rb") as f:
         elffile = ELFFile(f)
@@ -26,6 +34,10 @@ def elfsections() -> None:
             # Don't print sections that aren't mapped into memory
             if start == 0:
                 continue
+            
+            # Rebase the section address
+            if start < bin_base_addr:
+                start += bin_base_addr
 
             size = section["sh_size"]
             sections.append((start, start + size, section.name))

--- a/pwndbg/commands/elf.py
+++ b/pwndbg/commands/elf.py
@@ -18,9 +18,8 @@ from pwndbg.commands import CommandCategory
 @pwndbg.commands.OnlyWithFile
 def elfsections() -> None:
     local_path = pwndbg.aglib.file.get_proc_exe_file()
-    
+
     bin_base_addr = 0
-    
     # Get the binary base address, for rebase the section address if we need.
     if pwndbg.aglib.proc.alive:
         bin_base_addr = pwndbg.aglib.proc.binary_base_addr
@@ -34,7 +33,7 @@ def elfsections() -> None:
             # Don't print sections that aren't mapped into memory
             if start == 0:
                 continue
-            
+
             # Rebase the section address
             if start < bin_base_addr:
                 start += bin_base_addr

--- a/tests/gdb-tests/tests/test_commands_elf.py
+++ b/tests/gdb-tests/tests/test_commands_elf.py
@@ -260,3 +260,29 @@ def test_command_got_for_target_binary_and_loaded_library(binary_name):
         r"GOT protection: (?:Partial|Full) RELRO \| Found 0 GOT entries passing the filter", out[10]
     )
     assert len(out) == 11
+
+
+@pytest.mark.parametrize(
+    "binary_name,is_pie", ((PIE_BINARY_WITH_PLT, True), (NOPIE_BINARY_WITH_PLT, False))
+)
+def test_command_elf(start_binary, binary_name, is_pie):
+    binary = tests.binaries.get(binary_name)
+    gdb.execute(f"file {binary}")
+
+    gdb.execute("starti")
+    out = gdb.execute("elf", to_string=True).splitlines()
+    assert len(out) == 23
+    
+    for section in out:
+        assert re.match(r"0x[0-9a-f]+ - 0x[0-9a-f]+  .*", section)
+        if is_pie:
+            assert section.startswith("0x55555555")
+
+        
+        
+
+        
+        
+    
+    
+    

--- a/tests/gdb-tests/tests/test_commands_elf.py
+++ b/tests/gdb-tests/tests/test_commands_elf.py
@@ -268,21 +268,12 @@ def test_command_got_for_target_binary_and_loaded_library(binary_name):
 def test_command_elf(start_binary, binary_name, is_pie):
     binary = tests.binaries.get(binary_name)
     gdb.execute(f"file {binary}")
-
     gdb.execute("starti")
+    
     out = gdb.execute("elf", to_string=True).splitlines()
     assert len(out) == 23
-    
+
     for section in out:
         assert re.match(r"0x[0-9a-f]+ - 0x[0-9a-f]+  .*", section)
         if is_pie:
             assert section.startswith("0x55555555")
-
-        
-        
-
-        
-        
-    
-    
-    


### PR DESCRIPTION
The elf command will show the rebased address if the binary file is started and enable PIE.

With the binary doesn't run or disable PIE:
```
pwndbg> file ./tests/gdb-tests/tests/binaries/reference_bin_nopie.out 
Reading symbols from ./tests/gdb-tests/tests/binaries/reference_bin_nopie.out...
pwndbg> elf
0x10002a8 - 0x10002c4  .interp
0x10002c4 - 0x10002e4  .note.ABI-tag
0x10002e8 - 0x1000348  .dynsym
0x1000348 - 0x1000350  .gnu.version
0x1000350 - 0x1000380  .gnu.version_r
0x1000380 - 0x100039c  .gnu.hash
0x100039c - 0x10003c4  .hash
0x10003c4 - 0x100040c  .dynstr
0x1000410 - 0x1000440  .rela.dyn
0x1000440 - 0x1000458  .rela.plt
0x1000458 - 0x1000468  .rodata
0x1000468 - 0x1000494  .eh_frame_hdr
0x1000498 - 0x1000520  .eh_frame
0x1001520 - 0x100159f  .text
0x10015a0 - 0x10015bb  .init
0x10015bc - 0x10015c9  .fini
0x10015d0 - 0x10015f0  .plt
0x10025f0 - 0x1002760  .dynamic
0x1002760 - 0x1002770  .got
0x1002770 - 0x1002790  .got.plt
0x1002790 - 0x1003000  .relro_padding
0x1003790 - 0x1003794  .data
0x1003794 - 0x1003794  .bss
pwndbg> start
pwndbg> elf
0x10002a8 - 0x10002c4  .interp
0x10002c4 - 0x10002e4  .note.ABI-tag
0x10002e8 - 0x1000348  .dynsym
0x1000348 - 0x1000350  .gnu.version
0x1000350 - 0x1000380  .gnu.version_r
0x1000380 - 0x100039c  .gnu.hash
0x100039c - 0x10003c4  .hash
0x10003c4 - 0x100040c  .dynstr
0x1000410 - 0x1000440  .rela.dyn
0x1000440 - 0x1000458  .rela.plt
0x1000458 - 0x1000468  .rodata
0x1000468 - 0x1000494  .eh_frame_hdr
0x1000498 - 0x1000520  .eh_frame
0x1001520 - 0x100159f  .text
0x10015a0 - 0x10015bb  .init
0x10015bc - 0x10015c9  .fini
0x10015d0 - 0x10015f0  .plt
0x10025f0 - 0x1002760  .dynamic
0x1002760 - 0x1002770  .got
0x1002770 - 0x1002790  .got.plt
0x1002790 - 0x1003000  .relro_padding
0x1003790 - 0x1003794  .data
0x1003794 - 0x1003794  .bss
````

With the binary started and enable PIE:
```
pwndbg> file ./tests/gdb-tests/tests/binaries/reference_bin_pie.out 
Reading symbols from ./tests/gdb-tests/tests/binaries/reference_bin_pie.out...
pwndbg> elf
0x2a8 - 0x2c4  .interp
0x2c4 - 0x2e4  .note.ABI-tag
0x2e8 - 0x348  .dynsym
0x348 - 0x350  .gnu.version
0x350 - 0x380  .gnu.version_r
0x380 - 0x39c  .gnu.hash
0x39c - 0x3c4  .hash
0x3c4 - 0x40c  .dynstr
0x410 - 0x440  .rela.dyn
0x440 - 0x458  .rela.plt
0x458 - 0x468  .rodata
0x468 - 0x48c  .eh_frame_hdr
0x490 - 0x500  .eh_frame
0x1500 - 0x156f  .text
0x1570 - 0x158b  .init
0x158c - 0x1599  .fini
0x15a0 - 0x15c0  .plt
0x25c0 - 0x2730  .dynamic
0x2730 - 0x2740  .got
0x2740 - 0x2760  .got.plt
0x2760 - 0x3000  .relro_padding
0x3760 - 0x3764  .data
0x3764 - 0x3764  .bss
pwndbg> start
pwndbg> elf
0x5555555542a8 - 0x5555555542c4  .interp
0x5555555542c4 - 0x5555555542e4  .note.ABI-tag
0x5555555542e8 - 0x555555554348  .dynsym
0x555555554348 - 0x555555554350  .gnu.version
0x555555554350 - 0x555555554380  .gnu.version_r
0x555555554380 - 0x55555555439c  .gnu.hash
0x55555555439c - 0x5555555543c4  .hash
0x5555555543c4 - 0x55555555440c  .dynstr
0x555555554410 - 0x555555554440  .rela.dyn
0x555555554440 - 0x555555554458  .rela.plt
0x555555554458 - 0x555555554468  .rodata
0x555555554468 - 0x55555555448c  .eh_frame_hdr
0x555555554490 - 0x555555554500  .eh_frame
0x555555555500 - 0x55555555556f  .text
0x555555555570 - 0x55555555558b  .init
0x55555555558c - 0x555555555599  .fini
0x5555555555a0 - 0x5555555555c0  .plt
0x5555555565c0 - 0x555555556730  .dynamic
0x555555556730 - 0x555555556740  .got
0x555555556740 - 0x555555556760  .got.plt
0x555555556760 - 0x555555557000  .relro_padding
0x555555557760 - 0x555555557764  .data
0x555555557764 - 0x555555557764  .bss
```
