### PR TITLE
Add stepsyscall to disabled CI commands tests

### DIFF
--- a/tests/gdb-tests/tests/test_commands.py
+++ b/tests/gdb-tests/tests/test_commands.py
@@ -16,6 +16,7 @@ disallowed_commands = {
     "ipi",
     # takes too long
     "nextproginstr",
+    "stepsyscall",
 }
 
 filtered_commands = command_names - disallowed_commands


### PR DESCRIPTION
Disabling the stepsyscall command test since it is already tested in `gdb-tests/tests/test_command_stepsyscall.py` as well as in `gdb-tests/tests/test_commands_next.py`.

Fwiw this test took ~80% time of a test run?
> gdb-tests/tests/test_commands.py::test_commands[stepsyscall]           XPASS 364.60s
> Tests completed in 456 seconds
