### PR TITLE
lldb: version command show full lldb version without spaces etc

### DIFF
--- a/pwndbg/dbg/lldb/repl/__init__.py
+++ b/pwndbg/dbg/lldb/repl/__init__.py
@@ -474,8 +474,7 @@ def _exec_repl_command(
     # Not allowed to have this be a regular command, because of LLDB.
     if "version".startswith(line) and line.startswith("ve"):
         pwndbg.commands.version.version_impl()
-        print()
-        # Don't return. We want the LLDB command to also run.
+        return True
 
     # There are interactive commands that `SBDebugger.HandleCommand` will
     # silently ignore. We have to implement them manually, here.

--- a/pwndbginit/lldbinit.py
+++ b/pwndbginit/lldbinit.py
@@ -4,13 +4,14 @@ import cProfile
 import os
 import sys
 import time
+from typing import Tuple
 
 import lldb
 
 from pwndbginit.common import verify_venv
 
 
-def main(debugger: lldb.SBDebugger, major: int, minor: int, debug: bool = False) -> None:
+def main(debugger: lldb.SBDebugger, lldb_version: Tuple[int, ...], debug: bool = False) -> None:
     if "pwndbg" in sys.modules:
         print("Detected double-loading of Pwndbg.")
         print("This should not happen. Please report this issue if you're not sure how to fix it.")
@@ -27,7 +28,7 @@ def main(debugger: lldb.SBDebugger, major: int, minor: int, debug: bool = False)
     import pwndbg  # noqa: F811
     import pwndbg.dbg.lldb
 
-    pwndbg.dbg_mod.lldb.LLDB_VERSION = (major, minor)
+    pwndbg.dbg_mod.lldb.LLDB_VERSION = lldb_version
 
     pwndbg.dbg = pwndbg.dbg_mod.lldb.LLDB()
     pwndbg.dbg.setup(debugger, "pwndbglldbhandler", debug=debug)

--- a/pwndbginit/pwndbg_lldb.py
+++ b/pwndbginit/pwndbg_lldb.py
@@ -12,9 +12,10 @@ from typing import Any
 from typing import Callable
 from typing import Coroutine
 from typing import List
+from typing import Tuple
 
 
-def find_lldb_version() -> List[int]:
+def find_lldb_version() -> Tuple[int, ...]:
     """
     Parses the version string given to us by the LLDB executable.
     """
@@ -25,7 +26,7 @@ def find_lldb_version() -> List[int]:
     output = lldb.stdout.decode("utf-8").strip()
     output = re.sub("[^0-9.]", "", output)
 
-    return [int(component) for component in output.split(".")]
+    return tuple(int(component) for component in output.split("."))
 
 
 def find_lldb_python_path() -> str:
@@ -64,7 +65,7 @@ def launch(
     lldb_version = find_lldb_version()
 
     if debug:
-        print(f"[-] Launcher: LLDB version {lldb_version[0]}.{lldb_version[1]}")
+        print(f"[-] Launcher: LLDB version {'.'.join(map(str, lldb_version))}")
 
     if sys.version_info.minor >= 12 and lldb_version[0] <= 18:
         print("LLDB 18 and earlier is incompatible with Python 3.12 and later", file=sys.stderr)
@@ -92,7 +93,7 @@ def launch(
     # Initialize the debugger, proper.
     if debug:
         print("[-] Launcher: Initializing Pwndbg")
-    lldbinit.main(debugger, lldb_version[0], lldb_version[1], debug=debug)
+    lldbinit.main(debugger, lldb_version, debug=debug)
 
     from pwndbg.dbg.lldb.repl import run as run_repl
 


### PR DESCRIPTION
before:
```
Pwndbg:   2025.05.30 build: d817efc32
Python:   3.13.5 (main, Jun 22 2025, 16:29:31) [GCC 15.1.1 20250425]
LLDB:     20.1
Capstone: 6.0.0
Unicorn:  2.1.3
Pwnlib:   4.14.0

lldb version 20.1.5
```

after:
```
Pwndbg:   2025.05.30 build: d817efc32
Python:   3.13.5 (main, Jun 22 2025, 16:29:31) [GCC 15.1.1 20250425]
LLDB:     20.1.5
Capstone: 6.0.0
Unicorn:  2.1.3
Pwnlib:   4.14.0
```

<!--
    Please make sure to read the linting and testing instructions at
    https://pwndbg.re/pwndbg/dev/contributing/ before creating a PR.
-->
