### PR TITLE
Cleanup the "find gcc" code

### DIFF
--- a/pwndbg/commands/cymbol.py
+++ b/pwndbg/commands/cymbol.py
@@ -102,7 +102,12 @@ def generate_debug_symbols(
     ]
 
     # TODO: implement remote debugging support.
-    gcc_flags = pwndbg.lib.gcc.which(pwndbg.aglib.arch)
+    try:
+        gcc_flags = pwndbg.lib.gcc.which(pwndbg.aglib.arch)
+    except ValueError as _:
+        # The error message is already printed by pwntools.
+        return None
+
     if gcc_compiler_path != "":
         gcc_flags[0] = gcc_compiler_path  # type: ignore[call-overload]
 

--- a/pwndbg/commands/cymbol.py
+++ b/pwndbg/commands/cymbol.py
@@ -137,7 +137,7 @@ def add_custom_structure(custom_structure_name: str, force=False):
     if os.path.exists(pwndbg_custom_structure_path) and not force:
         option = input(
             message.notice(
-                "A custom structure was found with the given name, would you like to overwrite it? [y/n] "
+                "A custom structure was found with the given name, would you like to overwrite it? [y/N] "
             )
         )
         if option != "y":
@@ -178,7 +178,7 @@ def add_structure_from_header(
         if not force:
             option = input(
                 message.notice(
-                    f"Structure '{custom_structure_name}' already exists. Overwrite? [y/n] "
+                    f"Structure '{custom_structure_name}' already exists. Overwrite? [y/N] "
                 )
             )
             if option.lower() != "y":

--- a/pwndbg/lib/gcc.py
+++ b/pwndbg/lib/gcc.py
@@ -11,72 +11,20 @@ import platform
 from typing import Any
 from typing import List
 
+import pwnlib
+
 from pwndbg.lib.arch import ArchDefinition
 
 printed_message = False
 
 
 def which(arch: ArchDefinition) -> List[str]:
-    gcc = _which_binutils("g++", arch)
-
-    if gcc is None:
-        global printed_message
-        if not printed_message:
-            printed_message = True
-            print("Can't find appropriate GCC, using default version")
-
-        if arch.ptrsize == 32:
-            return ["g++", "-m32"]
-        elif arch.ptrsize == 64:
-            return ["g++", "-m64"]
-        else:
-            raise ValueError(f"Unknown pointer size: {arch.ptrsize}")
+    try:
+        gcc = pwnlib.asm.which_binutils("g++")
+    except pwnlib.exception.PwnlibException as _:
+        raise ValueError("Couldn't find g++ for the current architecture.")
 
     return [gcc] + _flags(arch.name)
-
-
-def _which_binutils(util: str, arch: ArchDefinition, **kwargs: Any) -> str | None:
-    ###############################
-    # Borrowed from pwntools' code
-    ###############################
-
-    arch_name = arch.name
-
-    # Fix up binjitsu vs Debian triplet naming, and account
-    # for 'thumb' being its own binjitsu architecture.
-    arches: List[str | None] = [arch_name] + {
-        "thumb": ["arm", "armcm", "aarch64"],
-        "i386": ["x86_64", "amd64"],
-        "i686": ["x86_64", "amd64"],
-        "i386:x86-64": ["x86_64", "amd64"],
-        "amd64": ["x86_64", "i386"],
-    }.get(arch_name, [])
-
-    # If one of the candidate architectures matches the native
-    # architecture, use that as a last resort.
-    machine = platform.machine()
-    machine = "i386" if machine == "i686" else machine
-
-    if arch_name in arches:
-        arches.append(None)
-
-    for arch_name in arches:
-        # hack for homebrew-installed binutils on mac
-        for gutil in ["g" + util, util]:
-            # e.g. objdump
-            if arch_name is None:
-                pattern = gutil
-
-            # e.g. aarch64-linux-gnu-objdump
-            else:
-                pattern = f"{arch_name}*linux*-{gutil}"
-
-            for dir in os.environ["PATH"].split(":"):
-                res = sorted(glob.glob(os.path.join(dir, pattern)))
-                if res:
-                    return res[0]
-
-    return None
 
 
 def _flags(arch_name: str) -> List[str]:

--- a/pwndbg/lib/gcc.py
+++ b/pwndbg/lib/gcc.py
@@ -28,7 +28,7 @@ def which(arch: ArchDefinition) -> List[str]:
         if arch.ptrsize == 32:
             return ["g++", "-m32"]
         elif arch.ptrsize == 64:
-            return ["g++", "-m32"]
+            return ["g++", "-m64"]
         else:
             raise ValueError(f"Unknown pointer size: {arch.ptrsize}")
 


### PR DESCRIPTION
Seems to be a typo. I was trying to include a header file into a 64-bit process that referenced the gcc intrinsic `__int128` type, but it's not available on `-m32` targets so the compilation was failing on me.