### PR TITLE
Fix terminfo in portable-lldb and fix terminal size

### DIFF
--- a/nix/portable.nix
+++ b/nix/portable.nix
@@ -187,6 +187,7 @@ let
         chmod -R +w $out
 
         # copy extra files
+        mkdir -p $out/pwndbg/share/
         cp -rf ${lib.getLib pkgs.ncurses}/share/terminfo/ $out/pwndbg/share/
 
         # fix ipython autocomplete

--- a/pwndbg/ui.py
+++ b/pwndbg/ui.py
@@ -57,7 +57,7 @@ def addrsz(address) -> str:
 
 
 def get_window_size(target=sys.stdout):
-    fallback = (int(os.environ.get("LINES", 20)), int(os.environ.get("COLUMNS", 80)))
+    fallback = (int(os.environ.get("LINES", 24)), int(os.environ.get("COLUMNS", 80)))
     if not target.isatty():
         return fallback
     if os.environ.get("PWNDBG_IN_TEST") is not None:
@@ -71,7 +71,7 @@ def get_window_size(target=sys.stdout):
 
     try:
         term = os.get_terminal_size(target.fileno())
-        return term.lines, term.columns
+        return term.lines or fallback[0], term.columns or fallback[1]
     except Exception:
         pass
 


### PR DESCRIPTION
Terminfo bug:
<img width="966" alt="image" src="https://github.com/user-attachments/assets/31e98c86-f629-4af7-a9a7-4066ef543d71" />


Terminal size bug:
<img width="789" alt="image" src="https://github.com/user-attachments/assets/eafc5100-616c-467e-a2ad-a71f6c6801c5" />
<img width="441" alt="image" src="https://github.com/user-attachments/assets/13100434-1e2e-4edd-aacc-bda7fed2c9b6" />
