### PR TITLE
Fix: Replaced assert with explicit ValueError in generate-readme.py

### DIFF
--- a/scripts/generate-readme.py
+++ b/scripts/generate-readme.py
@@ -22,15 +22,17 @@ gif = """
 
 def main():
     README_PATH = "README.md"
-    TARGET_PATH = "./docs/index.md"
+    TARGET_PATH = "docs/index.md"
 
     with open(README_PATH, "r") as readmefile:
         readme = readmefile.read()
+        
+        
+        if not readme.startswith("![repository-open-graph]("):
+          raise ValueError("The first line of the README.md has changed. Is it still safe to replace it?")
 
-        assert (
-            readme.splitlines()[0].startswith("![repository-open-graph](")
-            and "The first line of the README.md has changed. Is it still safe to replace it?"
-        )
+
+          
 
         # Delete the first line
         readme = readme.split("\n", 1)[1]


### PR DESCRIPTION

Replaced the assert statement in scripts/generate-readme.py with an explicit ValueError to ensure safer validation of the first line in README.md. This makes the script more robust, especially in production or optimized environments where assertions may be disabled.