### PR TITLE
version command: add OS name

### DIFF
--- a/pwndbg/commands/version.py
+++ b/pwndbg/commands/version.py
@@ -54,7 +54,7 @@ def debugger_version():
 def all_versions():
     py_version = sys.version.replace("\n", " ")
     return (
-        f"Pwndbg:   {pwndbg.__version__}",
+        f"Pwndbg:   {pwndbg.__version__} ({os.uname().sysname})",
         f"Python:   {py_version}",
         debugger_version(),
         f"Capstone: {module_version('capstone')}",


### PR DESCRIPTION
Before:
```
pwndbg> version
Pwndbg:   2025.05.30 build: d817efc32
Python:   3.13.5 (main, Jun 22 2025, 16:29:31) [GCC 15.1.1 20250425]
LLDB:     20.1
Capstone: 6.0.0
Unicorn:  2.1.3
Pwnlib:   4.14.0
```

After:
```
pwndbg> version
Pwndbg:   2025.05.30 build: d817efc32 (Linux)
Python:   3.13.5 (main, Jun 22 2025, 16:29:31) [GCC 15.1.1 20250425]
LLDB:     20.1
Capstone: 6.0.0
Unicorn:  2.1.3
Pwnlib:   4.14.0
```

<!--
    Please make sure to read the linting and testing instructions at
    https://pwndbg.re/pwndbg/dev/contributing/ before creating a PR.
-->
