### PR TITLE
Fix at&t disassembly-flavor setting breaking non-x86 architectures

### DIFF
--- a/pwndbg/aglib/disasm/instruction.py
+++ b/pwndbg/aglib/disasm/instruction.py
@@ -249,7 +249,7 @@ class PwndbgInstructionImpl(PwndbgInstruction):
         # For ease, for x86 we will assume Intel syntax (destination operand first).
         # However, Capstone will disassemble using the `set disassembly-flavor` preference,
         # and the order of operands are read left to right into the .operands array. So we flip operand order if AT&T
-        if self.cs_insn._cs.syntax == CS_OPT_SYNTAX_ATT:
+        if self.cs_insn._cs.arch == CS_ARCH_X86 and self.cs_insn._cs.syntax == CS_OPT_SYNTAX_ATT:
             self.cs_insn.operands.reverse()
 
         self.operands: List[EnhancedOperand] = [EnhancedOperand(op) for op in self.cs_insn.operands]

--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -1092,6 +1092,7 @@ def context_disasm(target=sys.stdout, with_banner=True, width=None):
     # The `None` case happens when the cache was not filled yet (see e.g. #881)
     if cs is not None and cs.syntax != syntax:
         pwndbg.lib.cache.clear_caches()
+        pwndbg.aglib.disasm.disassembly.computed_instruction_cache.clear()
 
     result = try_emulate_if_bug_disable(
         lambda: pwndbg.aglib.nearpc.nearpc(

--- a/tests/qemu-tests/tests/user/test_riscv64.py
+++ b/tests/qemu-tests/tests/user/test_riscv64.py
@@ -143,6 +143,17 @@ def test_riscv64_compressed_loads(qemu_assembly_run):
     assert dis == expected
 
 
+def test_att_syntax_non_x86(qemu_assembly_run):
+    """
+    https://github.com/pwndbg/pwndbg/issues/3073
+
+    `set disassembly-flavor att` should not have an effect on the disassembly or enhancement of non-x86 architectures.
+    """
+
+    gdb.execute("set disassembly-flavor att")
+    test_riscv64_compressed_loads(qemu_assembly_run)
+
+
 RISCV64_JUMPS = f"""
 {RISCV64_PREAMBLE}
 li t0, 4


### PR DESCRIPTION
Fix #3073

The implementation didn't take into account that the GDB setting `set disassembly-flavor` could be set to `att` while debugging a non-x86 architecture.

The PR also adds a test for this.

