### PR TITLE
refactor pwndbg.lib.abi: use tuples instead of lists

### DIFF
--- a/pwndbg/commands/hijack_fd.py
+++ b/pwndbg/commands/hijack_fd.py
@@ -41,7 +41,8 @@ def get_shellcode_regs() -> ShellcodeRegs:
         (
             reg_name
             for reg_name in register_set.gpr
-            if reg_name not in syscall_abi.register_arguments + [syscall_abi.syscall_register]
+            if reg_name not in syscall_abi.register_arguments
+            and reg_name != syscall_abi.syscall_register
         )
     )
     assert (

--- a/pwndbg/lib/abi.py
+++ b/pwndbg/lib/abi.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import Any
 from typing import Dict
-from typing import List
 from typing import Tuple
 
 
@@ -11,9 +10,9 @@ class ABI:
     Encapsulates information about a calling convention.
     """
 
-    #: List or registers which should be filled with arguments before
+    #: Tuple of registers which should be filled with arguments before
     #: spilling onto the stack.
-    register_arguments: List[str] = []
+    register_arguments: Tuple[str, ...] = ()
 
     #: Minimum alignment of the stack.
     #: The value used is min(context.bytes, stack_alignment)
@@ -28,7 +27,7 @@ class ABI:
     #: Indicates that this ABI returns to the next address on the slot
     returns = True
 
-    def __init__(self, regs: List[str], align: int, minimum: int) -> None:
+    def __init__(self, regs: Tuple[str, ...], align: int, minimum: int) -> None:
         self.register_arguments = regs
         self.arg_alignment = align
         self.stack_minimum = minimum
@@ -40,9 +39,9 @@ class SyscallABI(ABI):
     which must be loaded into the specified register.
     """
 
-    def __init__(self, register_arguments: List[str], *a: Any, **kw: Any) -> None:
-        self.syscall_register = register_arguments.pop(0)
-        super().__init__(register_arguments, *a, **kw)
+    def __init__(self, register_arguments: Tuple[str, ...], *a: Any, **kw: Any) -> None:
+        self.syscall_register = register_arguments[0]
+        super().__init__(register_arguments[1:], *a, **kw)
 
 
 class SigreturnABI(SyscallABI):
@@ -55,36 +54,36 @@ class SigreturnABI(SyscallABI):
     returns = False
 
 
-linux_i386 = ABI([], 4, 0)
-linux_amd64 = ABI(["rdi", "rsi", "rdx", "rcx", "r8", "r9"], 8, 0)
-linux_arm = ABI(["r0", "r1", "r2", "r3"], 8, 0)
-linux_aarch64 = ABI(["x0", "x1", "x2", "x3", "x4", "x5", "x6", "x7"], 16, 0)
-linux_mips = ABI(["$a0", "$a1", "$a2", "$a3"], 4, 0)
-linux_mips64 = ABI(["$a0", "$a1", "$a2", "$a3", "$a4", "$a5", "$a6", "$a7"], 8, 0)
-linux_ppc = ABI(["r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10"], 4, 0)
-linux_ppc64 = ABI(["r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10"], 8, 0)
-linux_riscv32 = ABI(["a0", "a1", "a2", "a3", "a4", "a5", "a6", "a7"], 4, 0)
-linux_riscv64 = ABI(["a0", "a1", "a2", "a3", "a4", "a5", "a6", "a7"], 8, 0)
+linux_i386 = ABI((), 4, 0)
+linux_amd64 = ABI(("rdi", "rsi", "rdx", "rcx", "r8", "r9"), 8, 0)
+linux_arm = ABI(("r0", "r1", "r2", "r3"), 8, 0)
+linux_aarch64 = ABI(("x0", "x1", "x2", "x3", "x4", "x5", "x6", "x7"), 16, 0)
+linux_mips = ABI(("$a0", "$a1", "$a2", "$a3"), 4, 0)
+linux_mips64 = ABI(("$a0", "$a1", "$a2", "$a3", "$a4", "$a5", "$a6", "$a7"), 8, 0)
+linux_ppc = ABI(("r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10"), 4, 0)
+linux_ppc64 = ABI(("r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10"), 8, 0)
+linux_riscv32 = ABI(("a0", "a1", "a2", "a3", "a4", "a5", "a6", "a7"), 4, 0)
+linux_riscv64 = ABI(("a0", "a1", "a2", "a3", "a4", "a5", "a6", "a7"), 8, 0)
 
-linux_i386_syscall = SyscallABI(["eax", "ebx", "ecx", "edx", "esi", "edi", "ebp"], 4, 0)
-linux_amd64_syscall = SyscallABI(["rax", "rdi", "rsi", "rdx", "r10", "r8", "r9"], 8, 0)
-linux_arm_syscall = SyscallABI(["r7", "r0", "r1", "r2", "r3", "r4", "r5", "r6"], 4, 0)
-linux_aarch64_syscall = SyscallABI(["x8", "x0", "x1", "x2", "x3", "x4", "x5"], 16, 0)
-linux_mips_syscall = SyscallABI(["$v0", "$a0", "$a1", "$a2", "$a3"], 4, 0)
-linux_mips64_syscall = SyscallABI(["$v0", "$a0", "$a1", "$a2", "$a3", "$a4", "$a5"], 4, 0)
-linux_ppc_syscall = SyscallABI(["r0", "r3", "r4", "r5", "r6", "r7", "r8", "r9"], 4, 0)
-linux_ppc64_syscall = SyscallABI(["r0", "r3", "r4", "r5", "r6", "r7", "r8"], 8, 0)
-linux_riscv32_syscall = SyscallABI(["a7", "a0", "a1", "a2", "a3", "a4", "a5", "a6"], 4, 0)
-linux_riscv64_syscall = SyscallABI(["a7", "a0", "a1", "a2", "a3", "a4", "a5", "a6"], 8, 0)
+linux_i386_syscall = SyscallABI(("eax", "ebx", "ecx", "edx", "esi", "edi", "ebp"), 4, 0)
+linux_amd64_syscall = SyscallABI(("rax", "rdi", "rsi", "rdx", "r10", "r8", "r9"), 8, 0)
+linux_arm_syscall = SyscallABI(("r7", "r0", "r1", "r2", "r3", "r4", "r5", "r6"), 4, 0)
+linux_aarch64_syscall = SyscallABI(("x8", "x0", "x1", "x2", "x3", "x4", "x5"), 16, 0)
+linux_mips_syscall = SyscallABI(("$v0", "$a0", "$a1", "$a2", "$a3"), 4, 0)
+linux_mips64_syscall = SyscallABI(("$v0", "$a0", "$a1", "$a2", "$a3", "$a4", "$a5"), 4, 0)
+linux_ppc_syscall = SyscallABI(("r0", "r3", "r4", "r5", "r6", "r7", "r8", "r9"), 4, 0)
+linux_ppc64_syscall = SyscallABI(("r0", "r3", "r4", "r5", "r6", "r7", "r8"), 8, 0)
+linux_riscv32_syscall = SyscallABI(("a7", "a0", "a1", "a2", "a3", "a4", "a5", "a6"), 4, 0)
+linux_riscv64_syscall = SyscallABI(("a7", "a0", "a1", "a2", "a3", "a4", "a5", "a6"), 8, 0)
 
-linux_i386_sigreturn = SigreturnABI(["eax"], 4, 0)
-linux_amd64_sigreturn = SigreturnABI(["rax"], 4, 0)
-linux_arm_sigreturn = SigreturnABI(["r7"], 4, 0)
+linux_i386_sigreturn = SigreturnABI(("eax",), 4, 0)
+linux_amd64_sigreturn = SigreturnABI(("rax",), 4, 0)
+linux_arm_sigreturn = SigreturnABI(("r7",), 4, 0)
 
 # Fake ABIs used by SROP
-linux_i386_srop = ABI(["eax"], 4, 0)
-linux_amd64_srop = ABI(["rax"], 4, 0)
-linux_arm_srop = ABI(["r7"], 4, 0)
+linux_i386_srop = ABI(("eax",), 4, 0)
+linux_amd64_srop = ABI(("rax",), 4, 0)
+linux_arm_srop = ABI(("r7",), 4, 0)
 
 DEFAULT_ABIS: Dict[Tuple[int, str, str], ABI] = {
     (32, "i386", "linux"): linux_i386,


### PR DESCRIPTION
Use tuples instead of lists when tuples are enough.

<!--
    Please make sure to read the linting and testing instructions at
    https://pwndbg.re/pwndbg/dev/contributing/ before creating a PR.
-->
