### PR TITLE
Fix relative path to .zig directory in Makefiles

### DIFF
--- a/tests/binaries/host/makefile
+++ b/tests/binaries/host/makefile
@@ -1,4 +1,4 @@
-ZIGPATH        ?=     ../../../../.zig
+ZIGPATH        ?=     ../../../.zig
 ZIGCC		=	  $(ZIGPATH)/zig cc
 
 CC              =	   gcc

--- a/tests/binaries/qemu-user/Makefile
+++ b/tests/binaries/qemu-user/Makefile
@@ -1,6 +1,6 @@
 .PHONY: all
 
-ZIGPATH ?= ../../../../../.zig
+ZIGPATH ?= ../../../.zig
 ZIGCC =	$(ZIGPATH)/zig cc
 
 ARCHS = aarch64 arm riscv64 mips32 mipsel32 mips64 loongarch64 s390x powerpc32 powerpc64


### PR DESCRIPTION
This PR fixes a relative path to the ZIGPATH environment variable in the Makefiles that compile programs for tests. A directory restructure in #3101 meant the paths were no longer accurate. This makes running `make` manually while in the test directory work.

The fixed assignment statement only takes effect when manually running "make" while in the directory - when running ./tests.sh, the $ZIGPATH environment variable is already set by the time it internally calls `make`, and the `ZIGPATH ?= ...` syntax means it won't override if the environment variable is already set.