### PR TITLE
Skip test_command_procinfo.py if unable to bind to address

### DIFF
--- a/tests/gdb-tests/tests/test_command_procinfo.py
+++ b/tests/gdb-tests/tests/test_command_procinfo.py
@@ -21,7 +21,7 @@ class TCPServerThread(threading.Thread):
         )
         try:
             self.sock.bind((ip, port))
-        except:
+        except OSError:
             pytest.skip(f"Could not bind to {ip}:{port}.")
         self.port = self.sock.getsockname()[1]
         self.sock.listen(1)

--- a/tests/gdb-tests/tests/test_command_procinfo.py
+++ b/tests/gdb-tests/tests/test_command_procinfo.py
@@ -19,7 +19,10 @@ class TCPServerThread(threading.Thread):
         self.sock = socket.socket(
             socket.AF_INET6 if ":" in ip else socket.AF_INET, socket.SOCK_STREAM
         )
-        self.sock.bind((ip, port))
+        try:
+            self.sock.bind((ip, port))
+        except:
+            pytest.skip(f"Could not bind to {ip}:{port}.")
         self.port = self.sock.getsockname()[1]
         self.sock.listen(1)
 


### PR DESCRIPTION
Patches test_command_procinfo.py to skip test if unable to bind to address; encountering failed test in WSL2 because of lack of IPv6 support.