### PR TITLE
Set frame register for aarch64

### DIFF
--- a/pwndbg/commands/ida.py
+++ b/pwndbg/commands/ida.py
@@ -168,7 +168,7 @@ def _ida_local(name: str) -> int | None:
         offset = pwndbg.integration.ida.GetMemberOffset(frame_id, local_name)
         if offset == -1:
             raise ValueError("ida.GetMemberOffset(%r) == -1" % local_name)
-        if saved_baseptr != -1:
+        if saved_baseptr != -1 and pwndbg.aglib.regs.frame is not None:
             return pwndbg.aglib.regs[pwndbg.aglib.regs.frame] + offset - saved_baseptr
         return pwndbg.aglib.regs[pwndbg.aglib.regs.stack] + offset
     return None

--- a/pwndbg/commands/telescope.py
+++ b/pwndbg/commands/telescope.py
@@ -139,6 +139,9 @@ def telescope(
 
     # Allow invocation of telescope -f (--frame) to dump all addresses in a frame
     if frame:
+        if not pwndbg.aglib.regs.frame:
+            print("The frame register is not defined for this architecture.")
+            return
         sp = pwndbg.aglib.regs.sp
         bp = pwndbg.aglib.regs[pwndbg.aglib.regs.frame]
         if sp > bp:
@@ -225,7 +228,6 @@ def telescope(
 
     bp = None
     if print_framepointer_offset and pwndbg.aglib.regs.frame is not None:
-        # regs.frame can be None on aarch64
         bp = pwndbg.aglib.regs[pwndbg.aglib.regs.frame]
 
     for i, addr in enumerate(range(start, stop, step)):

--- a/pwndbg/lib/regs.py
+++ b/pwndbg/lib/regs.py
@@ -598,7 +598,7 @@ armcm = RegisterSet(
 
 # AArch64 has a PSTATE register, but GDB represents it as the CPSR register
 aarch64 = RegisterSet(
-    retaddr=(Reg("lr", 8),),
+    retaddr=(Reg("lr", 8),), # x30
     flags={"cpsr": aarch64_cpsr_flags},
     extra_flags={
         "scr_el3": aarch64_scr_flags,
@@ -612,11 +612,7 @@ aarch64 = RegisterSet(
         "ttbr0_el1": BitFlags(),
         "ttbr1_el1": BitFlags(),
     },
-    # X29 is the frame pointer register (FP) but setting it
-    # as frame here messes up the register order to the point
-    # it's confusing. Think about improving this if frame
-    # pointer semantics are required for other functionalities.
-    # frame   = 'x29',
+    frame=Reg("fp", 8, subregisters=(Reg("w29", 4, zero_extend_writes=True),)), # x29
     gpr=(
         Reg("x0", 8, subregisters=(Reg("w0", 4, zero_extend_writes=True),)),
         Reg("x1", 8, subregisters=(Reg("w1", 4, zero_extend_writes=True),)),
@@ -647,7 +643,6 @@ aarch64 = RegisterSet(
         Reg("x26", 8, subregisters=(Reg("w26", 4, zero_extend_writes=True),)),
         Reg("x27", 8, subregisters=(Reg("w27", 4, zero_extend_writes=True),)),
         Reg("x28", 8, subregisters=(Reg("w28", 4, zero_extend_writes=True),)),
-        Reg("x29", 8, subregisters=(Reg("w29", 4, zero_extend_writes=True),)),
     ),
     args=("x0", "x1", "x2", "x3"),
     retval="x0",

--- a/pwndbg/lib/regs.py
+++ b/pwndbg/lib/regs.py
@@ -643,6 +643,7 @@ aarch64 = RegisterSet(
         Reg("x26", 8, subregisters=(Reg("w26", 4, zero_extend_writes=True),)),
         Reg("x27", 8, subregisters=(Reg("w27", 4, zero_extend_writes=True),)),
         Reg("x28", 8, subregisters=(Reg("w28", 4, zero_extend_writes=True),)),
+        # Note: x29 is FP (frame) and x30 is LR (retaddr) register
     ),
     args=("x0", "x1", "x2", "x3"),
     retval="x0",


### PR DESCRIPTION
It wasn't defined because of this before: https://github.com/pwndbg/pwndbg/issues/1039#issuecomment-1207312942 . But now that `LR` is shown seperately, the display isn't confusing anymore.

<img width="662" height="157" alt="image" src="https://github.com/user-attachments/assets/089bdb9d-fdcd-416a-bbbe-12bf712b75ce" />
