### PR TITLE
Run `run -s` automatically for `entry`

### DIFF
--- a/pwndbg/commands/start.py
+++ b/pwndbg/commands/start.py
@@ -134,11 +134,18 @@ def entry(args=None) -> None:
         args = []
 
     if pwndbg.dbg.is_gdblib_available():
+        # If this is GDB, just start the process ourselves.
         run = "starti " + " ".join(map(quote, args))
         gdb.execute(run, from_tty=False)
     else:
-        # TODO: LLDB, In the future, we should handle `run -s` here to automate setup.
-        # For now, we only support stopping at the entry breakpoint.
+        # For now, there is no debugger-agnostic way to start a process from
+        # inside a command, so the best we can do is expect that the back-end
+        # picks up that this command is being called, and starts the process on
+        # our behalf, and error out if it does not.
+        #
+        # `pwndbg-lldb` implements starting as a partial command override in the CLI.
+        #
+        # TODO: In the future, we should handle starts using an in-command mechanism.
         if not pwndbg.aglib.proc.alive:
             print(
                 M.error(

--- a/pwndbg/dbg/lldb/repl/__init__.py
+++ b/pwndbg/dbg/lldb/repl/__init__.py
@@ -514,6 +514,26 @@ def exec_repl_command(
         run_ipython_shell()
         return True
 
+    if (
+        bits[0] == pwndbg.commands.start.entry.command_name
+        or bits[0] in pwndbg.commands.start.entry.aliases
+    ):
+        # 'entry' is actually a Pwndbg command. For convenience, we launch the
+        # process on its behalf, before letting it run.
+        #
+        # In the LLDB back-end, there is no proper mechanism to make a process
+        # start from inside of a command, as there is in GDB. Ideally, we'd
+        # rework `ProcessDriver` so that it lets us do that with an execution
+        # controller, but that is quite a bit of work to fix a single command,
+        # when using an override is enough to achieve the same goal.
+        #
+        # In any case, we should consider doing it if this proves to be too janky.
+        if not driver.has_process():
+            process_launch(driver, relay, ["-s"], dbg)
+
+        # This intentionally falls through. We want LLDB to do the rest of the
+        # work of processing 'entry'.
+
     # The command hasn't matched any of our filtered commands, just let LLDB
     # handle it normally. Either in the context of the process, if we have
     # one, or just in a general context.


### PR DESCRIPTION
Fixes #3058

This PR makes it so that a process is automatically launched if needed when `entry` is called in LLDB, to better match the behavior of that command in GDB. This is achieved by using an override that launches the process.

I'm not particularly fond of using an override for this, personally. Ideally, we'd only ever use them for things LLDB absolutely wouldn't let us do otherwise, and I think the better solution for `entry` would be to launch using `ProcessController` from inside the command itself. Trouble with that is that it would require a bit of a rework of the ProcessDriver and of command handling under LLDB, which I feel is too much to support a single command, when achieving the same outcome with an override is so short and simple.

We should probably revisit this later, though, after we get rid of the whole "Pwndbg commands require an active inferior" deal.