### PR TITLE
fix: exec -a is not posix compliant

### DIFF
--- a/nix/portable.nix
+++ b/nix/portable.nix
@@ -61,7 +61,7 @@ let
       #!/bin/sh
       dir="$(cd -- "$(dirname "$(dirname "$(realpath "$0")")")" >/dev/null 2>&1 ; pwd -P)"
       ${commonEnvs}
-      exec -a "$0" ${ldLoader} "$dir/exe/python3" "$dir/${file}" "$@"
+      exec ${ldLoader} "$dir/exe/python3" "$dir/${file}" "$@"
     '';
   wrapperBin =
     file:
@@ -69,7 +69,7 @@ let
       #!/bin/sh
       dir="$(cd -- "$(dirname "$(dirname "$(realpath "$0")")")" >/dev/null 2>&1 ; pwd -P)"
       ${commonEnvs}
-      exec -a "$0" ${ldLoader} "$dir/${file}" "$@"
+      exec ${ldLoader} "$dir/${file}" "$@"
     '';
 
   pwndbgGdbBundled = bundler (


### PR DESCRIPTION
wrapper script does not work if /bin/sh is symlinked to /bin/dash which is typical for ubuntu/debian