### PR TITLE
Update .gitignore for refactored testing binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,12 +74,12 @@ venv/
 
 # PyTest files
 .pytest_cache/
-tests/**/binaries/*.o
-tests/**/binaries/*.out
-tests/**/binaries/gosample.x*
-tests/**/binaries/div_zero_binary/core
-tests/**/binaries/div_zero_binary/binary
-!tests/**/binaries/*.go
+tests/binaries/**/*.o
+tests/binaries/**/*.out
+tests/binaries/**/gosample.x*
+tests/binaries/**/div_zero_binary/core
+tests/binaries/**/div_zero_binary/binary
+!tests/binaries/**/*.go
 
 # QEMU test images
 tests/library/qemu-system/kimages


### PR DESCRIPTION
Complements #3101 by fixing binary paths in gitignore.