### PR TITLE
Port tests to debugger-agnostic test group: Second Batch

### DIFF
--- a/tests/binaries/host/heap_bugs.c
+++ b/tests/binaries/host/heap_bugs.c
@@ -38,7 +38,9 @@ malloc_chunk *f_real = (malloc_chunk*)(f - 2*SIZE_SZ); \
 malloc_chunk *g_real = (malloc_chunk*)(g - 2*SIZE_SZ); \
 int *tmp; \
 int tmp2, tmp3; \
-printf("a=%p\nb=%p\nc=%p\nd=%p\ne=%p\nf=%p\ng=%p\n", a, b, c, d, e, f, g);
+fprintf(output_file, "a=%p\nb=%p\nc=%p\nd=%p\ne=%p\nf=%p\ng=%p\n", a, b, c, d, e, f, g);
+
+FILE *output_file;
 
 /*
 Every function MUST have two comments: "break1" and "break2"
@@ -215,12 +217,16 @@ void corrupted_unsorted_chunks() {
 
 
 int main(int argc, char const *argv[]) {
-    setvbuf(stdout, NULL, _IONBF, 0);
-
-    if (argc < 2) {
-        printf("Usage: %s bug_to_trigger\n", argv[0]);
+    if (argc < 3) {
+        fprintf(stderr, "Usage: %s bug_to_trigger output_file_name\n", argv[0]);
         return 1;
     }
+    output_file = fopen(argv[2], "wb");
+    if (output_file == NULL) {
+        fprintf(stderr, "error: Could not open file %s for writing\n", argv[2]);
+        return 1;
+    }
+    setvbuf(output_file, NULL, _IONBF, 0);
 
     int choice;
     sscanf(argv[1], "%d", &choice);
@@ -239,9 +245,9 @@ int main(int argc, char const *argv[]) {
         case 12: invalid_next_size_normal(); break;
         case 13: corrupted_consolidate_backward(); break;
         case 14: corrupted_unsorted_chunks(); break;
-        default: printf("Unknown\n");
+        default: fprintf(output_file, "Unknown\n");
     }
 
-    puts("END");
+    fprintf(output_file, "END");
     return 0;
 }

--- a/tests/binaries/host/makefile
+++ b/tests/binaries/host/makefile
@@ -14,7 +14,7 @@ COMPILED_ASM    =      $(SOURCES_ASM:.asm=.o)
 LINKED_ASM      =      $(SOURCES_ASM:.asm=.out)
 LDFLAGS         =
 EXTRA_FLAGS     =
-EXTRA_FLAGS_ASM =
+EXTRA_FLAGS_ASM =      -g -F dwarf
 
 GO              =      go
 SOURCES_GO      =      $(wildcard *.go)

--- a/tests/binaries/host/makefile
+++ b/tests/binaries/host/makefile
@@ -14,7 +14,8 @@ COMPILED_ASM    =      $(SOURCES_ASM:.asm=.o)
 LINKED_ASM      =      $(SOURCES_ASM:.asm=.out)
 LDFLAGS         =
 EXTRA_FLAGS     =
-EXTRA_FLAGS_ASM =      -g -F dwarf
+EXTRA_FLAGS_ASM =
+#EXTRA_FLAGS_ASM =      -g -F dwarf
 
 GO              =      go
 SOURCES_GO      =      $(wildcard *.go)

--- a/tests/binaries/host/memory.asm
+++ b/tests/binaries/host/memory.asm
@@ -4,9 +4,11 @@ global _start
 ; like dq, dd, dw, db, dc etc.
 ; So while the program does nothing, we create some data for testing those
 
+SECTION .text
 _start:
     nop
 
+SECTION .data
 data:
     dq 0x0
     dq 0x1

--- a/tests/host/__init__.py
+++ b/tests/host/__init__.py
@@ -8,6 +8,7 @@ from typing import Any
 from typing import Awaitable
 from typing import Callable
 from typing import Coroutine
+from typing import Dict
 from typing import List
 
 
@@ -149,7 +150,9 @@ class TestHost:
 
 
 class Controller:
-    def launch(self, binary: Path, args: List[str] = []) -> Awaitable[None]:
+    def launch(
+        self, binary: Path, args: List[str] = [], env: Dict[str, str] = {}
+    ) -> Awaitable[None]:
         """
         Launch the binary with the given path, relative to the binaries folder
         for the calling test.

--- a/tests/host/__init__.py
+++ b/tests/host/__init__.py
@@ -197,6 +197,12 @@ class Controller:
         """
         raise NotImplementedError()
 
+    def select_thread(self, tid: int) -> Awaitable[None]:
+        """
+        Select the thread with the given ID.
+        """
+        raise NotImplementedError()
+
 
 def start(controller: Callable[[Controller], Coroutine[Any, Any, None]]) -> None:
     """

--- a/tests/host/gdb/pytests_launcher.py
+++ b/tests/host/gdb/pytests_launcher.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any
 from typing import Callable
 from typing import Coroutine
+from typing import Dict
 from typing import List
 
 import coverage
@@ -16,7 +17,9 @@ from ... import host
 
 
 class _GDBController(host.Controller):
-    async def launch(self, binary_path: Path, args: List[str] = []) -> None:
+    async def launch(
+        self, binary_path: Path, args: List[str] = [], env: Dict[str, str] = {}
+    ) -> None:
         """
         Launch the given binary.
 
@@ -29,13 +32,20 @@ class _GDBController(host.Controller):
         gdb.execute("set width 80")
         gdb.execute("set context-reserve-lines never")
         os.environ["COLUMNS"] = "80"
+        for k, v in env.items():
+            gdb.execute(f"set environment {k}={v}")
         gdb.execute("starti " + " ".join(args))
 
     async def cont(self) -> None:
         gdb.execute("continue")
 
     async def execute(self, command: str) -> None:
-        gdb.execute(command)
+        from pwndbg.dbg import Error
+
+        try:
+            gdb.execute(command)
+        except gdb.error as e:
+            raise Error(e)
 
     async def execute_and_capture(self, command: str) -> str:
         return gdb.execute(command, to_string=True)

--- a/tests/host/gdb/pytests_launcher.py
+++ b/tests/host/gdb/pytests_launcher.py
@@ -56,6 +56,9 @@ class _GDBController(host.Controller):
     async def finish(self) -> None:
         gdb.execute("finish")
 
+    async def select_thread(self, tid: int) -> None:
+        gdb.execute(f"thread {tid}")
+
 
 def _start(outer: Callable[[host.Controller], Coroutine[Any, Any, None]]) -> None:
     # The GDB controller is entirely synchronous, so keep advancing the

--- a/tests/host/lldb/__init__.py
+++ b/tests/host/lldb/__init__.py
@@ -48,6 +48,7 @@ class LLDBTestHost(TestHost):
         env["TEST_PYTEST_ROOT"] = str(self._pytest_root)
         env["TEST_BINARIES_ROOT"] = str(self._binaries_root)
         env["TEST_PDB_ON_FAIL"] = "1" if pdb else "0"
+        env["PWNDBG_IN_TEST"] = "1"
         if test_name is not None:
             env["TEST_NAME"] = test_name
 

--- a/tests/host/lldb/launch_guest.py
+++ b/tests/host/lldb/launch_guest.py
@@ -34,7 +34,8 @@ async def _run(ctrl: Any, outer: Callable[..., Coroutine[Any, Any, None]]) -> No
             await self.pc.execute(f"target create {binary}")
             env_args = " ".join((f"-E{k}={v}" for k, v in env.items()))
             await self.pc.execute(
-                f"process launch -A true {env_args} -s -- " + " ".join(shlex.quote(arg) for arg in args)
+                f"process launch -A true {env_args} -s -- "
+                + " ".join(shlex.quote(arg) for arg in args)
             )
 
         async def cont(self) -> None:

--- a/tests/host/lldb/launch_guest.py
+++ b/tests/host/lldb/launch_guest.py
@@ -34,7 +34,7 @@ async def _run(ctrl: Any, outer: Callable[..., Coroutine[Any, Any, None]]) -> No
             await self.pc.execute(f"target create {binary}")
             env_args = " ".join((f"-E{k}={v}" for k, v in env.items()))
             await self.pc.execute(
-                f"process launch {env_args} -s -- " + " ".join(shlex.quote(arg) for arg in args)
+                f"process launch -A true {env_args} -s -- " + " ".join(shlex.quote(arg) for arg in args)
             )
 
         async def cont(self) -> None:
@@ -98,6 +98,8 @@ class CollectTestFunctionNames:
 
 
 if __name__ == "__main__":
+    sys._pwndbg_unittest_run = True  # type: ignore[attr-defined]
+
     # Prepare the requested operation.
     op = Operation(os.environ["TEST_OPERATION"])
     match op:

--- a/tests/host/lldb/launch_guest.py
+++ b/tests/host/lldb/launch_guest.py
@@ -55,7 +55,7 @@ async def _run(ctrl: Any, outer: Callable[..., Coroutine[Any, Any, None]]) -> No
             await self.pc.execute("thread step-out")
 
         async def select_thread(self, tid: int) -> None:
-            await self.pc.execute(f"thread select -t {tid}")
+            await self.pc.execute(f"thread select {tid}")
 
     await outer(_LLDBController(ctrl))
 

--- a/tests/host/lldb/launch_guest.py
+++ b/tests/host/lldb/launch_guest.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 from typing import Callable
 from typing import Coroutine
+from typing import Dict
 from typing import List
 
 
@@ -26,11 +27,14 @@ async def _run(ctrl: Any, outer: Callable[..., Coroutine[Any, Any, None]]) -> No
         def __init__(self, pc: PwndbgController):
             self.pc = pc
 
-        async def launch(self, binary: Path, args: List[str] = []) -> None:
+        async def launch(
+            self, binary: Path, args: List[str] = [], env: Dict[str, str] = {}
+        ) -> None:
             await self.pc.execute("set context-reserve-lines never")
             await self.pc.execute(f"target create {binary}")
+            env_args = " ".join((f"-E{k}={v}" for k, v in env.items()))
             await self.pc.execute(
-                "process launch -s -- " + " ".join(shlex.quote(arg) for arg in args)
+                f"process launch {env_args} -s -- " + " ".join(shlex.quote(arg) for arg in args)
             )
 
         async def cont(self) -> None:

--- a/tests/host/lldb/launch_guest.py
+++ b/tests/host/lldb/launch_guest.py
@@ -54,6 +54,9 @@ async def _run(ctrl: Any, outer: Callable[..., Coroutine[Any, Any, None]]) -> No
         async def finish(self) -> None:
             await self.pc.execute("thread step-out")
 
+        async def select_thread(self, tid: int) -> None:
+            await self.pc.execute(f"thread select -t {tid}")
+
     await outer(_LLDBController(ctrl))
 
 

--- a/tests/library/dbg/tests/heap/test_find_fake_fast.py
+++ b/tests/library/dbg/tests/heap/test_find_fake_fast.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 import re
 
-from host import Controller
+from .....host import Controller
+from .. import get_binary
+from .. import launch_to
+from .. import pwndbg_test
 
-import tests
-
-HEAP_FIND_FAKE_FAST = tests.get_binary("heap_find_fake_fast.out")
+HEAP_FIND_FAKE_FAST = get_binary("heap_find_fake_fast.out")
 
 target_address = None
 
@@ -41,7 +42,7 @@ def check_no_results(result: str) -> None:
     assert len(matches) == 0
 
 
-@tests.pwndbg_test
+@pwndbg_test
 async def test_find_fake_fast_command(ctrl: Controller) -> None:
     import pwndbg
     import pwndbg.aglib.heap
@@ -50,11 +51,11 @@ async def test_find_fake_fast_command(ctrl: Controller) -> None:
 
     global target_address
 
-    await tests.launch_to(ctrl, HEAP_FIND_FAKE_FAST, "break_here")
+    await launch_to(ctrl, HEAP_FIND_FAKE_FAST, "break_here")
 
     # Ensure memory at fake_chunk's heap_info struct isn't mapped.
     unmapped_heap_info = pwndbg.aglib.heap.ptmalloc.heap_for_ptr(
-        int(pwndbg.aglib.symbol.lookup_symbol_value("fake_chunk"))
+        pwndbg.aglib.symbol.lookup_symbol_value("fake_chunk")
     )
     assert pwndbg.aglib.memory.peek(unmapped_heap_info) is None
 

--- a/tests/library/dbg/tests/heap/test_find_fake_fast.py
+++ b/tests/library/dbg/tests/heap/test_find_fake_fast.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import re
+
+from host import Controller
+
+import tests
+
+HEAP_FIND_FAKE_FAST = tests.get_binary("heap_find_fake_fast.out")
+
+target_address = None
+
+
+def check_result(result: str, expected_size: int) -> None:
+    import pwndbg.aglib.arch
+
+    ptrsize = pwndbg.aglib.arch.ptrsize
+
+    matches = re.findall(r"\bAddr: (0x[0-9a-f]+)", result)
+    assert len(matches) == 1
+    addr = int(matches[0], 16)
+
+    matches = re.findall(r"\bsize: (0x[0-9a-f]+)", result)
+    assert len(matches) == 1
+    size = int(matches[0], 16)
+
+    assert size == expected_size
+
+    # The chunk can't start too close to the target address
+    assert addr <= target_address - (2 * ptrsize)
+
+    # Clear the flags
+    size &= ~0xF
+
+    # The chunk should overlap the target address
+    assert addr + ptrsize + size > target_address
+
+
+def check_no_results(result: str) -> None:
+    matches = re.findall(r"\bAddr: (0x[0-9a-f]+)", result)
+    assert len(matches) == 0
+
+
+@tests.pwndbg_test
+async def test_find_fake_fast_command(ctrl: Controller) -> None:
+    import pwndbg
+    import pwndbg.aglib.heap
+    import pwndbg.aglib.memory
+    import pwndbg.aglib.symbol
+
+    global target_address
+
+    await tests.launch_to(ctrl, HEAP_FIND_FAKE_FAST, "break_here")
+
+    # Ensure memory at fake_chunk's heap_info struct isn't mapped.
+    unmapped_heap_info = pwndbg.aglib.heap.ptmalloc.heap_for_ptr(
+        int(gdb.lookup_global_symbol("fake_chunk").value())
+    )
+    assert pwndbg.aglib.memory.peek(unmapped_heap_info) is None
+
+    # A gdb.MemoryError raised here indicates a regression from PR #1145
+    await ctrl.execute("find-fake-fast fake_chunk+0x80")
+
+    target_address = pwndbg.aglib.symbol.lookup_symbol_addr("target_address")
+    assert target_address is not None
+    print(hex(target_address))
+
+    # setup_mem(0x20, 0x8)
+    result = await ctrl.execute_and_capture("find-fake-fast &target_address")
+    check_result(result, 0x20)
+
+    result = await ctrl.execute_and_capture("find-fake-fast --align &target_address")
+    check_result(result, 0x20)
+    await ctrl.cont()
+
+    # setup_mem(0x2F, 0x8)
+    result = await ctrl.execute_and_capture("find-fake-fast &target_address")
+    check_result(result, 0x28)
+
+    result = await ctrl.execute_and_capture("find-fake-fast --align &target_address")
+    check_result(result, 0x28)
+    await ctrl.cont()
+
+    # setup_mem(0x20, 0x9)
+    result = await ctrl.execute_and_capture("find-fake-fast &target_address")
+    check_result(result, 0x20)
+
+    result = await ctrl.execute_and_capture("find-fake-fast --align &target_address")
+    check_no_results(result)
+    await ctrl.cont()
+
+    # setup_mem(0x20, 0x0)
+    result = await ctrl.execute_and_capture("find-fake-fast &target_address")
+    check_no_results(result)
+
+    result = await ctrl.execute_and_capture("find-fake-fast --align &target_address")
+    check_no_results(result)
+    await ctrl.cont()
+
+    # setup_mem(0x20, 0x7)
+    result = await ctrl.execute_and_capture("find-fake-fast &target_address")
+    check_no_results(result)
+
+    result = await ctrl.execute_and_capture("find-fake-fast --align &target_address")
+    check_no_results(result)
+    await ctrl.cont()
+
+    # setup_mem(0x1F, 0x8)
+    result = await ctrl.execute_and_capture("find-fake-fast &target_address")
+    check_no_results(result)
+
+    result = await ctrl.execute_and_capture("find-fake-fast --align &target_address")
+    check_no_results(result)
+    await ctrl.cont()
+
+    # setup_mem(0x80, 0x78)
+    result = await ctrl.execute_and_capture("find-fake-fast &target_address")
+    check_result(result, 0x80)
+
+    result = await ctrl.execute_and_capture("find-fake-fast --align &target_address")
+    check_result(result, 0x80)
+    await ctrl.cont()
+
+    # # setup_mem(0x80, 0x7F)
+    # result = await ctrl.execute_and_capture("find-fake-fast &target_address")
+    # check_result(result, 0x80)
+    # await ctrl.cont()
+
+    # setup_mem(0x80, 0x80)
+    result = await ctrl.execute_and_capture("find-fake-fast &target_address")
+    check_no_results(result)
+
+    result = await ctrl.execute_and_capture("find-fake-fast --align &target_address")
+    check_no_results(result)
+    await ctrl.cont()
+
+    # setup_mem(0x100, 0x10)
+    result = await ctrl.execute_and_capture("find-fake-fast &target_address")
+    check_no_results(result)
+
+    result = await ctrl.execute_and_capture("find-fake-fast &target_address 0x100")
+    check_result(result, 0x100)
+    await ctrl.cont()
+
+    # setup_mem(0x100, 0x90)
+    result = await ctrl.execute_and_capture("find-fake-fast &target_address")
+    check_no_results(result)
+
+    result = await ctrl.execute_and_capture("find-fake-fast &target_address 0x100")
+    check_result(result, 0x100)
+    await ctrl.cont()
+
+    # setup_mem(0x100, 0x100)
+    result = await ctrl.execute_and_capture("find-fake-fast &target_address")
+    check_no_results(result)
+
+    result = await ctrl.execute_and_capture("find-fake-fast &target_address 0x100")
+    check_no_results(result)
+    await ctrl.cont()
+
+    # setup_mem(0xAABBCCDD00000020, 0x8)
+    result = await ctrl.execute_and_capture("find-fake-fast &target_address")
+    check_no_results(result)
+
+    result = await ctrl.execute_and_capture("find-fake-fast &target_address --glibc-fastbin-bug")
+    check_result(result, 0xAABBCCDD00000020)
+    await ctrl.cont()
+
+    # setup_mem(0x8000, 0x80)
+    result = await ctrl.execute_and_capture("find-fake-fast &target_address")
+    check_no_results(result)
+
+    result = await ctrl.execute_and_capture("find-fake-fast &target_address --partial-overwrite")
+    check_result(result, 0x80)

--- a/tests/library/dbg/tests/heap/test_find_fake_fast.py
+++ b/tests/library/dbg/tests/heap/test_find_fake_fast.py
@@ -54,7 +54,7 @@ async def test_find_fake_fast_command(ctrl: Controller) -> None:
 
     # Ensure memory at fake_chunk's heap_info struct isn't mapped.
     unmapped_heap_info = pwndbg.aglib.heap.ptmalloc.heap_for_ptr(
-        int(gdb.lookup_global_symbol("fake_chunk").value())
+        int(pwndbg.aglib.symbol.lookup_symbol_value("fake_chunk"))
     )
     assert pwndbg.aglib.memory.peek(unmapped_heap_info) is None
 

--- a/tests/library/dbg/tests/heap/test_heap.py
+++ b/tests/library/dbg/tests/heap/test_heap.py
@@ -4,12 +4,15 @@ import re
 from typing import Dict
 
 import pytest
-from host import Controller
 
-import tests
+from .....host import Controller
+from .. import break_at_sym
+from .. import get_binary
+from .. import launch_to
+from .. import pwndbg_test
 
-HEAP_MALLOC_CHUNK = tests.get_binary("heap_malloc_chunk.out")
-HEAP_MALLOC_CHUNK_DUMP = tests.get_binary("heap_malloc_chunk_dump.out")
+HEAP_MALLOC_CHUNK = get_binary("heap_malloc_chunk.out")
+HEAP_MALLOC_CHUNK_DUMP = get_binary("heap_malloc_chunk_dump.out")
 
 
 def generate_expected_malloc_chunk_output(chunks: Dict[str, ...]) -> Dict[str, ...]:
@@ -132,14 +135,14 @@ def generate_expected_malloc_chunk_output(chunks: Dict[str, ...]) -> Dict[str, .
     return expected
 
 
-@tests.pwndbg_test
+@pwndbg_test
 async def test_malloc_chunk_command(ctrl: Controller) -> None:
     import pwndbg
     import pwndbg.aglib.heap
     import pwndbg.aglib.memory
     import pwndbg.aglib.symbol
 
-    await tests.launch_to(ctrl, HEAP_MALLOC_CHUNK, "break_here")
+    await launch_to(ctrl, HEAP_MALLOC_CHUNK, "break_here")
 
     chunks = {}
     results = {}
@@ -189,7 +192,7 @@ async def test_malloc_chunk_command(ctrl: Controller) -> None:
     assert results["large"] == expected["large"]
 
 
-@tests.pwndbg_test
+@pwndbg_test
 async def test_malloc_chunk_command_heuristic(ctrl: Controller) -> None:
     import pwndbg
     import pwndbg.aglib.heap
@@ -197,7 +200,7 @@ async def test_malloc_chunk_command_heuristic(ctrl: Controller) -> None:
 
     await ctrl.launch(HEAP_MALLOC_CHUNK)
     await ctrl.execute("set resolve-heap-via-heuristic force")
-    tests.break_at_sym("break_here")
+    break_at_sym("break_here")
     await ctrl.cont()
 
     chunks = {}
@@ -246,13 +249,13 @@ async def test_malloc_chunk_command_heuristic(ctrl: Controller) -> None:
     assert results["large"] == expected["large"]
 
 
-@tests.pwndbg_test
+@pwndbg_test
 async def test_malloc_chunk_dump_command(ctrl: Controller) -> None:
     import pwndbg.aglib.heap
     import pwndbg.aglib.memory
     import pwndbg.aglib.symbol
 
-    await tests.launch_to(ctrl, HEAP_MALLOC_CHUNK_DUMP, "break_here")
+    await launch_to(ctrl, HEAP_MALLOC_CHUNK_DUMP, "break_here")
 
     chunk = pwndbg.aglib.memory.get_typed_pointer_value(
         pwndbg.aglib.heap.current.malloc_chunk,
@@ -328,7 +331,7 @@ class mock_for_heuristic:
         pwndbg.dbg.selected_inferior = self.saved_func
 
 
-@tests.pwndbg_test
+@pwndbg_test
 async def test_main_arena_heuristic(ctrl: Controller) -> None:
     import pwndbg.aglib.heap
     import pwndbg.aglib.symbol
@@ -336,7 +339,7 @@ async def test_main_arena_heuristic(ctrl: Controller) -> None:
 
     await ctrl.launch(HEAP_MALLOC_CHUNK)
     await ctrl.execute("set resolve-heap-via-heuristic force")
-    tests.break_at_sym("break_here")
+    break_at_sym("break_here")
     await ctrl.cont()
 
     # Use the debug symbol to get the address of `main_arena`
@@ -362,7 +365,7 @@ async def test_main_arena_heuristic(ctrl: Controller) -> None:
         assert pwndbg.aglib.heap.current.main_arena.address == main_arena_addr_via_debug_symbol
 
 
-@tests.pwndbg_test
+@pwndbg_test
 async def test_mp_heuristic(ctrl: Controller) -> None:
     import pwndbg.aglib.heap
     import pwndbg.aglib.symbol
@@ -370,7 +373,7 @@ async def test_mp_heuristic(ctrl: Controller) -> None:
 
     await ctrl.launch(HEAP_MALLOC_CHUNK)
     await ctrl.execute("set resolve-heap-via-heuristic force")
-    tests.break_at_sym("break_here")
+    break_at_sym("break_here")
     await ctrl.cont()
 
     # Use the debug symbol to get the address of `mp_`
@@ -397,7 +400,7 @@ async def test_mp_heuristic(ctrl: Controller) -> None:
 @pytest.mark.parametrize(
     "is_multi_threaded", [False, True], ids=["single-threaded", "multi-threaded"]
 )
-@tests.pwndbg_test
+@pwndbg_test
 async def test_thread_cache_heuristic(ctrl: Controller, is_multi_threaded: bool) -> None:
     import pwndbg
     import pwndbg.aglib.heap
@@ -408,7 +411,7 @@ async def test_thread_cache_heuristic(ctrl: Controller, is_multi_threaded: bool)
     # TODO: Support other architectures or different libc versions
     await ctrl.launch(HEAP_MALLOC_CHUNK)
     await ctrl.execute("set resolve-heap-via-heuristic force")
-    tests.break_at_sym("break_here")
+    break_at_sym("break_here")
     await ctrl.cont()
     if is_multi_threaded:
         await ctrl.cont()
@@ -448,7 +451,7 @@ async def test_thread_cache_heuristic(ctrl: Controller, is_multi_threaded: bool)
 @pytest.mark.parametrize(
     "is_multi_threaded", [False, True], ids=["single-threaded", "multi-threaded"]
 )
-@tests.pwndbg_test
+@pwndbg_test
 async def test_thread_arena_heuristic(ctrl: Controller, is_multi_threaded: bool) -> None:
     import pwndbg
     import pwndbg.aglib.heap
@@ -458,7 +461,7 @@ async def test_thread_arena_heuristic(ctrl: Controller, is_multi_threaded: bool)
     # TODO: Support other architectures or different libc versions
     await ctrl.launch(HEAP_MALLOC_CHUNK)
     await ctrl.execute("set resolve-heap-via-heuristic force")
-    tests.break_at_sym("break_here")
+    break_at_sym("break_here")
     await ctrl.cont()
 
     if is_multi_threaded:
@@ -488,14 +491,14 @@ async def test_thread_arena_heuristic(ctrl: Controller, is_multi_threaded: bool)
         assert pwndbg.aglib.heap.current.thread_arena.address == thread_arena_via_debug_symbol
 
 
-@tests.pwndbg_test
+@pwndbg_test
 async def test_global_max_fast_heuristic(ctrl: Controller) -> None:
     import pwndbg.aglib.heap
 
     # TODO: Support other architectures or different libc versions
     await ctrl.launch(HEAP_MALLOC_CHUNK)
     await ctrl.execute("set resolve-heap-via-heuristic force")
-    tests.break_at_sym("break_here")
+    break_at_sym("break_here")
     await ctrl.cont()
 
     # Use the debug symbol to find the address of `global_max_fast`
@@ -520,7 +523,7 @@ async def test_global_max_fast_heuristic(ctrl: Controller) -> None:
 @pytest.mark.parametrize(
     "is_multi_threaded", [False, True], ids=["single-threaded", "multi-threaded"]
 )
-@tests.pwndbg_test
+@pwndbg_test
 async def test_heuristic_fail_gracefully(ctrl: Controller, is_multi_threaded: bool) -> None:
     import pwndbg.aglib.heap
     from pwndbg.aglib.heap.ptmalloc import SymbolUnresolvableError
@@ -528,7 +531,7 @@ async def test_heuristic_fail_gracefully(ctrl: Controller, is_multi_threaded: bo
     # TODO: Support other architectures or different libc versions
     await ctrl.launch(HEAP_MALLOC_CHUNK)
     await ctrl.execute("set resolve-heap-via-heuristic force")
-    tests.break_at_sym("break_here")
+    break_at_sym("break_here")
     await ctrl.cont()
     if is_multi_threaded:
         await ctrl.cont()
@@ -556,14 +559,14 @@ async def test_heuristic_fail_gracefully(ctrl: Controller, is_multi_threaded: bo
 ##
 # Jemalloc Tests
 ##
-HEAP_JEMALLOC_EXTENT_INFO = tests.get_binary("heap_jemalloc_extent_info.out")
-HEAP_JEMALLOC_HEAP = tests.get_binary("heap_jemalloc_heap.out")
+HEAP_JEMALLOC_EXTENT_INFO = get_binary("heap_jemalloc_extent_info.out")
+HEAP_JEMALLOC_HEAP = get_binary("heap_jemalloc_heap.out")
 re_match_valid_address = r"0x7ffff[0-9a-fA-F]{6,9}"
 
 
-@tests.pwndbg_test
+@pwndbg_test
 async def test_jemalloc_find_extent(ctrl: Controller) -> None:
-    await tests.launch_to(ctrl, HEAP_JEMALLOC_EXTENT_INFO, "break_here")
+    await launch_to(ctrl, HEAP_JEMALLOC_EXTENT_INFO, "break_here")
 
     # run jemalloc extent_info command
     result = (await ctrl.execute_and_capture("jemalloc-find-extent ptr")).splitlines()
@@ -590,9 +593,9 @@ async def test_jemalloc_find_extent(ctrl: Controller) -> None:
     assert expected_idx == len(expected_output)
 
 
-@tests.pwndbg_test
+@pwndbg_test
 async def test_jemalloc_extent_info(ctrl: Controller) -> None:
-    await tests.launch_to(ctrl, HEAP_JEMALLOC_EXTENT_INFO, "break_here")
+    await launch_to(ctrl, HEAP_JEMALLOC_EXTENT_INFO, "break_here")
 
     find_extent_results = (await ctrl.execute_and_capture("jemalloc-find-extent ptr")).splitlines()
     extent_address = None
@@ -623,9 +626,9 @@ async def test_jemalloc_extent_info(ctrl: Controller) -> None:
     assert expected_idx == len(expected_output)
 
 
-@tests.pwndbg_test
+@pwndbg_test
 async def test_jemalloc_heap(ctrl: Controller) -> None:
-    await tests.launch_to(ctrl, HEAP_JEMALLOC_HEAP, "break_here")
+    await launch_to(ctrl, HEAP_JEMALLOC_HEAP, "break_here")
 
     # run jemalloc extent_info command
     result = (await ctrl.execute_and_capture("jemalloc-heap")).splitlines()

--- a/tests/library/dbg/tests/heap/test_heap.py
+++ b/tests/library/dbg/tests/heap/test_heap.py
@@ -1,0 +1,631 @@
+from __future__ import annotations
+
+import re
+from typing import Dict
+
+import pytest
+from host import Controller
+
+import tests
+
+HEAP_MALLOC_CHUNK = tests.get_binary("heap_malloc_chunk.out")
+HEAP_MALLOC_CHUNK_DUMP = tests.get_binary("heap_malloc_chunk_dump.out")
+
+
+def generate_expected_malloc_chunk_output(chunks: Dict[str, ...]) -> Dict[str, ...]:
+    import pwndbg.aglib.heap
+
+    expected = {}
+
+    size = int(
+        chunks["allocated"][
+            (
+                "mchunk_size"
+                if "mchunk_size" in (f.name for f in chunks["allocated"].type.fields())
+                else "size"
+            )
+        ]
+    )
+    real_size = size & (0xFFFFFFFFFFFFFFF - 0b111)
+    expected["allocated"] = [
+        "Allocated chunk | PREV_INUSE",
+        f"Addr: {int(chunks['allocated'].address):#x}",
+        f"Size: 0x{real_size:02x} (with flag bits: 0x{size:02x})",
+        "",
+    ]
+
+    size = int(
+        chunks["tcache"][
+            (
+                "mchunk_size"
+                if "mchunk_size" in (f.name for f in chunks["tcache"].type.fields())
+                else "size"
+            )
+        ]
+    )
+    real_size = size & (0xFFFFFFFFFFFFFFF - 0b111)
+    expected["tcache"] = [
+        f"Free chunk ({'tcachebins' if pwndbg.aglib.heap.current.has_tcache else 'fastbins'}) | PREV_INUSE",
+        f"Addr: {int(chunks['tcache'].address):#x}",
+        f"Size: 0x{real_size:02x} (with flag bits: 0x{size:02x})",
+        f"fd: 0x{int(chunks['tcache']['fd']):02x}",
+        "",
+    ]
+
+    size = int(
+        chunks["fast"][
+            (
+                "mchunk_size"
+                if "mchunk_size" in (f.name for f in chunks["fast"].type.fields())
+                else "size"
+            )
+        ]
+    )
+    real_size = size & (0xFFFFFFFFFFFFFFF - 0b111)
+    expected["fast"] = [
+        "Free chunk (fastbins) | PREV_INUSE",
+        f"Addr: {int(chunks['fast'].address):#x}",
+        f"Size: 0x{real_size:02x} (with flag bits: 0x{size:02x})",
+        f"fd: 0x{int(chunks['fast']['fd']):02x}",
+        "",
+    ]
+
+    size = int(
+        chunks["small"][
+            (
+                "mchunk_size"
+                if "mchunk_size" in (f.name for f in chunks["small"].type.fields())
+                else "size"
+            )
+        ]
+    )
+    real_size = size & (0xFFFFFFFFFFFFFFF - 0b111)
+    expected["small"] = [
+        "Free chunk (smallbins) | PREV_INUSE",
+        f"Addr: {int(chunks['small'].address):#x}",
+        f"Size: 0x{real_size:02x} (with flag bits: 0x{size:02x})",
+        f"fd: 0x{int(chunks['small']['fd']):02x}",
+        f"bk: 0x{int(chunks['small']['bk']):02x}",
+        "",
+    ]
+
+    size = int(
+        chunks["large"][
+            (
+                "mchunk_size"
+                if "mchunk_size" in (f.name for f in chunks["large"].type.fields())
+                else "size"
+            )
+        ]
+    )
+    real_size = size & (0xFFFFFFFFFFFFFFF - 0b111)
+    expected["large"] = [
+        "Free chunk (largebins) | PREV_INUSE",
+        f"Addr: {int(chunks['large'].address):#x}",
+        f"Size: 0x{real_size:02x} (with flag bits: 0x{size:02x})",
+        f"fd: 0x{int(chunks['large']['fd']):02x}",
+        f"bk: 0x{int(chunks['large']['bk']):02x}",
+        f"fd_nextsize: 0x{int(chunks['large']['fd_nextsize']):02x}",
+        f"bk_nextsize: 0x{int(chunks['large']['bk_nextsize']):02x}",
+        "",
+    ]
+
+    size = int(
+        chunks["unsorted"][
+            (
+                "mchunk_size"
+                if "mchunk_size" in (f.name for f in chunks["unsorted"].type.fields())
+                else "size"
+            )
+        ]
+    )
+    real_size = size & (0xFFFFFFFFFFFFFFF - 0b111)
+    expected["unsorted"] = [
+        "Free chunk (unsortedbin) | PREV_INUSE",
+        f"Addr: {int(chunks['unsorted'].address):#x}",
+        f"Size: 0x{real_size:02x} (with flag bits: 0x{size:02x})",
+        f"fd: 0x{int(chunks['unsorted']['fd']):02x}",
+        f"bk: 0x{int(chunks['unsorted']['bk']):02x}",
+        "",
+    ]
+
+    return expected
+
+
+@tests.pwndbg_test
+async def test_malloc_chunk_command(ctrl: Controller) -> None:
+    import pwndbg
+    import pwndbg.aglib.heap
+    import pwndbg.aglib.memory
+    import pwndbg.aglib.symbol
+
+    await tests.launch_to(ctrl, HEAP_MALLOC_CHUNK, "break_here")
+
+    chunks = {}
+    results = {}
+    chunk_types = ["allocated", "tcache", "fast", "small", "large", "unsorted"]
+    for name in chunk_types:
+        chunks[name] = pwndbg.aglib.memory.get_typed_pointer_value(
+            pwndbg.aglib.heap.current.malloc_chunk,
+            int(pwndbg.aglib.symbol.lookup_symbol(f"{name}_chunk")),
+        )
+        results[name] = (await ctrl.execute_and_capture(f"malloc-chunk {name}_chunk")).splitlines()
+
+    expected = generate_expected_malloc_chunk_output(chunks)
+
+    for name in chunk_types:
+        assert results[name] == expected[name]
+
+    await ctrl.cont()
+
+    # Print main thread's chunk from another thread
+    assert pwndbg.dbg.selected_thread().index() == 2
+    results["large"] = (await ctrl.execute_and_capture("malloc-chunk large_chunk")).splitlines()
+    expected = generate_expected_malloc_chunk_output(chunks)
+    assert results["large"] == expected["large"]
+
+    await ctrl.cont()
+
+    # Test some non-main-arena chunks
+    for name in chunk_types:
+        chunks[name] = pwndbg.aglib.memory.get_typed_pointer_value(
+            pwndbg.aglib.heap.current.malloc_chunk,
+            int(pwndbg.aglib.symbol.lookup_symbol(f"{name}_chunk")),
+        )
+        results[name] = (await ctrl.execute_and_capture(f"malloc-chunk {name}_chunk")).splitlines()
+
+    expected = generate_expected_malloc_chunk_output(chunks)
+    expected["allocated"][0] += " | NON_MAIN_ARENA"
+    expected["tcache"][0] += " | NON_MAIN_ARENA"
+    expected["fast"][0] += " | NON_MAIN_ARENA"
+
+    for name in chunk_types:
+        assert results[name] == expected[name]
+
+    # Print another thread's chunk from the main thread
+    await ctrl.select_thread(1)
+    assert pwndbg.dbg.selected_thread().index() == 1
+    results["large"] = (await ctrl.execute_and_capture("malloc-chunk large_chunk")).splitlines()
+    assert results["large"] == expected["large"]
+
+
+@tests.pwndbg_test
+async def test_malloc_chunk_command_heuristic(ctrl: Controller) -> None:
+    import pwndbg
+    import pwndbg.aglib.heap
+    import pwndbg.aglib.symbol
+
+    await ctrl.launch(HEAP_MALLOC_CHUNK)
+    await ctrl.execute("set resolve-heap-via-heuristic force")
+    tests.break_at_sym("break_here")
+    await ctrl.cont()
+
+    chunks = {}
+    results = {}
+    chunk_types = ["allocated", "tcache", "fast", "small", "large", "unsorted"]
+    for name in chunk_types:
+        chunks[name] = pwndbg.aglib.heap.current.malloc_chunk(
+            int(pwndbg.aglib.symbol.lookup_symbol(f"{name}_chunk"))
+        )
+        results[name] = (await ctrl.execute_and_capture(f"malloc-chunk {name}_chunk")).splitlines()
+
+    expected = generate_expected_malloc_chunk_output(chunks)
+
+    for name in chunk_types:
+        assert results[name] == expected[name]
+
+    await ctrl.cont()
+
+    # Print main thread's chunk from another thread
+    assert pwndbg.dbg.selected_thread().index() == 2
+    results["large"] = (await ctrl.execute_and_capture("malloc-chunk large_chunk")).splitlines()
+    expected = generate_expected_malloc_chunk_output(chunks)
+    assert results["large"] == expected["large"]
+
+    await ctrl.cont()
+
+    # Test some non-main-arena chunks
+    for name in chunk_types:
+        chunks[name] = pwndbg.aglib.heap.current.malloc_chunk(
+            int(pwndbg.aglib.symbol.lookup_symbol(f"{name}_chunk"))
+        )
+        results[name] = (await ctrl.execute_and_capture(f"malloc-chunk {name}_chunk")).splitlines()
+
+    expected = generate_expected_malloc_chunk_output(chunks)
+    expected["allocated"][0] += " | NON_MAIN_ARENA"
+    expected["tcache"][0] += " | NON_MAIN_ARENA"
+    expected["fast"][0] += " | NON_MAIN_ARENA"
+
+    for name in chunk_types:
+        assert results[name] == expected[name]
+
+    # Print another thread's chunk from the main thread
+    await ctrl.select_thread(1)
+    assert pwndbg.dbg.selected_thread().index() == 1
+    results["large"] = (await ctrl.execute_and_capture("malloc-chunk large_chunk")).splitlines()
+    assert results["large"] == expected["large"]
+
+
+@tests.pwndbg_test
+async def test_malloc_chunk_dump_command(ctrl: Controller) -> None:
+    import pwndbg.aglib.heap
+    import pwndbg.aglib.memory
+    import pwndbg.aglib.symbol
+
+    await tests.launch_to(ctrl, HEAP_MALLOC_CHUNK_DUMP, "break_here")
+
+    chunk = pwndbg.aglib.memory.get_typed_pointer_value(
+        pwndbg.aglib.heap.current.malloc_chunk, int(pwndbg.aglib.symbol.lookup_symbol("test_chunk"))
+    )
+    chunk_addr = chunk.address
+
+    malloc_chunk = await ctrl.execute_and_capture(f"malloc-chunk {int(chunk_addr):#x} -d")
+
+    size = int(
+        chunk[("mchunk_size" if "mchunk_size" in (f.name for f in chunk.type.fields()) else "size")]
+    )
+
+    real_size = size & (0xFFFFFFFFFFFFFFF - 0b111)
+
+    chunk_addr = int(chunk.address)
+    expected = [
+        "Allocated chunk | PREV_INUSE",
+        f"Addr: 0x{chunk_addr:x}",
+        f"Size: 0x{real_size:02x} (with flag bits: 0x{size:02x})",
+        "",
+        "hexdump",
+        f"+0000 0x{chunk_addr:x}  00 00 00 00 00 00 00 00  31 00 00 00 00 00 00 00  │........│1.......│",
+        f"+0010 0x{chunk_addr+0x10:x}  54 68 69 73 20 69 73 20  61 20 74 65 73 74 20 73  │This.is.│a.test.s│",
+        f"+0020 0x{chunk_addr+0x20:x}  74 72 69 6e 67 00 00 00  00 00 00 00 00 00 00 00  │tring...│........│",
+        f"+0030 0x{chunk_addr+0x30:x}  00 00 00 00 00 00 00 00                           │........│        │",
+    ]
+
+    # now just compare the output
+    assert malloc_chunk.splitlines() == expected
+
+
+class mock_for_heuristic:
+    def __init__(self, mock_symbols=[], mock_all=False):
+        self.mock_symbols = (
+            mock_symbols  # every symbol's address in the list will be mocked to `None`
+        )
+        self.mock_all = mock_all  # all symbols will be mocked to `None`
+        # Save `selected_inferior` before mocking
+        self.saved_func = pwndbg.dbg.selected_inferior
+
+    def __enter__(self):
+        def mock_lookup_symbol(original):
+            def _mock(symbol, *args, **kwargs):
+                if self.mock_all:
+                    return None
+                for s in self.mock_symbols:
+                    if s == symbol:
+                        return None
+                return original(symbol, *args, **kwargs)
+
+            return _mock
+
+        def mock_interior(original):
+            def _mock(*args, **kwargs):
+                inst = original(*args, **kwargs)
+                inst.lookup_symbol = mock_lookup_symbol(inst.lookup_symbol)
+                return inst
+
+            return _mock
+
+        # Mock `symbol_address_from_name` from `selected_inferior`
+        pwndbg.dbg.selected_inferior = mock_interior(pwndbg.dbg.selected_inferior)
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        # Restore `selected_inferior`
+        pwndbg.dbg.selected_inferior = self.saved_func
+
+
+@tests.pwndbg_test
+async def test_main_arena_heuristic(ctrl: Controller) -> None:
+    import pwndbg.aglib.heap
+    import pwndbg.aglib.symbol
+    import pwndbg.aglib.typeinfo
+
+    await ctrl.launch(HEAP_MALLOC_CHUNK)
+    await ctrl.execute("set resolve-heap-via-heuristic force")
+    tests.break_at_sym("break_here")
+    await ctrl.cont()
+
+    # Use the debug symbol to get the address of `main_arena`
+    main_arena_addr_via_debug_symbol = pwndbg.aglib.symbol.lookup_symbol_addr(
+        "main_arena", prefer_static=True
+    )
+
+    # Check if we can get the address of `main_arena` from debug symbols and the struct of `main_arena` is correct
+    assert pwndbg.aglib.heap.current.main_arena is not None
+    # Check the address of `main_arena` is correct
+    assert pwndbg.aglib.heap.current.main_arena.address == main_arena_addr_via_debug_symbol
+    # Check the struct size is correct
+    assert (
+        pwndbg.aglib.heap.current.main_arena._gdbValue.type.sizeof
+        == pwndbg.aglib.typeinfo.lookup_types("struct malloc_state").sizeof
+    )
+    pwndbg.aglib.heap.current = type(pwndbg.aglib.heap.current)()  # Reset the heap object of pwndbg
+
+    # Check if we can get the address of `main_arena` by parsing the .data section of the ELF of libc
+    with mock_for_heuristic(["main_arena"]):
+        assert pwndbg.aglib.heap.current.main_arena is not None
+        # Check the address of `main_arena` is correct
+        assert pwndbg.aglib.heap.current.main_arena.address == main_arena_addr_via_debug_symbol
+
+
+@tests.pwndbg_test
+async def test_mp_heuristic(ctrl: Controller) -> None:
+    import pwndbg.aglib.heap
+    import pwndbg.aglib.symbol
+    import pwndbg.aglib.typeinfo
+
+    await ctrl.launch(HEAP_MALLOC_CHUNK)
+    await ctrl.execute("set resolve-heap-via-heuristic force")
+    tests.break_at_sym("break_here")
+    await ctrl.cont()
+
+    # Use the debug symbol to get the address of `mp_`
+    mp_addr_via_debug_symbol = pwndbg.aglib.symbol.lookup_symbol_addr("mp_", prefer_static=True)
+
+    # Check if we can get the address of `mp_` from debug symbols and the struct of `mp_` is correct
+    assert pwndbg.aglib.heap.current.mp is not None
+    # Check the address of `main_arena` is correct
+    assert pwndbg.aglib.heap.current.mp.address == mp_addr_via_debug_symbol
+    # Check the struct size is correct
+    assert (
+        pwndbg.aglib.heap.current.mp.type.sizeof
+        == pwndbg.aglib.typeinfo.lookup_types("struct malloc_par").sizeof
+    )
+    pwndbg.aglib.heap.current = type(pwndbg.aglib.heap.current)()  # Reset the heap object of pwndbg
+
+    # Check if we can get the address of `mp_` by parsing the .data section of the ELF of libc
+    with mock_for_heuristic(["mp_"]):
+        assert pwndbg.aglib.heap.current.mp is not None
+        # Check the address of `mp_` is correct
+        assert pwndbg.aglib.heap.current.mp.address == mp_addr_via_debug_symbol
+
+
+@pytest.mark.parametrize(
+    "is_multi_threaded", [False, True], ids=["single-threaded", "multi-threaded"]
+)
+@tests.pwndbg_test
+async def test_thread_cache_heuristic(ctrl: Controller, is_multi_threaded: bool) -> None:
+    import pwndbg
+    import pwndbg.aglib.heap
+    import pwndbg.aglib.memory
+    import pwndbg.aglib.symbol
+    import pwndbg.aglib.typeinfo
+
+    # TODO: Support other architectures or different libc versions
+    await ctrl.launch(HEAP_MALLOC_CHUNK)
+    await ctrl.execute("set resolve-heap-via-heuristic force")
+    tests.break_at_sym("break_here")
+    await ctrl.cont()
+    if is_multi_threaded:
+        await ctrl.cont()
+        assert pwndbg.dbg.selected_thread().index() == 2
+
+    # Use the debug symbol to find the address of `thread_cache`
+    tcache_addr_via_debug_symbol = pwndbg.aglib.symbol.lookup_symbol_addr(
+        "tcache", prefer_static=True
+    )
+    thread_cache_addr_via_debug_symbol = pwndbg.aglib.memory.u(tcache_addr_via_debug_symbol)
+
+    # Check if we can get the address of `thread_cache` from debug symbols and the struct of `thread_cache` is correct
+    assert pwndbg.aglib.heap.current.thread_cache is not None
+    # Check the address of `thread_cache` is correct
+    assert pwndbg.aglib.heap.current.thread_cache.address == thread_cache_addr_via_debug_symbol
+    # Check the struct size is correct
+    assert (
+        pwndbg.aglib.heap.current.thread_cache.type.sizeof
+        == pwndbg.aglib.typeinfo.lookup_types("struct tcache_perthread_struct").sizeof
+    )
+    pwndbg.aglib.heap.current = type(pwndbg.aglib.heap.current)()  # Reset the heap object of pwndbg
+
+    # Check if we can get the address of `tcache` by using the first chunk or by brute force
+    with mock_for_heuristic(["tcache"]):
+        # Check if we can find tcache by brute force
+        pwndbg.aglib.heap.current.prompt_for_brute_force_thread_cache_permission = lambda: True
+        assert pwndbg.aglib.heap.current.thread_cache.address == thread_cache_addr_via_debug_symbol
+        pwndbg.aglib.heap.current = type(
+            pwndbg.aglib.heap.current
+        )()  # Reset the heap object of pwndbg
+        # Check if we can find tcache by using the first chunk
+        # # Note: This will NOT work when can NOT find the heap boundaries or the the arena is been shared
+        pwndbg.aglib.heap.current.prompt_for_brute_force_thread_cache_permission = lambda: False
+        assert pwndbg.aglib.heap.current.thread_cache.address == thread_cache_addr_via_debug_symbol
+
+
+@pytest.mark.parametrize(
+    "is_multi_threaded", [False, True], ids=["single-threaded", "multi-threaded"]
+)
+@tests.pwndbg_test
+async def test_thread_arena_heuristic(ctrl: Controller, is_multi_threaded: bool) -> None:
+    import pwndbg
+    import pwndbg.aglib.heap
+    import pwndbg.aglib.memory
+    import pwndbg.aglib.symbol
+
+    # TODO: Support other architectures or different libc versions
+    await ctrl.launch(HEAP_MALLOC_CHUNK)
+    await ctrl.execute("set resolve-heap-via-heuristic force")
+    tests.break_at_sym("break_here")
+    await ctrl.cont()
+
+    if is_multi_threaded:
+        await ctrl.cont()
+        assert pwndbg.dbg.selected_thread().index() == 2
+
+    # Use the debug symbol to find the value of `thread_arena`
+    thread_arena_via_debug_symbol = pwndbg.aglib.symbol.lookup_symbol_addr(
+        "thread_arena", prefer_static=True
+    )
+    assert thread_arena_via_debug_symbol is not None
+    thread_arena_via_debug_symbol = pwndbg.aglib.memory.u(thread_arena_via_debug_symbol)
+    assert thread_arena_via_debug_symbol > 0
+
+    # Check if we can get the address of `thread_arena` from debug symbols and the value of `thread_arena` is correct
+    assert pwndbg.aglib.heap.current.thread_arena is not None
+    # Check the address of `thread_arena` is correct
+    assert pwndbg.aglib.heap.current.thread_arena.address == thread_arena_via_debug_symbol
+    pwndbg.aglib.heap.current = type(pwndbg.aglib.heap.current)()  # Reset the heap object of pwndbg
+
+    # Check if we can use brute-force to find the `thread_arena` when multi-threaded, and if we can use the `main_arena` as the `thread_arena` when single-threaded
+    with mock_for_heuristic(["thread_arena"]):
+        # mock the prompt to avoid input
+        pwndbg.aglib.heap.current.prompt_for_brute_force_thread_arena_permission = lambda: True
+        assert pwndbg.aglib.heap.current.thread_arena is not None
+        # Check the value of `thread_arena` is correct
+        assert pwndbg.aglib.heap.current.thread_arena.address == thread_arena_via_debug_symbol
+
+
+@tests.pwndbg_test
+async def test_global_max_fast_heuristic(ctrl: Controller) -> None:
+    import pwndbg.aglib.heap
+
+    # TODO: Support other architectures or different libc versions
+    await ctrl.launch(HEAP_MALLOC_CHUNK)
+    await ctrl.execute("set resolve-heap-via-heuristic force")
+    tests.break_at_sym("break_here")
+    await ctrl.cont()
+
+    # Use the debug symbol to find the address of `global_max_fast`
+    global_max_fast_addr_via_debug_symbol = pwndbg.aglib.symbol.lookup_symbol_addr(
+        "global_max_fast", prefer_static=True
+    )
+    assert global_max_fast_addr_via_debug_symbol is not None
+
+    # Check if we can get the address of `global_max_fast` from debug symbols and the value of `global_max_fast` is correct
+    assert pwndbg.aglib.heap.current.global_max_fast is not None
+    # Check the address of `global_max_fast` is correct
+    assert pwndbg.aglib.heap.current._global_max_fast_addr == global_max_fast_addr_via_debug_symbol
+    pwndbg.aglib.heap.current = type(pwndbg.aglib.heap.current)()  # Reset the heap object of pwndbg
+
+    # Check if we can return the default value even if we can NOT find the address of `global_max_fast`
+    with mock_for_heuristic(["global_max_fast"]):
+        assert pwndbg.aglib.heap.current.global_max_fast == pwndbg.aglib.memory.u(
+            global_max_fast_addr_via_debug_symbol
+        )
+
+
+@pytest.mark.parametrize(
+    "is_multi_threaded", [False, True], ids=["single-threaded", "multi-threaded"]
+)
+@tests.pwndbg_test
+async def test_heuristic_fail_gracefully(ctrl: Controller, is_multi_threaded: bool) -> None:
+    import pwndbg.aglib.heap
+
+    # TODO: Support other architectures or different libc versions
+    await ctrl.launch(HEAP_MALLOC_CHUNK)
+    await ctrl.execute("set resolve-heap-via-heuristic force")
+    tests.break_at_sym("break_here")
+    await ctrl.cont()
+    if is_multi_threaded:
+        await ctrl.cont()
+        assert pwndbg.dbg.selected_thread().index() == 2
+
+    def _test_heuristic_fail_gracefully(name):
+        try:
+            getattr(pwndbg.aglib.heap.current, name)
+        except SymbolUnresolvableError as e:
+            # That's the only exception we expect
+            assert e.symbol  # we should show what symbol we failed to resolve
+
+    # Mock all address and mess up the memory
+    with mock_for_heuristic(mock_all=True):
+        # mock the prompt to avoid input
+        pwndbg.aglib.heap.current.prompt_for_brute_force_thread_arena_permission = lambda: False
+        pwndbg.aglib.heap.current.prompt_for_brute_force_thread_cache_permission = lambda: False
+        _test_heuristic_fail_gracefully("main_arena")
+        _test_heuristic_fail_gracefully("mp")
+        _test_heuristic_fail_gracefully("global_max_fast")
+        _test_heuristic_fail_gracefully("thread_cache")
+        _test_heuristic_fail_gracefully("thread_arena")
+
+
+##
+# Jemalloc Tests
+##
+HEAP_JEMALLOC_EXTENT_INFO = tests.get_binary("heap_jemalloc_extent_info.out")
+HEAP_JEMALLOC_HEAP = tests.get_binary("heap_jemalloc_heap.out")
+re_match_valid_address = r"0x7ffff[0-9a-fA-F]{6,9}"
+
+
+@tests.pwndbg_test
+async def test_jemalloc_find_extent(ctrl: Controller) -> None:
+    await tests.launch_to(ctrl, HEAP_JEMALLOC_EXTENT_INFO, "break_here")
+
+    # run jemalloc extent_info command
+    result = (await ctrl.execute_and_capture("jemalloc-find-extent ptr")).splitlines()
+
+    expected_output = [
+        "Jemalloc find extent",
+        "This command was tested only for jemalloc 5.3.0 and does not support lower versions",
+        "",
+        r"Pointer Address: " + re_match_valid_address,
+        r"Extent Address: " + re_match_valid_address,
+        "",
+        r"Allocated Address: " + re_match_valid_address,
+        r"Extent Address: " + re_match_valid_address,
+        "Size: 0x1000",
+        "Small class: True",
+    ]
+
+    for i in range(len(expected_output)):
+        assert re.match(expected_output[i], result[i])
+
+
+@tests.pwndbg_test
+async def test_jemalloc_extent_info(ctrl: Controller) -> None:
+    await tests.launch_to(ctrl, HEAP_JEMALLOC_EXTENT_INFO, "break_here")
+
+    find_extent_results = (await ctrl.execute_and_capture("jemalloc-find-extent ptr")).splitlines()
+    extent_address = None
+    for line in find_extent_results:
+        if "Extent Address:" in line:
+            extent_address = int(line.split(" ")[-1], 16)
+    if extent_address is None:
+        raise ValueError("Could not find extent address")
+    # run jemalloc extent_info command
+    result = (await ctrl.execute_and_capture(f"jemalloc-extent-info {extent_address}")).splitlines()
+
+    expected_output = [
+        "Jemalloc extent info",
+        "This command was tested only for jemalloc 5.3.0 and does not support lower versions",
+        "",
+        r"Allocated Address: " + re_match_valid_address,
+        r"Extent Address: " + re_match_valid_address,
+        "Size: 0x1000",
+        "Small class: True",
+    ]
+
+    for i in range(len(expected_output)):
+        assert re.match(expected_output[i], result[i])
+
+
+@tests.pwndbg_test
+async def test_jemalloc_heap(ctrl: Controller) -> None:
+    await tests.launch_to(ctrl, HEAP_JEMALLOC_HEAP, "break_here")
+
+    # run jemalloc extent_info command
+    result = (await ctrl.execute_and_capture("jemalloc-heap")).splitlines()
+
+    expected_output = [
+        "Jemalloc heap",
+        "This command was tested only for jemalloc 5.3.0 and does not support lower versions",
+    ]
+
+    # Extent sizes different depending on the system built (it would seem), so only check for the 0x8000 size,
+    # since it seems consistent. The output of an extent implies the rest of the command is working
+    expected_output += [
+        "",
+        "Allocated Address: " + re_match_valid_address,
+        r"Extent Address: " + re_match_valid_address,
+        "Size: 0x8000",
+        "Small class: False",
+    ]
+
+    for i in range(len(expected_output)):
+        assert re.match(expected_output[i], result[i])

--- a/tests/library/dbg/tests/heap/test_heap.py
+++ b/tests/library/dbg/tests/heap/test_heap.py
@@ -147,7 +147,7 @@ async def test_malloc_chunk_command(ctrl: Controller) -> None:
     for name in chunk_types:
         chunks[name] = pwndbg.aglib.memory.get_typed_pointer_value(
             pwndbg.aglib.heap.current.malloc_chunk,
-            int(pwndbg.aglib.symbol.lookup_symbol(f"{name}_chunk")),
+            pwndbg.aglib.symbol.lookup_symbol_value(f"{name}_chunk"),
         )
         results[name] = (await ctrl.execute_and_capture(f"malloc-chunk {name}_chunk")).splitlines()
 
@@ -170,7 +170,7 @@ async def test_malloc_chunk_command(ctrl: Controller) -> None:
     for name in chunk_types:
         chunks[name] = pwndbg.aglib.memory.get_typed_pointer_value(
             pwndbg.aglib.heap.current.malloc_chunk,
-            int(pwndbg.aglib.symbol.lookup_symbol(f"{name}_chunk")),
+            pwndbg.aglib.symbol.lookup_symbol_value(f"{name}_chunk"),
         )
         results[name] = (await ctrl.execute_and_capture(f"malloc-chunk {name}_chunk")).splitlines()
 
@@ -205,7 +205,7 @@ async def test_malloc_chunk_command_heuristic(ctrl: Controller) -> None:
     chunk_types = ["allocated", "tcache", "fast", "small", "large", "unsorted"]
     for name in chunk_types:
         chunks[name] = pwndbg.aglib.heap.current.malloc_chunk(
-            int(pwndbg.aglib.symbol.lookup_symbol(f"{name}_chunk"))
+            pwndbg.aglib.symbol.lookup_symbol_value(f"{name}_chunk")
         )
         results[name] = (await ctrl.execute_and_capture(f"malloc-chunk {name}_chunk")).splitlines()
 
@@ -227,7 +227,7 @@ async def test_malloc_chunk_command_heuristic(ctrl: Controller) -> None:
     # Test some non-main-arena chunks
     for name in chunk_types:
         chunks[name] = pwndbg.aglib.heap.current.malloc_chunk(
-            int(pwndbg.aglib.symbol.lookup_symbol(f"{name}_chunk"))
+            pwndbg.aglib.symbol.lookup_symbol_value(f"{name}_chunk")
         )
         results[name] = (await ctrl.execute_and_capture(f"malloc-chunk {name}_chunk")).splitlines()
 
@@ -255,7 +255,8 @@ async def test_malloc_chunk_dump_command(ctrl: Controller) -> None:
     await tests.launch_to(ctrl, HEAP_MALLOC_CHUNK_DUMP, "break_here")
 
     chunk = pwndbg.aglib.memory.get_typed_pointer_value(
-        pwndbg.aglib.heap.current.malloc_chunk, int(pwndbg.aglib.symbol.lookup_symbol("test_chunk"))
+        pwndbg.aglib.heap.current.malloc_chunk,
+        pwndbg.aglib.symbol.lookup_symbol_value("test_chunk"),
     )
     chunk_addr = chunk.address
 
@@ -286,6 +287,8 @@ async def test_malloc_chunk_dump_command(ctrl: Controller) -> None:
 
 class mock_for_heuristic:
     def __init__(self, mock_symbols=[], mock_all=False):
+        import pwndbg
+
         self.mock_symbols = (
             mock_symbols  # every symbol's address in the list will be mocked to `None`
         )
@@ -294,6 +297,8 @@ class mock_for_heuristic:
         self.saved_func = pwndbg.dbg.selected_inferior
 
     def __enter__(self):
+        import pwndbg
+
         def mock_lookup_symbol(original):
             def _mock(symbol, *args, **kwargs):
                 if self.mock_all:
@@ -317,6 +322,8 @@ class mock_for_heuristic:
         pwndbg.dbg.selected_inferior = mock_interior(pwndbg.dbg.selected_inferior)
 
     def __exit__(self, exc_type, exc_value, traceback):
+        import pwndbg
+
         # Restore `selected_inferior`
         pwndbg.dbg.selected_inferior = self.saved_func
 
@@ -516,6 +523,7 @@ async def test_global_max_fast_heuristic(ctrl: Controller) -> None:
 @tests.pwndbg_test
 async def test_heuristic_fail_gracefully(ctrl: Controller, is_multi_threaded: bool) -> None:
     import pwndbg.aglib.heap
+    from pwndbg.aglib.heap.ptmalloc import SymbolUnresolvableError
 
     # TODO: Support other architectures or different libc versions
     await ctrl.launch(HEAP_MALLOC_CHUNK)
@@ -573,8 +581,13 @@ async def test_jemalloc_find_extent(ctrl: Controller) -> None:
         "Small class: True",
     ]
 
-    for i in range(len(expected_output)):
-        assert re.match(expected_output[i], result[i])
+    expected_idx = 0
+    for i in range(len(result)):
+        if expected_idx == len(expected_output):
+            break
+        if re.match(expected_output[expected_idx], result[i]) is not None:
+            expected_idx += 1
+    assert expected_idx == len(expected_output)
 
 
 @tests.pwndbg_test
@@ -601,8 +614,13 @@ async def test_jemalloc_extent_info(ctrl: Controller) -> None:
         "Small class: True",
     ]
 
-    for i in range(len(expected_output)):
-        assert re.match(expected_output[i], result[i])
+    expected_idx = 0
+    for i in range(len(result)):
+        if expected_idx == len(expected_output):
+            break
+        if re.match(expected_output[expected_idx], result[i]) is not None:
+            expected_idx += 1
+    assert expected_idx == len(expected_output)
 
 
 @tests.pwndbg_test
@@ -627,5 +645,10 @@ async def test_jemalloc_heap(ctrl: Controller) -> None:
         "Small class: False",
     ]
 
-    for i in range(len(expected_output)):
-        assert re.match(expected_output[i], result[i])
+    expected_idx = 0
+    for i in range(len(result)):
+        if expected_idx == len(expected_output):
+            break
+        if re.match(expected_output[expected_idx], result[i]) is not None:
+            expected_idx += 1
+    assert expected_idx == len(expected_output)

--- a/tests/library/dbg/tests/heap/test_heap_bins.py
+++ b/tests/library/dbg/tests/heap/test_heap_bins.py
@@ -1,0 +1,500 @@
+from __future__ import annotations
+
+from host import Controller
+
+import tests
+
+BINARY = tests.get_binary("heap_bins.out")
+
+
+@tests.pwndbg_test
+async def test_heap_bins(ctrl: Controller) -> None:
+    """
+    Tests pwndbg.aglib.heap bins commands
+    """
+    import pwndbg
+    import pwndbg.aglib.heap
+    import pwndbg.aglib.memory
+    import pwndbg.aglib.symbol
+    import pwndbg.aglib.vmmap
+    from pwndbg.aglib.heap.ptmalloc import BinType
+
+    await ctrl.execute("set context-output /dev/null")
+    await tests.launch_to(ctrl, BINARY, "breakpoint")
+
+    # check if all bins are empty at first
+    allocator = pwndbg.aglib.heap.current
+
+    addr = pwndbg.aglib.symbol.lookup_symbol_addr("tcache_size")
+    tcache_size = allocator._request2size(pwndbg.aglib.memory.u64(addr))
+    addr = pwndbg.aglib.symbol.lookup_symbol_addr("tcache_count")
+    tcache_count = pwndbg.aglib.memory.u64(addr)
+    addr = pwndbg.aglib.symbol.lookup_symbol_addr("fastbin_size")
+    fastbin_size = allocator._request2size(pwndbg.aglib.memory.u64(addr))
+    addr = pwndbg.aglib.symbol.lookup_symbol_addr("fastbin_count")
+    fastbin_count = pwndbg.aglib.memory.u64(addr)
+    addr = pwndbg.aglib.symbol.lookup_symbol_addr("smallbin_size")
+    smallbin_size = allocator._request2size(pwndbg.aglib.memory.u64(addr))
+    addr = pwndbg.aglib.symbol.lookup_symbol_addr("smallbin_count")
+    smallbin_count = pwndbg.aglib.memory.u64(addr)
+    addr = pwndbg.aglib.symbol.lookup_symbol_addr("largebin_size")
+    largebin_size = allocator._request2size(pwndbg.aglib.memory.u64(addr))
+    addr = pwndbg.aglib.symbol.lookup_symbol_addr("largebin_count")
+    largebin_count = pwndbg.aglib.memory.u64(addr)
+
+    result = allocator.tcachebins()
+    assert result.bin_type == BinType.TCACHE
+    assert tcache_size in result.bins
+    assert result.bins[tcache_size].bk_chain is None and len(result.bins[tcache_size].fd_chain) == 1
+
+    result = allocator.fastbins()
+    assert result.bin_type == BinType.FAST
+    assert fastbin_size in result.bins
+    assert len(result.bins[fastbin_size].fd_chain) == 1
+
+    result = allocator.unsortedbin()
+    assert result.bin_type == BinType.UNSORTED
+    assert len(result.bins["all"].fd_chain) == 1
+    assert not result.bins["all"].is_corrupted
+
+    result = allocator.smallbins()
+    assert result.bin_type == BinType.SMALL
+    assert smallbin_size in result.bins
+    assert (
+        len(result.bins[smallbin_size].fd_chain) == 1
+        and len(result.bins[smallbin_size].bk_chain) == 1
+    )
+    assert not result.bins[smallbin_size].is_corrupted
+
+    result = allocator.largebins()
+    assert result.bin_type == BinType.LARGE
+    largebin_size = list(result.bins.items())[allocator.largebin_index(largebin_size) - 64][0]
+    assert largebin_size in result.bins
+    assert (
+        len(result.bins[largebin_size].fd_chain) == 1
+        and len(result.bins[largebin_size].bk_chain) == 1
+    )
+    assert not result.bins[largebin_size].is_corrupted
+
+    # check tcache
+    await ctrl.cont()
+
+    result = allocator.tcachebins()
+    assert result.bin_type == BinType.TCACHE
+    assert tcache_size in result.bins
+    assert (
+        result.bins[tcache_size].count == tcache_count
+        and len(result.bins[tcache_size].fd_chain) == tcache_count + 1
+    )
+    for addr in result.bins[tcache_size].fd_chain[:-1]:
+        assert pwndbg.aglib.vmmap.find(addr)
+
+    # check fastbin
+    await ctrl.cont()
+
+    result = allocator.fastbins()
+    assert result.bin_type == BinType.FAST
+    assert (fastbin_size in result.bins) and (
+        len(result.bins[fastbin_size].fd_chain) == fastbin_count + 1
+    )
+    for addr in result.bins[fastbin_size].fd_chain[:-1]:
+        assert pwndbg.aglib.vmmap.find(addr)
+
+    # check unsortedbin
+    await ctrl.cont()
+
+    result = allocator.unsortedbin()
+    assert result.bin_type == BinType.UNSORTED
+    assert (
+        len(result.bins["all"].fd_chain) == smallbin_count + 2
+        and len(result.bins["all"].bk_chain) == smallbin_count + 2
+    )
+    assert not result.bins["all"].is_corrupted
+    for addr in result.bins["all"].fd_chain[:-1]:
+        assert pwndbg.aglib.vmmap.find(addr)
+    for addr in result.bins["all"].bk_chain[:-1]:
+        assert pwndbg.aglib.vmmap.find(addr)
+
+    # check smallbins
+    await ctrl.cont()
+
+    result = allocator.smallbins()
+    assert result.bin_type == "smallbins"
+    assert (
+        len(result.bins[smallbin_size].fd_chain) == smallbin_count + 2
+        and len(result.bins[smallbin_size].bk_chain) == smallbin_count + 2
+    )
+    assert not result.bins[smallbin_size].is_corrupted
+    for addr in result.bins[smallbin_size].fd_chain[:-1]:
+        assert pwndbg.aglib.vmmap.find(addr)
+    for addr in result.bins[smallbin_size].bk_chain[:-1]:
+        assert pwndbg.aglib.vmmap.find(addr)
+
+    # check largebins
+    await ctrl.cont()
+
+    result = allocator.largebins()
+    assert result.bin_type == BinType.LARGE
+    assert (
+        len(result.bins[largebin_size].fd_chain) == largebin_count + 2
+        and len(result.bins[largebin_size].bk_chain) == largebin_count + 2
+    )
+    assert not result.bins[largebin_size].is_corrupted
+    for addr in result.bins[largebin_size].fd_chain[:-1]:
+        assert pwndbg.aglib.vmmap.find(addr)
+    for addr in result.bins[largebin_size].bk_chain[:-1]:
+        assert pwndbg.aglib.vmmap.find(addr)
+
+    # check corrupted
+    await ctrl.cont()
+    result = allocator.smallbins()
+    assert result.bin_type == BinType.SMALL
+    assert result.bins[smallbin_size].is_corrupted
+
+    result = allocator.largebins()
+    assert result.bin_type == BinType.LARGE
+    assert result.bins[largebin_size].is_corrupted
+
+    await ctrl.execute("bins")
+
+
+@tests.pwndbg_test
+async def test_largebins_size_range_64bit(ctrl: Controller) -> None:
+    """
+    Ensure the "largebins" command displays the correct largebin size ranges.
+    This test targets 64-bit architectures.
+    """
+    await tests.launch_to(ctrl, tests.get_binary("initialized_heap_x64.out"), "break_here")
+
+    command_output = (await ctrl.execute_and_capture("largebins --verbose")).splitlines()[1:]
+
+    expected = [
+        "0x400-0x430",
+        "0x440-0x470",
+        "0x480-0x4b0",
+        "0x4c0-0x4f0",
+        "0x500-0x530",
+        "0x540-0x570",
+        "0x580-0x5b0",
+        "0x5c0-0x5f0",
+        "0x600-0x630",
+        "0x640-0x670",
+        "0x680-0x6b0",
+        "0x6c0-0x6f0",
+        "0x700-0x730",
+        "0x740-0x770",
+        "0x780-0x7b0",
+        "0x7c0-0x7f0",
+        "0x800-0x830",
+        "0x840-0x870",
+        "0x880-0x8b0",
+        "0x8c0-0x8f0",
+        "0x900-0x930",
+        "0x940-0x970",
+        "0x980-0x9b0",
+        "0x9c0-0x9f0",
+        "0xa00-0xa30",
+        "0xa40-0xa70",
+        "0xa80-0xab0",
+        "0xac0-0xaf0",
+        "0xb00-0xb30",
+        "0xb40-0xb70",
+        "0xb80-0xbb0",
+        "0xbc0-0xbf0",
+        "0xc00-0xc30",
+        "0xc40-0xdf0",
+        "0xe00-0xff0",
+        "0x1000-0x11f0",
+        "0x1200-0x13f0",
+        "0x1400-0x15f0",
+        "0x1600-0x17f0",
+        "0x1800-0x19f0",
+        "0x1a00-0x1bf0",
+        "0x1c00-0x1df0",
+        "0x1e00-0x1ff0",
+        "0x2000-0x21f0",
+        "0x2200-0x23f0",
+        "0x2400-0x25f0",
+        "0x2600-0x27f0",
+        "0x2800-0x29f0",
+        "0x2a00-0x2ff0",
+        "0x3000-0x3ff0",
+        "0x4000-0x4ff0",
+        "0x5000-0x5ff0",
+        "0x6000-0x6ff0",
+        "0x7000-0x7ff0",
+        "0x8000-0x8ff0",
+        "0x9000-0x9ff0",
+        "0xa000-0xfff0",
+        "0x10000-0x17ff0",
+        "0x18000-0x1fff0",
+        "0x20000-0x27ff0",
+        "0x28000-0x3fff0",
+        "0x40000-0x7fff0",
+        "0x80000-∞",
+    ]
+
+    for bin_index, size_range in enumerate(command_output):
+        assert size_range.split(":")[0] == expected[bin_index]
+
+
+@tests.pwndbg_test
+async def test_largebins_size_range_32bit_big(ctrl: Controller) -> None:
+    """
+    Ensure the "largebins" command displays the correct largebin size ranges.
+    This test targets 32-bit architectures with MALLOC_ALIGNMENT == 16.
+    """
+    await tests.launch_to(ctrl, tests.get_binary("initialized_heap_i386_big.out"), "break_here")
+
+    command_output = (await ctrl.execute_and_capture("largebins --verbose")).splitlines()[1:]
+
+    expected = [
+        "0x3f0-0x3f0",
+        "0x400-0x430",
+        "0x440-0x470",
+        "0x480-0x4b0",
+        "0x4c0-0x4f0",
+        "0x500-0x530",
+        "0x540-0x570",
+        "0x580-0x5b0",
+        "0x5c0-0x5f0",
+        "0x600-0x630",
+        "0x640-0x670",
+        "0x680-0x6b0",
+        "0x6c0-0x6f0",
+        "0x700-0x730",
+        "0x740-0x770",
+        "0x780-0x7b0",
+        "0x7c0-0x7f0",
+        "0x800-0x830",
+        "0x840-0x870",
+        "0x880-0x8b0",
+        "0x8c0-0x8f0",
+        "0x900-0x930",
+        "0x940-0x970",
+        "0x980-0x9b0",
+        "0x9c0-0x9f0",
+        "0xa00-0xa30",
+        "0xa40-0xa70",
+        "0xa80-0xab0",
+        "0xac0-0xaf0",
+        "0xb00-0xb30",
+        "0xb40-0xb70",
+        "0xb80-0xb70",  # Largebin 31 (bin 95) is unused, but its size is used to calculate the previous bin's maximum chunk size.
+        "0xb80-0xbf0",
+        "0xc00-0xdf0",
+        "0xe00-0xff0",
+        "0x1000-0x11f0",
+        "0x1200-0x13f0",
+        "0x1400-0x15f0",
+        "0x1600-0x17f0",
+        "0x1800-0x19f0",
+        "0x1a00-0x1bf0",
+        "0x1c00-0x1df0",
+        "0x1e00-0x1ff0",
+        "0x2000-0x21f0",
+        "0x2200-0x23f0",
+        "0x2400-0x25f0",
+        "0x2600-0x27f0",
+        "0x2800-0x29f0",
+        "0x2a00-0x2ff0",
+        "0x3000-0x3ff0",
+        "0x4000-0x4ff0",
+        "0x5000-0x5ff0",
+        "0x6000-0x6ff0",
+        "0x7000-0x7ff0",
+        "0x8000-0x8ff0",
+        "0x9000-0x9ff0",
+        "0xa000-0xfff0",
+        "0x10000-0x17ff0",
+        "0x18000-0x1fff0",
+        "0x20000-0x27ff0",
+        "0x28000-0x3fff0",
+        "0x40000-0x7fff0",
+        "0x80000-∞",
+    ]
+
+    for bin_index, size_range in enumerate(command_output):
+        assert size_range.split(":")[0] == expected[bin_index]
+
+
+@tests.pwndbg_test
+async def test_smallbins_sizes_64bit(ctrl: Controller) -> None:
+    """
+    Ensure the "smallbins" command displays the correct smallbin sizes.
+    This test targets 64-bit architectures.
+    """
+    await tests.launch_to(ctrl, tests.get_binary("initialized_heap_x64.out"), "break_here")
+
+    command_output = (await ctrl.execute_and_capture("smallbins --verbose")).splitlines()[1:]
+
+    expected = [
+        "0x20",
+        "0x30",
+        "0x40",
+        "0x50",
+        "0x60",
+        "0x70",
+        "0x80",
+        "0x90",
+        "0xa0",
+        "0xb0",
+        "0xc0",
+        "0xd0",
+        "0xe0",
+        "0xf0",
+        "0x100",
+        "0x110",
+        "0x120",
+        "0x130",
+        "0x140",
+        "0x150",
+        "0x160",
+        "0x170",
+        "0x180",
+        "0x190",
+        "0x1a0",
+        "0x1b0",
+        "0x1c0",
+        "0x1d0",
+        "0x1e0",
+        "0x1f0",
+        "0x200",
+        "0x210",
+        "0x220",
+        "0x230",
+        "0x240",
+        "0x250",
+        "0x260",
+        "0x270",
+        "0x280",
+        "0x290",
+        "0x2a0",
+        "0x2b0",
+        "0x2c0",
+        "0x2d0",
+        "0x2e0",
+        "0x2f0",
+        "0x300",
+        "0x310",
+        "0x320",
+        "0x330",
+        "0x340",
+        "0x350",
+        "0x360",
+        "0x370",
+        "0x380",
+        "0x390",
+        "0x3a0",
+        "0x3b0",
+        "0x3c0",
+        "0x3d0",
+        "0x3e0",
+        "0x3f0",
+    ]
+
+    for bin_index, bin_size in enumerate(command_output):
+        assert bin_size.split(":")[0] == expected[bin_index]
+
+
+@tests.pwndbg_test
+async def test_smallbins_sizes_32bit_big(ctrl: Controller) -> None:
+    """
+    Ensure the "smallbins" command displays the correct smallbin sizes.
+    This test targets 32-bit architectures with MALLOC_ALIGNMENT == 16.
+    """
+
+    await tests.launch_to(ctrl, tests.get_binary("initialized_heap_i386_big.out"), "break_here")
+
+    command_output = (await ctrl.execute_and_capture("smallbins --verbose")).splitlines()[1:]
+
+    expected = [
+        "0x10",
+        "0x20",
+        "0x30",
+        "0x40",
+        "0x50",
+        "0x60",
+        "0x70",
+        "0x80",
+        "0x90",
+        "0xa0",
+        "0xb0",
+        "0xc0",
+        "0xd0",
+        "0xe0",
+        "0xf0",
+        "0x100",
+        "0x110",
+        "0x120",
+        "0x130",
+        "0x140",
+        "0x150",
+        "0x160",
+        "0x170",
+        "0x180",
+        "0x190",
+        "0x1a0",
+        "0x1b0",
+        "0x1c0",
+        "0x1d0",
+        "0x1e0",
+        "0x1f0",
+        "0x200",
+        "0x210",
+        "0x220",
+        "0x230",
+        "0x240",
+        "0x250",
+        "0x260",
+        "0x270",
+        "0x280",
+        "0x290",
+        "0x2a0",
+        "0x2b0",
+        "0x2c0",
+        "0x2d0",
+        "0x2e0",
+        "0x2f0",
+        "0x300",
+        "0x310",
+        "0x320",
+        "0x330",
+        "0x340",
+        "0x350",
+        "0x360",
+        "0x370",
+        "0x380",
+        "0x390",
+        "0x3a0",
+        "0x3b0",
+        "0x3c0",
+        "0x3d0",
+        "0x3e0",
+    ]
+
+    for bin_index, bin_size in enumerate(command_output):
+        assert bin_size.split(":")[0] == expected[bin_index]
+
+
+@tests.pwndbg_test
+async def test_heap_corruption_low_dereference(ctrl: Controller) -> None:
+    """
+    Tests that the bins corruption check doesn't report
+    corrupted bins when heap-dereference-limit is less
+    than the number of chunks in a bin.
+    """
+
+    await ctrl.execute("set context-output /dev/null")
+    await tests.launch_to(ctrl, BINARY, "breakpoint")
+
+    await ctrl.cont()
+    await ctrl.cont()
+    await ctrl.cont()
+
+    # unsorted bin now has 3 chunks
+
+    await ctrl.execute("set heap-dereference-limit 1")
+
+    bins_output = await ctrl.execute_and_capture("bins")
+    assert "corrupted" not in bins_output

--- a/tests/library/dbg/tests/heap/test_heap_bins.py
+++ b/tests/library/dbg/tests/heap/test_heap_bins.py
@@ -19,8 +19,10 @@ async def test_heap_bins(ctrl: Controller) -> None:
     import pwndbg.aglib.vmmap
     from pwndbg.aglib.heap.ptmalloc import BinType
 
+    await ctrl.launch(BINARY)
     await ctrl.execute("set context-output /dev/null")
-    await tests.launch_to(ctrl, BINARY, "breakpoint")
+    await ctrl.execute("b breakpoint")
+    await ctrl.cont()
 
     # check if all bins are empty at first
     allocator = pwndbg.aglib.heap.current

--- a/tests/library/dbg/tests/heap/test_heap_bins.py
+++ b/tests/library/dbg/tests/heap/test_heap_bins.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
-from host import Controller
+from .....host import Controller
+from .. import get_binary
+from .. import launch_to
+from .. import pwndbg_test
 
-import tests
-
-BINARY = tests.get_binary("heap_bins.out")
+BINARY = get_binary("heap_bins.out")
 
 
-@tests.pwndbg_test
+@pwndbg_test
 async def test_heap_bins(ctrl: Controller) -> None:
     """
     Tests pwndbg.aglib.heap bins commands
@@ -160,13 +161,13 @@ async def test_heap_bins(ctrl: Controller) -> None:
     await ctrl.execute("bins")
 
 
-@tests.pwndbg_test
+@pwndbg_test
 async def test_largebins_size_range_64bit(ctrl: Controller) -> None:
     """
     Ensure the "largebins" command displays the correct largebin size ranges.
     This test targets 64-bit architectures.
     """
-    await tests.launch_to(ctrl, tests.get_binary("initialized_heap_x64.out"), "break_here")
+    await launch_to(ctrl, get_binary("initialized_heap_x64.out"), "break_here")
 
     command_output = (await ctrl.execute_and_capture("largebins --verbose")).splitlines()[1:]
 
@@ -240,13 +241,13 @@ async def test_largebins_size_range_64bit(ctrl: Controller) -> None:
         assert size_range.split(":")[0] == expected[bin_index]
 
 
-@tests.pwndbg_test
+@pwndbg_test
 async def test_largebins_size_range_32bit_big(ctrl: Controller) -> None:
     """
     Ensure the "largebins" command displays the correct largebin size ranges.
     This test targets 32-bit architectures with MALLOC_ALIGNMENT == 16.
     """
-    await tests.launch_to(ctrl, tests.get_binary("initialized_heap_i386_big.out"), "break_here")
+    await launch_to(ctrl, get_binary("initialized_heap_i386_big.out"), "break_here")
 
     command_output = (await ctrl.execute_and_capture("largebins --verbose")).splitlines()[1:]
 
@@ -320,13 +321,13 @@ async def test_largebins_size_range_32bit_big(ctrl: Controller) -> None:
         assert size_range.split(":")[0] == expected[bin_index]
 
 
-@tests.pwndbg_test
+@pwndbg_test
 async def test_smallbins_sizes_64bit(ctrl: Controller) -> None:
     """
     Ensure the "smallbins" command displays the correct smallbin sizes.
     This test targets 64-bit architectures.
     """
-    await tests.launch_to(ctrl, tests.get_binary("initialized_heap_x64.out"), "break_here")
+    await launch_to(ctrl, get_binary("initialized_heap_x64.out"), "break_here")
 
     command_output = (await ctrl.execute_and_capture("smallbins --verbose")).splitlines()[1:]
 
@@ -399,14 +400,14 @@ async def test_smallbins_sizes_64bit(ctrl: Controller) -> None:
         assert bin_size.split(":")[0] == expected[bin_index]
 
 
-@tests.pwndbg_test
+@pwndbg_test
 async def test_smallbins_sizes_32bit_big(ctrl: Controller) -> None:
     """
     Ensure the "smallbins" command displays the correct smallbin sizes.
     This test targets 32-bit architectures with MALLOC_ALIGNMENT == 16.
     """
 
-    await tests.launch_to(ctrl, tests.get_binary("initialized_heap_i386_big.out"), "break_here")
+    await launch_to(ctrl, get_binary("initialized_heap_i386_big.out"), "break_here")
 
     command_output = (await ctrl.execute_and_capture("smallbins --verbose")).splitlines()[1:]
 
@@ -479,7 +480,7 @@ async def test_smallbins_sizes_32bit_big(ctrl: Controller) -> None:
         assert bin_size.split(":")[0] == expected[bin_index]
 
 
-@tests.pwndbg_test
+@pwndbg_test
 async def test_heap_corruption_low_dereference(ctrl: Controller) -> None:
     """
     Tests that the bins corruption check doesn't report
@@ -488,7 +489,7 @@ async def test_heap_corruption_low_dereference(ctrl: Controller) -> None:
     """
 
     await ctrl.execute("set context-output /dev/null")
-    await tests.launch_to(ctrl, BINARY, "breakpoint")
+    await launch_to(ctrl, BINARY, "breakpoint")
 
     await ctrl.cont()
     await ctrl.cont()

--- a/tests/library/dbg/tests/heap/test_try_free.py
+++ b/tests/library/dbg/tests/heap/test_try_free.py
@@ -76,7 +76,7 @@ async def setup_heap(ctrl: Controller, bug_no: int) -> Dict[str, int]:
     except FileNotFoundError:
         pass
 
-    await ctrl.launch(HEAP_BINARY, args=[str(bug_no), f"> {OUTPUT_FILE}"])
+    await ctrl.launch(HEAP_BINARY, args=[str(bug_no), f"{OUTPUT_FILE}"])
     await ctrl.execute("b " + str(breakpoints[bug_no][0]))
     await ctrl.execute("b " + str(breakpoints[bug_no][1]))
 

--- a/tests/library/dbg/tests/heap/test_try_free.py
+++ b/tests/library/dbg/tests/heap/test_try_free.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+import os
+import tempfile
+from typing import Dict
+from typing import Tuple
+
+import pytest
+from host import Controller
+
+import tests
+
+HEAP_BINARY = tests.get_binary("heap_bugs.out")
+HEAP_CODE = tests.get_binary("heap_bugs.c")
+_, OUTPUT_FILE = tempfile.mkstemp()
+
+
+def binary_parse_breakpoints(binary_code: str) -> Dict[str, Tuple[int, int]]:
+    """
+    Find comments with breakpoints in binary code
+    and map them to function's cmd line ids
+    """
+    # map bug id to function name (f.e: 2 -> invalid_pointer_misaligned())
+    with open(binary_code) as f:
+        func_names = {}
+        for line in f:
+            if "case " in line:
+                bug_id = int(line.split(":")[0].split()[-1])
+                func_name = line.split(":")[1].split(";")[0].strip()
+                func_names[bug_id] = func_name
+
+    # map bug id to breakpoint line numbers
+    with open(binary_code) as f:
+        breakpoints = {}
+        lines = f.readlines()
+        line_no = 0
+
+        # find functions
+        while line_no < len(lines) and len(breakpoints) < len(func_names):
+            line = lines[line_no]
+            line_no += 1
+            for bug_id, func_name in func_names.items():
+                if f"void {func_name}" in line:
+                    # find break1 and break2 inside function
+                    b1, b2 = None, None
+                    while line_no < len(lines) and (b1 is None or b2 is None):
+                        line = lines[line_no]
+                        line_no += 1
+
+                        if "break1" in line:
+                            b1 = line_no
+                        if "break2" in line:
+                            b2 = line_no
+
+                    breakpoints[bug_id] = (b1, b2)
+
+    return breakpoints
+
+
+# breakpoints: (line after setup_heap, line before the one triggering the bug)
+breakpoints = binary_parse_breakpoints(HEAP_CODE)
+
+
+async def setup_heap(ctrl: Controller, bug_no: int) -> Dict[str, int]:
+    """
+    Start binary
+    Pause after (valid) heap is set-up
+    Save valid chunks
+    Continue up until buggy code line
+    """
+    global breakpoints
+
+    # for communication python<->HEAP_BINARY
+    try:
+        os.remove(OUTPUT_FILE)
+    except FileNotFoundError:
+        pass
+
+    await ctrl.launch(HEAP_BINARY, args=[str(bug_no), f"> {OUTPUT_FILE}"])
+    await ctrl.execute("b " + str(breakpoints[bug_no][0]))
+    await ctrl.execute("b " + str(breakpoints[bug_no][1]))
+
+    await ctrl.cont()
+    await ctrl.cont()
+
+    chunks = {}
+    with open(OUTPUT_FILE) as f:
+        chunk_id = "a"
+        for _ in range(7):
+            chunk = int(f.readline().split("=")[1], 16)
+            chunks[chunk_id] = chunk
+            chunk_id = chr(ord(chunk_id) + 1)
+    return chunks
+
+
+@tests.pwndbg_test
+async def test_try_free_invalid_overflow(ctrl: Controller) -> None:
+    chunks = await setup_heap(ctrl, 1)
+
+    result = await ctrl.execute_and_capture(f"try-free {hex(chunks['a'])}")
+    assert "free(): invalid pointer -> &chunk + chunk->size > max memory" in result
+    os.remove(OUTPUT_FILE)
+
+
+@tests.pwndbg_test
+async def test_try_free_invalid_misaligned(ctrl: Controller) -> None:
+    chunks = await setup_heap(ctrl, 2)
+
+    result = await ctrl.execute_and_capture(f"try-free {hex(chunks['a'] + 2)}")
+    assert "free(): invalid pointer -> misaligned chunk" in result
+    os.remove(OUTPUT_FILE)
+
+
+@tests.pwndbg_test
+async def test_try_free_invalid_size_minsize(ctrl: Controller) -> None:
+    chunks = await setup_heap(ctrl, 3)
+
+    result = await ctrl.execute_and_capture(f"try-free {hex(chunks['a'])}")
+    assert "free(): invalid size -> chunk's size smaller than MINSIZE" in result
+    os.remove(OUTPUT_FILE)
+
+
+@tests.pwndbg_test
+async def test_try_free_invalid_size_misaligned(ctrl: Controller) -> None:
+    chunks = await setup_heap(ctrl, 4)
+
+    result = await ctrl.execute_and_capture(f"try-free {hex(chunks['a'])}")
+    assert "free(): invalid size -> chunk's size is not aligned" in result
+    os.remove(OUTPUT_FILE)
+
+
+@tests.pwndbg_test
+async def test_try_free_double_free_tcache(ctrl: Controller) -> None:
+    chunks = await setup_heap(ctrl, 5)
+
+    result = await ctrl.execute_and_capture(f"try-free {hex(chunks['a'])}")
+    assert "Will do checks for tcache double-free" in result
+    os.remove(OUTPUT_FILE)
+
+
+@tests.pwndbg_test
+async def test_try_free_invalid_next_size_fast(ctrl: Controller) -> None:
+    chunks = await setup_heap(ctrl, 6)
+
+    result = await ctrl.execute_and_capture(f"try-free {hex(chunks['a'])}")
+    assert "free(): invalid next size (fast)" in result
+    os.remove(OUTPUT_FILE)
+
+
+@tests.pwndbg_test
+async def test_try_free_double_free(ctrl: Controller) -> None:
+    chunks = await setup_heap(ctrl, 7)
+
+    result = await ctrl.execute_and_capture(f"try-free {hex(chunks['a'])}")
+    assert "double free or corruption (fasttop)" in result
+    os.remove(OUTPUT_FILE)
+
+
+@tests.pwndbg_test
+async def test_try_free_invalid_fastbin_entry(ctrl: Controller) -> None:
+    chunks = await setup_heap(ctrl, 8)
+
+    result = await ctrl.execute_and_capture(f"try-free {hex(chunks['c'])}")
+    assert "invalid fastbin entry (free)" in result
+    os.remove(OUTPUT_FILE)
+
+
+@tests.pwndbg_test
+async def test_try_free_double_free_or_corruption_top(ctrl: Controller) -> None:
+    import pwndbg.aglib.arch
+    import pwndbg.aglib.heap
+
+    await setup_heap(ctrl, 9)
+    allocator = pwndbg.aglib.heap.current
+
+    ptr_size = pwndbg.aglib.arch.ptrsize
+    arena = allocator.thread_arena or allocator.main_arena
+    top_chunk = arena.top + (2 * ptr_size)
+
+    result = await ctrl.execute_and_capture(f"try-free {hex(top_chunk)}")
+    assert "double free or corruption (top)" in result
+    os.remove(OUTPUT_FILE)
+
+
+@tests.pwndbg_test
+async def test_try_free_double_free_or_corruption_out(ctrl: Controller) -> None:
+    chunks = await setup_heap(ctrl, 10)
+
+    result = await ctrl.execute_and_capture(f"try-free {hex(chunks['d'])}")
+    assert "double free or corruption (out)" in result
+    os.remove(OUTPUT_FILE)
+
+
+@tests.pwndbg_test
+async def test_try_free_double_free_or_corruption_prev(ctrl: Controller) -> None:
+    chunks = await setup_heap(ctrl, 11)
+
+    result = await ctrl.execute_and_capture(f"try-free {hex(chunks['d'])}")
+    assert "double free or corruption (!prev)" in result
+    os.remove(OUTPUT_FILE)
+
+
+@tests.pwndbg_test
+async def test_try_free_invalid_next_size_normal(ctrl: Controller) -> None:
+    chunks = await setup_heap(ctrl, 12)
+
+    result = await ctrl.execute_and_capture(f"try-free {hex(chunks['d'])}")
+    assert "free(): invalid next size (normal)" in result
+    os.remove(OUTPUT_FILE)
+
+
+@tests.pwndbg_test
+async def test_try_free_corrupted_consolidate_backward(ctrl: Controller) -> None:
+    chunks = await setup_heap(ctrl, 13)
+
+    result = await ctrl.execute_and_capture(f"try-free {hex(chunks['e'])}")
+    assert "corrupted size vs. prev_size while consolidating" in result
+    os.remove(OUTPUT_FILE)
+
+
+@pytest.mark.skip(
+    reason="Needs review. In the heap.py on the line 972 the condition is true always. The heap_bug.c file has the function: corrupted_unsorted_chunks()"
+)
+@tests.pwndbg_test
+async def test_try_free_corrupted_unsorted_chunks(ctrl: Controller) -> None:
+    chunks = await setup_heap(ctrl, 14)
+
+    result = await ctrl.execute_and_capture(f"try-free {hex(chunks['f'])}")
+    assert "free(): corrupted unsorted chunks" in result
+    os.remove(OUTPUT_FILE)

--- a/tests/library/dbg/tests/heap/test_try_free.py
+++ b/tests/library/dbg/tests/heap/test_try_free.py
@@ -6,12 +6,13 @@ from typing import Dict
 from typing import Tuple
 
 import pytest
-from host import Controller
 
-import tests
+from .....host import Controller
+from .. import get_binary
+from .. import pwndbg_test
 
-HEAP_BINARY = tests.get_binary("heap_bugs.out")
-HEAP_CODE = tests.get_binary("heap_bugs.c")
+HEAP_BINARY = get_binary("heap_bugs.out")
+HEAP_CODE = get_binary("heap_bugs.c")
 _, OUTPUT_FILE = tempfile.mkstemp()
 
 
@@ -93,7 +94,7 @@ async def setup_heap(ctrl: Controller, bug_no: int) -> Dict[str, int]:
     return chunks
 
 
-@tests.pwndbg_test
+@pwndbg_test
 async def test_try_free_invalid_overflow(ctrl: Controller) -> None:
     chunks = await setup_heap(ctrl, 1)
 
@@ -102,7 +103,7 @@ async def test_try_free_invalid_overflow(ctrl: Controller) -> None:
     os.remove(OUTPUT_FILE)
 
 
-@tests.pwndbg_test
+@pwndbg_test
 async def test_try_free_invalid_misaligned(ctrl: Controller) -> None:
     chunks = await setup_heap(ctrl, 2)
 
@@ -111,7 +112,7 @@ async def test_try_free_invalid_misaligned(ctrl: Controller) -> None:
     os.remove(OUTPUT_FILE)
 
 
-@tests.pwndbg_test
+@pwndbg_test
 async def test_try_free_invalid_size_minsize(ctrl: Controller) -> None:
     chunks = await setup_heap(ctrl, 3)
 
@@ -120,7 +121,7 @@ async def test_try_free_invalid_size_minsize(ctrl: Controller) -> None:
     os.remove(OUTPUT_FILE)
 
 
-@tests.pwndbg_test
+@pwndbg_test
 async def test_try_free_invalid_size_misaligned(ctrl: Controller) -> None:
     chunks = await setup_heap(ctrl, 4)
 
@@ -129,7 +130,7 @@ async def test_try_free_invalid_size_misaligned(ctrl: Controller) -> None:
     os.remove(OUTPUT_FILE)
 
 
-@tests.pwndbg_test
+@pwndbg_test
 async def test_try_free_double_free_tcache(ctrl: Controller) -> None:
     chunks = await setup_heap(ctrl, 5)
 
@@ -138,7 +139,7 @@ async def test_try_free_double_free_tcache(ctrl: Controller) -> None:
     os.remove(OUTPUT_FILE)
 
 
-@tests.pwndbg_test
+@pwndbg_test
 async def test_try_free_invalid_next_size_fast(ctrl: Controller) -> None:
     chunks = await setup_heap(ctrl, 6)
 
@@ -147,7 +148,7 @@ async def test_try_free_invalid_next_size_fast(ctrl: Controller) -> None:
     os.remove(OUTPUT_FILE)
 
 
-@tests.pwndbg_test
+@pwndbg_test
 async def test_try_free_double_free(ctrl: Controller) -> None:
     chunks = await setup_heap(ctrl, 7)
 
@@ -156,7 +157,7 @@ async def test_try_free_double_free(ctrl: Controller) -> None:
     os.remove(OUTPUT_FILE)
 
 
-@tests.pwndbg_test
+@pwndbg_test
 async def test_try_free_invalid_fastbin_entry(ctrl: Controller) -> None:
     chunks = await setup_heap(ctrl, 8)
 
@@ -165,7 +166,7 @@ async def test_try_free_invalid_fastbin_entry(ctrl: Controller) -> None:
     os.remove(OUTPUT_FILE)
 
 
-@tests.pwndbg_test
+@pwndbg_test
 async def test_try_free_double_free_or_corruption_top(ctrl: Controller) -> None:
     import pwndbg.aglib.arch
     import pwndbg.aglib.heap
@@ -182,7 +183,7 @@ async def test_try_free_double_free_or_corruption_top(ctrl: Controller) -> None:
     os.remove(OUTPUT_FILE)
 
 
-@tests.pwndbg_test
+@pwndbg_test
 async def test_try_free_double_free_or_corruption_out(ctrl: Controller) -> None:
     chunks = await setup_heap(ctrl, 10)
 
@@ -191,7 +192,7 @@ async def test_try_free_double_free_or_corruption_out(ctrl: Controller) -> None:
     os.remove(OUTPUT_FILE)
 
 
-@tests.pwndbg_test
+@pwndbg_test
 async def test_try_free_double_free_or_corruption_prev(ctrl: Controller) -> None:
     chunks = await setup_heap(ctrl, 11)
 
@@ -200,7 +201,7 @@ async def test_try_free_double_free_or_corruption_prev(ctrl: Controller) -> None
     os.remove(OUTPUT_FILE)
 
 
-@tests.pwndbg_test
+@pwndbg_test
 async def test_try_free_invalid_next_size_normal(ctrl: Controller) -> None:
     chunks = await setup_heap(ctrl, 12)
 
@@ -209,7 +210,7 @@ async def test_try_free_invalid_next_size_normal(ctrl: Controller) -> None:
     os.remove(OUTPUT_FILE)
 
 
-@tests.pwndbg_test
+@pwndbg_test
 async def test_try_free_corrupted_consolidate_backward(ctrl: Controller) -> None:
     chunks = await setup_heap(ctrl, 13)
 
@@ -221,7 +222,7 @@ async def test_try_free_corrupted_consolidate_backward(ctrl: Controller) -> None
 @pytest.mark.skip(
     reason="Needs review. In the heap.py on the line 972 the condition is true always. The heap_bug.c file has the function: corrupted_unsorted_chunks()"
 )
-@tests.pwndbg_test
+@pwndbg_test
 async def test_try_free_corrupted_unsorted_chunks(ctrl: Controller) -> None:
     chunks = await setup_heap(ctrl, 14)
 

--- a/tests/library/dbg/tests/heap/test_vis_heap_chunks.py
+++ b/tests/library/dbg/tests/heap/test_vis_heap_chunks.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+from host import Controller
+
+import tests
+
+HEAP_VIS = tests.get_binary("heap_vis.out")
+
+
+@tests.pwndbg_test
+async def test_vis_heap_chunk_command(ctrl: Controller) -> None:
+    import pwndbg.aglib.arch
+    import pwndbg.aglib.memory
+    import pwndbg.aglib.vmmap
+
+    await tests.launch_to(ctrl, HEAP_VIS, "break_here")
+
+    # TODO/FIXME: Shall we have a standard method to do this kind of filtering?
+    # Note that we have `pages_filter` in pwndbg/pwndbg/commands/vmmap.py heh
+    heap_page = next(page for page in pwndbg.aglib.vmmap.get() if page.objfile == "[heap]")
+
+    first_chunk_size = pwndbg.aglib.memory.u64(heap_page.start + pwndbg.aglib.arch.ptrsize)
+
+    # Just a sanity check...
+    assert (heap_page.start & 0xFFF) == 0
+
+    result = (await ctrl.execute_and_capture("vis-heap-chunk 1")).splitlines()
+
+    # We will use `heap_addr` variable to fill in proper addresses below
+    heap_addr = heap_page.start
+
+    # We sometimes need that value, so let's cache it
+    dq2 = None
+
+    def heap_iter(offset=0x10):
+        nonlocal heap_addr
+        heap_addr += offset
+        return heap_addr
+
+    def hexdump_16B(gdb_symbol):
+        from pwndbg.commands.ptmalloc2 import bin_ascii
+
+        first, second = (await ctrl.execute_and_capture(f"x/16xb {gdb_symbol}")).splitlines()
+        first = [int(v, 16) for v in first.split(":")[1].split("\t")[1:]]
+        second = [int(v, 16) for v in second.split(":")[1].split("\t")[1:]]
+
+        return bin_ascii(first + second)
+
+    def vis_heap_line(heap_iter_offset=0x10, suffix=""):
+        """Returns data to format a vis_heap_chunk line"""
+        addr = heap_iter(heap_iter_offset)
+        hexdump = hexdump_16B(addr)
+
+        nonlocal dq2
+        dq1, dq2 = map(pwndbg.aglib.memory.u64, (addr, addr + 8))
+
+        formatted = f"{addr:#x}\t{dq1:#018x}\t{dq2:#018x}\t{hexdump}"
+        formatted += suffix
+
+        return formatted
+
+    first_hexdump = hexdump_16B(hex(heap_page.start))
+
+    expected = [
+        "",
+        f"{heap_iter(0):#x}\t0x0000000000000000\t{first_chunk_size | 1:#018x}\t{first_hexdump}",
+    ]
+    for _ in range(first_chunk_size // 16 - 1):
+        expected.append(
+            "%#x\t0x0000000000000000\t0x0000000000000000\t................" % heap_iter()
+        )
+    expected.append("%#x\t0x0000000000000000\t                  \t........" % heap_iter())
+    assert result == expected
+
+    ## This time using `default-visualize-chunk-number` to set `count`, to make sure that the config can work
+    await ctrl.execute("set default-visualize-chunk-number 1")
+    assert pwndbg.config.default_visualize_chunk_number == 1
+    result = (await ctrl.execute_and_capture("vis-heap-chunk")).splitlines()
+    # No parameters were passed and top isn't reached so help text is shown
+    no_params_help = "Not all chunks were shown, see `vis --help` for more information."
+    assert result == expected + [no_params_help]
+    await ctrl.execute(
+        "set default-visualize-chunk-number %d"
+        % pwndbg.config.default_visualize_chunk_number.default
+    )
+
+    del result
+
+    ## Test vis_heap_chunk with count=2
+    result2 = (await ctrl.execute("vis-heap-chunk 2")).splitlines()
+
+    # Note: we copy expected here but we truncate last line as it is easier
+    # to provide it in full here
+    expected2 = expected[:-1] + [
+        "%#x\t0x0000000000000000\t0x0000000000000021\t........!......." % heap_iter(0),
+        "%#x\t0x0000000000000000\t0x0000000000000000\t................" % heap_iter(),
+        "%#x\t0x0000000000000000\t                  \t........" % heap_iter(),
+    ]
+    assert result2 == expected2
+
+    del expected
+    del result2
+
+    ## Test vis_heap_chunk with count=3
+    result3 = (await ctrl.execute_and_capture("vis-heap-chunk 3")).splitlines()
+
+    # Note: we copy expected here but we truncate last line as it is easier
+    # to provide it in full here
+    expected3 = expected2[:-1] + [
+        "%#x\t0x0000000000000000\t0x0000000000000021\t........!......." % heap_iter(0),
+        "%#x\t0x0000000000000000\t0x0000000000000000\t................" % heap_iter(),
+        vis_heap_line(suffix="\t <-- Top chunk"),
+    ]
+    assert result3 == expected3
+
+    del expected2
+    del result3
+
+    ## Test vis_heap_chunk with count=4
+    result4 = (await ctrl.execute_and_capture("vis-heap-chunk 4")).splitlines()
+
+    # Since on this breakpoint we only have 4 chunks, the output should probably be the same?
+    # TODO/FIXME: Shall we maybe print user that there are only 3 chunks?
+    assert result4 == expected3
+
+    del result4
+
+    ## Test vis_heap_chunk with no flags
+    result_all = (await ctrl.execute_and_capture("vis-heap-chunk")).splitlines()
+    assert result_all == expected3
+
+    del result_all
+
+    # Continue, so that another allocation is made
+    await ctrl.cont()
+
+    ## Test vis_heap_chunk with count=4 again
+    result4_b = (await ctrl.execute_and_capture("vis-heap-chunk 4")).splitlines()
+
+    expected4_b = expected3[:-1] + [
+        "%#x\t0x0000000000000000\t0x0000000000000031\t........1......." % heap_iter(0),
+        "%#x\t0x0000000000000000\t0x0000000000000000\t................" % heap_iter(),
+        "%#x\t0x0000000000000000\t0x0000000000000000\t................" % heap_iter(),
+        vis_heap_line(suffix="\t <-- Top chunk"),
+    ]
+
+    assert result4_b == expected4_b
+
+    del expected3
+    del result4_b
+
+    ## Test vis_heap_chunk with no flags
+    result_all2 = (await ctrl.execute_and_capture("vis-heap-chunk")).splitlines()
+    assert result_all2 == expected4_b
+
+    del result_all2
+    del expected4_b
+
+    ## Continue, so that alloc[1] is freed
+    await ctrl.cont()
+
+    result_all3 = (await ctrl.execute_and_capture("vis-heap-chunk")).splitlines()
+
+    # The tcache chunks have two fields: next and key
+    # We are fetching it from the glibc's TLS tcache variable :)
+    tcache_next = int(pwndbg.dbg.selected_frame().evaluate_expression("tcache->entries[0]->next"))
+    tcache_key = int(pwndbg.dbg.selected_frame().evaluate_expression("tcache->entries[0]->key"))
+
+    tcache_hexdump = hexdump_16B("tcache->entries[0]")
+    freed_chunk = "{:#x}\t{:#018x}\t{:#018x}\t{}\t ".format(
+        heap_iter(-0x40),
+        tcache_next,
+        tcache_key,
+        tcache_hexdump,
+    )
+    freed_chunk += "<-- tcachebins[0x20][0/1]"
+
+    heap_addr = heap_page.start
+
+    expected_all3 = [""]
+
+    # Add the biggest chunk, the one from libc
+    expected_all3.append(vis_heap_line(0))
+
+    last_chunk_size = dq2
+    for _ in range(last_chunk_size // 16):
+        expected_all3.append(vis_heap_line())
+
+    last_chunk_size = dq2
+    for _ in range(last_chunk_size // 16):
+        expected_all3.append(vis_heap_line())
+    expected_all3.append(vis_heap_line(suffix="\t <-- tcachebins[0x20][0/1]"))
+
+    expected_all3.append(vis_heap_line())
+    last_chunk_size = dq2
+    for _ in range(last_chunk_size // 16 - 1):
+        expected_all3.append(vis_heap_line())
+    expected_all3.append(vis_heap_line(suffix="\t <-- Top chunk"))
+
+    assert result_all3 == expected_all3
+
+    del result_all3
+    del expected_all3
+
+    # Continue, malloc two large chunks and free one
+    await ctrl.cont()
+
+    # Get default result without max-visualize-chunk-size setting
+    default_result = (await ctrl.execute_and_capture("vis-heap-chunk")).splitlines()
+    assert len(default_result) > 0x300
+
+    # Set max display size to 100 (no "0x" for misalignment)
+    await ctrl.execute("set max-visualize-chunk-size 100")
+
+    omitted_result = (await ctrl.execute_and_capture("vis-heap-chunk")).splitlines()
+    assert len(omitted_result) < 0x30
+    for omitted_line in omitted_result:
+        assert omitted_line in default_result or set(omitted_line) == {"."}
+
+    no_truncate_result = (await ctrl.execute_and_capture("vis-heap-chunk -n")).splitlines()
+    assert no_truncate_result == default_result
+
+    del default_result
+    del omitted_result
+    del no_truncate_result
+
+    # Continue, mock overflow changing the chunk size
+    await ctrl.cont()
+
+    overflow_result = await ctrl.execute_and_capture("vis-heap-chunk")
+    assert "\t0x0000000000000000\t0x4141414141414141\t........AAAAAAAA" in overflow_result
+    assert len(overflow_result.splitlines()) < 0x500
+
+    del overflow_result

--- a/tests/library/dbg/tests/heap/test_vis_heap_chunks.py
+++ b/tests/library/dbg/tests/heap/test_vis_heap_chunks.py
@@ -1,19 +1,20 @@
 from __future__ import annotations
 
-from host import Controller
+from .....host import Controller
+from .. import get_binary
+from .. import launch_to
+from .. import pwndbg_test
 
-import tests
-
-HEAP_VIS = tests.get_binary("heap_vis.out")
+HEAP_VIS = get_binary("heap_vis.out")
 
 
-@tests.pwndbg_test
+@pwndbg_test
 async def test_vis_heap_chunk_command(ctrl: Controller) -> None:
     import pwndbg.aglib.arch
     import pwndbg.aglib.memory
     import pwndbg.aglib.vmmap
 
-    await tests.launch_to(ctrl, HEAP_VIS, "break_here")
+    await launch_to(ctrl, HEAP_VIS, "break_here")
 
     # TODO/FIXME: Shall we have a standard method to do this kind of filtering?
     # Note that we have `pages_filter` in pwndbg/pwndbg/commands/vmmap.py heh

--- a/tests/library/dbg/tests/heap/test_vis_heap_chunks.py
+++ b/tests/library/dbg/tests/heap/test_vis_heap_chunks.py
@@ -37,7 +37,7 @@ async def test_vis_heap_chunk_command(ctrl: Controller) -> None:
         heap_addr += offset
         return heap_addr
 
-    def hexdump_16B(gdb_symbol):
+    async def hexdump_16B(gdb_symbol):
         from pwndbg.commands.ptmalloc2 import bin_ascii
 
         first, second = (await ctrl.execute_and_capture(f"x/16xb {gdb_symbol}")).splitlines()
@@ -46,10 +46,10 @@ async def test_vis_heap_chunk_command(ctrl: Controller) -> None:
 
         return bin_ascii(first + second)
 
-    def vis_heap_line(heap_iter_offset=0x10, suffix=""):
+    async def vis_heap_line(heap_iter_offset=0x10, suffix=""):
         """Returns data to format a vis_heap_chunk line"""
         addr = heap_iter(heap_iter_offset)
-        hexdump = hexdump_16B(addr)
+        hexdump = await hexdump_16B(addr)
 
         nonlocal dq2
         dq1, dq2 = map(pwndbg.aglib.memory.u64, (addr, addr + 8))
@@ -59,7 +59,7 @@ async def test_vis_heap_chunk_command(ctrl: Controller) -> None:
 
         return formatted
 
-    first_hexdump = hexdump_16B(hex(heap_page.start))
+    first_hexdump = await hexdump_16B(hex(heap_page.start))
 
     expected = [
         "",
@@ -87,7 +87,7 @@ async def test_vis_heap_chunk_command(ctrl: Controller) -> None:
     del result
 
     ## Test vis_heap_chunk with count=2
-    result2 = (await ctrl.execute("vis-heap-chunk 2")).splitlines()
+    result2 = (await ctrl.execute_and_capture("vis-heap-chunk 2")).splitlines()
 
     # Note: we copy expected here but we truncate last line as it is easier
     # to provide it in full here
@@ -109,7 +109,7 @@ async def test_vis_heap_chunk_command(ctrl: Controller) -> None:
     expected3 = expected2[:-1] + [
         "%#x\t0x0000000000000000\t0x0000000000000021\t........!......." % heap_iter(0),
         "%#x\t0x0000000000000000\t0x0000000000000000\t................" % heap_iter(),
-        vis_heap_line(suffix="\t <-- Top chunk"),
+        await vis_heap_line(suffix="\t <-- Top chunk"),
     ]
     assert result3 == expected3
 
@@ -141,7 +141,7 @@ async def test_vis_heap_chunk_command(ctrl: Controller) -> None:
         "%#x\t0x0000000000000000\t0x0000000000000031\t........1......." % heap_iter(0),
         "%#x\t0x0000000000000000\t0x0000000000000000\t................" % heap_iter(),
         "%#x\t0x0000000000000000\t0x0000000000000000\t................" % heap_iter(),
-        vis_heap_line(suffix="\t <-- Top chunk"),
+        await vis_heap_line(suffix="\t <-- Top chunk"),
     ]
 
     assert result4_b == expected4_b
@@ -166,7 +166,7 @@ async def test_vis_heap_chunk_command(ctrl: Controller) -> None:
     tcache_next = int(pwndbg.dbg.selected_frame().evaluate_expression("tcache->entries[0]->next"))
     tcache_key = int(pwndbg.dbg.selected_frame().evaluate_expression("tcache->entries[0]->key"))
 
-    tcache_hexdump = hexdump_16B("tcache->entries[0]")
+    tcache_hexdump = await hexdump_16B("tcache->entries[0]")
     freed_chunk = "{:#x}\t{:#018x}\t{:#018x}\t{}\t ".format(
         heap_iter(-0x40),
         tcache_next,
@@ -180,22 +180,22 @@ async def test_vis_heap_chunk_command(ctrl: Controller) -> None:
     expected_all3 = [""]
 
     # Add the biggest chunk, the one from libc
-    expected_all3.append(vis_heap_line(0))
+    expected_all3.append(await vis_heap_line(0))
 
     last_chunk_size = dq2
     for _ in range(last_chunk_size // 16):
-        expected_all3.append(vis_heap_line())
+        expected_all3.append(await vis_heap_line())
 
     last_chunk_size = dq2
     for _ in range(last_chunk_size // 16):
-        expected_all3.append(vis_heap_line())
-    expected_all3.append(vis_heap_line(suffix="\t <-- tcachebins[0x20][0/1]"))
+        expected_all3.append(await vis_heap_line())
+    expected_all3.append(await vis_heap_line(suffix="\t <-- tcachebins[0x20][0/1]"))
 
-    expected_all3.append(vis_heap_line())
+    expected_all3.append(await vis_heap_line())
     last_chunk_size = dq2
     for _ in range(last_chunk_size // 16 - 1):
-        expected_all3.append(vis_heap_line())
-    expected_all3.append(vis_heap_line(suffix="\t <-- Top chunk"))
+        expected_all3.append(await vis_heap_line())
+    expected_all3.append(await vis_heap_line(suffix="\t <-- Top chunk"))
 
     assert result_all3 == expected_all3
 

--- a/tests/library/dbg/tests/test_command_tls.py
+++ b/tests/library/dbg/tests/test_command_tls.py
@@ -1,22 +1,24 @@
 from __future__ import annotations
 
 import pytest
-from host import Controller
 
-import tests
+from ....host import Controller
+from . import get_binary
+from . import launch_to
+from . import pwndbg_test
 
-TLS_X86_64_BINARY = tests.get_binary("tls.x86-64.out")
-TLS_I386_BINARY = tests.get_binary("tls.i386.out")
+TLS_X86_64_BINARY = get_binary("tls.x86-64.out")
+TLS_I386_BINARY = get_binary("tls.i386.out")
 
 
 # TODO: Support other architectures
-@tests.pwndbg_test
+@pwndbg_test
 @pytest.mark.parametrize("binary", [TLS_X86_64_BINARY, TLS_I386_BINARY], ids=["x86-64", "i386"])
 async def test_tls_address_and_command(ctrl: Controller, binary: str):
     import pwndbg.aglib.tls
     import pwndbg.aglib.vmmap
 
-    await tests.launch_to(ctrl, binary, "break_here")
+    await launch_to(ctrl, binary, "break_here")
 
     expected_tls_address = int(
         pwndbg.dbg.selected_frame().evaluate_expression("(void *)tls_address")

--- a/tests/library/dbg/tests/test_command_tls.py
+++ b/tests/library/dbg/tests/test_command_tls.py
@@ -16,7 +16,7 @@ async def test_tls_address_and_command(ctrl: Controller, binary: str):
     import pwndbg.aglib.tls
     import pwndbg.aglib.vmmap
 
-    await ctrl.launch(binary)
+    await tests.launch_to(ctrl, binary, "break_here")
 
     expected_tls_address = int(
         pwndbg.dbg.selected_frame().evaluate_expression("(void *)tls_address")

--- a/tests/library/dbg/tests/test_command_tls.py
+++ b/tests/library/dbg/tests/test_command_tls.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import pytest
+from host import Controller
+
+import tests
+
+TLS_X86_64_BINARY = tests.get_binary("tls.x86-64.out")
+TLS_I386_BINARY = tests.get_binary("tls.i386.out")
+
+
+# TODO: Support other architectures
+@tests.pwndbg_test
+@pytest.mark.parametrize("binary", [TLS_X86_64_BINARY, TLS_I386_BINARY], ids=["x86-64", "i386"])
+async def test_tls_address_and_command(ctrl: Controller, binary: str):
+    import pwndbg.aglib.tls
+    import pwndbg.aglib.vmmap
+
+    await ctrl.launch(binary)
+
+    expected_tls_address = int(
+        pwndbg.dbg.selected_frame().evaluate_expression("(void *)tls_address")
+    )
+
+    assert pwndbg.aglib.tls.find_address_with_register() == expected_tls_address
+
+    assert pwndbg.aglib.tls.find_address_with_pthread_self() == expected_tls_address
+
+    output = await ctrl.execute_and_capture("tls")
+
+    assert f"Thread Local Storage (TLS) base: {expected_tls_address:#x}" in output
+    assert "TLS is located at:\n" and f"{pwndbg.aglib.vmmap.find(expected_tls_address)}\n" in output
+    assert "Output truncated. Rerun with option -a to display the full output." in output
+
+    output_pthread = await ctrl.execute_and_capture("tls --pthread-self")
+
+    assert f"Thread Local Storage (TLS) base: {expected_tls_address:#x}" in output_pthread
+    assert (
+        "TLS is located at:"
+        and f"{pwndbg.aglib.vmmap.find(expected_tls_address)}\n" in output_pthread
+    )
+    assert "Output truncated. Rerun with option -a to display the full output." in output_pthread
+
+    # Argument `-a`
+    output_all = await ctrl.execute_and_capture("tls --all")
+
+    assert f"Thread Local Storage (TLS) base: {expected_tls_address:#x}" in output_all
+    assert (
+        "TLS is located at:\n"
+        and f"{pwndbg.aglib.vmmap.find(expected_tls_address)}\n" in output_all
+    )
+    assert "Output truncated. Rerun with option -a to display the full output." not in output_all

--- a/tests/library/dbg/tests/test_commands_elf.py
+++ b/tests/library/dbg/tests/test_commands_elf.py
@@ -13,12 +13,13 @@ NOPIE_BINARY_WITH_PLT = "reference_bin_nopie.out"
 NOPIE_I386_BINARY_WITH_PLT = "reference_bin_nopie.i386.out"
 
 
-def test_commands_plt_gotplt_got_when_no_sections(start_binary):
-    start_binary(NO_SECTS_BINARY)
+@tests.pwndbg_test
+async def test_commands_plt_gotplt_got_when_no_sections(ctrl: Controller) -> None:
+    await ctrl.launch(NO_SECTS_BINARY)
 
     # elf.py commands
-    assert gdb.execute("plt", to_string=True) == "No .plt.* sections found\n"
-    assert gdb.execute("gotplt", to_string=True) == "Could not find section .got.plt\n"
+    assert (await ctrl.execute_and_capture("plt")) == "No .plt.* sections found\n"
+    assert (await ctrl.execute_and_capture("gotplt")) == "Could not find section .got.plt\n"
 
 
 @pytest.mark.parametrize(

--- a/tests/library/dbg/tests/test_commands_elf.py
+++ b/tests/library/dbg/tests/test_commands_elf.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import re
+
+import pytest
+from host import Controller
+
+import tests
+
+NO_SECTS_BINARY = tests.get_binary("gosample.x86")
+PIE_BINARY_WITH_PLT = "reference_bin_pie.out"
+NOPIE_BINARY_WITH_PLT = "reference_bin_nopie.out"
+NOPIE_I386_BINARY_WITH_PLT = "reference_bin_nopie.i386.out"
+
+
+def test_commands_plt_gotplt_got_when_no_sections(start_binary):
+    start_binary(NO_SECTS_BINARY)
+
+    # elf.py commands
+    assert gdb.execute("plt", to_string=True) == "No .plt.* sections found\n"
+    assert gdb.execute("gotplt", to_string=True) == "Could not find section .got.plt\n"
+
+
+@pytest.mark.parametrize(
+    "binary_name,is_pie", ((PIE_BINARY_WITH_PLT, True), (NOPIE_BINARY_WITH_PLT, False))
+)
+@tests.pwndbg_test
+async def test_command_plt(ctrl: Controller, binary_name: str, is_pie: bool) -> None:
+    import pwndbg
+
+    binary = tests.get_binary(binary_name)
+
+    if pwndbg.dbg.is_gdblib_available():
+        # Currently only GDB has pre-launch inferiors that let us run commands
+        # like `plt`.
+        import gdb
+
+        gdb.execute(f"file {binary}")
+
+        out = gdb.execute("plt", to_string=True).splitlines()
+
+        assert len(out) == 2
+        assert re.match(r"Section \.plt 0x[0-9a-f]+ - 0x[0-9a-f]+:", out[0])
+        assert re.match(r"0x[0-9a-f]+: puts@plt", out[1])
+
+    await ctrl.launch(binary)
+
+    out2 = (await ctrl.execute_and_capture("plt")).splitlines()
+
+    assert len(out2) == 2
+    assert re.match(r"Section \.plt 0x[0-9a-f]+ - 0x[0-9a-f]+:", out2[0])
+    assert re.match(r"0x[0-9a-f]+: puts@plt", out2[1])
+
+    if pwndbg.dbg.is_gdblib_available():
+        if is_pie:
+            assert out != out2
+        else:
+            assert out == out2
+
+
+@pytest.mark.parametrize(
+    "binary_name,is_pie", ((NOPIE_BINARY_WITH_PLT, False), (PIE_BINARY_WITH_PLT, True))
+)
+@tests.pwndbg_test
+async def test_command_elf(ctrl: Controller, binary_name: str, is_pie: bool) -> None:
+    binary = tests.get_binary(binary_name)
+
+    await ctrl.launch(binary)
+
+    out = (await ctrl.execute_and_capture("elf")).splitlines()
+    assert len(out) == 25
+
+    # test for default
+    for section in out[2:]:
+        assert re.match(
+            r"^\s*0x[\da-fA-F]+\s+0x[\da-fA-F]+\s+(?:[RWX-]{3})\s+0x[\da-fA-F]+\s+\.([^\s]+)$",
+            section,
+        )
+        if is_pie:
+            address = section.split()
+            assert address[0].startswith("0x55555555")
+
+    # if this is a pie binary, test for --no-rebase
+    if is_pie:
+        out = (await ctrl.execute_and_capture("elf -R")).splitlines()
+        assert len(out) == 25
+
+        for section in out[2:]:
+            assert re.match(
+                r"^\s*0x[\da-fA-F]+\s+0x[\da-fA-F]+\s+(?:[RWX-]{3})\s+0x[\da-fA-F]+\s+\.([^\s]+)$",
+                section,
+            )

--- a/tests/library/dbg/tests/test_commands_elf.py
+++ b/tests/library/dbg/tests/test_commands_elf.py
@@ -3,17 +3,18 @@ from __future__ import annotations
 import re
 
 import pytest
-from host import Controller
 
-import tests
+from ....host import Controller
+from . import get_binary
+from . import pwndbg_test
 
-NO_SECTS_BINARY = tests.get_binary("gosample.x86")
+NO_SECTS_BINARY = get_binary("gosample.x86")
 PIE_BINARY_WITH_PLT = "reference_bin_pie.out"
 NOPIE_BINARY_WITH_PLT = "reference_bin_nopie.out"
 NOPIE_I386_BINARY_WITH_PLT = "reference_bin_nopie.i386.out"
 
 
-@tests.pwndbg_test
+@pwndbg_test
 async def test_commands_plt_gotplt_got_when_no_sections(ctrl: Controller) -> None:
     await ctrl.launch(NO_SECTS_BINARY)
 
@@ -25,11 +26,11 @@ async def test_commands_plt_gotplt_got_when_no_sections(ctrl: Controller) -> Non
 @pytest.mark.parametrize(
     "binary_name,is_pie", ((PIE_BINARY_WITH_PLT, True), (NOPIE_BINARY_WITH_PLT, False))
 )
-@tests.pwndbg_test
+@pwndbg_test
 async def test_command_plt(ctrl: Controller, binary_name: str, is_pie: bool) -> None:
     import pwndbg
 
-    binary = tests.get_binary(binary_name)
+    binary = get_binary(binary_name)
 
     if pwndbg.dbg.is_gdblib_available():
         # Currently only GDB has pre-launch inferiors that let us run commands
@@ -62,9 +63,9 @@ async def test_command_plt(ctrl: Controller, binary_name: str, is_pie: bool) -> 
 @pytest.mark.parametrize(
     "binary_name,is_pie", ((NOPIE_BINARY_WITH_PLT, False), (PIE_BINARY_WITH_PLT, True))
 )
-@tests.pwndbg_test
+@pwndbg_test
 async def test_command_elf(ctrl: Controller, binary_name: str, is_pie: bool) -> None:
-    binary = tests.get_binary(binary_name)
+    binary = get_binary(binary_name)
 
     await ctrl.launch(binary)
 

--- a/tests/library/dbg/tests/test_commands_elf.py
+++ b/tests/library/dbg/tests/test_commands_elf.py
@@ -38,19 +38,19 @@ async def test_command_plt(ctrl: Controller, binary_name: str, is_pie: bool) -> 
 
         gdb.execute(f"file {binary}")
 
-        out = gdb.execute("plt", to_string=True).splitlines()
+        out = gdb.execute("plt -a", to_string=True).splitlines()
 
         assert len(out) == 2
         assert re.match(r"Section \.plt 0x[0-9a-f]+ - 0x[0-9a-f]+:", out[0])
-        assert re.match(r"0x[0-9a-f]+: puts@plt", out[1])
+        assert re.match(r"0x[0-9a-f]+: puts(@plt)?", out[1])
 
     await ctrl.launch(binary)
 
-    out2 = (await ctrl.execute_and_capture("plt")).splitlines()
+    out2 = (await ctrl.execute_and_capture("plt -a")).splitlines()
 
     assert len(out2) == 2
     assert re.match(r"Section \.plt 0x[0-9a-f]+ - 0x[0-9a-f]+:", out2[0])
-    assert re.match(r"0x[0-9a-f]+: puts@plt", out2[1])
+    assert re.match(r"0x[0-9a-f]+: puts(@plt)?", out2[1])
 
     if pwndbg.dbg.is_gdblib_available():
         if is_pie:

--- a/tests/library/dbg/tests/test_commands_next.py
+++ b/tests/library/dbg/tests/test_commands_next.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 import pytest
-from host import Controller
 
-import tests
+from ....host import Controller
+from . import break_at_sym
+from . import get_binary
+from . import launch_to
+from . import pwndbg_test
 
-REFERENCE_BINARY = tests.get_binary("reference-binary.out")
-CRASH_SIMPLE_BINARY = tests.get_binary("crash_simple.out.hardcoded")
+REFERENCE_BINARY = get_binary("reference-binary.out")
+CRASH_SIMPLE_BINARY = get_binary("crash_simple.out.hardcoded")
 
 NEXT_COMMANDS = (
     "pc",
@@ -20,13 +23,13 @@ NEXT_COMMANDS = (
 )
 
 
-@tests.pwndbg_test
+@pwndbg_test
 async def test_command_nextproginstr(ctrl: Controller) -> None:
     import pwndbg.aglib.proc
     import pwndbg.aglib.regs
     import pwndbg.aglib.vmmap
 
-    await tests.launch_to(ctrl, REFERENCE_BINARY, "main")
+    await launch_to(ctrl, REFERENCE_BINARY, "main")
 
     out = await ctrl.execute_and_capture("nextproginstr")
     assert out == "The pc is already at the binary objfile code. Not stepping.\n"
@@ -38,7 +41,7 @@ async def test_command_nextproginstr(ctrl: Controller) -> None:
     assert any(pwndbg.aglib.regs.pc in p for p in exec_bin_pages)
     main_page = pwndbg.aglib.vmmap.find(pwndbg.aglib.regs.pc)
 
-    tests.break_at_sym("puts")
+    break_at_sym("puts")
     await ctrl.cont()
 
     # Sanity check that we are in libc
@@ -54,7 +57,7 @@ async def test_command_nextproginstr(ctrl: Controller) -> None:
 
 
 @pytest.mark.parametrize("command", NEXT_COMMANDS)
-@tests.pwndbg_test
+@pwndbg_test
 async def test_next_command_doesnt_freeze_crashed_binary(ctrl: Controller, command: str) -> None:
     import pwndbg.aglib.regs
 

--- a/tests/library/dbg/tests/test_commands_next.py
+++ b/tests/library/dbg/tests/test_commands_next.py
@@ -49,13 +49,15 @@ async def test_command_nextproginstr(ctrl: Controller) -> None:
     assert pwndbg.aglib.regs.pc in main_page
 
     # Ensure that nextproginstr won't jump now
-    out = ctrl.execute("nextproginstr")
+    out = await ctrl.execute_and_capture("nextproginstr")
     assert out == "The pc is already at the binary objfile code. Not stepping.\n"
 
 
 @pytest.mark.parametrize("command", NEXT_COMMANDS)
 @tests.pwndbg_test
 async def test_next_command_doesnt_freeze_crashed_binary(ctrl: Controller, command: str) -> None:
+    import pwndbg.aglib.regs
+
     await ctrl.launch(CRASH_SIMPLE_BINARY)
 
     # The nextproginstr won't step if we are already on the binary address

--- a/tests/library/dbg/tests/test_commands_next.py
+++ b/tests/library/dbg/tests/test_commands_next.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import pytest
+from host import Controller
+
+import tests
+
+REFERENCE_BINARY = tests.get_binary("reference-binary.out")
+CRASH_SIMPLE_BINARY = tests.get_binary("crash_simple.out.hardcoded")
+
+NEXT_COMMANDS = (
+    "pc",
+    "nextcall",
+    "nextjmp",
+    "nextproginstr",
+    "nextret",
+    "nextsyscall",
+    "stepret",
+    "stepsyscall",
+)
+
+
+@tests.pwndbg_test
+async def test_command_nextproginstr(ctrl: Controller) -> None:
+    import pwndbg.aglib.proc
+    import pwndbg.aglib.regs
+    import pwndbg.aglib.vmmap
+
+    await tests.launch_to(ctrl, REFERENCE_BINARY, "main")
+
+    out = await ctrl.execute_and_capture("nextproginstr")
+    assert out == "The pc is already at the binary objfile code. Not stepping.\n"
+
+    # Sanity check
+    exec_bin_pages = [
+        p for p in pwndbg.aglib.vmmap.get() if p.objfile == pwndbg.aglib.proc.exe and p.execute
+    ]
+    assert any(pwndbg.aglib.regs.pc in p for p in exec_bin_pages)
+    main_page = pwndbg.aglib.vmmap.find(pwndbg.aglib.regs.pc)
+
+    tests.break_at_sym("puts")
+    await ctrl.cont()
+
+    # Sanity check that we are in libc
+    assert "libc" in pwndbg.aglib.vmmap.find(pwndbg.aglib.regs.rip).objfile
+
+    # Execute nextproginstr and see if we came back to the same vmmap page
+    await ctrl.execute("nextproginstr")
+    assert pwndbg.aglib.regs.pc in main_page
+
+    # Ensure that nextproginstr won't jump now
+    out = ctrl.execute("nextproginstr")
+    assert out == "The pc is already at the binary objfile code. Not stepping.\n"
+
+
+@pytest.mark.parametrize("command", NEXT_COMMANDS)
+@tests.pwndbg_test
+async def test_next_command_doesnt_freeze_crashed_binary(ctrl: Controller, command: str) -> None:
+    await ctrl.launch(CRASH_SIMPLE_BINARY)
+
+    # The nextproginstr won't step if we are already on the binary address
+    # and interestingly, other commands won't step if the address can't be disassemblied
+    if command == "nextproginstr":
+        pwndbg.aglib.regs.pc = 0x1234
+
+    # This should not halt/freeze the program
+    await ctrl.execute(command)

--- a/tests/library/dbg/tests/test_context_commands.py
+++ b/tests/library/dbg/tests/test_context_commands.py
@@ -92,7 +92,7 @@ async def test_empty_context_sections(ctrl: Controller, sections: str) -> None:
     # Actual test check
     await ctrl.execute(f"set context-sections {sections}")
     assert pwndbg.config.context_sections.value == ""
-    assert (await ctrl.execute_and_capture("context")) != ""
+    assert (await ctrl.execute_and_capture("context")) == ""
 
     # Bring back old values && sanity check
     await ctrl.execute(f"set context-sections {default_ctx_sects}")
@@ -201,7 +201,7 @@ async def test_context_disasm_syscalls_args_display(ctrl: Controller) -> None:
 async def test_context_disasm_syscalls_args_display_no_emulate(ctrl: Controller) -> None:
     await ctrl.execute("set emulate off")
 
-    await ctlr.launch(SYSCALLS_BINARY)
+    await ctrl.launch(SYSCALLS_BINARY)
 
     await ctrl.execute("nextsyscall")
     dis = await ctrl.execute_and_capture("context disasm")
@@ -402,7 +402,7 @@ async def test_context_disasm_call_instruction_split(ctrl: Controller) -> None:
     """
     import pwndbg.color
 
-    await ctlr.launch(LONG_FUNCTION_X64_BINARY)
+    await ctrl.launch(LONG_FUNCTION_X64_BINARY)
 
     # Call ctx so instructions get disassembled and cached
     await ctrl.execute("ctx")
@@ -478,6 +478,8 @@ async def test_context_hide_sections(ctrl: Controller) -> None:
 
 @tests.pwndbg_test
 async def test_context_history_prev_next(ctrl: Controller) -> None:
+    import pwndbg
+
     await ctrl.launch(LONG_FUNCTION_X64_BINARY)
 
     # Add two context outputs to the history
@@ -544,10 +546,8 @@ async def test_context_history_search(ctrl: Controller) -> None:
     tests.break_at_sym("break_here")
 
     await ctrl.cont()
-
-    await ctrl.execute("continue")
     await ctrl.execute("context")
-    await ctrl.execute("continue")
+    await ctrl.cont()
     await ctrl.execute("context")
 
     for _ in range(5):

--- a/tests/library/dbg/tests/test_context_commands.py
+++ b/tests/library/dbg/tests/test_context_commands.py
@@ -3,18 +3,21 @@ from __future__ import annotations
 import re
 
 import pytest
-from host import Controller
 
-import tests
+from ....host import Controller
+from . import break_at_sym
+from . import get_binary
+from . import launch_to
+from . import pwndbg_test
 
-REFERENCE_BINARY = tests.get_binary("reference-binary.out")
-USE_FDS_BINARY = tests.get_binary("use-fds.out")
-TABSTOP_BINARY = tests.get_binary("tabstop.out")
-SYSCALLS_BINARY = tests.get_binary("syscalls-x64.out")
-MANGLING_BINARY = tests.get_binary("symbol_1600_and_752.out")
+REFERENCE_BINARY = get_binary("reference-binary.out")
+USE_FDS_BINARY = get_binary("use-fds.out")
+TABSTOP_BINARY = get_binary("tabstop.out")
+SYSCALLS_BINARY = get_binary("syscalls-x64.out")
+MANGLING_BINARY = get_binary("symbol_1600_and_752.out")
 
 
-@tests.pwndbg_test
+@pwndbg_test
 async def test_context_disasm_show_fd_filepath(ctrl: Controller) -> None:
     """
     Tests context disasm command and whether it shows properly opened fd filepath
@@ -25,7 +28,7 @@ async def test_context_disasm_show_fd_filepath(ctrl: Controller) -> None:
     import pwndbg.commands.canary
     import pwndbg.commands.context
 
-    await tests.launch_to(ctrl, USE_FDS_BINARY, "main")
+    await launch_to(ctrl, USE_FDS_BINARY, "main")
 
     # Stop on read(0, ...) -> should show /dev/pts/X or pipe:X on CI
     await ctrl.execute("nextcall")
@@ -82,7 +85,7 @@ async def test_context_disasm_show_fd_filepath(ctrl: Controller) -> None:
 
 
 @pytest.mark.parametrize("sections", ("''", '""', "none", "-"))
-@tests.pwndbg_test
+@pwndbg_test
 async def test_empty_context_sections(ctrl: Controller, sections: str) -> None:
     import pwndbg
 
@@ -104,7 +107,7 @@ async def test_empty_context_sections(ctrl: Controller, sections: str) -> None:
     assert (await ctrl.execute_and_capture("context")) != ""
 
 
-@tests.pwndbg_test
+@pwndbg_test
 async def test_source_code_tabstop(ctrl: Controller) -> None:
     await ctrl.launch(TABSTOP_BINARY)
 
@@ -154,7 +157,7 @@ async def test_source_code_tabstop(ctrl: Controller) -> None:
     assert """10 \n""" in src
 
 
-@tests.pwndbg_test
+@pwndbg_test
 async def test_context_disasm_syscalls_args_display(ctrl: Controller) -> None:
     await ctrl.launch(SYSCALLS_BINARY)
 
@@ -201,7 +204,7 @@ async def test_context_disasm_syscalls_args_display(ctrl: Controller) -> None:
     )
 
 
-@tests.pwndbg_test
+@pwndbg_test
 async def test_context_disasm_syscalls_args_display_no_emulate(ctrl: Controller) -> None:
     await ctrl.execute("set emulate off")
 
@@ -250,7 +253,7 @@ async def test_context_disasm_syscalls_args_display_no_emulate(ctrl: Controller)
     )
 
 
-@tests.pwndbg_test
+@pwndbg_test
 async def test_context_backtrace_show_proper_symbol_names(ctrl: Controller) -> None:
     await ctrl.launch(MANGLING_BINARY)
 
@@ -288,7 +291,7 @@ async def test_context_backtrace_show_proper_symbol_names(ctrl: Controller) -> N
     assert backtrace[-1] == ""
 
 
-@tests.pwndbg_test
+@pwndbg_test
 async def test_context_disasm_works_properly_with_disasm_flavor_switch(ctrl: Controller) -> None:
     await ctrl.launch(SYSCALLS_BINARY)
 
@@ -323,7 +326,7 @@ async def test_context_disasm_works_properly_with_disasm_flavor_switch(ctrl: Con
 
 
 @pytest.mark.parametrize("patch_or_api", (True, False))
-@tests.pwndbg_test
+@pwndbg_test
 async def test_context_disasm_proper_render_on_mem_change_issue_1818(
     ctrl: Controller, patch_or_api: bool
 ) -> None:
@@ -364,10 +367,10 @@ async def test_context_disasm_proper_render_on_mem_change_issue_1818(
     assert "syscall" in new[10]
 
 
-ONE_GADGET_BINARY = tests.get_binary("onegadget.x86-64.out")
+ONE_GADGET_BINARY = get_binary("onegadget.x86-64.out")
 
 
-@tests.pwndbg_test
+@pwndbg_test
 async def test_context_disasm_fsbase_annotations(ctrl: Controller) -> none:
     """
     This test checks that fsbase support in annotations is working properly.
@@ -379,7 +382,7 @@ async def test_context_disasm_fsbase_annotations(ctrl: Controller) -> none:
     Between compilations and between x86 vs x86_64, the exact instruction changes, but matches a regex pattern.
 
     """
-    await tests.launch_to(ctrl, ONE_GADGET_BINARY, "break_here")
+    await launch_to(ctrl, ONE_GADGET_BINARY, "break_here")
 
     # In view, there should now be the fs/gs memory reference
     output = (await ctrl.execute_and_capture("context disasm")).split("\n")
@@ -394,10 +397,10 @@ async def test_context_disasm_fsbase_annotations(ctrl: Controller) -> none:
     assert found
 
 
-LONG_FUNCTION_X64_BINARY = tests.get_binary("long_function_x64.out")
+LONG_FUNCTION_X64_BINARY = get_binary("long_function_x64.out")
 
 
-@tests.pwndbg_test
+@pwndbg_test
 async def test_context_disasm_call_instruction_split(ctrl: Controller) -> None:
     """
     This checks for the following scenario:
@@ -439,7 +442,7 @@ async def test_context_disasm_call_instruction_split(ctrl: Controller) -> None:
     assert dis == expected
 
 
-@tests.pwndbg_test
+@pwndbg_test
 async def test_context_hide_sections(ctrl: Controller) -> None:
     await ctrl.launch(SYSCALLS_BINARY)
 
@@ -480,7 +483,7 @@ async def test_context_hide_sections(ctrl: Controller) -> None:
     assert "DISASM" in out
 
 
-@tests.pwndbg_test
+@pwndbg_test
 async def test_context_history_prev_next(ctrl: Controller) -> None:
     import pwndbg
 
@@ -541,13 +544,13 @@ async def test_context_history_prev_next(ctrl: Controller) -> None:
         gdb.execute("cunwatch 1")
 
 
-@tests.pwndbg_test
+@pwndbg_test
 async def test_context_history_search(ctrl: Controller) -> None:
     await ctrl.launch(REFERENCE_BINARY)
     await ctrl.execute("context")
 
-    tests.break_at_sym("main")
-    tests.break_at_sym("break_here")
+    break_at_sym("main")
+    break_at_sym("break_here")
 
     await ctrl.cont()
     await ctrl.execute("context")
@@ -587,7 +590,7 @@ async def test_context_history_search(ctrl: Controller) -> None:
     assert "Section 'nonexistent' not found in context history." in search_result
 
 
-@tests.pwndbg_test
+@pwndbg_test
 async def test_context_output_redirection(ctrl: Controller) -> None:
     import pwndbg.commands.context
 

--- a/tests/library/dbg/tests/test_context_commands.py
+++ b/tests/library/dbg/tests/test_context_commands.py
@@ -1,0 +1,607 @@
+from __future__ import annotations
+
+import re
+
+import pytest
+from host import Controller
+
+import tests
+
+REFERENCE_BINARY = tests.get_binary("reference-binary.out")
+USE_FDS_BINARY = tests.get_binary("use-fds.out")
+TABSTOP_BINARY = tests.get_binary("tabstop.out")
+SYSCALLS_BINARY = tests.get_binary("syscalls-x64.out")
+MANGLING_BINARY = tests.get_binary("symbol_1600_and_752.out")
+
+
+@tests.pwndbg_test
+async def test_context_disasm_show_fd_filepath(ctrl: Controller) -> None:
+    """
+    Tests context disasm command and whether it shows properly opened fd filepath
+    """
+    import pwndbg.aglib.memory
+    import pwndbg.aglib.regs
+    import pwndbg.commands
+    import pwndbg.commands.canary
+    import pwndbg.commands.context
+
+    await tests.launch_to(ctrl, USE_FDS_BINARY, "main")
+
+    # Stop on read(0, ...) -> should show /dev/pts/X or pipe:X on CI
+    await ctrl.execute("nextcall")
+
+    out = pwndbg.commands.context.context_disasm()
+    assert "[ DISASM / x86-64 / set emulate on ]" in out[0]  # Sanity check
+
+    call_read_line_idx = out.index(next(line for line in out if "<read@plt>" in line))
+    lines_after_call_read = out[call_read_line_idx:]
+
+    line_call_read, line_fd, line_buf, line_nbytes, *_rest = lines_after_call_read
+
+    assert "call   read@plt" in line_call_read
+
+    # When running tests with GNU Parallel, sometimes the file name looks
+    # '/tmp/parZ4YC4.par', and occasionally '(deleted)' is present after the
+    # filename
+    line_fd = line_fd.strip()
+    assert re.match(
+        r"fd:\s+1 \((/dev/pts/\d+|/tmp/par.+\.par(?: \(deleted\))?|pipe:\[\d+\])\)", line_fd
+    )
+
+    line_buf = line_buf.strip()
+    assert re.match(r"buf:\s+0x[0-9a-f]+ ◂— 0", line_buf)
+
+    line_nbytes = line_nbytes.strip()
+    assert re.match(r"nbytes:\s+0", line_nbytes)
+
+    # Stop on open(...)
+    await ctrl.execute("nextcall")
+    # Stop on read(...) -> should show use-fds.out
+    await ctrl.execute("nextcall")
+
+    out = pwndbg.commands.context.context_disasm()
+    assert "[ DISASM / x86-64 / set emulate on ]" in out[0]  # Sanity check
+
+    call_read_line_idx = out.index(next(line for line in out if "<read@plt>" in line))
+    lines_after_call_read = out[call_read_line_idx:]
+
+    line_call_read, line_fd, line_buf, line_nbytes, *_rest = lines_after_call_read
+
+    line_fd = line_fd.strip()
+    assert re.match(r"fd:\s+3 \([a-z/]*pwndbg/tests/binaries/host/use-fds.out\)", line_fd)
+
+    line_buf = line_buf.strip()
+    assert re.match(r"buf:\s+0x[0-9a-f]+ ◂— 0", line_buf)
+
+    line_nbytes = line_nbytes.strip()
+    assert re.match(r"nbytes:\s+0x10", line_nbytes)
+
+
+@pytest.mark.parametrize("sections", ("''", '""', "none", "-", ""))
+@tests.pwndbg_test
+async def test_empty_context_sections(ctrl: Controller, sections: str) -> None:
+    import pwndbg
+
+    await ctrl.launch(USE_FDS_BINARY)
+
+    # Sanity check
+    default_ctx_sects = "regs disasm code ghidra stack backtrace expressions threads heap_tracker"
+    assert pwndbg.config.context_sections.value == default_ctx_sects
+    assert (await ctrl.execute_and_capture("context")) != ""
+
+    # Actual test check
+    await ctrl.execute(f"set context-sections {sections}")
+    assert pwndbg.config.context_sections.value == ""
+    assert (await ctrl.execute_and_capture("context")) != ""
+
+    # Bring back old values && sanity check
+    await ctrl.execute(f"set context-sections {default_ctx_sects}")
+    assert pwndbg.config.context_sections.value == default_ctx_sects
+    assert (await ctrl.execute_and_capture("context")) != ""
+
+
+@tests.pwndbg_test
+async def test_source_code_tabstop(ctrl: Controller) -> None:
+    await ctrl.launch(TABSTOP_BINARY)
+
+    # Run until line 6
+    await ctrl.execute("b tabstop.c:6")
+    await ctrl.cont()
+
+    # Default context-code-tabstop = 8
+    src = await ctrl.execute_and_capture("context code")
+    assert """ 1 #include <stdio.h>\n""" in src
+    assert """ 2 \n""" in src
+    assert """ 3 int main() {\n""" in src
+    assert """ 4         // test mix indent\n""" in src
+    assert """ 5         do {\n""" in src
+    assert """ 6                 puts("tab line");\n""" in src
+    assert """ 7         } while (0);\n""" in src
+    assert """ 8         return 0;\n""" in src
+    assert """ 9 }\n""" in src
+    assert """10 \n""" in src
+
+    # Test context-code-tabstop = 2
+    await ctrl.execute("set context-code-tabstop 2")
+    src = await ctrl.execute_and_capture("context code")
+    assert """ 1 #include <stdio.h>\n""" in src
+    assert """ 2 \n""" in src
+    assert """ 3 int main() {\n""" in src
+    assert """ 4   // test mix indent\n""" in src
+    assert """ 5         do {\n""" in src
+    assert """ 6     puts("tab line");\n""" in src
+    assert """ 7         } while (0);\n""" in src
+    assert """ 8         return 0;\n""" in src
+    assert """ 9 }\n""" in src
+    assert """10 \n""" in src
+
+    # Disable context-code-tabstop
+    await ctrl.execute("set context-code-tabstop 0")
+    src = await ctrl.execute_and_capture("context code")
+    assert """ 1 #include <stdio.h>\n""" in src
+    assert """ 2 \n""" in src
+    assert """ 3 int main() {\n""" in src
+    assert """ 4 \t// test mix indent\n""" in src
+    assert """ 5         do {\n""" in src
+    assert """ 6 \t\tputs("tab line");\n""" in src
+    assert """ 7         } while (0);\n""" in src
+    assert """ 8         return 0;\n""" in src
+    assert """ 9 }\n""" in src
+    assert """10 \n""" in src
+
+
+@tests.pwndbg_test
+async def test_context_disasm_syscalls_args_display(ctrl: Controller) -> None:
+    await ctrl.launch(SYSCALLS_BINARY)
+
+    await ctrl.execute("nextsyscall")
+    dis = await ctrl.execute_and_capture("context disasm")
+    assert dis == (
+        "LEGEND: STACK | HEAP | CODE | DATA | WX | RODATA\n"
+        "──────────────────────[ DISASM / x86-64 / set emulate on ]──────────────────────\n"
+        "   0x400080 <_start>       mov    eax, 0                 EAX => 0\n"
+        "   0x400085 <_start+5>     mov    edi, 0x1337            EDI => 0x1337\n"
+        "   0x40008a <_start+10>    mov    esi, 0xdeadbeef        ESI => 0xdeadbeef\n"
+        "   0x40008f <_start+15>    mov    ecx, 0x10              ECX => 0x10\n"
+        " ► 0x400094 <_start+20>    syscall  <SYS_read>\n"
+        "        fd:        0x1337\n"
+        "        buf:       0xdeadbeef\n"
+        "        nbytes:    0\n"
+        "   0x400096 <_start+22>    mov    eax, 0xa               EAX => 0xa\n"
+        "   0x40009b <_start+27>    int    0x80\n"
+        "   0x40009d                add    byte ptr [rax], al\n"
+        "   0x40009f                add    byte ptr [rax], al\n"
+        "   0x4000a1                add    byte ptr [rax], al\n"
+        "   0x4000a3                add    byte ptr [rax], al\n"
+        "────────────────────────────────────────────────────────────────────────────────\n"
+    )
+
+    await ctrl.execute("nextsyscall")
+    dis = await ctrl.execute_and_capture("context disasm")
+    assert dis == (
+        "LEGEND: STACK | HEAP | CODE | DATA | WX | RODATA\n"
+        "──────────────────────[ DISASM / x86-64 / set emulate on ]──────────────────────\n"
+        "   0x400085 <_start+5>     mov    edi, 0x1337            EDI => 0x1337\n"
+        "   0x40008a <_start+10>    mov    esi, 0xdeadbeef        ESI => 0xdeadbeef\n"
+        "   0x40008f <_start+15>    mov    ecx, 0x10              ECX => 0x10\n"
+        "   0x400094 <_start+20>    syscall  <SYS_read>\n"
+        "   0x400096 <_start+22>    mov    eax, 0xa               EAX => 0xa\n"
+        " ► 0x40009b <_start+27>    int    0x80 <SYS_unlink>\n"
+        "        name:      0x1337\n"
+        "   0x40009d                add    byte ptr [rax], al\n"
+        "   0x40009f                add    byte ptr [rax], al\n"
+        "   0x4000a1                add    byte ptr [rax], al\n"
+        "   0x4000a3                add    byte ptr [rax], al\n"
+        "   0x4000a5                add    byte ptr [rax], al\n"
+        "────────────────────────────────────────────────────────────────────────────────\n"
+    )
+
+
+@tests.pwndbg_test
+async def test_context_disasm_syscalls_args_display_no_emulate(ctrl: Controller) -> None:
+    await ctrl.execute("set emulate off")
+
+    await ctlr.launch(SYSCALLS_BINARY)
+
+    await ctrl.execute("nextsyscall")
+    dis = await ctrl.execute_and_capture("context disasm")
+    assert dis == (
+        "LEGEND: STACK | HEAP | CODE | DATA | WX | RODATA\n"
+        "─────────────────────[ DISASM / x86-64 / set emulate off ]──────────────────────\n"
+        "   0x400080 <_start>       mov    eax, 0                 EAX => 0\n"
+        "   0x400085 <_start+5>     mov    edi, 0x1337            EDI => 0x1337\n"
+        "   0x40008a <_start+10>    mov    esi, 0xdeadbeef        ESI => 0xdeadbeef\n"
+        "   0x40008f <_start+15>    mov    ecx, 0x10              ECX => 0x10\n"
+        " ► 0x400094 <_start+20>    syscall  <SYS_read>\n"
+        "        fd:        0x1337\n"
+        "        buf:       0xdeadbeef\n"
+        "        nbytes:    0\n"
+        "   0x400096 <_start+22>    mov    eax, 0xa               EAX => 0xa\n"
+        "   0x40009b <_start+27>    int    0x80\n"
+        "   0x40009d                add    byte ptr [rax], al\n"
+        "   0x40009f                add    byte ptr [rax], al\n"
+        "   0x4000a1                add    byte ptr [rax], al\n"
+        "   0x4000a3                add    byte ptr [rax], al\n"
+        "────────────────────────────────────────────────────────────────────────────────\n"
+    )
+
+    await ctrl.execute("nextsyscall")
+    dis = await ctrl.execute_and_capture("context disasm")
+    assert dis == (
+        "LEGEND: STACK | HEAP | CODE | DATA | WX | RODATA\n"
+        "─────────────────────[ DISASM / x86-64 / set emulate off ]──────────────────────\n"
+        "   0x400085 <_start+5>     mov    edi, 0x1337            EDI => 0x1337\n"
+        "   0x40008a <_start+10>    mov    esi, 0xdeadbeef        ESI => 0xdeadbeef\n"
+        "   0x40008f <_start+15>    mov    ecx, 0x10              ECX => 0x10\n"
+        "   0x400094 <_start+20>    syscall  <SYS_read>\n"
+        "   0x400096 <_start+22>    mov    eax, 0xa               EAX => 0xa\n"
+        " ► 0x40009b <_start+27>    int    0x80 <SYS_unlink>\n"
+        "        name:      0x1337\n"
+        "   0x40009d                add    byte ptr [rax], al\n"
+        "   0x40009f                add    byte ptr [rax], al\n"
+        "   0x4000a1                add    byte ptr [rax], al\n"
+        "   0x4000a3                add    byte ptr [rax], al\n"
+        "   0x4000a5                add    byte ptr [rax], al\n"
+        "────────────────────────────────────────────────────────────────────────────────\n"
+    )
+
+
+@tests.pwndbg_test
+async def test_context_backtrace_show_proper_symbol_names(ctrl: Controller) -> None:
+    await ctrl.launch(MANGLING_BINARY)
+
+    await ctrl.execute("b A::foo")
+    await ctrl.cont()
+
+    backtrace = (await ctrl.execute_and_capture("context backtrace")).split("\n")
+
+    assert backtrace[0] == "LEGEND: STACK | HEAP | CODE | DATA | WX | RODATA"
+    assert (
+        backtrace[1]
+        == "─────────────────────────────────[ BACKTRACE ]──────────────────────────────────"
+    )
+
+    assert re.match(r".*0   0x[0-9a-f]+ A::foo\(int, int\)", backtrace[2])
+
+    # Match A::call_foo()+38 or similar: the offset may change so we match \d+ at the end
+    assert re.match(r".*1   0x[0-9a-f]+ A::call_foo\(\)\+\d+", backtrace[3])
+
+    # Match main+87 or similar offset
+    assert re.match(r".*2   0x[0-9a-f]+ main\+\d+", backtrace[4])
+
+    # Match __libc_start_main+243 or similar offset
+    # Note: on Ubuntu 22.04 there will be __libc_start_call_main and then __libc_start_main
+    # but on older distros there will be only __libc_start_main
+    # Let's not bother too much about it and make it the last call assertion here
+    assert re.match(
+        r".*3   0x[0-9a-f]+ (__libc_start_main|__libc_start_call_main)\+\d+", backtrace[5]
+    )
+
+    assert (
+        backtrace[-2]
+        == "────────────────────────────────────────────────────────────────────────────────"
+    )
+    assert backtrace[-1] == ""
+
+
+@tests.pwndbg_test
+async def test_context_disasm_works_properly_with_disasm_flavor_switch(ctrl: Controller) -> None:
+    await ctrl.launch(SYSCALLS_BINARY)
+
+    def assert_intel(out):
+        assert "mov    eax, 0" in out[2]
+        assert "mov    edi, 0x1337" in out[3]
+        assert "mov    esi, 0xdeadbeef" in out[4]
+        assert "mov    ecx, 0x10" in out[5]
+        assert "syscall" in out[6]
+
+    def assert_att(out):
+        assert "mov    movl   $0, %eax" not in out[2]
+        assert "mov    movl   $0x1337, %edi" not in out[3]
+        assert "mov    movl   $0xdeadbeef, %esi" not in out[4]
+        assert "mov    movl   $0x10, %ecx" not in out[5]
+        assert "syscall" in out[6]
+
+    out = (await ctrl.execute_and_capture("context disasm")).split("\n")
+    assert out[0] == "LEGEND: STACK | HEAP | CODE | DATA | WX | RODATA"
+    assert (
+        out[1] == "──────────────────────[ DISASM / x86-64 / set emulate on ]──────────────────────"
+    )
+    assert_intel(out)
+
+    await ctrl.execute("set disassembly-flavor att")
+    out = (await ctrl.execute_and_capture("context disasm")).split("\n")
+    assert out[0] == "LEGEND: STACK | HEAP | CODE | DATA | WX | RODATA"
+    assert (
+        out[1] == "──────────────────────[ DISASM / x86-64 / set emulate on ]──────────────────────"
+    )
+    assert_att(out)
+
+
+@pytest.mark.parametrize("patch_or_api", (True, False))
+@tests.pwndbg_test
+async def test_context_disasm_proper_render_on_mem_change_issue_1818(
+    ctrl: Controller, patch_or_api: bool
+) -> None:
+    import pwndbg.aglib.memory
+
+    await ctrl.launch(SYSCALLS_BINARY)
+
+    old = (await ctrl.execute_and_capture("context disasm")).split("\n")
+
+    # Just a sanity check
+    assert old[0] == "LEGEND: STACK | HEAP | CODE | DATA | WX | RODATA"
+    assert "mov    eax, 0" in old[2]
+    assert "mov    edi, 0x1337" in old[3]
+    assert "mov    esi, 0xdeadbeef" in old[4]
+    assert "mov    ecx, 0x10" in old[5]
+    assert "syscall" in old[6]
+
+    # 5 bytes because 'mov eax, 0' is 5 bytes long
+    if patch_or_api:
+        await ctrl.execute("patch $rip nop;nop;nop;nop;nop")
+    else:
+        # Do the same, but through write API
+        pwndbg.aglib.memory.write(pwndbg.aglib.regs.rip, b"\x90" * 5)
+
+    # Actual test: we expect the read memory to be different now ;)
+    # (and not e.g. returned incorrectly from a not cleared cache)
+    new = (await ctrl.execute_and_capture("context disasm")).split("\n")
+
+    assert new[0] == "LEGEND: STACK | HEAP | CODE | DATA | WX | RODATA"
+    assert "nop" in new[2]
+    assert "nop" in new[3]
+    assert "nop" in new[4]
+    assert "nop" in new[5]
+    assert "nop" in new[6]
+    assert "mov    edi, 0x1337" in new[7]
+    assert "mov    esi, 0xdeadbeef" in new[8]
+    assert "mov    ecx, 0x10" in new[9]
+    assert "syscall" in new[10]
+
+
+ONE_GADGET_BINARY = tests.get_binary("onegadget.x86-64.out")
+
+
+@tests.pwndbg_test
+async def test_context_disasm_fsbase_annotations(ctrl: Controller) -> none:
+    """
+    This test checks that fsbase support in annotations is working properly.
+
+    If this breaks, either our x86 memory operand parser is broken, we cannot fetch fsbase, or we are not passing FSBASE to Unicorn.
+    See: https://github.com/pwndbg/pwndbg/pull/2317
+
+    For this test, we use a binary we know has a stack canary.
+    Between compilations and between x86 vs x86_64, the exact instruction changes, but matches a regex pattern.
+
+    """
+    await tests.launch_to(ctrl, ONE_GADGET_BINARY, "break_here")
+
+    # In view, there should now be the fs/gs memory reference
+    output = (await ctrl.execute_and_capture("context disasm")).split("\n")
+
+    pattern = re.compile(r"\b(mov|sub)\s+\w+,\s+(qword|dword)\s+ptr\s+(gs|fs):\[0x[0-9a-f]+\]")
+    found = False
+    for line in output:
+        if pattern.search(line):
+            found = True
+            break
+
+    assert found
+
+
+LONG_FUNCTION_X64_BINARY = tests.get_binary("long_function_x64.out")
+
+
+@tests.pwndbg_test
+async def test_context_disasm_call_instruction_split(ctrl: Controller) -> None:
+    """
+    This checks for the following scenario:
+    We are on a `call` instruction, and `si` to enter the function. Then, we do `fin` to return to the caller.
+    There should be a split in the disassembly after the call instruction.
+    """
+    import pwndbg.color
+
+    await ctlr.launch(LONG_FUNCTION_X64_BINARY)
+
+    # Call ctx so instructions get disassembled and cached
+    await ctrl.execute("ctx")
+
+    await ctrl.step_instruction()
+    await ctrl.execute("fin")
+
+    dis = await ctrl.execute_and_capture("context disasm")
+    dis = pwndbg.color.strip(dis)
+
+    expected = (
+        "LEGEND: STACK | HEAP | CODE | DATA | WX | RODATA\n"
+        "──────────────────────[ DISASM / x86-64 / set emulate on ]──────────────────────\n"
+        "   0x400080 <_start>       call   function                    <function>\n"
+        " \n"
+        " ► 0x400085 <_start+5>     mov    eax, 2       EAX => 2\n"
+        "   0x40008a <_start+10>    mov    ebx, 3       EBX => 3\n"
+        "   0x40008f <_start+15>    add    rax, rbx     RAX => 5 (2 + 3)\n"
+        "   0x400092 <_start+18>    xor    rax, rbx     RAX => 6 (5 ^ 3)\n"
+        "   0x400095 <_start+21>    nop    \n"
+        "   0x400096 <_start+22>    jmp    exit                        <exit>\n"
+        "    ↓\n"
+        "   0x4000ab <exit>         mov    eax, 0x3c              EAX => 0x3c\n"
+        "   0x4000b0 <exit+5>       mov    edi, 0                 EDI => 0\n"
+        "   0x4000b5 <exit+10>      syscall  <SYS_exit>\n"
+        "   0x4000b7                add    byte ptr [rax], al\n"
+        "────────────────────────────────────────────────────────────────────────────────\n"
+    )
+
+    assert dis == expected
+
+
+@tests.pwndbg_test
+async def test_context_hide_sections(ctrl: Controller) -> None:
+    await ctrl.launch(SYSCALLS_BINARY)
+
+    # Disable one section
+    out = await ctrl.execute_and_capture("context")
+    assert "REGISTERS" in out
+    assert "STACK" in out
+    await ctrl.execute("context regs --off")
+    out = await ctrl.execute_and_capture("context")
+    assert "REGISTERS" not in out
+    assert "STACK" in out
+    await ctrl.execute("context regs --on")
+    out = await ctrl.execute_and_capture("context")
+    assert "REGISTERS" in out
+    assert "STACK" in out
+
+    # Disable multiple sections
+    await ctrl.execute("context stack disasm --off")
+    out = await ctrl.execute_and_capture("context")
+    assert "STACK" not in out
+    assert "DISASM" not in out
+    await ctrl.execute("context stack --on")
+    out = await ctrl.execute_and_capture("context")
+    assert "STACK" in out
+    assert "DISASM" not in out
+    await ctrl.execute("context stack disasm --on")
+    out = await ctrl.execute_and_capture("context")
+    assert "STACK" in out
+    assert "DISASM" in out
+
+    # Disable all sections at once
+    await ctrl.execute("context --off")
+    out = await ctrl.execute_and_capture("context")
+    assert len(out) == 0
+    await ctrl.execute("context --on")
+    out = await ctrl.execute_and_capture("context")
+    assert "REGISTERS" in out
+    assert "DISASM" in out
+
+
+@tests.pwndbg_test
+async def test_context_history_prev_next(ctrl: Controller) -> None:
+    await ctrl.launch(LONG_FUNCTION_X64_BINARY)
+
+    # Add two context outputs to the history
+    first_ctx = await ctrl.execute_and_capture("ctx")
+    await ctrl.step_instruction()
+    second_ctx = await ctrl.execute_and_capture("ctx")
+    assert first_ctx != second_ctx
+
+    # Go back to the first context
+    await ctrl.execute("contextprev")
+    history_ctx = await ctrl.execute_and_capture("ctx")
+    assert first_ctx == history_ctx.replace(" (history 1/2)", "")
+    assert "(history 1/2)" in history_ctx
+
+    # Go to the second context again
+    await ctrl.execute("contextnext")
+    history_ctx = await ctrl.execute_and_capture("ctx")
+    assert second_ctx == history_ctx.replace(" (history 2/2)", "")
+    assert "(history 2/2)" in history_ctx
+
+    # Make sure new events are displayed right away
+    # and disable the history scroll.
+    await ctrl.step_instruction()
+    # Execute twice since the prompt hook isn't installed in tests
+    # which causes the legend to still have the (history 2/2) string at first.
+    await ctrl.execute("ctx")
+    third_ctx = await ctrl.execute_and_capture("ctx")
+    assert history_ctx != third_ctx
+    assert "(history " not in third_ctx
+
+    if pwndbg.dbg.is_gdblib_available():
+        # Currently only works in GDB.
+        import gdb
+
+        # Check if cwatch expressions are also stored in the history
+        gdb.execute("cwatch $rip")
+        gdb.execute("cwatch execute 'p/z $rsp'")
+        fourth_ctx = gdb.execute("ctx", to_string=True)
+        assert "1: $rip = " in fourth_ctx
+        assert "2: p/z $rsp\n$1 = 0x" in fourth_ctx
+
+        # The next context shows a different output variable $2
+        gdb.execute("si")
+        fifth_ctx = gdb.execute("ctx", to_string=True)
+        assert "1: $rip = " in fifth_ctx
+        assert "2: p/z $rsp\n$2 = 0x" in fifth_ctx
+
+        # Check that the expression section shows the old gdb variable $1 again.
+        gdb.execute("contextprev")
+        history_ctx = gdb.execute("ctx", to_string=True)
+        assert "1: $rip = " in history_ctx
+        assert "2: p/z $rsp\n$1 = 0x" in history_ctx
+
+        gdb.execute("cunwatch 2")
+        gdb.execute("cunwatch 1")
+
+
+@tests.pwndbg_test
+async def test_context_history_search(ctrl: Controller) -> None:
+    await ctrl.launch(REFERENCE_BINARY)
+    await ctrl.execute("context")
+
+    tests.break_at_sym("main")
+    tests.break_at_sym("break_here")
+
+    await ctrl.cont()
+
+    await ctrl.execute("continue")
+    await ctrl.execute("context")
+    await ctrl.execute("continue")
+    await ctrl.execute("context")
+
+    for _ in range(5):
+        await ctrl.execute("ni")
+        await ctrl.execute("context")
+
+    # Search for something in the past
+    search_result = await ctrl.execute_and_capture("contextsearch puts@plt")
+    assert "Found 1 match. Selected entry 2 for match in section 'disasm'." in search_result
+
+    # Search for something that happened later and have the search wrap around
+    search_result = await ctrl.execute_and_capture("contextsearch 'Hello World'")
+    assert "No more matches before the current entry. Starting from the top." in search_result
+    assert "Found 7 matches. Selected entry 8 for match in section " in search_result
+    search_result = await ctrl.execute_and_capture("contextsearch 'Hello World'")
+    assert "Found 7 matches. Selected entry 7 for match in section " in search_result
+
+    # Select a section to search in
+    search_result = await ctrl.execute_and_capture("contextsearch 'Hello World' disasm")
+    assert "Found 1 match. Selected entry 2 for match in section 'disasm'." in search_result
+
+    # Search for something that doesn't exist
+    search_result = await ctrl.execute_and_capture("contextsearch 'nonexistent'")
+    assert "String 'nonexistent' not found in context history." in search_result
+
+    # Search in non-existing section
+    search_result = await ctrl.execute_and_capture("ctxsearch 'Hello World' nonexistent")
+    assert "Section 'nonexistent' not found in context history." in search_result
+
+
+@tests.pwndbg_test
+async def test_context_output_redirection(ctrl: Controller) -> None:
+    import pwndbg.commands.context
+
+    await ctrl.launch(REFERENCE_BINARY)
+
+    # Test CallOutput redirection
+    def receive_output(output):
+        receive_output.context_output = output
+
+    receive_output.context_output = ""
+
+    pwndbg.commands.context.contextoutput(
+        "regs",
+        receive_output,
+        clearing=True,
+        banner="top",
+        width=80,
+    )
+
+    out = await ctrl.execute_and_capture("ctx")
+    assert "REGISTERS" not in out
+    assert "STACK" in out
+    assert "REGISTERS" in receive_output.context_output
+    assert "STACK" not in receive_output.context_output
+
+    pwndbg.commands.context.resetcontextoutput("regs")

--- a/tests/library/dbg/tests/test_context_commands.py
+++ b/tests/library/dbg/tests/test_context_commands.py
@@ -33,12 +33,14 @@ async def test_context_disasm_show_fd_filepath(ctrl: Controller) -> None:
     out = pwndbg.commands.context.context_disasm()
     assert "[ DISASM / x86-64 / set emulate on ]" in out[0]  # Sanity check
 
-    call_read_line_idx = out.index(next(line for line in out if "<read@plt>" in line))
+    call_read_line_idx = out.index(
+        next(line for line in out if "<read@plt>" in line or "<read>" in line)
+    )
     lines_after_call_read = out[call_read_line_idx:]
 
     line_call_read, line_fd, line_buf, line_nbytes, *_rest = lines_after_call_read
 
-    assert "call   read@plt" in line_call_read
+    assert "call   read@plt" in line_call_read or "call   read" in line_call_read
 
     # When running tests with GNU Parallel, sometimes the file name looks
     # '/tmp/parZ4YC4.par', and occasionally '(deleted)' is present after the
@@ -62,7 +64,9 @@ async def test_context_disasm_show_fd_filepath(ctrl: Controller) -> None:
     out = pwndbg.commands.context.context_disasm()
     assert "[ DISASM / x86-64 / set emulate on ]" in out[0]  # Sanity check
 
-    call_read_line_idx = out.index(next(line for line in out if "<read@plt>" in line))
+    call_read_line_idx = out.index(
+        next(line for line in out if "<read@plt>" in line or "<read>" in line)
+    )
     lines_after_call_read = out[call_read_line_idx:]
 
     line_call_read, line_fd, line_buf, line_nbytes, *_rest = lines_after_call_read
@@ -77,7 +81,7 @@ async def test_context_disasm_show_fd_filepath(ctrl: Controller) -> None:
     assert re.match(r"nbytes:\s+0x10", line_nbytes)
 
 
-@pytest.mark.parametrize("sections", ("''", '""', "none", "-", ""))
+@pytest.mark.parametrize("sections", ("''", '""', "none", "-"))
 @tests.pwndbg_test
 async def test_empty_context_sections(ctrl: Controller, sections: str) -> None:
     import pwndbg
@@ -95,7 +99,7 @@ async def test_empty_context_sections(ctrl: Controller, sections: str) -> None:
     assert (await ctrl.execute_and_capture("context")) == ""
 
     # Bring back old values && sanity check
-    await ctrl.execute(f"set context-sections {default_ctx_sects}")
+    await ctrl.execute(f"set context-sections '{default_ctx_sects}'")
     assert pwndbg.config.context_sections.value == default_ctx_sects
     assert (await ctrl.execute_and_capture("context")) != ""
 
@@ -337,24 +341,24 @@ async def test_context_disasm_proper_render_on_mem_change_issue_1818(
     assert "mov    ecx, 0x10" in old[5]
     assert "syscall" in old[6]
 
-    # 5 bytes because 'mov eax, 0' is 5 bytes long
+    # 5 bytes because 'mov edi, 0x1337' is 5 bytes long
+    # Overwrite
     if patch_or_api:
-        await ctrl.execute("patch $rip nop;nop;nop;nop;nop")
+        await ctrl.execute("patch $rip+5 nop;nop;nop;nop;nop")
     else:
         # Do the same, but through write API
-        pwndbg.aglib.memory.write(pwndbg.aglib.regs.rip, b"\x90" * 5)
+        pwndbg.aglib.memory.write(pwndbg.aglib.regs.rip + 5, b"\x90" * 5)
 
     # Actual test: we expect the read memory to be different now ;)
     # (and not e.g. returned incorrectly from a not cleared cache)
     new = (await ctrl.execute_and_capture("context disasm")).split("\n")
 
     assert new[0] == "LEGEND: STACK | HEAP | CODE | DATA | WX | RODATA"
-    assert "nop" in new[2]
     assert "nop" in new[3]
     assert "nop" in new[4]
     assert "nop" in new[5]
     assert "nop" in new[6]
-    assert "mov    edi, 0x1337" in new[7]
+    assert "nop" in new[7]
     assert "mov    esi, 0xdeadbeef" in new[8]
     assert "mov    ecx, 0x10" in new[9]
     assert "syscall" in new[10]
@@ -555,8 +559,13 @@ async def test_context_history_search(ctrl: Controller) -> None:
         await ctrl.execute("context")
 
     # Search for something in the past
-    search_result = await ctrl.execute_and_capture("contextsearch puts@plt")
-    assert "Found 1 match. Selected entry 2 for match in section 'disasm'." in search_result
+    search_result0 = await ctrl.execute_and_capture("contextsearch puts@plt")
+    search_result1 = await ctrl.execute_and_capture("contextsearch puts disasm")
+
+    assert (
+        "Found 1 match. Selected entry 2 for match in section 'disasm'." in search_result0
+        or "Found 1 match. Selected entry 2 for match in section 'disasm'." in search_result1
+    )
 
     # Search for something that happened later and have the search wrap around
     search_result = await ctrl.execute_and_capture("contextsearch 'Hello World'")

--- a/tests/library/dbg/tests/test_emulate.py
+++ b/tests/library/dbg/tests/test_emulate.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
-from host import Controller
+from ....host import Controller
+from . import get_binary
+from . import pwndbg_test
 
-import tests
-
-EMULATE_DISASM_BINARY = tests.get_binary("emulate_disasm.out")
-EMULATE_DISASM_LOOP_BINARY = tests.get_binary("emulate_disasm_loop.out")
+EMULATE_DISASM_BINARY = get_binary("emulate_disasm.out")
+EMULATE_DISASM_LOOP_BINARY = get_binary("emulate_disasm_loop.out")
 
 
-@tests.pwndbg_test
+@pwndbg_test
 async def test_emulate_disasm(ctrl: Controller) -> None:
     """
     Tests emulate command and its caching behavior
@@ -49,7 +49,7 @@ async def test_emulate_disasm(ctrl: Controller) -> None:
     compare_output_without_emu(disasm_without_emu_0x400080)
 
 
-@tests.pwndbg_test
+@pwndbg_test
 async def test_emulate_disasm_loop(ctrl: Controller) -> None:
     import pwndbg.aglib.regs
 

--- a/tests/library/dbg/tests/test_emulate.py
+++ b/tests/library/dbg/tests/test_emulate.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from host import Controller
+
+import tests
+
+EMULATE_DISASM_BINARY = tests.get_binary("emulate_disasm.out")
+EMULATE_DISASM_LOOP_BINARY = tests.get_binary("emulate_disasm_loop.out")
+
+
+@tests.pwndbg_test
+async def test_emulate_disasm(ctrl: Controller) -> None:
+    """
+    Tests emulate command and its caching behavior
+    """
+    await ctrl.launch(EMULATE_DISASM_BINARY)
+
+    disasm_with_emu_0x400080 = [
+        " ► 0x400080 <_start>    jmp    label                       <label>",
+        "    ↓",
+        "   0x400083 <label>     nop    ",
+        "   0x400084             add    byte ptr [rax], al",
+        "   0x400086             add    byte ptr [rax], al",
+        "   0x400088             add    byte ptr [rax], al",
+        "   0x40008a             add    byte ptr [rax], al",
+        "   0x40008c             add    byte ptr [rax], al",
+        "   0x40008e             add    byte ptr [rax], al",
+        "   0x400090             add    byte ptr [rax], al",
+        "   0x400092             add    byte ptr [rax], al",
+        "   0x400094             add    byte ptr [rax], al",
+    ]
+
+    disasm_without_emu_0x400080 = [
+        " ► 0x400080 <_start>      jmp    label                       <label>",
+        " ",
+        "   0x400082 <_start+2>    nop    ",
+        "   0x400083 <label>       nop    ",
+        "   0x400084               add    byte ptr [rax], al",
+        "   0x400086               add    byte ptr [rax], al",
+        "   0x400088               add    byte ptr [rax], al",
+        "   0x40008a               add    byte ptr [rax], al",
+        "   0x40008c               add    byte ptr [rax], al",
+        "   0x40008e               add    byte ptr [rax], al",
+        "   0x400090               add    byte ptr [rax], al",
+        "   0x400092               add    byte ptr [rax], al",
+    ]
+
+    compare_output_emu(disasm_with_emu_0x400080)
+    compare_output_without_emu(disasm_without_emu_0x400080)
+
+
+@tests.pwndbg_test
+async def test_emulate_disasm_loop(ctrl: Controller) -> None:
+    import pwndbg.aglib.regs
+
+    await ctrl.launch(EMULATE_DISASM_LOOP_BINARY)
+
+    disasm_with_emu_0x400080 = [
+        " ► 0x400080 <_start>       movabs rsi, string                           RSI => 0x400094 (string) ◂— xor dword ptr [rdx], esi /* '12345' */",
+        f"   0x40008a <_start+10>    mov    rdi, rsp                              RDI => {hex(pwndbg.aglib.regs.rsp)} ◂— 1",
+        "   0x40008d <_start+13>    mov    ecx, 3                                ECX => 3",
+        "   0x400092 <_start+18>    rep movsb byte ptr [rdi], byte ptr [rsi]",
+        "    ↓",
+        "   0x400092 <_start+18>    rep movsb byte ptr [rdi], byte ptr [rsi]",
+        "    ↓",
+        "   0x400092 <_start+18>    rep movsb byte ptr [rdi], byte ptr [rsi]",
+        "    ↓",
+        "   0x400092 <_start+18>    rep movsb byte ptr [rdi], byte ptr [rsi]",
+        "   0x400094 <string>       xor    dword ptr [rdx], esi",
+        "   0x400096 <string+2>     xor    esi, dword ptr [rsi]",
+        "   0x40009d                add    byte ptr [rax], al",
+        "   0x40009f                add    byte ptr [rax], al",
+    ]
+
+    disasm_without_emu_0x400080 = [
+        " ► 0x400080 <_start>       movabs rsi, string                           RSI => 0x400094 (string) ◂— xor dword ptr [rdx], esi /* '12345' */",
+        "   0x40008a <_start+10>    mov    rdi, rsp",
+        "   0x40008d <_start+13>    mov    ecx, 3                                ECX => 3",
+        "   0x400092 <_start+18>    rep movsb byte ptr [rdi], byte ptr [rsi]",
+        "   0x400094 <string>       xor    dword ptr [rdx], esi",
+        "   0x400096 <string+2>     xor    esi, dword ptr [rsi]",
+        "   0x40009d                add    byte ptr [rax], al",
+        "   0x40009f                add    byte ptr [rax], al",
+        "   0x4000a1                add    byte ptr [rax], al",
+        "   0x4000a3                add    byte ptr [rax], al",
+        "   0x4000a5                add    byte ptr [rax], al",
+    ]
+
+    compare_output_emu(disasm_with_emu_0x400080)
+    compare_output_without_emu(disasm_without_emu_0x400080)
+
+
+def compare_output_emu(expected_output):
+    from pwndbg.aglib.nearpc import nearpc
+
+    assert nearpc(emulate=True) == expected_output
+
+
+def compare_output_without_emu(expected_output):
+    from pwndbg.aglib.nearpc import nearpc
+
+    assert nearpc(linear=True) == expected_output

--- a/tests/library/dbg/tests/test_go.py
+++ b/tests/library/dbg/tests/test_go.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from host import Controller
+
+import tests
+
+GOSAMPLE_X64 = tests.get_binary("gosample.x64")
+GOSAMPLE_X86 = tests.get_binary("gosample.x86")
+
+
+async def helper_test_dump(ctrl: Controller, target: str) -> None:
+    gdb.execute("set environment GOMAXPROCS=1")
+
+    await ctrl.launch(filename, env={"GOMAXPROCS": "1"})
+
+    await ctrl.execute("b gosample.go:6")
+    await ctrl.cont()
+
+    dump = await ctrl.execute_and_capture("go-dump any &x")
+    assert dump.strip() == """(map[uint8]uint64) &{1: 2, 3: 4, 5: 6}"""
+    await ctrl.cont()
+
+    dump = await ctrl.execute_and_capture("go-dump any &x")
+    assert dump.strip() == """(map[string]int) &{"a": 1, "b": 2, "c": 3}"""
+    await ctrl.cont()
+
+    dump = await ctrl.execute_and_capture("go-dump any &x")
+    assert (
+        dump.strip()
+        == """([]struct { a int; b string }) [struct {a: 1, b: "first"}, struct {a: 2, b: "second"}]"""
+    )
+    await ctrl.cont()
+
+    dump = await ctrl.execute_and_capture("go-dump -f 1 any &x")
+    assert dump.strip() == """([3]complex64) [(1.1 + 2.2i), (-2.5 - 5.0i), (4.2 - 2.1i)]"""
+
+
+@tests.pwndbg_test
+async def test_go_dumping_x64(ctrl: Controller) -> None:
+    await helper_test_dump(start_binary, GOSAMPLE_X64)
+
+
+@tests.pwndbg_test
+async def test_go_dumping_x86(ctrl: Controller) -> None:
+    await helper_test_dump(start_binary, GOSAMPLE_X86)

--- a/tests/library/dbg/tests/test_go.py
+++ b/tests/library/dbg/tests/test_go.py
@@ -35,9 +35,21 @@ async def helper_test_dump(ctrl: Controller, target: str) -> None:
 
 @pwndbg_test
 async def test_go_dumping_x64(ctrl: Controller) -> None:
+    import pwndbg
+    from pwndbg.dbg import DebuggerType
+
+    if pwndbg.dbg.name() == DebuggerType.LLDB:
+        pytest.skip("Go tests are not supported in LLDB")
+
     await helper_test_dump(ctrl, GOSAMPLE_X64)
 
 
 @pwndbg_test
 async def test_go_dumping_x86(ctrl: Controller) -> None:
+    import pwndbg
+    from pwndbg.dbg import DebuggerType
+
+    if pwndbg.dbg.name() == DebuggerType.LLDB:
+        pytest.skip("Go tests are not supported in LLDB")
+
     await helper_test_dump(ctrl, GOSAMPLE_X86)

--- a/tests/library/dbg/tests/test_go.py
+++ b/tests/library/dbg/tests/test_go.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-from host import Controller
+from ....host import Controller
+from . import get_binary
+from . import pwndbg_test
 
-import tests
-
-GOSAMPLE_X64 = tests.get_binary("gosample.x64")
-GOSAMPLE_X86 = tests.get_binary("gosample.x86")
+GOSAMPLE_X64 = get_binary("gosample.x64")
+GOSAMPLE_X86 = get_binary("gosample.x86")
 
 
 async def helper_test_dump(ctrl: Controller, target: str) -> None:
@@ -33,11 +33,11 @@ async def helper_test_dump(ctrl: Controller, target: str) -> None:
     assert dump.strip() == """([3]complex64) [(1.1 + 2.2i), (-2.5 - 5.0i), (4.2 - 2.1i)]"""
 
 
-@tests.pwndbg_test
+@pwndbg_test
 async def test_go_dumping_x64(ctrl: Controller) -> None:
     await helper_test_dump(ctrl, GOSAMPLE_X64)
 
 
-@tests.pwndbg_test
+@pwndbg_test
 async def test_go_dumping_x86(ctrl: Controller) -> None:
     await helper_test_dump(ctrl, GOSAMPLE_X86)

--- a/tests/library/dbg/tests/test_go.py
+++ b/tests/library/dbg/tests/test_go.py
@@ -9,9 +9,7 @@ GOSAMPLE_X86 = tests.get_binary("gosample.x86")
 
 
 async def helper_test_dump(ctrl: Controller, target: str) -> None:
-    gdb.execute("set environment GOMAXPROCS=1")
-
-    await ctrl.launch(filename, env={"GOMAXPROCS": "1"})
+    await ctrl.launch(target, env={"GOMAXPROCS": "1"})
 
     await ctrl.execute("b gosample.go:6")
     await ctrl.cont()
@@ -37,9 +35,9 @@ async def helper_test_dump(ctrl: Controller, target: str) -> None:
 
 @tests.pwndbg_test
 async def test_go_dumping_x64(ctrl: Controller) -> None:
-    await helper_test_dump(start_binary, GOSAMPLE_X64)
+    await helper_test_dump(ctrl, GOSAMPLE_X64)
 
 
 @tests.pwndbg_test
 async def test_go_dumping_x86(ctrl: Controller) -> None:
-    await helper_test_dump(start_binary, GOSAMPLE_X86)
+    await helper_test_dump(ctrl, GOSAMPLE_X86)

--- a/tests/library/dbg/tests/test_hexdump.py
+++ b/tests/library/dbg/tests/test_hexdump.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import pytest
+from host import Controller
+
+import tests
+
+BINARY = tests.get_binary("reference-binary.out")
+
+
+async def run_tests(ctrl: Controller, stack: int, use_big_endian: bool, expected: str) -> None:
+    import pwndbg
+    import pwndbg.aglib.memory
+
+    pwndbg.config.hexdump_group_use_big_endian.value = use_big_endian
+
+    # Put some data onto the stack
+    pwndbg.aglib.memory.write(stack, cyclic(0x100))
+
+    # Test empty hexdump
+    result = await ctrl.execute_and_capture("hexdump 0")
+    assert result == "Could not read memory at specified address\n"
+
+    results = []
+    # TODO: Repetition is not working in tests
+    results.append(await ctrl.execute_and_capture(f"hexdump {stack} 64"))
+    results.append(await ctrl.execute_and_capture(f"hexdump {stack} 3"))
+
+    assert len(results) == len(expected)
+    for i, result in enumerate(results):
+        expected_result = expected[i]
+        assert result == expected_result
+
+
+@tests.pwndbg_test
+async def test_hexdump(ctrl: Controller) -> None:
+    import pwndbg
+    import pwndbg.aglib.regs
+
+    await ctrl.launch(BINARY)
+    pwndbg.config.hexdump_group_width.value = -1
+
+    # TODO: Setting theme options with Python isn't working
+    await ctrl.execute("set hexdump-byte-separator")
+    stack_addr = pwndbg.aglib.regs.rsp - 0x100
+
+    expected = [
+        f"""+0000 0x{stack_addr:x}  6161616261616161 6161616461616163 │aaaabaaa│caaadaaa│
++0010 0x{stack_addr+0x10:x}  6161616661616165 6161616861616167 │eaaafaaa│gaaahaaa│
++0020 0x{stack_addr+0x20:x}  6161616a61616169 6161616c6161616b │iaaajaaa│kaaalaaa│
++0030 0x{stack_addr+0x30:x}  6161616e6161616d 616161706161616f │maaanaaa│oaaapaaa│\n""",
+        f"""+0000 0x{stack_addr:x}            616161                  │aaa     │        │\n""",
+    ]
+    await run_tests(ctrl, stack_addr, True, expected)
+
+    expected = [
+        f"""+0000 0x{stack_addr:x}  6161616162616161 6361616164616161 │aaaabaaa│caaadaaa│
++0010 0x{stack_addr+0x10:x}  6561616166616161 6761616168616161 │eaaafaaa│gaaahaaa│
++0020 0x{stack_addr+0x20:x}  696161616a616161 6b6161616c616161 │iaaajaaa│kaaalaaa│
++0030 0x{stack_addr+0x30:x}  6d6161616e616161 6f61616170616161 │maaanaaa│oaaapaaa│\n""",
+        f"""+0000 0x{stack_addr:x}  616161                            │aaa     │        │\n""",
+    ]
+    await run_tests(ctrl, stack_addr, False, expected)
+
+
+@tests.pwndbg_test
+async def test_hexdump_collapse_lines(ctrl: Controller) -> None:
+    import pwndbg.aglib.memory
+    import pwndbg.aglib.regs
+
+    await ctrl.launch(BINARY)
+    sp = pwndbg.aglib.regs.rsp
+
+    pwndbg.aglib.memory.write(sp, b"abcdefgh\x01\x02\x03\x04\x05\x06\x07\x08" * 16)
+
+    async def hexdump_lines(lines: int):
+        offset = (lines - 1) * 0x10  # last line offset
+        skipped_lines = lines - 2
+
+        out = await ctrl.execute_and_capture(f"hexdump $rsp {offset+16}")
+
+        expected = (
+            f"+0000 0x{sp:x}  61 62 63 64 65 66 67 68  01 02 03 04 05 06 07 08  │abcdefgh│........│\n"
+            f"... ↓            skipped {skipped_lines} identical lines ({skipped_lines*16} bytes)\n"
+            f"+{offset:04x} 0x{sp+offset:x}  61 62 63 64 65 66 67 68  01 02 03 04 05 06 07 08  │abcdefgh│........│\n"
+        )
+        assert out == expected
+
+    await hexdump_lines(3)
+    await hexdump_lines(4)
+    await hexdump_lines(10)
+
+
+@tests.pwndbg_test
+async def test_hexdump_saved_address_and_offset(ctrl: Controller) -> None:
+    import pwndbg.aglib.memory
+    import pwndbg.aglib.regs
+    import pwndbg.commands.hexdump
+
+    # TODO There is no way to verify repetition: the last_address and offset are reset
+    # before each command
+    await ctrl.launch(BINARY)
+    sp = pwndbg.aglib.regs.rsp
+
+    SIZE = 21
+
+    pwndbg.aglib.memory.write(sp, b"abcdefgh\x01\x02\x03\x04\x05\x06\x07\x08" * 16)
+
+    out1 = await ctrl.execute_and_capture(f"hexdump $rsp {SIZE}")
+    out2 = (
+        f"+0000 0x{sp:x}  61 62 63 64 65 66 67 68  01 02 03 04 05 06 07 08  │abcdefgh│........│\n"
+        f"+0010 0x{sp+0x10:x}  61 62 63 64 65                                    │abcde   │        │\n"
+    )
+
+    assert out1 == out2
+    assert pwndbg.commands.hexdump.hexdump.last_address == sp + SIZE
+    assert pwndbg.commands.hexdump.hexdump.offset == SIZE
+
+
+@tests.pwndbg_test
+async def test_hexdump_limit_check(ctrl: Controller):
+    """
+    Tests that the hexdump command respects the hexdump-limit-mb settings.
+    """
+    await ctrl.launch(BINARY)
+    sp = pwndbg.aglib.regs.rsp
+
+    # Default limit is 10 MB
+    default_limit_mb = 10
+    limit_bytes = default_limit_mb * 1024 * 1024
+    count_over_limit = limit_bytes + 1
+    count_within_limit = limit_bytes // 2  # Using a value clearly within the limit
+
+    # 1. Test that count over the default limit raises PwndbgError
+    print(f"Testing count over default limit ({count_over_limit} bytes)")
+    with pytest.raises(gdb.error, match="exceeds the current limit"):
+        gdb.execute(f"hexdump {sp} {count_over_limit}", to_string=True)
+    print(" -> Correctly raised error.")
+
+    # 2. Test that count within the default limit works
+    print(f"Testing count within default limit ({count_within_limit} bytes)")
+    # We don't expect an error here. Just executing it is the test.
+    # We could assert on the output, but simply not crashing/erroring is the main goal.
+    try:
+        gdb.execute(f"hexdump {sp} {count_within_limit}", to_string=True)
+    except Exception as e:
+        pytest.fail(f"Hexdump failed unexpectedly with count within limit: {e}")
+    print(" -> Correctly executed.")
+
+    # 3. Test increasing the limit allows larger dumps
+    new_limit_mb = 15
+    count_over_default_under_new = (default_limit_mb + 1) * 1024 * 1024
+    print(f"Setting limit to {new_limit_mb} MB and testing count {count_over_default_under_new}")
+    gdb.execute(f"set hexdump-limit-mb {new_limit_mb}")
+    try:
+        gdb.execute(f"hexdump {sp} {count_over_default_under_new}", to_string=True)
+    except Exception as e:
+        pytest.fail(f"Hexdump failed unexpectedly after increasing limit: {e}")
+    print(" -> Correctly executed after increasing limit.")
+
+    # 4. Test disabling the limit (set to 0) allows larger dumps
+    print(f"Setting limit to 0 and testing count {count_over_default_under_new}")
+    gdb.execute("set hexdump-limit-mb 0")
+    try:
+        gdb.execute(f"hexdump {sp} {count_over_default_under_new}", to_string=True)
+    except Exception as e:
+        pytest.fail(f"Hexdump failed unexpectedly after disabling limit: {e}")
+    print(" -> Correctly executed after disabling limit.")
+
+    # Reset to default for subsequent tests if any
+    gdb.execute(f"set hexdump-limit-mb {default_limit_mb}")

--- a/tests/library/dbg/tests/test_hexdump.py
+++ b/tests/library/dbg/tests/test_hexdump.py
@@ -9,6 +9,8 @@ BINARY = tests.get_binary("reference-binary.out")
 
 
 async def run_tests(ctrl: Controller, stack: int, use_big_endian: bool, expected: str) -> None:
+    from pwnlib.util.cyclic import cyclic
+
     import pwndbg
     import pwndbg.aglib.memory
 
@@ -122,6 +124,9 @@ async def test_hexdump_limit_check(ctrl: Controller):
     """
     Tests that the hexdump command respects the hexdump-limit-mb settings.
     """
+    import pwndbg.aglib.regs
+    from pwndbg.dbg import Error
+
     await ctrl.launch(BINARY)
     sp = pwndbg.aglib.regs.rsp
 
@@ -133,8 +138,8 @@ async def test_hexdump_limit_check(ctrl: Controller):
 
     # 1. Test that count over the default limit raises PwndbgError
     print(f"Testing count over default limit ({count_over_limit} bytes)")
-    with pytest.raises(gdb.error, match="exceeds the current limit"):
-        gdb.execute(f"hexdump {sp} {count_over_limit}", to_string=True)
+    with pytest.raises(Error, match="exceeds the current limit"):
+        await ctrl.execute(f"hexdump {sp} {count_over_limit}")
     print(" -> Correctly raised error.")
 
     # 2. Test that count within the default limit works
@@ -142,7 +147,7 @@ async def test_hexdump_limit_check(ctrl: Controller):
     # We don't expect an error here. Just executing it is the test.
     # We could assert on the output, but simply not crashing/erroring is the main goal.
     try:
-        gdb.execute(f"hexdump {sp} {count_within_limit}", to_string=True)
+        await ctrl.execute(f"hexdump {sp} {count_within_limit}")
     except Exception as e:
         pytest.fail(f"Hexdump failed unexpectedly with count within limit: {e}")
     print(" -> Correctly executed.")
@@ -151,21 +156,18 @@ async def test_hexdump_limit_check(ctrl: Controller):
     new_limit_mb = 15
     count_over_default_under_new = (default_limit_mb + 1) * 1024 * 1024
     print(f"Setting limit to {new_limit_mb} MB and testing count {count_over_default_under_new}")
-    gdb.execute(f"set hexdump-limit-mb {new_limit_mb}")
+    await ctrl.execute(f"set hexdump-limit-mb {new_limit_mb}")
     try:
-        gdb.execute(f"hexdump {sp} {count_over_default_under_new}", to_string=True)
+        await ctrl.execute(f"hexdump {sp} {count_over_default_under_new}")
     except Exception as e:
         pytest.fail(f"Hexdump failed unexpectedly after increasing limit: {e}")
     print(" -> Correctly executed after increasing limit.")
 
     # 4. Test disabling the limit (set to 0) allows larger dumps
     print(f"Setting limit to 0 and testing count {count_over_default_under_new}")
-    gdb.execute("set hexdump-limit-mb 0")
+    await ctrl.execute("set hexdump-limit-mb 0")
     try:
-        gdb.execute(f"hexdump {sp} {count_over_default_under_new}", to_string=True)
+        await ctrl.execute(f"hexdump {sp} {count_over_default_under_new}")
     except Exception as e:
         pytest.fail(f"Hexdump failed unexpectedly after disabling limit: {e}")
     print(" -> Correctly executed after disabling limit.")
-
-    # Reset to default for subsequent tests if any
-    gdb.execute(f"set hexdump-limit-mb {default_limit_mb}")

--- a/tests/library/dbg/tests/test_hexdump.py
+++ b/tests/library/dbg/tests/test_hexdump.py
@@ -43,8 +43,7 @@ async def test_hexdump(ctrl: Controller) -> None:
     await ctrl.launch(BINARY)
     pwndbg.config.hexdump_group_width.value = -1
 
-    # TODO: Setting theme options with Python isn't working
-    await ctrl.execute("set hexdump-byte-separator ''")
+    pwndbg.config.hexdump_byte_separator.value = ""
     stack_addr = pwndbg.aglib.regs.rsp - 0x100
 
     expected = [

--- a/tests/library/dbg/tests/test_hexdump.py
+++ b/tests/library/dbg/tests/test_hexdump.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import pytest
-from host import Controller
 
-import tests
+from ....host import Controller
+from . import get_binary
+from . import pwndbg_test
 
-BINARY = tests.get_binary("reference-binary.out")
+BINARY = get_binary("reference-binary.out")
 
 
 async def run_tests(ctrl: Controller, stack: int, use_big_endian: bool, expected: str) -> None:
@@ -34,7 +35,7 @@ async def run_tests(ctrl: Controller, stack: int, use_big_endian: bool, expected
         assert result == expected_result
 
 
-@tests.pwndbg_test
+@pwndbg_test
 async def test_hexdump(ctrl: Controller) -> None:
     import pwndbg
     import pwndbg.aglib.regs
@@ -65,7 +66,7 @@ async def test_hexdump(ctrl: Controller) -> None:
     await run_tests(ctrl, stack_addr, False, expected)
 
 
-@tests.pwndbg_test
+@pwndbg_test
 async def test_hexdump_collapse_lines(ctrl: Controller) -> None:
     import pwndbg.aglib.memory
     import pwndbg.aglib.regs
@@ -93,7 +94,7 @@ async def test_hexdump_collapse_lines(ctrl: Controller) -> None:
     await hexdump_lines(10)
 
 
-@tests.pwndbg_test
+@pwndbg_test
 async def test_hexdump_saved_address_and_offset(ctrl: Controller) -> None:
     import pwndbg.aglib.memory
     import pwndbg.aglib.regs
@@ -119,7 +120,7 @@ async def test_hexdump_saved_address_and_offset(ctrl: Controller) -> None:
     assert pwndbg.commands.hexdump.hexdump.offset == SIZE
 
 
-@tests.pwndbg_test
+@pwndbg_test
 async def test_hexdump_limit_check(ctrl: Controller):
     """
     Tests that the hexdump command respects the hexdump-limit-mb settings.

--- a/tests/library/dbg/tests/test_hexdump.py
+++ b/tests/library/dbg/tests/test_hexdump.py
@@ -43,7 +43,7 @@ async def test_hexdump(ctrl: Controller) -> None:
     pwndbg.config.hexdump_group_width.value = -1
 
     # TODO: Setting theme options with Python isn't working
-    await ctrl.execute("set hexdump-byte-separator")
+    await ctrl.execute("set hexdump-byte-separator ''")
     stack_addr = pwndbg.aglib.regs.rsp - 0x100
 
     expected = [

--- a/tests/library/dbg/tests/test_memory.py
+++ b/tests/library/dbg/tests/test_memory.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+from host import Controller
+
+import tests
+
+REFERENCE_BINARY = tests.get_binary("reference-binary.out")
+NESTED_STRUCTS_BINARY = tests.get_binary("nested_structs.out")
+
+
+@tests.pwndbg_test
+async def test_memory_read_write(ctrl: Controller) -> None:
+    """
+    Tests simple pwndbg's memory read/write operations with different argument types
+    """
+    import pwndbg.aglib.memory
+
+    await ctrl.launch(REFERENCE_BINARY)
+    stack_addr = next(iter(pwndbg.aglib.stack.get().values())).vaddr
+
+    # Testing write(addr, str)
+    val = "X" * 50
+    pwndbg.aglib.memory.write(stack_addr, val)
+    assert pwndbg.aglib.memory.read(stack_addr, len(val) + 1) == bytearray(b"X" * 50 + b"\x00")
+
+    # Testing write(addr, bytearray)
+    val = bytearray("Y" * 10, "utf8")
+    pwndbg.aglib.memory.write(stack_addr, val)
+    assert pwndbg.aglib.memory.read(stack_addr, len(val) + 4) == val + bytearray(b"XXXX")
+
+    # Testing write(addr, bytes)
+    val = bytes("Z" * 8, "utf8")
+    pwndbg.aglib.memory.write(stack_addr, val)
+    assert pwndbg.aglib.memory.read(stack_addr, len(val) + 4) == bytearray("Z" * 8 + "YYXX", "utf8")
+
+
+@tests.pwndbg_test
+async def test_memory_peek_poke(ctrl: Controller) -> None:
+    """
+    This tests ensures that doing a peek, poke, peek round-robin operations
+    ends up with the same value in memory.
+    It also sets a given byte in memory via memory.write
+    and tests all single-byte values.
+    """
+    import pwndbg.aglib.memory
+
+    await ctrl.launch(REFERENCE_BINARY)
+
+    # Address 0 is not mapped, so peek should return None
+    # and poke should fail
+    assert pwndbg.aglib.memory.poke(0) is False
+    assert pwndbg.aglib.memory.peek(0) is None
+
+    stack_addr = pwndbg.aglib.regs.rsp
+
+    for v in range(256):
+        data = bytearray([v, 0, 0, 0])
+        pwndbg.aglib.memory.write(stack_addr, data)
+
+        # peek should return the first byte
+        assert pwndbg.aglib.memory.peek(stack_addr) == bytearray([v])
+
+        # Now poke it!
+        assert pwndbg.aglib.memory.poke(stack_addr) is True
+
+        # Now make sure poke did not change the underlying bytes
+        assert pwndbg.aglib.memory.read(stack_addr, 4) == data
+
+    # TODO/FIXME: Fix peek/poke exception handling and uncomment this!
+    """
+    # Ensure that peek and poke correctly raises exceptions
+    # when incorrect argument type is passed
+    for not_parsable_as_int in (b"asdf", "asdf"):
+        with pytest.raises(ValueError):
+            pwndbg.aglib.memory.peek(not_parsable_as_int)
+
+    for not_parsable_as_int in (b"asdf", "asdf"):
+        with pytest.raises(ValueError):
+            pwndbg.aglib.memory.poke(not_parsable_as_int)
+    """
+
+    # Acceptable inputs (not great; maybe we should ban them?)
+    # Note: they return 0 because the address 0 is not mapped
+    assert pwndbg.aglib.memory.peek(0.0) is None
+    assert pwndbg.aglib.memory.peek("0") is None
+    assert pwndbg.aglib.memory.peek(b"0") is None
+
+
+@tests.pwndbg_test
+async def test_fetch_struct_as_dictionary(ctrl: Controller) -> None:
+    """
+    Test pwndbg.aglib.memory.fetch_struct_as_dictionary()
+    Ensure it can handle nested structs, anonymous structs & nested typedefs.
+    """
+    import pwndbg.aglib.memory
+    import pwndbg.aglib.symbol
+
+    await tests.launch_to(ctrl, NESTED_STRUCTS_BINARY, "break_here")
+
+    expected_result = {
+        "outer_x": 1,
+        "outer_y": 2,
+        "inner": {"inner_a": 3, "inner_b": 4, "anonymous_i": 42, "anonymous_j": 44},
+        "anonymous_k": 82,
+        "anonymous_l": 84,
+        "anonymous_nested": 100,
+        "outer_z": 5,
+    }
+
+    struct_address = pwndbg.aglib.symbol.lookup_symbol_addr("outer")
+    assert struct_address is not None
+
+    result = pwndbg.aglib.memory.fetch_struct_as_dictionary("outer_struct", struct_address)
+
+    assert result == expected_result
+
+
+@tests.pwndbg_test
+async def test_fetch_struct_as_dictionary_include_filter(ctrl: Controller) -> None:
+    """
+    Test pwndbg.aglib.memory.fetch_struct_as_dictionary()
+    Ensure its include_only_fields filter works.
+    """
+    import pwndbg.aglib.memory
+    import pwndbg.aglib.symbol
+
+    await tests.launch_to(ctrl, NESTED_STRUCTS_BINARY, "break_here")
+
+    expected_result = {
+        "outer_x": 1,
+        "inner": {"inner_a": 3, "inner_b": 4, "anonymous_i": 42, "anonymous_j": 44},
+        "anonymous_k": 82,
+        "anonymous_nested": 100,
+    }
+
+    struct_address = pwndbg.aglib.symbol.lookup_symbol_addr("outer")
+    assert struct_address is not None
+
+    result = pwndbg.aglib.memory.fetch_struct_as_dictionary(
+        "outer_struct",
+        struct_address,
+        include_only_fields={"outer_x", "inner", "anonymous_k", "anonymous_nested"},
+    )
+
+    assert result == expected_result
+
+
+@tests.pwndbg_test
+async def test_fetch_struct_as_dictionary_exclude_filter(ctrl: Controller) -> None:
+    """
+    Test pwndbg.aglib.memory.fetch_struct_as_dictionary()
+    Ensure its exclude_fields filter works.
+    Note that the exclude filter cannot filter fields of anonymous structs.
+    """
+    import pwndbg.aglib.memory
+    import pwndbg.aglib.symbol
+
+    await tests.launch_to(ctrl, NESTED_STRUCTS_BINARY, "break_here")
+
+    expected_result = {
+        "outer_y": 2,
+        "anonymous_k": 82,
+        "anonymous_l": 84,
+        "anonymous_nested": 100,
+    }
+
+    struct_address = pwndbg.aglib.symbol.lookup_symbol_addr("outer")
+    assert struct_address is not None
+
+    result = pwndbg.aglib.memory.fetch_struct_as_dictionary(
+        "outer_struct",
+        struct_address,
+        exclude_fields={"outer_x", "inner", "outer_z"},
+    )
+
+    assert result == expected_result

--- a/tests/library/dbg/tests/test_memory.py
+++ b/tests/library/dbg/tests/test_memory.py
@@ -1,14 +1,15 @@
 from __future__ import annotations
 
-from host import Controller
+from ....host import Controller
+from . import get_binary
+from . import launch_to
+from . import pwndbg_test
 
-import tests
-
-REFERENCE_BINARY = tests.get_binary("reference-binary.out")
-NESTED_STRUCTS_BINARY = tests.get_binary("nested_structs.out")
+REFERENCE_BINARY = get_binary("reference-binary.out")
+NESTED_STRUCTS_BINARY = get_binary("nested_structs.out")
 
 
-@tests.pwndbg_test
+@pwndbg_test
 async def test_memory_read_write(ctrl: Controller) -> None:
     """
     Tests simple pwndbg's memory read/write operations with different argument types
@@ -34,7 +35,7 @@ async def test_memory_read_write(ctrl: Controller) -> None:
     assert pwndbg.aglib.memory.read(stack_addr, len(val) + 4) == bytearray("Z" * 8 + "YYXX", "utf8")
 
 
-@tests.pwndbg_test
+@pwndbg_test
 async def test_memory_peek_poke(ctrl: Controller) -> None:
     """
     This tests ensures that doing a peek, poke, peek round-robin operations
@@ -86,7 +87,7 @@ async def test_memory_peek_poke(ctrl: Controller) -> None:
     assert pwndbg.aglib.memory.peek(b"0") is None
 
 
-@tests.pwndbg_test
+@pwndbg_test
 async def test_fetch_struct_as_dictionary(ctrl: Controller) -> None:
     """
     Test pwndbg.aglib.memory.fetch_struct_as_dictionary()
@@ -95,7 +96,7 @@ async def test_fetch_struct_as_dictionary(ctrl: Controller) -> None:
     import pwndbg.aglib.memory
     import pwndbg.aglib.symbol
 
-    await tests.launch_to(ctrl, NESTED_STRUCTS_BINARY, "break_here")
+    await launch_to(ctrl, NESTED_STRUCTS_BINARY, "break_here")
 
     expected_result = {
         "outer_x": 1,
@@ -115,7 +116,7 @@ async def test_fetch_struct_as_dictionary(ctrl: Controller) -> None:
     assert result == expected_result
 
 
-@tests.pwndbg_test
+@pwndbg_test
 async def test_fetch_struct_as_dictionary_include_filter(ctrl: Controller) -> None:
     """
     Test pwndbg.aglib.memory.fetch_struct_as_dictionary()
@@ -124,7 +125,7 @@ async def test_fetch_struct_as_dictionary_include_filter(ctrl: Controller) -> No
     import pwndbg.aglib.memory
     import pwndbg.aglib.symbol
 
-    await tests.launch_to(ctrl, NESTED_STRUCTS_BINARY, "break_here")
+    await launch_to(ctrl, NESTED_STRUCTS_BINARY, "break_here")
 
     expected_result = {
         "outer_x": 1,
@@ -145,7 +146,7 @@ async def test_fetch_struct_as_dictionary_include_filter(ctrl: Controller) -> No
     assert result == expected_result
 
 
-@tests.pwndbg_test
+@pwndbg_test
 async def test_fetch_struct_as_dictionary_exclude_filter(ctrl: Controller) -> None:
     """
     Test pwndbg.aglib.memory.fetch_struct_as_dictionary()
@@ -155,7 +156,7 @@ async def test_fetch_struct_as_dictionary_exclude_filter(ctrl: Controller) -> No
     import pwndbg.aglib.memory
     import pwndbg.aglib.symbol
 
-    await tests.launch_to(ctrl, NESTED_STRUCTS_BINARY, "break_here")
+    await launch_to(ctrl, NESTED_STRUCTS_BINARY, "break_here")
 
     expected_result = {
         "outer_y": 2,

--- a/tests/library/dbg/tests/test_misc.py
+++ b/tests/library/dbg/tests/test_misc.py
@@ -5,10 +5,8 @@ import tests
 STACK_COMMANDS = [
     ("canary", [], "Stack", "Print out the current stack canary."),
     # The aliases 'do' and 'dow' were added to support the help consistency test.
-    ("down", ["do", "dow"], "Misc", "Select and print stack frame called by this one."),
     ("retaddr", [], "Stack", "Print out the stack addresses that contain return addresses."),
     ("stack", [], "Stack", "Dereferences on stack data with specified count and offset."),
-    ("up", [], "Misc", "Select and print stack frame that called this one."),
 ]
 
 

--- a/tests/library/dbg/tests/test_misc.py
+++ b/tests/library/dbg/tests/test_misc.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import tests
+
 STACK_COMMANDS = [
     ("canary", [], "Stack", "Print out the current stack canary."),
     # The aliases 'do' and 'dow' were added to support the help consistency test.

--- a/tests/library/dbg/tests/test_misc.py
+++ b/tests/library/dbg/tests/test_misc.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import tests
+from . import pwndbg_test
 
 STACK_COMMANDS = [
     ("canary", [], "Stack", "Print out the current stack canary."),
@@ -10,7 +10,7 @@ STACK_COMMANDS = [
 ]
 
 
-@tests.pwndbg_test
+@pwndbg_test
 async def test_list_and_filter_commands_filter(_ctrl: Controller):
     from pwndbg.commands.misc import list_and_filter_commands
 
@@ -18,7 +18,7 @@ async def test_list_and_filter_commands_filter(_ctrl: Controller):
         assert cmd in list_and_filter_commands("stack")
 
 
-@tests.pwndbg_test
+@pwndbg_test
 async def test_list_and_filter_commands_full_list(_ctrl: Controller):
     import pwndbg.commands
     from pwndbg.commands.misc import list_and_filter_commands

--- a/tests/library/dbg/tests/test_misc.py
+++ b/tests/library/dbg/tests/test_misc.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+STACK_COMMANDS = [
+    ("canary", [], "Stack", "Print out the current stack canary."),
+    # The aliases 'do' and 'dow' were added to support the help consistency test.
+    ("down", ["do", "dow"], "Misc", "Select and print stack frame called by this one."),
+    ("retaddr", [], "Stack", "Print out the stack addresses that contain return addresses."),
+    ("stack", [], "Stack", "Dereferences on stack data with specified count and offset."),
+    ("up", [], "Misc", "Select and print stack frame that called this one."),
+]
+
+
+@tests.pwndbg_test
+async def test_list_and_filter_commands_filter(_ctrl: Controller):
+    from pwndbg.commands.misc import list_and_filter_commands
+
+    for cmd in STACK_COMMANDS:
+        assert cmd in list_and_filter_commands("stack")
+
+
+@tests.pwndbg_test
+async def test_list_and_filter_commands_full_list(_ctrl: Controller):
+    import pwndbg.commands
+    from pwndbg.commands.misc import list_and_filter_commands
+
+    all_commands = list_and_filter_commands("")
+
+    def get_doc(c):
+        return c.description.splitlines()[0]
+
+    cmd_name_docs = [
+        (c.command_name, c.aliases, c.category, get_doc(c)) for c in pwndbg.commands.commands
+    ]
+    cmd_name_docs.sort()
+
+    assert all_commands == cmd_name_docs

--- a/tests/library/dbg/tests/test_mmap.py
+++ b/tests/library/dbg/tests/test_mmap.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
-from host import Controller
+from ....host import Controller
+from . import get_binary
+from . import pwndbg_test
 
-import tests
-
-USE_FDS_BINARY = tests.get_binary("use-fds.out")
+USE_FDS_BINARY = get_binary("use-fds.out")
 
 
-@tests.pwndbg_test
+@pwndbg_test
 async def test_mmap_executes_properly(ctrl: Controller) -> None:
     """
     Tests the mmap command

--- a/tests/library/dbg/tests/test_mmap.py
+++ b/tests/library/dbg/tests/test_mmap.py
@@ -55,8 +55,8 @@ async def test_mmap_executes_properly(ctrl: Controller) -> None:
         if page is None:
             break
         base_addr = page.end
-    output = gdb.execute(
-        f"mmap {base_addr:#x} {page_size} 7 MAP_FIXED|MAP_ANONYMOUS|MAP_PRIVATE", to_string=True
+    output = await ctrl.execute_and_capture(
+        f"mmap {base_addr:#x} {page_size} 7 MAP_FIXED|MAP_ANONYMOUS|MAP_PRIVATE"
     )
     assert output.startswith("mmap syscall returned ")
     ptr = int(output.split(" returned ")[1].rstrip(), 16)

--- a/tests/library/dbg/tests/test_mmap.py
+++ b/tests/library/dbg/tests/test_mmap.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from host import Controller
+
+import tests
+
+USE_FDS_BINARY = tests.get_binary("use-fds.out")
+
+
+@tests.pwndbg_test
+async def test_mmap_executes_properly(ctrl: Controller) -> None:
+    """
+    Tests the mmap command
+    """
+    import pwndbg.aglib.arch
+    import pwndbg.aglib.memory
+    import pwndbg.aglib.vmmap
+    import pwndbg.lib.memory
+
+    await ctrl.launch(USE_FDS_BINARY)
+
+    page_size = pwndbg.lib.memory.PAGE_SIZE
+
+    # Checks for an mmap(2) error.
+    #
+    # mmap(2) is documented to only return a (void*) -1 on failure, but we are a
+    # little stricter and consider any value on the last page to be a mapping
+    # error. While technically we don't need to do this, we make the assumption
+    # that any mapping landing in the last page during a test should warrant
+    # manual investigation.
+    def is_mmap_error(ptr):
+        err = ((1 << pwndbg.aglib.arch.ptrsize) - 1) & pwndbg.lib.memory.PAGE_MASK
+        return ptr & pwndbg.lib.memory.PAGE_MASK == err
+
+    # Checks whether permissions match.
+    def has_correct_perms(ptr, perm):
+        page = pwndbg.aglib.vmmap.find(ptr)
+        return (
+            not (page.read ^ ("r" in perm))
+            and not (page.write ^ ("w" in perm))
+            and not (page.execute ^ ("x" in perm))
+        )
+
+    # Check basic private+anonymous page mmap.
+    output = await ctrl.execute_and_capture(f"mmap 0x0 {page_size}")
+    assert output.startswith("mmap syscall returned ")
+    ptr = int(output.split(" returned ")[1].rstrip(), 16)
+    assert not is_mmap_error(ptr)
+    assert has_correct_perms(ptr, "rwx")
+
+    # Check basic fixed mapping.
+    base_addr = 0xDEADBEEF & pwndbg.lib.memory.PAGE_MASK
+    while True:
+        page = pwndbg.aglib.vmmap.find(base_addr)
+        if page is None:
+            break
+        base_addr = page.end
+    output = gdb.execute(
+        f"mmap {base_addr:#x} {page_size} 7 MAP_FIXED|MAP_ANONYMOUS|MAP_PRIVATE", to_string=True
+    )
+    assert output.startswith("mmap syscall returned ")
+    ptr = int(output.split(" returned ")[1].rstrip(), 16)
+    assert not is_mmap_error(ptr)
+    assert has_correct_perms(ptr, "rwx")
+    assert ptr == base_addr
+
+    # Continue the program until just before close(2) is called.
+    await ctrl.execute("b use-fds.c:16")
+    await ctrl.cont()
+
+    # Retrieve the file descriptor number and map it to memory.
+    fd_num = int(pwndbg.dbg.selected_frame().evaluate_expression("fd"))
+    output = await ctrl.execute_and_capture(f"mmap 0x0 16 PROT_READ MAP_PRIVATE {fd_num} 0")
+    assert output.startswith("mmap syscall returned ")
+    ptr = int(output.split(" returned ")[1].rstrip(), 16)
+    assert not is_mmap_error(ptr)
+    assert has_correct_perms(ptr, "r")
+
+    # Load the 16 bytes read in by the read() call in the program, as well as
+    # the first 16 bytes present in our newly created memory map, and compare
+    # them.
+    data_ptr = int(pwndbg.dbg.selected_frame().evaluate_expression("buf").address)
+    data_local = pwndbg.aglib.memory.read(data_ptr, 16)
+    data_mapped = pwndbg.aglib.memory.read(ptr, 16)
+    assert data_local == data_mapped

--- a/tests/library/dbg/tests/test_mprotect.py
+++ b/tests/library/dbg/tests/test_mprotect.py
@@ -26,7 +26,7 @@ async def test_mprotect_executes_properly(ctrl: Controller) -> None:
     assert vm.read and vm.write and vm.execute
 
     # Check if we can use mprotect with address provided as register
-    # and to set page permissions to none
-    await ctrl.execute("mprotect $pc 0x1000 PROT_NONE")
+    # and to set page permissions back to RX
+    await ctrl.execute("mprotect $pc 0x1000 PROT_EXEC|PROT_READ")
     vm = pwndbg.aglib.vmmap.find(pc)
-    assert not (vm.read and vm.write and vm.execute)
+    assert vm.read and vm.execute and not vm.write

--- a/tests/library/dbg/tests/test_mprotect.py
+++ b/tests/library/dbg/tests/test_mprotect.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from host import Controller
+
+import tests
+
+SMALL_BINARY = tests.get_binary("crash_simple.out.hardcoded")
+
+
+@tests.pwndbg_test
+async def test_mprotect_executes_properly(ctrl: Controller) -> None:
+    """
+    Tests the mprotect command
+    """
+    import pwndbg.aglib.regs
+    import pwndbg.aglib.vmmap
+
+    await ctrl.launch(SMALL_BINARY)
+
+    pc = pwndbg.aglib.regs.pc
+
+    # Check if we can use mprotect with address provided as value
+    # and to set page permissions to RWX
+    await ctrl.execute(f"mprotect {pc} 4096 PROT_EXEC|PROT_READ|PROT_WRITE")
+    vm = pwndbg.aglib.vmmap.find(pc)
+    assert vm.read and vm.write and vm.execute
+
+    # Check if we can use mprotect with address provided as register
+    # and to set page permissions to none
+    await ctrl.execute("mprotect $pc 0x1000 PROT_NONE")
+    vm = pwndbg.aglib.vmmap.find(pc)
+    assert not (vm.read and vm.write and vm.execute)

--- a/tests/library/dbg/tests/test_mprotect.py
+++ b/tests/library/dbg/tests/test_mprotect.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
-from host import Controller
+from ....host import Controller
+from . import get_binary
+from . import pwndbg_test
 
-import tests
-
-SMALL_BINARY = tests.get_binary("crash_simple.out.hardcoded")
+SMALL_BINARY = get_binary("crash_simple.out.hardcoded")
 
 
-@tests.pwndbg_test
+@pwndbg_test
 async def test_mprotect_executes_properly(ctrl: Controller) -> None:
     """
     Tests the mprotect command

--- a/tests/library/dbg/tests/test_nearpc.py
+++ b/tests/library/dbg/tests/test_nearpc.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import pytest
-from host import Controller
 
-import tests
+from ....host import Controller
+from . import get_binary
+from . import pwndbg_test
 
-SYSCALLS_BINARY = tests.get_binary("syscalls-x64.out")
+SYSCALLS_BINARY = get_binary("syscalls-x64.out")
 
 OPCODE_BYTES_TESTS_EXPECTED_OUTPUT = {
     1: [
@@ -118,7 +119,7 @@ OPCODE_SEPERATOR_TESTS_EXPECTED_OUTPUT = {
 }
 
 
-@tests.pwndbg_test
+@pwndbg_test
 @pytest.mark.parametrize("opcode_bytes", (1, 2, 3, 4, 5))
 async def test_nearpc_opcode_bytes(ctrl: Controller, opcode_bytes: int) -> None:
     await ctrl.launch(SYSCALLS_BINARY)
@@ -145,7 +146,7 @@ async def test_nearpc_opcode_bytes(ctrl: Controller, opcode_bytes: int) -> None:
     assert dis == expected
 
 
-@tests.pwndbg_test
+@pwndbg_test
 @pytest.mark.parametrize("separator_bytes", (0, 1, 2))
 async def test_nearpc_opcode_seperator(ctrl: Controller, separator_bytes: int) -> None:
     await ctrl.launch(SYSCALLS_BINARY)
@@ -174,7 +175,7 @@ async def test_nearpc_opcode_seperator(ctrl: Controller, separator_bytes: int) -
     assert dis == excepted
 
 
-@tests.pwndbg_test
+@pwndbg_test
 async def test_nearpc_highlight_breakpoint(ctrl: Controller) -> None:
     import pwndbg.aglib.symbol
     from pwndbg.dbg import BreakpointLocation

--- a/tests/library/dbg/tests/test_nearpc.py
+++ b/tests/library/dbg/tests/test_nearpc.py
@@ -254,7 +254,7 @@ async def test_nearpc_highlight_breakpoint(ctrl: Controller) -> None:
     )
     assert dis == expected
 
-    bp2.set_enabled(True)
+    bp1.set_enabled(True)
     dis = await ctrl.execute_and_capture("nearpc")
     expected = (
         "   0x400080 <_start>       mov    eax, 0                 EAX => 0\n"

--- a/tests/library/dbg/tests/test_nearpc.py
+++ b/tests/library/dbg/tests/test_nearpc.py
@@ -1,0 +1,306 @@
+from __future__ import annotations
+
+import pytest
+from host import Controller
+
+import tests
+
+SYSCALLS_BINARY = tests.get_binary("syscalls-x64.out")
+
+OPCODE_BYTES_TESTS_EXPECTED_OUTPUT = {
+    1: [
+        "b8\x1b[90m...\x1b[0m",
+        "bf\x1b[90m...\x1b[0m",
+        "be\x1b[90m...\x1b[0m",
+        "b9\x1b[90m...\x1b[0m",
+        "0f\x1b[90m...\x1b[0m",
+        "b8\x1b[90m...\x1b[0m",
+        "cd\x1b[90m...\x1b[0m",
+        "00\x1b[90m...\x1b[0m",
+        "00\x1b[90m...\x1b[0m",
+        "00\x1b[90m...\x1b[0m",
+        "00\x1b[90m...\x1b[0m",
+    ],
+    2: [
+        "b8 00\x1b[90m...\x1b[0m",
+        "bf 37\x1b[90m...\x1b[0m",
+        "be ef\x1b[90m...\x1b[0m",
+        "b9 10\x1b[90m...\x1b[0m",
+        "0f 05   ",
+        "b8 0a\x1b[90m...\x1b[0m",
+        "cd 80   ",
+        "00 00   ",
+        "00 00   ",
+        "00 00   ",
+        "00 00   ",
+    ],
+    3: [
+        "b8 00 00\x1b[90m...\x1b[0m",
+        "bf 37 13\x1b[90m...\x1b[0m",
+        "be ef be\x1b[90m...\x1b[0m",
+        "b9 10 00\x1b[90m...\x1b[0m",
+        "0f 05      ",
+        "b8 0a 00\x1b[90m...\x1b[0m",
+        "cd 80      ",
+        "00 00      ",
+        "00 00      ",
+        "00 00      ",
+        "00 00      ",
+    ],
+    4: [
+        "b8 00 00 00\x1b[90m...\x1b[0m",
+        "bf 37 13 00\x1b[90m...\x1b[0m",
+        "be ef be ad\x1b[90m...\x1b[0m",
+        "b9 10 00 00\x1b[90m...\x1b[0m",
+        "0f 05         ",
+        "b8 0a 00 00\x1b[90m...\x1b[0m",
+        "cd 80         ",
+        "00 00         ",
+        "00 00         ",
+        "00 00         ",
+        "00 00         ",
+    ],
+    5: [
+        "b8 00 00 00 00   ",
+        "bf 37 13 00 00   ",
+        "be ef be ad de   ",
+        "b9 10 00 00 00   ",
+        "0f 05            ",
+        "b8 0a 00 00 00   ",
+        "cd 80            ",
+        "00 00            ",
+        "00 00            ",
+        "00 00            ",
+        "00 00            ",
+    ],
+}
+
+OPCODE_SEPERATOR_TESTS_EXPECTED_OUTPUT = {
+    0: [
+        "b800000000   ",
+        "bf37130000   ",
+        "beefbeadde   ",
+        "b910000000   ",
+        "0f05         ",
+        "b80a000000   ",
+        "cd80         ",
+        "0000         ",
+        "0000         ",
+        "0000         ",
+        "0000         ",
+    ],
+    1: [
+        "b8 00 00 00 00   ",
+        "bf 37 13 00 00   ",
+        "be ef be ad de   ",
+        "b9 10 00 00 00   ",
+        "0f 05            ",
+        "b8 0a 00 00 00   ",
+        "cd 80            ",
+        "00 00            ",
+        "00 00            ",
+        "00 00            ",
+        "00 00            ",
+    ],
+    2: [
+        "b8  00  00  00  00   ",
+        "bf  37  13  00  00   ",
+        "be  ef  be  ad  de   ",
+        "b9  10  00  00  00   ",
+        "0f  05               ",
+        "b8  0a  00  00  00   ",
+        "cd  80               ",
+        "00  00               ",
+        "00  00               ",
+        "00  00               ",
+        "00  00               ",
+    ],
+}
+
+
+@tests.pwndbg_test
+@pytest.mark.parametrize("opcode_bytes", (1, 2, 3, 4, 5))
+async def test_nearpc_opcode_bytes(ctrl: Controller, opcode_bytes: int) -> None:
+    await ctrl.launch(SYSCALLS_BINARY)
+    await ctrl.execute("nextsyscall")
+
+    await ctrl.execute(f"set nearpc-num-opcode-bytes {opcode_bytes}")
+    dis = await ctrl.execute_and_capture("nearpc")
+    expected = (
+        "   0x400080 {} <_start>       mov    eax, 0                 EAX => 0\n"
+        "   0x400085 {} <_start+5>     mov    edi, 0x1337            EDI => 0x1337\n"
+        "   0x40008a {} <_start+10>    mov    esi, 0xdeadbeef        ESI => 0xdeadbeef\n"
+        "   0x40008f {} <_start+15>    mov    ecx, 0x10              ECX => 0x10\n"
+        " ► 0x400094 {} <_start+20>    syscall  <SYS_read>\n"
+        "        fd:        0x1337\n"
+        "        buf:       0xdeadbeef\n"
+        "        nbytes:    0\n"
+        "   0x400096 {} <_start+22>    mov    eax, 0xa               EAX => 0xa\n"
+        "   0x40009b {} <_start+27>    int    0x80\n"
+        "   0x40009d {}                add    byte ptr [rax], al\n"
+        "   0x40009f {}                add    byte ptr [rax], al\n"
+        "   0x4000a1 {}                add    byte ptr [rax], al\n"
+        "   0x4000a3 {}                add    byte ptr [rax], al\n"
+    ).format(*OPCODE_BYTES_TESTS_EXPECTED_OUTPUT[opcode_bytes])
+    assert dis == expected
+
+
+@tests.pwndbg_test
+@pytest.mark.parametrize("separator_bytes", (0, 1, 2))
+async def test_nearpc_opcode_seperator(ctrl: Controller, separator_bytes: int) -> None:
+    await ctrl.launch(SYSCALLS_BINARY)
+    await ctrl.execute("nextsyscall")
+
+    await ctrl.execute("set nearpc-num-opcode-bytes 5")
+    await ctrl.execute(f"set nearpc-opcode-separator-bytes {separator_bytes}")
+
+    dis = await ctrl.execute_and_capture("nearpc")
+    excepted = (
+        "   0x400080 {} <_start>       mov    eax, 0                 EAX => 0\n"
+        "   0x400085 {} <_start+5>     mov    edi, 0x1337            EDI => 0x1337\n"
+        "   0x40008a {} <_start+10>    mov    esi, 0xdeadbeef        ESI => 0xdeadbeef\n"
+        "   0x40008f {} <_start+15>    mov    ecx, 0x10              ECX => 0x10\n"
+        " ► 0x400094 {} <_start+20>    syscall  <SYS_read>\n"
+        "        fd:        0x1337\n"
+        "        buf:       0xdeadbeef\n"
+        "        nbytes:    0\n"
+        "   0x400096 {} <_start+22>    mov    eax, 0xa               EAX => 0xa\n"
+        "   0x40009b {} <_start+27>    int    0x80\n"
+        "   0x40009d {}                add    byte ptr [rax], al\n"
+        "   0x40009f {}                add    byte ptr [rax], al\n"
+        "   0x4000a1 {}                add    byte ptr [rax], al\n"
+        "   0x4000a3 {}                add    byte ptr [rax], al\n"
+    ).format(*OPCODE_SEPERATOR_TESTS_EXPECTED_OUTPUT[separator_bytes])
+    assert dis == excepted
+
+
+@tests.pwndbg_test
+async def test_nearpc_highlight_breakpoint(ctrl: Controller) -> None:
+    import pwndbg.aglib.symbol
+    from pwndbg.dbg import BreakpointLocation
+
+    await ctrl.launch(SYSCALLS_BINARY)
+
+    start_base = pwndbg.aglib.symbol.lookup_symbol_addr("_start")
+
+    bp1 = pwndbg.dbg.selected_inferior().break_at(BreakpointLocation(start_base + 5))
+    bp2 = pwndbg.dbg.selected_inferior().break_at(BreakpointLocation(start_base + 22))
+
+    dis = await ctrl.execute_and_capture("nearpc")
+    expected = (
+        " ► 0x400080 <_start>       mov    eax, 0                 EAX => 0\n"
+        "b+ 0x400085 <_start+5>     mov    edi, 0x1337            EDI => 0x1337\n"
+        "   0x40008a <_start+10>    mov    esi, 0xdeadbeef        ESI => 0xdeadbeef\n"
+        "   0x40008f <_start+15>    mov    ecx, 0x10              ECX => 0x10\n"
+        "   0x400094 <_start+20>    syscall \n"
+        "b+ 0x400096 <_start+22>    mov    eax, 0xa               EAX => 0xa\n"
+        "   0x40009b <_start+27>    int    0x80\n"
+        "   0x40009d                add    byte ptr [rax], al\n"
+        "   0x40009f                add    byte ptr [rax], al\n"
+        "   0x4000a1                add    byte ptr [rax], al\n"
+        "   0x4000a3                add    byte ptr [rax], al\n"
+    )
+    assert dis == expected
+
+    await ctrl.step_instruction()
+    dis = await ctrl.execute_and_capture("nearpc")
+    # When we stop on a breakpoint, we only highlight it (and not show the "b+" marker)
+    expected = (
+        "   0x400080 <_start>       mov    eax, 0                 EAX => 0\n"
+        " ► 0x400085 <_start+5>     mov    edi, 0x1337            EDI => 0x1337\n"
+        "   0x40008a <_start+10>    mov    esi, 0xdeadbeef        ESI => 0xdeadbeef\n"
+        "   0x40008f <_start+15>    mov    ecx, 0x10              ECX => 0x10\n"
+        "   0x400094 <_start+20>    syscall \n"
+        "b+ 0x400096 <_start+22>    mov    eax, 0xa               EAX => 0xa\n"
+        "   0x40009b <_start+27>    int    0x80\n"
+        "   0x40009d                add    byte ptr [rax], al\n"
+        "   0x40009f                add    byte ptr [rax], al\n"
+        "   0x4000a1                add    byte ptr [rax], al\n"
+        "   0x4000a3                add    byte ptr [rax], al\n"
+    )
+    assert dis == expected
+
+    await ctrl.step_instruction()
+    dis = await ctrl.execute_and_capture("nearpc")
+    expected = (
+        "   0x400080 <_start>       mov    eax, 0                 EAX => 0\n"
+        "b+ 0x400085 <_start+5>     mov    edi, 0x1337            EDI => 0x1337\n"
+        " ► 0x40008a <_start+10>    mov    esi, 0xdeadbeef        ESI => 0xdeadbeef\n"
+        "   0x40008f <_start+15>    mov    ecx, 0x10              ECX => 0x10\n"
+        "   0x400094 <_start+20>    syscall \n"
+        "b+ 0x400096 <_start+22>    mov    eax, 0xa               EAX => 0xa\n"
+        "   0x40009b <_start+27>    int    0x80\n"
+        "   0x40009d                add    byte ptr [rax], al\n"
+        "   0x40009f                add    byte ptr [rax], al\n"
+        "   0x4000a1                add    byte ptr [rax], al\n"
+        "   0x4000a3                add    byte ptr [rax], al\n"
+    )
+    assert dis == expected
+
+    bp1.set_enabled(False)
+    dis = await ctrl.execute_and_capture("nearpc")
+    expected = (
+        "   0x400080 <_start>       mov    eax, 0                 EAX => 0\n"
+        "   0x400085 <_start+5>     mov    edi, 0x1337            EDI => 0x1337\n"
+        " ► 0x40008a <_start+10>    mov    esi, 0xdeadbeef        ESI => 0xdeadbeef\n"
+        "   0x40008f <_start+15>    mov    ecx, 0x10              ECX => 0x10\n"
+        "   0x400094 <_start+20>    syscall \n"
+        "b+ 0x400096 <_start+22>    mov    eax, 0xa               EAX => 0xa\n"
+        "   0x40009b <_start+27>    int    0x80\n"
+        "   0x40009d                add    byte ptr [rax], al\n"
+        "   0x40009f                add    byte ptr [rax], al\n"
+        "   0x4000a1                add    byte ptr [rax], al\n"
+        "   0x4000a3                add    byte ptr [rax], al\n"
+    )
+    assert dis == expected
+
+    bp2.set_enabled(True)
+    dis = await ctrl.execute_and_capture("nearpc")
+    expected = (
+        "   0x400080 <_start>       mov    eax, 0                 EAX => 0\n"
+        "b+ 0x400085 <_start+5>     mov    edi, 0x1337            EDI => 0x1337\n"
+        " ► 0x40008a <_start+10>    mov    esi, 0xdeadbeef        ESI => 0xdeadbeef\n"
+        "   0x40008f <_start+15>    mov    ecx, 0x10              ECX => 0x10\n"
+        "   0x400094 <_start+20>    syscall \n"
+        "b+ 0x400096 <_start+22>    mov    eax, 0xa               EAX => 0xa\n"
+        "   0x40009b <_start+27>    int    0x80\n"
+        "   0x40009d                add    byte ptr [rax], al\n"
+        "   0x40009f                add    byte ptr [rax], al\n"
+        "   0x4000a1                add    byte ptr [rax], al\n"
+        "   0x4000a3                add    byte ptr [rax], al\n"
+    )
+    assert dis == expected
+
+    bp1.remove()
+    dis = await ctrl.execute_and_capture("nearpc")
+    expected = (
+        "   0x400080 <_start>       mov    eax, 0                 EAX => 0\n"
+        "   0x400085 <_start+5>     mov    edi, 0x1337            EDI => 0x1337\n"
+        " ► 0x40008a <_start+10>    mov    esi, 0xdeadbeef        ESI => 0xdeadbeef\n"
+        "   0x40008f <_start+15>    mov    ecx, 0x10              ECX => 0x10\n"
+        "   0x400094 <_start+20>    syscall \n"
+        "b+ 0x400096 <_start+22>    mov    eax, 0xa               EAX => 0xa\n"
+        "   0x40009b <_start+27>    int    0x80\n"
+        "   0x40009d                add    byte ptr [rax], al\n"
+        "   0x40009f                add    byte ptr [rax], al\n"
+        "   0x4000a1                add    byte ptr [rax], al\n"
+        "   0x4000a3                add    byte ptr [rax], al\n"
+    )
+    assert dis == expected
+
+    bp2.remove()
+    dis = await ctrl.execute_and_capture("nearpc")
+    expected = (
+        "   0x400080 <_start>       mov    eax, 0                 EAX => 0\n"
+        "   0x400085 <_start+5>     mov    edi, 0x1337            EDI => 0x1337\n"
+        " ► 0x40008a <_start+10>    mov    esi, 0xdeadbeef        ESI => 0xdeadbeef\n"
+        "   0x40008f <_start+15>    mov    ecx, 0x10              ECX => 0x10\n"
+        "   0x400094 <_start+20>    syscall \n"
+        "   0x400096 <_start+22>    mov    eax, 0xa               EAX => 0xa\n"
+        "   0x40009b <_start+27>    int    0x80\n"
+        "   0x40009d                add    byte ptr [rax], al\n"
+        "   0x40009f                add    byte ptr [rax], al\n"
+        "   0x4000a1                add    byte ptr [rax], al\n"
+        "   0x4000a3                add    byte ptr [rax], al\n"
+    )
+    assert dis == expected

--- a/tests/library/dbg/tests/test_symbol.py
+++ b/tests/library/dbg/tests/test_symbol.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from host import Controller
+
+import tests
+
+MANGLING_BINARY = tests.get_binary("symbol_1600_and_752.out")
+
+
+@tests.pwndbg_test
+async def test_symbol_get(ctrl: Controller) -> None:
+    import pwndbg
+
+    await ctrl.launch(MANGLING_BINARY)
+    tests.break_at_sym("break_here")
+
+    async def get_next_ptr():
+        await ctrl.cont()
+
+        # To fetch the value of 'p' it must be set first
+        # and it will be set by the program copying from register to the stack
+        # (we pass `to_string=True` to suppress the context output)
+        await ctrl.execute_and_capture("nextret")
+        p = int(pwndbg.dbg.selected_frame().evaluate_expression("p"))
+        return pwndbg.dbg.selected_inferior().symbol_name_at_address(p)
+
+    assert (await get_next_ptr()) == "main"
+
+    assert (await get_next_ptr()) == "break_here(void*)"
+
+    # Test for the bug https://github.com/pwndbg/pwndbg/issues/1600
+    assert (await get_next_ptr()) == "A::foo(int, int)"
+
+    assert (await get_next_ptr()) == "A::call_foo()"

--- a/tests/library/dbg/tests/test_symbol.py
+++ b/tests/library/dbg/tests/test_symbol.py
@@ -1,18 +1,19 @@
 from __future__ import annotations
 
-from host import Controller
+from ....host import Controller
+from . import break_at_sym
+from . import get_binary
+from . import pwndbg_test
 
-import tests
-
-MANGLING_BINARY = tests.get_binary("symbol_1600_and_752.out")
+MANGLING_BINARY = get_binary("symbol_1600_and_752.out")
 
 
-@tests.pwndbg_test
+@pwndbg_test
 async def test_symbol_get(ctrl: Controller) -> None:
     import pwndbg
 
     await ctrl.launch(MANGLING_BINARY)
-    tests.break_at_sym("break_here")
+    break_at_sym("break_here")
 
     async def get_next_ptr():
         await ctrl.cont()

--- a/tests/library/dbg/tests/test_triggers.py
+++ b/tests/library/dbg/tests/test_triggers.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from typing import Any
+from unittest import mock
+
+from host import Controller
+
+import pwndbg.lib.config
+
+
+async def set_param(ctrl: Controller, param_name: str, value: Any):
+    await ctrl.execute(f"set {param_name} {value}")
+
+
+async def single_param(ctrl: Controller, param_name: str, triggers: Any):
+    from pwndbg import config
+
+    p = getattr(config, param_name.replace("-", "_"))
+
+    mock_triggers = []
+    for trigger in triggers:
+        mock_triggers.append(mock.Mock(side_effect=trigger))
+
+    orig_triggers = config.triggers[param_name]
+    config.triggers[param_name] = mock_triggers
+
+    if p.value is True:
+        await set_param(ctrl, param_name, "off")
+    elif p.value is False:
+        await set_param(ctrl, param_name, "on")
+    elif isinstance(p.value, int):
+        await set_param(ctrl, param_name, 0)
+        await set_param(ctrl, param_name, 1)
+        await set_param(ctrl, param_name, -1)
+    elif isinstance(p.value, str) and p.param_class != pwndbg.lib.config.PARAM_ENUM:
+        await set_param(ctrl, param_name, "")
+        await set_param(ctrl, param_name, "some invalid text")
+        await set_param(ctrl, param_name, "red")
+        await set_param(ctrl, param_name, "bold,yellow")
+    elif isinstance(p.value, str) and p.param_class == pwndbg.lib.config.PARAM_ENUM:
+        # Only valid values are allowed, invalid values will cause an error
+        for enum in p.enum_sequence:
+            await set_param(ctrl, param_name, enum)
+    else:
+        print(p.value, type(p.value))
+        assert False
+
+    for mock_trigger in mock_triggers:
+        mock_trigger.assert_called()
+
+    config.triggers[param_name] = orig_triggers
+
+
+@tests.pwndbg_test
+async def test_triggers(ctrl: Controller) -> None:
+    # The behavior of some triggers depend on the value of other parameters!
+    #
+    # This means that the order in which we run through the parameters matters,
+    # and, in particular, some instances will cause the test to fail, where
+    # others will not. If this test starts failing seemingly for no reason after
+    # a change to the order of imports, this might be the reason.
+    #
+    # Important time dependencies to keep in mind:
+    #     - `disable-colors` will normally be disabled during the test, so we
+    #       must ensure this only happens after this test case has gone through
+    #       all parameters that set color, or the test will likely fail.
+    #
+
+    deferred = []
+    for param_name, triggers in config.triggers.items():
+        if param_name == "disable-colors":
+            deferred.append((param_name, triggers))
+            continue
+
+        await single_param(ctrl, param_name, triggers)
+
+    for param_name, triggers in deferred:
+        await single_param(ctrl, param_name, triggers)

--- a/tests/library/dbg/tests/test_triggers.py
+++ b/tests/library/dbg/tests/test_triggers.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 from typing import Any
 from unittest import mock
 
-from host import Controller
+from ....host import Controller
+from . import get_binary
+from . import pwndbg_test
 
-import tests
-
-REFERENCE_BINARY = tests.get_binary("reference-binary.out")
+REFERENCE_BINARY = get_binary("reference-binary.out")
 
 
 async def set_param(ctrl: Controller, param_name: str, value: Any):
@@ -56,7 +56,7 @@ async def single_param(ctrl: Controller, param_name: str, triggers: Any):
     config.triggers[param_name] = orig_triggers
 
 
-@tests.pwndbg_test
+@pwndbg_test
 async def test_triggers(ctrl: Controller) -> None:
     # The behavior of some triggers depend on the value of other parameters!
     #

--- a/tests/library/dbg/tests/test_triggers.py
+++ b/tests/library/dbg/tests/test_triggers.py
@@ -5,8 +5,9 @@ from unittest import mock
 
 from host import Controller
 
-import pwndbg.lib.config
 import tests
+
+REFERENCE_BINARY = tests.get_binary("reference-binary.out")
 
 
 async def set_param(ctrl: Controller, param_name: str, value: Any):
@@ -14,13 +15,16 @@ async def set_param(ctrl: Controller, param_name: str, value: Any):
 
 
 async def single_param(ctrl: Controller, param_name: str, triggers: Any):
+    import pwndbg
     from pwndbg import config
 
     p = getattr(config, param_name.replace("-", "_"))
 
     mock_triggers = []
-    for trigger in triggers:
-        mock_triggers.append(mock.Mock(side_effect=trigger))
+    # Side-effects of some `integration-provider` triggers require GDB.
+    if param_name != "integration-provider" or pwndbg.dbg.is_gdblib_available():
+        for trigger in triggers:
+            mock_triggers.append(mock.Mock(side_effect=trigger))
 
     orig_triggers = config.triggers[param_name]
     config.triggers[param_name] = mock_triggers
@@ -67,6 +71,9 @@ async def test_triggers(ctrl: Controller) -> None:
     #       all parameters that set color, or the test will likely fail.
     #
     from pwndbg import config
+
+    # Some triggers require an active inferior, so launch it.
+    await ctrl.launch(REFERENCE_BINARY)
 
     deferred = []
     for param_name, triggers in config.triggers.items():

--- a/tests/library/dbg/tests/test_triggers.py
+++ b/tests/library/dbg/tests/test_triggers.py
@@ -6,6 +6,7 @@ from unittest import mock
 from host import Controller
 
 import pwndbg.lib.config
+import tests
 
 
 async def set_param(ctrl: Controller, param_name: str, value: Any):
@@ -65,6 +66,7 @@ async def test_triggers(ctrl: Controller) -> None:
     #       must ensure this only happens after this test case has gone through
     #       all parameters that set color, or the test will likely fail.
     #
+    from pwndbg import config
 
     deferred = []
     for param_name, triggers in config.triggers.items():

--- a/tests/library/dbg/tests/test_windbg.py
+++ b/tests/library/dbg/tests/test_windbg.py
@@ -1,0 +1,377 @@
+from __future__ import annotations
+
+from host import Controller
+
+import tests
+
+MEMORY_BINARY = tests.get_binary("memory.out")
+X86_BINARY = tests.get_binary("gosample.x86")
+
+data_addr = "0x400081"
+
+
+@tests.pwndbg_test
+async def test_windbg_dX_commands(ctrl: Controller) -> None:
+    """
+    Tests windbg compatibility commands that dump memory
+    like dq, dw, db, ds etc.
+    """
+    import pwndbg.aglib.regs
+
+    await ctrl.launch(MEMORY_BINARY)
+
+    # Try to fail commands in different way
+    for cmd_prefix in ("dq", "dd", "dw", "db"):
+        # With a non-existent symbol
+        cmd = cmd_prefix + " nonexistentsymbol"
+        assert (await ctrl.execute_and_capture(cmd)) == (
+            "usage: XX [-h] address [count]\n"
+            "XX: error: argument address: Incorrect address (or GDB expression): nonexistentsymbol\n"
+        ).replace("XX", cmd_prefix)
+
+        # With an invalid/unmapped address
+        cmd = cmd_prefix + " 0"
+        assert (await ctrl.execute_and_capture(cmd)) == "Could not access the provided address\n"
+
+    #################################################
+    #### dq command tests
+    #################################################
+    # Try `dq` with symbol, &symbol, 0x<address> and <address> without 0x prefix (treated as hex!)
+    dq1 = await ctrl.execute_and_capture("dq data")
+    dq2 = await ctrl.execute_and_capture("dq &data")
+    dq3 = await ctrl.execute_and_capture(f"dq {data_addr}")
+    dq4 = await ctrl.execute_and_capture(f"dq {data_addr.replace('0x', '')}")
+    assert (
+        dq1
+        == dq2
+        == dq3
+        == dq4
+        == (
+            "0000000000400081     0000000000000000 0000000000000001\n"
+            "0000000000400091     0000000100000002 0001000200030004\n"
+            "00000000004000a1     0102030405060708 1122334455667788\n"
+            "00000000004000b1     0123456789abcdef 0000000000000000\n"
+        )
+    )
+
+    # Try `dq` with different counts
+    dq_count1 = await ctrl.execute_and_capture("dq data 2")
+    dq_count2 = await ctrl.execute_and_capture("dq &data 2")
+    dq_count3 = await ctrl.execute_and_capture(f"dq {data_addr} 2")
+    assert (
+        dq_count1
+        == dq_count2
+        == dq_count3
+        == "0000000000400081     0000000000000000 0000000000000001\n"
+    )
+
+    assert (
+        await ctrl.execute_and_capture("dq data 1")
+    ) == "0000000000400081     0000000000000000\n"
+    assert (await ctrl.execute_and_capture("dq data 3")) == (
+        "0000000000400081     0000000000000000 0000000000000001\n"
+        "0000000000400091     0000000100000002\n"
+    )
+
+    # Try 'dq' with count equal to a register, but lets set it before ;)
+    # also note that we use `data2` here
+    pwndbg.aglib.regs.eax = 4
+    assert (await ctrl.execute_and_capture("dq data2 $eax")) == (
+        "00000000004000a9     1122334455667788 0123456789abcdef\n"
+        "00000000004000b9     0000000000000000 ffffffffffffffff\n"
+    )
+
+    # See if we can repeat dq command (use count for shorter data)
+    assert (await ctrl.execute_and_capture("dq data2 2")) == (
+        "00000000004000a9     1122334455667788 0123456789abcdef\n"
+    )
+
+    # TODO/FIXME: Can we test command repeating here? Neither passing `from_tty=True`
+    # or setting `pwndbg.commands.windbg.dq.repeat = True` works here
+    # assert await ctrl.execute_and_capture('dq data2 2') == (
+    #    '00000000004000b9     0000000000000000 ffffffffffffffff\n'
+    # )
+
+    #################################################
+    #### dd command tests
+    #################################################
+    dd1 = await ctrl.execute_and_capture("dd data")
+    dd2 = await ctrl.execute_and_capture("dd &data")
+    dd3 = await ctrl.execute_and_capture(f"dd {data_addr}")
+    dd4 = await ctrl.execute_and_capture(f"dd {data_addr.replace('0x', '')}")
+    assert (
+        dd1
+        == dd2
+        == dd3
+        == dd4
+        == (
+            "0000000000400081     00000000 00000000 00000001 00000000\n"
+            "0000000000400091     00000002 00000001 00030004 00010002\n"
+            "00000000004000a1     05060708 01020304 55667788 11223344\n"
+            "00000000004000b1     89abcdef 01234567 00000000 00000000\n"
+        )
+    )
+
+    # count tests
+    assert (await ctrl.execute_and_capture("dd data 4")) == (
+        "0000000000400081     00000000 00000000 00000001 00000000\n"
+    )
+    assert (await ctrl.execute_and_capture("dd data 3")) == (
+        "0000000000400081     00000000 00000000 00000001\n"
+    )
+
+    #################################################
+    #### dw command tests
+    #################################################
+    dw1 = await ctrl.execute_and_capture("dw data")
+    dw2 = await ctrl.execute_and_capture("dw &data")
+    dw3 = await ctrl.execute_and_capture(f"dw {data_addr}")
+    dw4 = await ctrl.execute_and_capture(f"dw {data_addr.replace('0x', '')}")
+    assert (
+        dw1
+        == dw2
+        == dw3
+        == dw4
+        == (
+            "0000000000400081     0000 0000 0000 0000 0001 0000 0000 0000\n"
+            "0000000000400091     0002 0000 0001 0000 0004 0003 0002 0001\n"
+            "00000000004000a1     0708 0506 0304 0102 7788 5566 3344 1122\n"
+            "00000000004000b1     cdef 89ab 4567 0123 0000 0000 0000 0000\n"
+        )
+    )
+
+    # count tests
+    assert (await ctrl.execute_and_capture("dw data 8")) == (
+        "0000000000400081     0000 0000 0000 0000 0001 0000 0000 0000\n"
+    )
+
+    assert (await ctrl.execute_and_capture("dw data 8/2")) == (
+        "0000000000400081     0000 0000 0000 0000\n"
+    )
+
+    assert (await ctrl.execute_and_capture("dw data $eax")) == (
+        "0000000000400081     0000 0000 0000 0000\n"
+    )
+
+    #################################################
+    #### db command tests
+    #################################################
+    db1 = await ctrl.execute_and_capture("db data")
+    db2 = await ctrl.execute_and_capture("db &data")
+    db3 = await ctrl.execute_and_capture(f"db {data_addr}")
+    db4 = await ctrl.execute_and_capture(f"db {data_addr.replace('0x', '')}")
+    assert (
+        db1
+        == db2
+        == db3
+        == db4
+        == (
+            "0000000000400081     00 00 00 00 00 00 00 00 01 00 00 00 00 00 00 00\n"
+            "0000000000400091     02 00 00 00 01 00 00 00 04 00 03 00 02 00 01 00\n"
+            "00000000004000a1     08 07 06 05 04 03 02 01 88 77 66 55 44 33 22 11\n"
+            "00000000004000b1     ef cd ab 89 67 45 23 01 00 00 00 00 00 00 00 00\n"
+        )
+    )
+
+    # count tests
+    assert (await ctrl.execute_and_capture("db data 31")) == (
+        "0000000000400081     00 00 00 00 00 00 00 00 01 00 00 00 00 00 00 00\n"
+        "0000000000400091     02 00 00 00 01 00 00 00 04 00 03 00 02 00 01\n"
+    )
+    assert (await ctrl.execute_and_capture("db data $ax")) == ("0000000000400081     00 00 00 00\n")
+
+    #################################################
+    #### dc command tests
+    #################################################
+    dc1 = await ctrl.execute_and_capture("dc data")
+    dc2 = await ctrl.execute_and_capture("dc &data")
+    dc3 = await ctrl.execute_and_capture(f"dc {data_addr}")
+    dc4 = await ctrl.execute_and_capture(f"dc {data_addr.replace('0x', '')}")
+    assert (
+        dc1
+        == dc2
+        == dc3
+        == dc4
+        == (
+            "+0000 0x400081  00 00 00 00 00 00 00 00                           "
+            "│........│        │\n"
+        )
+    )
+
+    assert (await ctrl.execute_and_capture("dc data 3")) == (
+        "+0000 0x400081  00 00 00                                          │...     │        │\n"
+    )
+
+    #################################################
+    #### ds command tests
+    #################################################
+    ds1 = await ctrl.execute_and_capture("ds short_str")
+    ds2 = await ctrl.execute_and_capture("ds &short_str")
+    ds3 = await ctrl.execute_and_capture("ds 0x4000d9")
+    ds4 = await ctrl.execute_and_capture("ds 4000d9")
+    assert ds1 == ds2 == ds3 == ds4 == "4000d9 'some cstring here'\n"
+
+    # Check too low maxlen
+    assert (await ctrl.execute_and_capture("ds short_str 5")) == (
+        "Max str len of 5 too low, changing to 256\n4000d9 'some cstring here'\n"
+    )
+
+    # Check output for a string longer than (the default) maxlen of 256
+    assert (await ctrl.execute_and_capture("ds long_str")) == (
+        "4000eb 'long string: "
+        "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA...'\n"
+    )
+
+    # Check impossible address
+    assert (await ctrl.execute_and_capture("ds 0")) == (
+        "Data at address can't be dereferenced or is not a printable null-terminated "
+        "string or is too short.\n"
+        "Perhaps try: db <address> <count> or hexdump <address>\n"
+    )
+
+
+@tests.pwndbg_test
+async def test_windbg_eX_commands(ctrl: Controller) -> None:
+    """
+    Tests windbg compatibility commands that write to memory
+    like eq, ed, ew, eb etc.
+    """
+    import pwndbg
+
+    await ctrl.launch(MEMORY_BINARY)
+
+    # Try to fail commands in different way
+    for cmd_prefix in ("eq", "ed", "ew", "eb"):
+        # With a non-existent symbol
+        cmd = cmd_prefix + " nonexistentsymbol"
+
+        # Seems there is some mismatch between Python 3.x argparse output
+        expected_in = (
+            # This version occurred locally when tested on Python 3.9.5
+            (
+                "usage: XX [-h] address [data ...]\n"
+                "XX: error: argument address: Incorrect address (or GDB expression): nonexistentsymbol\n"
+            ).replace("XX", cmd_prefix),
+            # This version occurs on CI on Python 3.8.10
+            (
+                "usage: XX [-h] address [data [data ...]]\n"
+                "XX: error: argument address: Incorrect address (or GDB expression): nonexistentsymbol\n"
+            ).replace("XX", cmd_prefix),
+        )
+
+        assert (await ctrl.execute_and_capture(cmd)) in expected_in
+        assert (await ctrl.execute_and_capture(cmd)) in expected_in
+
+        # With no data arguments provided
+        cmd = cmd_prefix + " 0"
+        assert (await ctrl.execute_and_capture(cmd)) == "Cannot write empty data into memory.\n"
+
+        # With invalid/unmapped address 0
+        cmd = cmd_prefix + " 0 1122"
+        assert (await ctrl.execute_and_capture(cmd)) == ("Cannot access memory at address 0x0\n")
+
+        # With invalid data which can't be parsed as hex
+        cmd = cmd_prefix + " 0 x"
+        assert (await ctrl.execute_and_capture(cmd)) == (
+            "Incorrect data format: it must all be a hex value (0x1234 or 1234, both "
+            "interpreted as 0x1234)\n"
+        )
+    #########################################
+    ### Test eq write
+    #########################################
+    assert (await ctrl.execute_and_capture("eq $sp 0xcafebabe")) == ""
+    assert "0x00000000cafebabe" in (await ctrl.execute_and_capture("x/xg $sp"))
+
+    assert (await ctrl.execute_and_capture("eq $sp 0xbabe 0xcafe")) == ""
+    assert "0x000000000000babe\t0x000000000000cafe" in (await ctrl.execute_and_capture("x/2xg $sp"))
+
+    assert (await ctrl.execute_and_capture("eq $sp cafe000000000000 babe000000000000")) == ""
+    assert "0xcafe000000000000\t0xbabe000000000000" in (await ctrl.execute_and_capture("x/2xg $sp"))
+
+    # TODO/FIXME: implement tests for others (ed, ew, eb etc)
+
+    #########################################
+    ### Test write & output on partial write
+    #########################################
+    # e.g. when we make a write to the last stack address
+    stack_ea = pwndbg.aglib.regs[pwndbg.aglib.regs.stack]
+    stack_page = pwndbg.aglib.vmmap.find(stack_ea)
+
+    # Last possible address on stack where we can perform an 8-byte write
+    stack_last_qword_ea = stack_page.end - 8
+
+    gdb_result = (
+        await ctrl.execute_and_capture("eq %#x 0xCAFEBABEdeadbeef 0xABCD" % stack_last_qword_ea)
+    ).split("\n")
+    assert "Cannot access memory at address" in gdb_result[0]
+    assert gdb_result[1] == "(Made 1 writes to memory; skipping further writes)"
+
+    # Check if the write actually occurred
+    assert pwndbg.aglib.memory.read(stack_last_qword_ea, 8) == b"\xef\xbe\xad\xde\xbe\xba\xfe\xca"
+
+
+@tests.pwndbg_test
+async def test_windbg_commands_x86(ctrl: Controller) -> None:
+    """
+    Tests windbg compatibility commands that dump memory
+    like dq, dw, db, ds etc.
+    """
+    import pwndbg
+
+    await ctrl.launch(X86_BINARY)
+
+    # Prepare memory
+    pwndbg.aglib.memory.write(pwndbg.aglib.regs.esp, b"1234567890abcdef_")
+    pwndbg.aglib.memory.write(pwndbg.aglib.regs.esp + 16, b"\x00" * 16)
+    pwndbg.aglib.memory.write(pwndbg.aglib.regs.esp + 32, bytes(range(16)))
+    pwndbg.aglib.memory.write(pwndbg.aglib.regs.esp + 48, b"Z" * 16)
+
+    #################################################
+    #### dX command tests
+    #################################################
+    db = (await ctrl.execute_and_capture("db $esp")).splitlines()
+    assert db == [
+        "%x     31 32 33 34 35 36 37 38 39 30 61 62 63 64 65 66" % pwndbg.aglib.regs.esp,
+        "%x     00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00" % (pwndbg.aglib.regs.esp + 16),
+        "%x     00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f" % (pwndbg.aglib.regs.esp + 32),
+        "%x     5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a" % (pwndbg.aglib.regs.esp + 48),
+    ]
+
+    dw = (await ctrl.execute_and_capture("dw $esp")).splitlines()
+    assert dw == [
+        "%x     3231 3433 3635 3837 3039 6261 6463 6665" % pwndbg.aglib.regs.esp,
+        "%x     0000 0000 0000 0000 0000 0000 0000 0000" % (pwndbg.aglib.regs.esp + 16),
+        "%x     0100 0302 0504 0706 0908 0b0a 0d0c 0f0e" % (pwndbg.aglib.regs.esp + 32),
+        "%x     5a5a 5a5a 5a5a 5a5a 5a5a 5a5a 5a5a 5a5a" % (pwndbg.aglib.regs.esp + 48),
+    ]
+
+    dd = (await ctrl.execute_and_capture("dd $esp")).splitlines()
+    assert dd == [
+        "%x     34333231 38373635 62613039 66656463" % pwndbg.aglib.regs.esp,
+        "%x     00000000 00000000 00000000 00000000" % (pwndbg.aglib.regs.esp + 16),
+        "%x     03020100 07060504 0b0a0908 0f0e0d0c" % (pwndbg.aglib.regs.esp + 32),
+        "%x     5a5a5a5a 5a5a5a5a 5a5a5a5a 5a5a5a5a" % (pwndbg.aglib.regs.esp + 48),
+    ]
+
+    dq = (await ctrl.execute_and_capture("dq $esp")).splitlines()
+    assert dq == [
+        "%x     3837363534333231 6665646362613039" % pwndbg.aglib.regs.esp,
+        "%x     0000000000000000 0000000000000000" % (pwndbg.aglib.regs.esp + 16),
+        "%x     0706050403020100 0f0e0d0c0b0a0908" % (pwndbg.aglib.regs.esp + 32),
+        "%x     5a5a5a5a5a5a5a5a 5a5a5a5a5a5a5a5a" % (pwndbg.aglib.regs.esp + 48),
+    ]
+
+    #################################################
+    #### eX command tests
+    #################################################
+    await ctrl.execute("eb $esp 00")
+    assert pwndbg.aglib.memory.read(pwndbg.aglib.regs.esp, 1) == b"\x00"
+
+    await ctrl.execute("ew $esp 4141")
+    assert pwndbg.aglib.memory.read(pwndbg.aglib.regs.esp, 2) == b"\x41\x41"
+
+    await ctrl.execute("ed $esp 5252525252")
+    assert pwndbg.aglib.memory.read(pwndbg.aglib.regs.esp, 4) == b"\x52" * 4
+
+    await ctrl.execute("eq $esp 1122334455667788")
+    assert pwndbg.aglib.memory.read(pwndbg.aglib.regs.esp, 8) == b"\x88\x77\x66\x55\x44\x33\x22\x11"

--- a/tests/library/dbg/tests/test_windbg.py
+++ b/tests/library/dbg/tests/test_windbg.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import re
+
 from host import Controller
 
 import tests
@@ -7,7 +9,7 @@ import tests
 MEMORY_BINARY = tests.get_binary("memory.out")
 X86_BINARY = tests.get_binary("gosample.x86")
 
-data_addr = "0x400081"
+data_addr = "0x401000"
 
 
 @tests.pwndbg_test
@@ -47,10 +49,10 @@ async def test_windbg_dX_commands(ctrl: Controller) -> None:
         == dq3
         == dq4
         == (
-            "0000000000400081     0000000000000000 0000000000000001\n"
-            "0000000000400091     0000000100000002 0001000200030004\n"
-            "00000000004000a1     0102030405060708 1122334455667788\n"
-            "00000000004000b1     0123456789abcdef 0000000000000000\n"
+            "0000000000401000     0000000000000000 0000000000000001\n"
+            "0000000000401010     0000000100000002 0001000200030004\n"
+            "0000000000401020     0102030405060708 1122334455667788\n"
+            "0000000000401030     0123456789abcdef 0000000000000000\n"
         )
     )
 
@@ -62,28 +64,28 @@ async def test_windbg_dX_commands(ctrl: Controller) -> None:
         dq_count1
         == dq_count2
         == dq_count3
-        == "0000000000400081     0000000000000000 0000000000000001\n"
+        == "0000000000401000     0000000000000000 0000000000000001\n"
     )
 
     assert (
         await ctrl.execute_and_capture("dq data 1")
-    ) == "0000000000400081     0000000000000000\n"
+    ) == "0000000000401000     0000000000000000\n"
     assert (await ctrl.execute_and_capture("dq data 3")) == (
-        "0000000000400081     0000000000000000 0000000000000001\n"
-        "0000000000400091     0000000100000002\n"
+        "0000000000401000     0000000000000000 0000000000000001\n"
+        "0000000000401010     0000000100000002\n"
     )
 
     # Try 'dq' with count equal to a register, but lets set it before ;)
     # also note that we use `data2` here
     pwndbg.aglib.regs.eax = 4
     assert (await ctrl.execute_and_capture("dq data2 $eax")) == (
-        "00000000004000a9     1122334455667788 0123456789abcdef\n"
-        "00000000004000b9     0000000000000000 ffffffffffffffff\n"
+        "0000000000401028     1122334455667788 0123456789abcdef\n"
+        "0000000000401038     0000000000000000 ffffffffffffffff\n"
     )
 
     # See if we can repeat dq command (use count for shorter data)
     assert (await ctrl.execute_and_capture("dq data2 2")) == (
-        "00000000004000a9     1122334455667788 0123456789abcdef\n"
+        "0000000000401028     1122334455667788 0123456789abcdef\n"
     )
 
     # TODO/FIXME: Can we test command repeating here? Neither passing `from_tty=True`
@@ -105,19 +107,19 @@ async def test_windbg_dX_commands(ctrl: Controller) -> None:
         == dd3
         == dd4
         == (
-            "0000000000400081     00000000 00000000 00000001 00000000\n"
-            "0000000000400091     00000002 00000001 00030004 00010002\n"
-            "00000000004000a1     05060708 01020304 55667788 11223344\n"
-            "00000000004000b1     89abcdef 01234567 00000000 00000000\n"
+            "0000000000401000     00000000 00000000 00000001 00000000\n"
+            "0000000000401010     00000002 00000001 00030004 00010002\n"
+            "0000000000401020     05060708 01020304 55667788 11223344\n"
+            "0000000000401030     89abcdef 01234567 00000000 00000000\n"
         )
     )
 
     # count tests
     assert (await ctrl.execute_and_capture("dd data 4")) == (
-        "0000000000400081     00000000 00000000 00000001 00000000\n"
+        "0000000000401000     00000000 00000000 00000001 00000000\n"
     )
     assert (await ctrl.execute_and_capture("dd data 3")) == (
-        "0000000000400081     00000000 00000000 00000001\n"
+        "0000000000401000     00000000 00000000 00000001\n"
     )
 
     #################################################
@@ -133,24 +135,24 @@ async def test_windbg_dX_commands(ctrl: Controller) -> None:
         == dw3
         == dw4
         == (
-            "0000000000400081     0000 0000 0000 0000 0001 0000 0000 0000\n"
-            "0000000000400091     0002 0000 0001 0000 0004 0003 0002 0001\n"
-            "00000000004000a1     0708 0506 0304 0102 7788 5566 3344 1122\n"
-            "00000000004000b1     cdef 89ab 4567 0123 0000 0000 0000 0000\n"
+            "0000000000401000     0000 0000 0000 0000 0001 0000 0000 0000\n"
+            "0000000000401010     0002 0000 0001 0000 0004 0003 0002 0001\n"
+            "0000000000401020     0708 0506 0304 0102 7788 5566 3344 1122\n"
+            "0000000000401030     cdef 89ab 4567 0123 0000 0000 0000 0000\n"
         )
     )
 
     # count tests
     assert (await ctrl.execute_and_capture("dw data 8")) == (
-        "0000000000400081     0000 0000 0000 0000 0001 0000 0000 0000\n"
+        "0000000000401000     0000 0000 0000 0000 0001 0000 0000 0000\n"
     )
 
     assert (await ctrl.execute_and_capture("dw data 8/2")) == (
-        "0000000000400081     0000 0000 0000 0000\n"
+        "0000000000401000     0000 0000 0000 0000\n"
     )
 
     assert (await ctrl.execute_and_capture("dw data $eax")) == (
-        "0000000000400081     0000 0000 0000 0000\n"
+        "0000000000401000     0000 0000 0000 0000\n"
     )
 
     #################################################
@@ -166,19 +168,19 @@ async def test_windbg_dX_commands(ctrl: Controller) -> None:
         == db3
         == db4
         == (
-            "0000000000400081     00 00 00 00 00 00 00 00 01 00 00 00 00 00 00 00\n"
-            "0000000000400091     02 00 00 00 01 00 00 00 04 00 03 00 02 00 01 00\n"
-            "00000000004000a1     08 07 06 05 04 03 02 01 88 77 66 55 44 33 22 11\n"
-            "00000000004000b1     ef cd ab 89 67 45 23 01 00 00 00 00 00 00 00 00\n"
+            "0000000000401000     00 00 00 00 00 00 00 00 01 00 00 00 00 00 00 00\n"
+            "0000000000401010     02 00 00 00 01 00 00 00 04 00 03 00 02 00 01 00\n"
+            "0000000000401020     08 07 06 05 04 03 02 01 88 77 66 55 44 33 22 11\n"
+            "0000000000401030     ef cd ab 89 67 45 23 01 00 00 00 00 00 00 00 00\n"
         )
     )
 
     # count tests
     assert (await ctrl.execute_and_capture("db data 31")) == (
-        "0000000000400081     00 00 00 00 00 00 00 00 01 00 00 00 00 00 00 00\n"
-        "0000000000400091     02 00 00 00 01 00 00 00 04 00 03 00 02 00 01\n"
+        "0000000000401000     00 00 00 00 00 00 00 00 01 00 00 00 00 00 00 00\n"
+        "0000000000401010     02 00 00 00 01 00 00 00 04 00 03 00 02 00 01\n"
     )
-    assert (await ctrl.execute_and_capture("db data $ax")) == ("0000000000400081     00 00 00 00\n")
+    assert (await ctrl.execute_and_capture("db data $ax")) == ("0000000000401000     00 00 00 00\n")
 
     #################################################
     #### dc command tests
@@ -193,13 +195,13 @@ async def test_windbg_dX_commands(ctrl: Controller) -> None:
         == dc3
         == dc4
         == (
-            "+0000 0x400081  00 00 00 00 00 00 00 00                           "
+            "+0000 0x401000  00 00 00 00 00 00 00 00                           "
             "│........│        │\n"
         )
     )
 
     assert (await ctrl.execute_and_capture("dc data 3")) == (
-        "+0000 0x400081  00 00 00                                          │...     │        │\n"
+        "+0000 0x401000  00 00 00                                          │...     │        │\n"
     )
 
     #################################################
@@ -207,18 +209,18 @@ async def test_windbg_dX_commands(ctrl: Controller) -> None:
     #################################################
     ds1 = await ctrl.execute_and_capture("ds short_str")
     ds2 = await ctrl.execute_and_capture("ds &short_str")
-    ds3 = await ctrl.execute_and_capture("ds 0x4000d9")
-    ds4 = await ctrl.execute_and_capture("ds 4000d9")
-    assert ds1 == ds2 == ds3 == ds4 == "4000d9 'some cstring here'\n"
+    ds3 = await ctrl.execute_and_capture("ds 0x401058")
+    ds4 = await ctrl.execute_and_capture("ds 401058")
+    assert ds1 == ds2 == ds3 == ds4 == "401058 'some cstring here'\n"
 
     # Check too low maxlen
     assert (await ctrl.execute_and_capture("ds short_str 5")) == (
-        "Max str len of 5 too low, changing to 256\n4000d9 'some cstring here'\n"
+        "Max str len of 5 too low, changing to 256\n401058 'some cstring here'\n"
     )
 
     # Check output for a string longer than (the default) maxlen of 256
     assert (await ctrl.execute_and_capture("ds long_str")) == (
-        "4000eb 'long string: "
+        "40106a 'long string: "
         "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA...'\n"
     )
 
@@ -283,10 +285,14 @@ async def test_windbg_eX_commands(ctrl: Controller) -> None:
     assert "0x00000000cafebabe" in (await ctrl.execute_and_capture("x/xg $sp"))
 
     assert (await ctrl.execute_and_capture("eq $sp 0xbabe 0xcafe")) == ""
-    assert "0x000000000000babe\t0x000000000000cafe" in (await ctrl.execute_and_capture("x/2xg $sp"))
+    assert re.search(
+        "0x000000000000babe\\s+0x000000000000cafe", await ctrl.execute_and_capture("x/2xg $sp")
+    )
 
     assert (await ctrl.execute_and_capture("eq $sp cafe000000000000 babe000000000000")) == ""
-    assert "0xcafe000000000000\t0xbabe000000000000" in (await ctrl.execute_and_capture("x/2xg $sp"))
+    assert re.search(
+        "0xcafe000000000000\\s+0xbabe000000000000", await ctrl.execute_and_capture("x/2xg $sp")
+    )
 
     # TODO/FIXME: implement tests for others (ed, ew, eb etc)
 

--- a/tests/library/dbg/tests/test_windbg.py
+++ b/tests/library/dbg/tests/test_windbg.py
@@ -2,17 +2,17 @@ from __future__ import annotations
 
 import re
 
-from host import Controller
+from ....host import Controller
+from . import get_binary
+from . import pwndbg_test
 
-import tests
-
-MEMORY_BINARY = tests.get_binary("memory.out")
-X86_BINARY = tests.get_binary("gosample.x86")
+MEMORY_BINARY = get_binary("memory.out")
+X86_BINARY = get_binary("gosample.x86")
 
 data_addr = "0x401000"
 
 
-@tests.pwndbg_test
+@pwndbg_test
 async def test_windbg_dX_commands(ctrl: Controller) -> None:
     """
     Tests windbg compatibility commands that dump memory
@@ -232,7 +232,7 @@ async def test_windbg_dX_commands(ctrl: Controller) -> None:
     )
 
 
-@tests.pwndbg_test
+@pwndbg_test
 async def test_windbg_eX_commands(ctrl: Controller) -> None:
     """
     Tests windbg compatibility commands that write to memory
@@ -316,7 +316,7 @@ async def test_windbg_eX_commands(ctrl: Controller) -> None:
     assert pwndbg.aglib.memory.read(stack_last_qword_ea, 8) == b"\xef\xbe\xad\xde\xbe\xba\xfe\xca"
 
 
-@tests.pwndbg_test
+@pwndbg_test
 async def test_windbg_commands_x86(ctrl: Controller) -> None:
     """
     Tests windbg compatibility commands that dump memory

--- a/tests/library/gdb/tests/heap/test_try_free.py
+++ b/tests/library/gdb/tests/heap/test_try_free.py
@@ -77,7 +77,7 @@ def setup_heap(start_binary, bug_no):
     except FileNotFoundError:
         pass
 
-    start_binary(HEAP_BINARY, str(bug_no), f"> {OUTPUT_FILE}")
+    start_binary(HEAP_BINARY, str(bug_no), OUTPUT_FILE)
     gdb.execute("break " + str(breakpoints[bug_no][0]))
     gdb.execute("break " + str(breakpoints[bug_no][1]))
 

--- a/tests/library/gdb/tests/test_windbg.py
+++ b/tests/library/gdb/tests/test_windbg.py
@@ -11,7 +11,7 @@ from . import get_binary
 MEMORY_BINARY = get_binary("memory.out")
 X86_BINARY = get_binary("gosample.x86")
 
-data_addr = "0x400081"
+data_addr = "0x401000"
 
 
 def test_windbg_dX_commands(start_binary):
@@ -48,10 +48,10 @@ def test_windbg_dX_commands(start_binary):
         == dq3
         == dq4
         == (
-            "0000000000400081     0000000000000000 0000000000000001\n"
-            "0000000000400091     0000000100000002 0001000200030004\n"
-            "00000000004000a1     0102030405060708 1122334455667788\n"
-            "00000000004000b1     0123456789abcdef 0000000000000000\n"
+            "0000000000401000     0000000000000000 0000000000000001\n"
+            "0000000000401010     0000000100000002 0001000200030004\n"
+            "0000000000401020     0102030405060708 1122334455667788\n"
+            "0000000000401030     0123456789abcdef 0000000000000000\n"
         )
     )
 
@@ -63,26 +63,26 @@ def test_windbg_dX_commands(start_binary):
         dq_count1
         == dq_count2
         == dq_count3
-        == "0000000000400081     0000000000000000 0000000000000001\n"
+        == "0000000000401000     0000000000000000 0000000000000001\n"
     )
 
-    assert gdb.execute("dq data 1", to_string=True) == "0000000000400081     0000000000000000\n"
+    assert gdb.execute("dq data 1", to_string=True) == "0000000000401000     0000000000000000\n"
     assert gdb.execute("dq data 3", to_string=True) == (
-        "0000000000400081     0000000000000000 0000000000000001\n"
-        "0000000000400091     0000000100000002\n"
+        "0000000000401000     0000000000000000 0000000000000001\n"
+        "0000000000401010     0000000100000002\n"
     )
 
     # Try 'dq' with count equal to a register, but lets set it before ;)
     # also note that we use `data2` here
     assert gdb.execute("set $eax=4", to_string=True) == ""  # assert as a sanity check
     assert gdb.execute("dq data2 $eax", to_string=True) == (
-        "00000000004000a9     1122334455667788 0123456789abcdef\n"
-        "00000000004000b9     0000000000000000 ffffffffffffffff\n"
+        "0000000000401028     1122334455667788 0123456789abcdef\n"
+        "0000000000401038     0000000000000000 ffffffffffffffff\n"
     )
 
     # See if we can repeat dq command (use count for shorter data)
     assert gdb.execute("dq data2 2", to_string=True) == (
-        "00000000004000a9     1122334455667788 0123456789abcdef\n"
+        "0000000000401028     1122334455667788 0123456789abcdef\n"
     )
 
     # TODO/FIXME: Can we test command repeating here? Neither passing `from_tty=True`
@@ -104,19 +104,19 @@ def test_windbg_dX_commands(start_binary):
         == dd3
         == dd4
         == (
-            "0000000000400081     00000000 00000000 00000001 00000000\n"
-            "0000000000400091     00000002 00000001 00030004 00010002\n"
-            "00000000004000a1     05060708 01020304 55667788 11223344\n"
-            "00000000004000b1     89abcdef 01234567 00000000 00000000\n"
+            "0000000000401000     00000000 00000000 00000001 00000000\n"
+            "0000000000401010     00000002 00000001 00030004 00010002\n"
+            "0000000000401020     05060708 01020304 55667788 11223344\n"
+            "0000000000401030     89abcdef 01234567 00000000 00000000\n"
         )
     )
 
     # count tests
     assert gdb.execute("dd data 4", to_string=True) == (
-        "0000000000400081     00000000 00000000 00000001 00000000\n"
+        "0000000000401000     00000000 00000000 00000001 00000000\n"
     )
     assert gdb.execute("dd data 3", to_string=True) == (
-        "0000000000400081     00000000 00000000 00000001\n"
+        "0000000000401000     00000000 00000000 00000001\n"
     )
 
     #################################################
@@ -132,24 +132,24 @@ def test_windbg_dX_commands(start_binary):
         == dw3
         == dw4
         == (
-            "0000000000400081     0000 0000 0000 0000 0001 0000 0000 0000\n"
-            "0000000000400091     0002 0000 0001 0000 0004 0003 0002 0001\n"
-            "00000000004000a1     0708 0506 0304 0102 7788 5566 3344 1122\n"
-            "00000000004000b1     cdef 89ab 4567 0123 0000 0000 0000 0000\n"
+            "0000000000401000     0000 0000 0000 0000 0001 0000 0000 0000\n"
+            "0000000000401010     0002 0000 0001 0000 0004 0003 0002 0001\n"
+            "0000000000401020     0708 0506 0304 0102 7788 5566 3344 1122\n"
+            "0000000000401030     cdef 89ab 4567 0123 0000 0000 0000 0000\n"
         )
     )
 
     # count tests
     assert gdb.execute("dw data 8", to_string=True) == (
-        "0000000000400081     0000 0000 0000 0000 0001 0000 0000 0000\n"
+        "0000000000401000     0000 0000 0000 0000 0001 0000 0000 0000\n"
     )
 
     assert gdb.execute("dw data 8/2", to_string=True) == (
-        "0000000000400081     0000 0000 0000 0000\n"
+        "0000000000401000     0000 0000 0000 0000\n"
     )
 
     assert gdb.execute("dw data $eax", to_string=True) == (
-        "0000000000400081     0000 0000 0000 0000\n"
+        "0000000000401000     0000 0000 0000 0000\n"
     )
 
     #################################################
@@ -165,19 +165,19 @@ def test_windbg_dX_commands(start_binary):
         == db3
         == db4
         == (
-            "0000000000400081     00 00 00 00 00 00 00 00 01 00 00 00 00 00 00 00\n"
-            "0000000000400091     02 00 00 00 01 00 00 00 04 00 03 00 02 00 01 00\n"
-            "00000000004000a1     08 07 06 05 04 03 02 01 88 77 66 55 44 33 22 11\n"
-            "00000000004000b1     ef cd ab 89 67 45 23 01 00 00 00 00 00 00 00 00\n"
+            "0000000000401000     00 00 00 00 00 00 00 00 01 00 00 00 00 00 00 00\n"
+            "0000000000401010     02 00 00 00 01 00 00 00 04 00 03 00 02 00 01 00\n"
+            "0000000000401020     08 07 06 05 04 03 02 01 88 77 66 55 44 33 22 11\n"
+            "0000000000401030     ef cd ab 89 67 45 23 01 00 00 00 00 00 00 00 00\n"
         )
     )
 
     # count tests
     assert gdb.execute("db data 31", to_string=True) == (
-        "0000000000400081     00 00 00 00 00 00 00 00 01 00 00 00 00 00 00 00\n"
-        "0000000000400091     02 00 00 00 01 00 00 00 04 00 03 00 02 00 01\n"
+        "0000000000401000     00 00 00 00 00 00 00 00 01 00 00 00 00 00 00 00\n"
+        "0000000000401010     02 00 00 00 01 00 00 00 04 00 03 00 02 00 01\n"
     )
-    assert gdb.execute("db data $ax", to_string=True) == ("0000000000400081     00 00 00 00\n")
+    assert gdb.execute("db data $ax", to_string=True) == ("0000000000401000     00 00 00 00\n")
 
     #################################################
     #### dc command tests
@@ -192,13 +192,13 @@ def test_windbg_dX_commands(start_binary):
         == dc3
         == dc4
         == (
-            "+0000 0x400081  00 00 00 00 00 00 00 00                           "
+            "+0000 0x401000  00 00 00 00 00 00 00 00                           "
             "│........│        │\n"
         )
     )
 
     assert gdb.execute("dc data 3", to_string=True) == (
-        "+0000 0x400081  00 00 00                                          │...     │        │\n"
+        "+0000 0x401000  00 00 00                                          │...     │        │\n"
     )
 
     #################################################
@@ -206,18 +206,18 @@ def test_windbg_dX_commands(start_binary):
     #################################################
     ds1 = gdb.execute("ds short_str", to_string=True)
     ds2 = gdb.execute("ds &short_str", to_string=True)
-    ds3 = gdb.execute("ds 0x4000d9", to_string=True)
-    ds4 = gdb.execute("ds 4000d9", to_string=True)
-    assert ds1 == ds2 == ds3 == ds4 == "4000d9 'some cstring here'\n"
+    ds3 = gdb.execute("ds 0x401058", to_string=True)
+    ds4 = gdb.execute("ds 401058", to_string=True)
+    assert ds1 == ds2 == ds3 == ds4 == "401058 'some cstring here'\n"
 
     # Check too low maxlen
     assert gdb.execute("ds short_str 5", to_string=True) == (
-        "Max str len of 5 too low, changing to 256\n4000d9 'some cstring here'\n"
+        "Max str len of 5 too low, changing to 256\n401058 'some cstring here'\n"
     )
 
     # Check output for a string longer than (the default) maxlen of 256
     assert gdb.execute("ds long_str", to_string=True) == (
-        "4000eb 'long string: "
+        "40106a 'long string: "
         "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA...'\n"
     )
 


### PR DESCRIPTION
This PR completes #3165 with the second batch (out of two) of tests ported to the Debugger API test group introduced in https://github.com/pwndbg/pwndbg/pull/3120.

Keep in mind not all of these work! The enhancements to LLDB that allow them to work have were split into a separate PR.