### PR TITLE
FIX: reference_bin_nopie.i386 compiled with pie instead of no-pie

### DIFF
--- a/tests/gdb-tests/tests/binaries/makefile
+++ b/tests/gdb-tests/tests/binaries/makefile
@@ -175,7 +175,7 @@ reference_bin_nopie.out: reference-binary.c
 
 reference_bin_nopie.i386.out: reference-binary.c
 	@echo "[+] Building reference_bin_nopie.i386.out"
-	${ZIGCC} -fpie -target x86-linux-gnu -o reference_bin_nopie.i386.out reference-binary.c
+	${ZIGCC} -fno-pie -target x86-linux-gnu -o reference_bin_nopie.i386.out reference-binary.c
 
 symbol_1600_and_752.out: symbol_1600_and_752.cpp
 	${CXX} -O0 -ggdb -Wno-pmf-conversions symbol_1600_and_752.cpp -o symbol_1600_and_752.out


### PR DESCRIPTION
The binary `reference_bin_nopie.i386` was mistakenly compiled with `-fpie` instead of `-fno-pie`.
The change didn't break any test.