### PR TITLE
Additional fix to instruction.condition

### DIFF
--- a/pwndbg/aglib/disasm/arm.py
+++ b/pwndbg/aglib/disasm/arm.py
@@ -264,11 +264,10 @@ class ArmDisassemblyAssistant(pwndbg.aglib.disasm.arch.DisassemblyAssistant):
                 instruction.declare_conditional = False
             return InstructionCondition.UNDETERMINED
 
-        # We can't reason about anything except the current instruction
-        if instruction.address != pwndbg.aglib.regs.pc:
+        value = self._read_register_name(instruction, self.flags_reg, emu)
+        if value is None:
+            # We can't reason about the value of flags register
             return InstructionCondition.UNDETERMINED
-
-        value = pwndbg.aglib.regs[self.flags_reg]
 
         N = (value >> 31) & 1
         Z = (value >> 30) & 1

--- a/pwndbg/aglib/disasm/instruction.py
+++ b/pwndbg/aglib/disasm/instruction.py
@@ -49,6 +49,7 @@ from capstone.sparc import SPARC_INS_JMPL
 from capstone.systemz import SYSTEMZ_INS_B
 from capstone.systemz import SYSTEMZ_INS_BAL
 from capstone.systemz import SYSTEMZ_INS_BALR
+from capstone.x86 import X86_INS_CALL
 from capstone.x86 import X86_INS_JMP
 from capstone.x86 import X86Op
 from typing_extensions import override
@@ -60,7 +61,7 @@ from pwndbg.dbg import DisassembledInstruction
 # The Capstone RET and CALL groups are also used to filter CALL and RET types when we check for unconditional jumps,
 # so we don't need to manually specify those for each architecture
 UNCONDITIONAL_JUMP_INSTRUCTIONS: Dict[int, Set[int]] = {
-    CS_ARCH_X86: {X86_INS_JMP},
+    CS_ARCH_X86: {X86_INS_CALL, X86_INS_JMP},
     CS_ARCH_MIPS: {
         MIPS_INS_J,
         MIPS_INS_JR,


### PR DESCRIPTION
Additional fix to #3030 so x86 call instructions are handled correctly, not incorrectly labeled as conditional instructions.