### PR TITLE
add workaround for GDB crash when used with `target extended-remote` + `attach`

### DIFF
--- a/pwndbg/gdblib/events.py
+++ b/pwndbg/gdblib/events.py
@@ -122,6 +122,7 @@ queued_events: Deque[Callable[..., Any]] = deque()
 executing_event = False
 workaround_thread_conn = None
 
+
 def _update_start_event_state(event_type: Any):
     """
     Update the state of the StartEvent appropriately

--- a/pwndbg/gdblib/events.py
+++ b/pwndbg/gdblib/events.py
@@ -229,7 +229,7 @@ def wrap_safe_event_handler(event_handler: Callable[P, T], event_type: Any) -> C
             gdb.execute("", to_string=True)  # Trigger bug in gdb, it is like 'yield'
             executing_event = False
         elif event_type in (gdb.events.cont, gdb.events.new_thread):
-            # Workaround to crash gdb when used: `target extended-remote` + `attach`
+            # Workaround for crash in gdb when used: `target extended-remote` + `attach`
             # https://github.com/pwndbg/pwndbg/issues/3231
             global workaround_thread_conn
             conn = gdb.selected_inferior().connection

--- a/pwndbg/gdblib/events.py
+++ b/pwndbg/gdblib/events.py
@@ -120,7 +120,7 @@ def _is_safe_event_thread():
 
 queued_events: Deque[Callable[..., Any]] = deque()
 executing_event = False
-
+workaround_thread_conn = None
 
 def _update_start_event_state(event_type: Any):
     """
@@ -227,6 +227,19 @@ def wrap_safe_event_handler(event_handler: Callable[P, T], event_type: Any) -> C
             executing_event = True
             gdb.execute("", to_string=True)  # Trigger bug in gdb, it is like 'yield'
             executing_event = False
+        elif event_type in (gdb.events.cont, gdb.events.new_thread):
+            # Workaround to crash gdb when used: `target extended-remote` + `attach`
+            # https://github.com/pwndbg/pwndbg/issues/3231
+            global workaround_thread_conn
+            conn = gdb.selected_inferior().connection
+            if (
+                isinstance(conn, gdb.RemoteTargetConnection)
+                and conn.type == "extended-remote"
+                and conn.is_valid()
+                and workaround_thread_conn != conn
+            ):
+                gdb.selected_inferior().threads()[0].switch()
+                workaround_thread_conn = conn
 
         while queued_events:
             queued_events.popleft()()


### PR DESCRIPTION
This fix mostly blackmagic attaching to embedded device, or to `gdbserver` with `--multi` option 

Fixes:
- https://github.com/pwndbg/pwndbg/issues/3231


<img width="569" height="544" alt="image" src="https://github.com/user-attachments/assets/e2775f89-66f5-49b7-9f77-79848bf09350" />
