### PR TITLE
Remove `cast` in pwndbg.aglib.regs

### DIFF
--- a/pwndbg/aglib/regs.py
+++ b/pwndbg/aglib/regs.py
@@ -112,10 +112,7 @@ class module(ModuleType):
                 value = get_register("xPSR", frame)
             if value is None:
                 return None
-            size = pwndbg.aglib.typeinfo.unsigned.get(
-                value.type.sizeof, pwndbg.aglib.typeinfo.ulong
-            )
-            value = value.cast(size)
+            value = int(value)
             if reg == "pc" and pwndbg.aglib.arch.name == "i8086":
                 if self.cs is None:
                     return None


### PR DESCRIPTION
This `cast` was a fix for issue https://github.com/pwndbg/pwndbg/issues/743
and implemented here https://github.com/pwndbg/pwndbg/pull/775

I have no idea why we still need it... 

Removing cast, fix LLDB issue remote debugging for qemu-user/gdbserver:
<img width="530" height="192" alt="image" src="https://github.com/user-attachments/assets/8f398da1-54fd-4534-b554-e70f2992e412" />
^ this invalid size will cause casting pointer into `0`
(this is bug in lldb)