### PR TITLE
docs: update setup instructions for Arch Linux

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -38,7 +38,9 @@ apk add --allow-untrusted ./pwndbg_2025.05.30_x86_64.apk
 ```
 Arch Linux:
 ```{.bash .copy}
-pacman -U ./pwndbg-2025.05.30-1-x86_64.pkg.tar.zst
+pacman -S pwndbg
+# Make gdb load pwndbg on startup
+echo 'source /usr/share/pwndbg/gdbinit.py' >> ~/.gdbinit
 ```
 
 ## Installing pwndbg-lldb


### PR DESCRIPTION
The pwndbg package has been added to the official repositories of Arch Linux.

So, the recommended way to install should not be manually downloading and installing, instead it should be downloading the package from the official repository.

I also added the command to add `source /usr/share/pwndbg/gdbinit.py` to `~/.gdbinit` because I myself struggled to find out that this was a necessary step.\

I'm not sure if this is needed for other platforms too but I know for sure that on Arch Linux the package manager does not touch user controlled configuration, so this is necessary on Arch Linux. If that is a case on other platforms too, we can add it as a separate note on the page, but I feel it is important it be mentioned somewhere.

Build was successful with the instructions provided in the contributing guidelines.