### PR TITLE
TUI: Switch threads and expressions windows

### DIFF
--- a/docs/tutorials/gdb-tui.md
+++ b/docs/tutorials/gdb-tui.md
@@ -8,6 +8,6 @@ Use `focus cmd` to focus the command window and have the arrow keys scroll throu
 
 To create [your own layout](https://sourceware.org/gdb/current/onlinedocs/gdb.html/TUI-Commands.html) and selecting it use normal `tui new-layout` syntax like:
 ```
-tui new-layout pwndbg_custom {-horizontal { { -horizontal { pwndbg_code 1 pwndbg_disasm 1 } 2 { {-horizontal pwndbg_legend 8 pwndbg_control 2 } 0 pwndbg_regs 1 pwndbg_stack 1 } 3 } 7 cmd 3 } 3 { pwndbg_backtrace 2 pwndbg_threads 1 pwndbg_expressions 2 } 1 } 1 status 1
+tui new-layout pwndbg_custom {-horizontal { { -horizontal { pwndbg_code 1 pwndbg_disasm 1 } 2 { {-horizontal pwndbg_legend 8 pwndbg_control 2 } 0 pwndbg_regs 1 pwndbg_stack 1 } 3 } 7 cmd 3 } 3 { pwndbg_backtrace 2 pwndbg_expressions 2 pwndbg_threads 1 } 1 } 1 status 1
 layout pwndbg_custom
 ```

--- a/pwndbg/gdblib/tui/__init__.py
+++ b/pwndbg/gdblib/tui/__init__.py
@@ -18,7 +18,7 @@ def setup() -> None:
             "     { -horizontal pwndbg_legend 8 pwndbg_control 2 } 0 pwndbg_regs 1 pwndbg_stack 1 "
             "   } 3 "
             "  } 7 cmd 3 "
-            " } 3 { pwndbg_backtrace 2 pwndbg_threads 1 pwndbg_expressions 2 } 1 "
+            " } 3 { pwndbg_backtrace 2 pwndbg_expressions 2 pwndbg_threads 1 } 1 "
             "} 1 status 1"
         ),
         (
@@ -31,7 +31,7 @@ def setup() -> None:
             "     { -horizontal pwndbg_legend 8 pwndbg_control 2 } 0 pwndbg_regs 1 pwndbg_stack 1 "
             "   } 3 "
             "  } 7 cmd 3 "
-            " } 3 { pwndbg_backtrace 2 pwndbg_threads 1 pwndbg_expressions 2 } 1 "
+            " } 3 { pwndbg_backtrace 2 pwndbg_expressions 2 pwndbg_threads 1 } 1 "
             "} 1 status 1"
         ),
     ]


### PR DESCRIPTION
The order of the context section windows in the  pre-configured pwndbg layouts didn't match the order in which they are drawn in the CLI context output as specified by the `context-sections` config. This caused glitches while rendering the section titles.

This is a workaround for the current TUI layout and the context-sections order. If the order is changed later, it might break again.

Fixes #3045