### PR TITLE
Fix next commands tests for crashed binaries

### DIFF
--- a/tests/gdb-tests/tests/test_commands_next.py
+++ b/tests/gdb-tests/tests/test_commands_next.py
@@ -53,7 +53,7 @@ def test_command_nextproginstr(start_binary):
     ("nextcall", "nextjump", "nextproginstr", "nextret", "nextsyscall", "stepret", "stepsyscall"),
 )
 def test_next_command_doesnt_freeze_crashed_binary(start_binary, command):
-    start_binary(REFERENCE_BINARY)
+    start_binary(CRASH_SIMPLE_BINARY)
 
     # The nextproginstr won't step if we are already on the binary address
     # and interestingly, other commands won't step if the address can't be disassemblied


### PR DESCRIPTION
The `test_next_command_doesnt_freeze_crashed_binary` test incorrectly used `REFERENCE_BINARY` instead of `CRASH_SIMPLE_BINARY` so it didn't really checked what happens when we run next commands on a crashing binary but instead it ran it on a working binary...

This also speeds up test execution for the
`test_next_command_doesnt_freeze_crashed_binary[stepsyscall]` test from 30s to 1s on my machine.

<!--
    Please make sure to read the linting and testing instructions at
    https://pwndbg.re/pwndbg/dev/contributing/ before creating a PR.
-->
