### PR TITLE
LLDB: Change thread selection on STOP if it makes sense to do so

### DIFF
--- a/pwndbg/dbg/lldb/repl/__init__.py
+++ b/pwndbg/dbg/lldb/repl/__init__.py
@@ -61,6 +61,7 @@ import pwndbg.dbg.lldb
 from pwndbg.color import message
 from pwndbg.dbg import EventType
 from pwndbg.dbg.lldb import LLDB
+from pwndbg.dbg.lldb import LLDBProcess
 from pwndbg.dbg.lldb import OneShotAwaitable
 from pwndbg.dbg.lldb.pset import pset
 from pwndbg.dbg.lldb.repl.io import IODriver
@@ -129,7 +130,25 @@ class EventRelay(EventHandler):
         self.dbg._trigger_event(EventType.START)
 
     @override
-    def suspended(self):
+    def suspended(self, event: lldb.SBEvent):
+        # The event might have originated from a different source than the user
+        # currently has selected. Move focus to the where the event happened.
+        #
+        # state-changed events have no thread associated with them, and so
+        # SBThread::GetThreadFromEvent does not work. Interrogate each thread in
+        # the process and look for the most interesting one.
+        proc = lldb.SBProcess.GetProcessFromEvent(event)
+        for thread in proc.threads:
+            # Currently the one considered most interesting is simply the first
+            # that has any reason at all to be stopped.
+            if thread.stop_reason == lldb.eStopReasonNone:
+                continue
+
+            if proc.GetSelectedThread().idx != thread.idx:
+                print(message.notice(f"[Switched to Thread {thread.id}]"))
+                assert proc.SetSelectedThread(thread)
+            break
+
         self.dbg._trigger_event(EventType.STOP)
 
     @override

--- a/pwndbg/dbg/lldb/repl/proc.py
+++ b/pwndbg/dbg/lldb/repl/proc.py
@@ -35,7 +35,7 @@ class EventHandler:
         """
         pass
 
-    def suspended(self):
+    def suspended(self, cause: lldb.SBEvent):
         """
         This function is called when the execution of a process is suspended.
         """
@@ -206,7 +206,7 @@ class ProcessDriver:
                         # The process has stopped, so we're done processing events
                         # for the time being. Trigger the stopped event and return.
                         if fire_events:
-                            self.eh.suspended()
+                            self.eh.suspended(event)
                         expected = True
                         break
 


### PR DESCRIPTION
Fixes #2895

When LLDB Pwndbg receives a `state-changed` event from LLDB and is about to signal STOP, it should also automatically select for the user the thread that best reflects the event. This lets us better match the behavior of the LLDB CLI.

As LLDB doesn't give us exact threads as sources of `state-changed` events, however, what thread qualifies as "best reflecting" a given event is always bound to be a bit of an approximation. Currently, we just pick the first thread that has a stop reason[^1], but the exact criteria we use can be refined over time if need be.

[^1]: Threads that don't have a stop reason are effectively only stopped because some other thread had a valid reason to be stopped, so, they are exactly the kind of thread we're trying to filter out.