### PR TITLE
Drop `PWNDBG_PLEASE_SKIP_VENV` option

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,6 @@ jobs:
     timeout-minutes: 40
     env:
       TMPDIR: /tmp
-      PWNDBG_VENV_PATH: PWNDBG_PLEASE_SKIP_VENV
     steps:
     - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9  # @v3
     - uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72  # @v30

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,6 +25,7 @@ jobs:
     timeout-minutes: 40
     env:
       TMPDIR: /tmp
+      PWNDBG_NO_UV: 1
     steps:
     - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9  # @v3
     - uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72  # @v30

--- a/docs/tutorials/env-vars.md
+++ b/docs/tutorials/env-vars.md
@@ -6,8 +6,6 @@ Pwndbg relies on several environment variables to customize its behavior. Below 
 - `EDITOR`, `VISUAL`: Used by the `cymbol` command to open an editor.
 - `HOME`, `XDG_CACHE_HOME`: Used by `lib.tempfile` to determine temporary file locations.
 - `PWNDBG_VENV_PATH`: Specifies the virtual environment path for Pwndbg.
-    - Set to `PWNDBG_PLEASE_SKIP_VENV` if you don't want Pwndbg to use a python virtual environment.
-      This effectively disables the use of `uv` in the project.
 - `PWNDBG_DISABLE_COLORS`: Disables colored output in Pwndbg.
 - `PWNDBG_LOGLEVEL`: Initial log level to use for log messages.
 - `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`: Used by the `ai` command for accessing respective AI APIs.

--- a/gdbinit.py
+++ b/gdbinit.py
@@ -30,6 +30,10 @@ def fixup_paths(src_root: Path, venv_path: Path):
         sys.path.remove(site_pkgs_path)
     sys.path.insert(1, site_pkgs_path)
 
+    # sys.prefix must be changed to point to the virtual environment.
+    # This is what python expect: https://docs.python.org/3/library/sys.html#sys.prefix
+    sys.prefix = str(venv_path)
+
 
 def get_venv_path(src_root: Path):
     venv_path_env = os.environ.get("PWNDBG_VENV_PATH")

--- a/pwndbginit/common.py
+++ b/pwndbginit/common.py
@@ -49,7 +49,8 @@ def is_dev_mode(venv_path: Path) -> bool:
     return (venv_path / "dev.marker").exists()
 
 
-def update_deps(src_root: Path, venv_path: Path) -> None:
+def update_deps(src_root: Path) -> None:
+    venv_path = Path(sys.prefix)
     uv_lock_hash_path = venv_path / "uv.lock.hash"
 
     current_hash = hash_file(src_root / "uv.lock")
@@ -87,36 +88,27 @@ def update_deps(src_root: Path, venv_path: Path) -> None:
         print(stderr, file=sys.stderr)
 
 
-def get_venv_path(src_root: Path):
-    venv_path_env = os.environ.get("PWNDBG_VENV_PATH")
-    if venv_path_env:
-        return Path(venv_path_env).expanduser().resolve()
-    else:
-        return src_root / ".venv"
+def skip_autoupdate(src_root) -> bool:
+    no_auto_update = os.getenv("PWNDBG_NO_AUTOUPDATE") is not None
+    if no_auto_update:
+        return True
 
+    # If pwndbg is installed in `/venv/lib/pythonX.Y/site-packages/pwndbg/`,
+    # the `.pwndbg_root` file will not exist because `src_root` will point to the
+    # `/venv/lib/pythonX.Y/site-packages/` directory, not the original source directory
+    #
+    # However, if pwndbg is installed in editable mode (our recommended way), this file will exist,
+    # and the condition will be False, allowing auto-update.
+    is_system_install = not (src_root / ".pwndbg_root").exists()
+    if is_system_install:
+        return True
 
-def skip_venv(src_root) -> bool:
-    return (
-        os.environ.get("PWNDBG_VENV_PATH") == "PWNDBG_PLEASE_SKIP_VENV"
-        or not (src_root / ".pwndbg_root").exists()
-    )
+    return False
 
 
 def verify_venv():
     src_root = Path(__file__).parent.parent.resolve()
-    if skip_venv(src_root):
+    if skip_autoupdate(src_root):
         return
 
-    venv_path = get_venv_path(src_root)
-    if not venv_path.exists():
-        print(
-            f"Cannot find Pwndbg virtualenv directory: {venv_path}. Please re-run setup.sh",
-            flush=True,
-        )
-        os._exit(1)
-
-    no_auto_update = os.getenv("PWNDBG_NO_AUTOUPDATE") is not None
-    if no_auto_update:
-        return
-
-    update_deps(src_root, venv_path)
+    update_deps(src_root)

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -10,7 +10,7 @@ if [[ -z "${PWNDBG_VENV_PATH}" ]]; then
     PWNDBG_VENV_PATH="${PWNDBG_ABS_PATH}/.venv"
 fi
 
-if [[ "$PWNDBG_VENV_PATH" == "PWNDBG_PLEASE_SKIP_VENV" || "$PWNDBG_NO_UV" == "1" ]]; then
+if [[ "$PWNDBG_NO_UV" == "1" ]]; then
     # We are using the dependencies as installed on the system
     # so we shouldn't use uv (and can't, since it's not installed).
     UV=""

--- a/setup.sh
+++ b/setup.sh
@@ -209,7 +209,6 @@ if [[ -z "$is_supported" ]]; then
 fi
 
 # Create the python virtual environment
-# We don't care about PWNDBG_PLEASE_SKIP_VENV here.
 echo "Creating virtualenv in path: ${PWNDBG_VENV_PATH}"
 ${PYTHON} -m venv -- ${PWNDBG_VENV_PATH}
 


### PR DESCRIPTION
The `PWNDBG_PLEASE_SKIP_VENV` option is no longer needed — it was just a workaround for handling Nix in previous releases.