### PR TITLE
Detecting target file when debugging kernels

### DIFF
--- a/pwndbg/aglib/kernel/__init__.py
+++ b/pwndbg/aglib/kernel/__init__.py
@@ -10,6 +10,7 @@ from typing import List
 from typing import Tuple
 from typing import TypeVar
 
+from elftools.elf.elffile import ELFFile
 from typing_extensions import ParamSpec
 
 import pwndbg
@@ -45,15 +46,18 @@ def BIT(shift: int):
 def has_debug_symbols(required=[], checkall=True) -> bool:
     if len(required) == 0:
         return pwndbg.aglib.symbol.lookup_symbol("commit_creds") is not None
-    if checkall:
-        return all(pwndbg.aglib.symbol.lookup_symbol(sym) is not None for sym in required)
-    # check any
-    return any(pwndbg.aglib.symbol.lookup_symbol(sym) is not None for sym in required)
+    required_syms_iter = (pwndbg.aglib.symbol.lookup_symbol(sym) is not None for sym in required)
+    return all(required_syms_iter) if checkall else any(required_syms_iter)
 
 
 @pwndbg.lib.cache.cache_until("objfile")
 def has_debug_info() -> bool:
-    return pwndbg.wrappers.readelf.has_typeinfo()
+    path = pwndbg.aglib.proc.exe
+    if path is None:
+        return False
+    vmlinux = open(path, "rb")
+    elf = ELFFile(vmlinux)
+    return any(section.name == ".debug_info" for section in elf.iter_sections())
 
 
 def requires_debug_symbols(

--- a/pwndbg/aglib/kernel/__init__.py
+++ b/pwndbg/aglib/kernel/__init__.py
@@ -53,11 +53,7 @@ def has_debug_symbols(required=[], checkall=True) -> bool:
 
 @pwndbg.lib.cache.cache_until("objfile")
 def has_debug_info() -> bool:
-    # Check for an arbitrary type and symbol name that are not likely to change
-    return (
-        pwndbg.aglib.typeinfo.load("struct pipe_buffer") is not None
-        and pwndbg.aglib.symbol.lookup_symbol_addr("linux_banner") is not None
-    )
+    return pwndbg.wrappers.readelf.has_typeinfo()
 
 
 def requires_debug_symbols(

--- a/pwndbg/dbg/gdb/__init__.py
+++ b/pwndbg/dbg/gdb/__init__.py
@@ -927,11 +927,10 @@ class GDBProcess(pwndbg.dbg_mod.Process):
     def main_module_name(self) -> str | None:
         # Can GDB ever return a different value here from what we'd get with
         # `info files`, give or take a "remote:"?
-        if not self.alive():
-            return gdb.current_progspace().filename
-
-        exe = gdb.execute("info proc exe", to_string=True)
-        return exe[exe.find("exe = '") + 7 : exe.rfind("'")]
+        if self.alive() and not pwndbg.aglib.qemu.is_qemu_kernel():
+            exe = gdb.execute("info proc exe", to_string=True)
+            return exe[exe.find("exe = '") + 7 : exe.rfind("'")]
+        return gdb.current_progspace().filename
 
     @override
     def main_module_entry(self) -> int | None:

--- a/pwndbg/wrappers/__init__.py
+++ b/pwndbg/wrappers/__init__.py
@@ -43,5 +43,5 @@ class OnlyWithCommand:
         return _OnlyWithCommand
 
 
-def call_cmd(cmd: str | List[str]) -> str:
+def call_cmd(*cmd: str) -> str:
     return subprocess.check_output(cmd, stderr=STDOUT).decode("utf-8")

--- a/pwndbg/wrappers/readelf.py
+++ b/pwndbg/wrappers/readelf.py
@@ -20,8 +20,7 @@ class RelocationType(Enum):
 @pwndbg.wrappers.OnlyWithCommand(cmd_name)
 def get_got_entry(local_path: str) -> Dict[RelocationType, List[str]]:
     # --wide is for showing the full information, e.g.: R_X86_64_JUMP_SLOT instead of R_X86_64_JUMP_SLO
-    cmd = get_got_entry.cmd + ["--relocs", "--wide", local_path]
-    readelf_out = pwndbg.wrappers.call_cmd(cmd)
+    readelf_out = pwndbg.wrappers.call_cmd(cmd_name, "--relocs", "--wide", local_path)
 
     entries: Dict[RelocationType, List[str]] = {category: [] for category in RelocationType}
     for line in readelf_out.splitlines():
@@ -33,3 +32,11 @@ def get_got_entry(local_path: str) -> Dict[RelocationType, List[str]]:
             if c.name in category:
                 entries[c].append(line)
     return entries
+
+
+@pwndbg.wrappers.OnlyWithCommand(cmd_name)
+def has_typeinfo(path: str = None):
+    if path is None:
+        path = pwndbg.aglib.proc.exe
+    readelf_out = pwndbg.wrappers.call_cmd(cmd_name, "-SW", path)
+    return "debug_info" in readelf_out

--- a/pwndbg/wrappers/readelf.py
+++ b/pwndbg/wrappers/readelf.py
@@ -32,11 +32,3 @@ def get_got_entry(local_path: str) -> Dict[RelocationType, List[str]]:
             if c.name in category:
                 entries[c].append(line)
     return entries
-
-
-@pwndbg.wrappers.OnlyWithCommand(cmd_name)
-def has_typeinfo(path: str = None):
-    if path is None:
-        path = pwndbg.aglib.proc.exe
-    readelf_out = pwndbg.wrappers.call_cmd(cmd_name, "-SW", path)
-    return "debug_info" in readelf_out


### PR DESCRIPTION
 - fixes `main_module_name` in `class GDBProcess` to properly detect target file when debugging kernels
 - closes #3193 