### PR TITLE
Correct instruction.condition for emulated conditional branches

### DIFF
--- a/pwndbg/aglib/disasm/arch.py
+++ b/pwndbg/aglib/disasm/arch.py
@@ -27,6 +27,7 @@ from pwndbg.aglib.disasm.instruction import FORWARD_JUMP_GROUP
 from pwndbg.aglib.disasm.instruction import EnhancedOperand
 from pwndbg.aglib.disasm.instruction import InstructionCondition
 from pwndbg.aglib.disasm.instruction import PwndbgInstruction
+from pwndbg.aglib.disasm.instruction import boolean_to_instruction_condition
 from pwndbg.lib.arch import PWNDBG_SUPPORTED_ARCHITECTURES_TYPE
 
 # Emulator currently requires GDB, and we only use it here for type checking.
@@ -694,6 +695,20 @@ class DisassemblyAssistant:
         if instruction.has_jump_target and instruction.target >= 0:
             # Only bother doing the symbol lookup if this is a jump
             instruction.target_string = MemoryColor.get_address_or_symbol(instruction.target)
+
+        # Now that we have determined the target, if it was a conditional branch,
+        # go back and correct the instruction condition to reflect the branch decision of the emulator
+        # in case we didn't manually determine the condition.
+        if (
+            jump_emu
+            and instruction.condition == InstructionCondition.UNDETERMINED
+            and instruction.is_conditional_jump
+        ):
+            # At this point we know the emulator was used to determine
+            # the conditional branch
+            instruction.condition = boolean_to_instruction_condition(
+                instruction.is_conditional_jump_taken
+            )
 
         if (
             instruction.operands

--- a/pwndbg/aglib/disasm/x86.py
+++ b/pwndbg/aglib/disasm/x86.py
@@ -324,12 +324,9 @@ class X86DisassemblyAssistant(pwndbg.aglib.disasm.arch.DisassemblyAssistant):
         if instruction.id in (X86_INS_JMP, X86_INS_RET, X86_INS_CALL):
             return InstructionCondition.UNDETERMINED
 
-        # We can't reason about anything except the current instruction
-        if instruction.address != pwndbg.aglib.regs.pc:
-            return InstructionCondition.UNDETERMINED
-
-        efl = pwndbg.aglib.regs.eflags
+        efl = self._read_register_name(instruction, "eflags", emu)
         if efl is None:
+            # We can't reason about the value of flags register
             return InstructionCondition.UNDETERMINED
 
         cf = efl & (1 << 0)


### PR DESCRIPTION
To make #3027 work in all cases, this correctly sets the .condition property of conditional branches - they now are set to TRUE or FALSE correctly for future instructions.