### PR TITLE
Fix telescope alignment on architectures with two-letter registers

### DIFF
--- a/pwndbg/commands/telescope.py
+++ b/pwndbg/commands/telescope.py
@@ -284,7 +284,8 @@ def telescope(
 def regs_or_frame_offset(addr: int, bp: int | None, regs: Dict[int, str], longest_regs: int) -> str:
     # bp only set if print_framepointer_offset=True
     if bp is None or regs[addr] or not -0xFFF <= addr - bp <= 0xFFF:
-        return " " + T.register(regs[addr].ljust(longest_regs))
+        # We do .rjust(3) because some arches have two-letter registers.
+        return " " + T.register(regs[addr].ljust(longest_regs).rjust(3))
     else:
         # If offset to frame pointer as hex fits in hex 3 digits, print it
         return ("%+04x" % (addr - bp)).ljust(longest_regs + 1)


### PR DESCRIPTION
Before:
<img width="253" height="123" alt="image" src="https://github.com/user-attachments/assets/fa622b8e-b7f0-4cf4-a562-bbcf82c1739c" />

After:
<img width="241" height="127" alt="image" src="https://github.com/user-attachments/assets/f50cefca-2ec1-4b48-9bc0-8ebccea6a3e7" />
