### PR TITLE
nix: ziglang now supports s390x and riscv64

### DIFF
--- a/nix/pyenv.nix
+++ b/nix/pyenv.nix
@@ -143,6 +143,8 @@ let
           pkgs.stdenv.hostPlatform.isDarwin
           || (pkgs.stdenv.hostPlatform.isLinux && pkgs.stdenv.hostPlatform.isx86)
           || (pkgs.stdenv.hostPlatform.isLinux && pkgs.stdenv.hostPlatform.isAarch)
+          || (pkgs.stdenv.hostPlatform.isLinux && pkgs.stdenv.hostPlatform.isS390x)
+          || (pkgs.stdenv.hostPlatform.isLinux && pkgs.stdenv.hostPlatform.isRiscV64)
           || (
             pkgs.stdenv.hostPlatform.isLinux
             && pkgs.stdenv.hostPlatform.isPower64


### PR DESCRIPTION
fixed at https://github.com/ziglang/zig-pypi/pull/33#issuecomment-3151415250