### PR TITLE
Add support for `LLDBValue.string()` in array types

### DIFF
--- a/pwndbg/dbg/lldb/__init__.py
+++ b/pwndbg/dbg/lldb/__init__.py
@@ -527,7 +527,12 @@ class LLDBValue(pwndbg.dbg_mod.Value):
 
     @override
     def string(self) -> str:
-        addr = self.inner.unsigned
+        if self.inner.type.IsArrayType():
+            # Array types need to have their address taken in LLDB.
+            addr = self.inner.AddressOf().unsigned
+        else:
+            addr = self.inner.unsigned
+
         error = lldb.SBError()
 
         # Read strings up to 4GB.


### PR DESCRIPTION
Currently calling `LLDBValue.string()` on array types such as `char[8]` will fail. This PR adds support for array types to the string method.