### PR TITLE
Add Config Option for Branch Jump Markers

### DIFF
--- a/docs/configuration/theme.md
+++ b/docs/configuration/theme.md
@@ -348,6 +348,28 @@ Color for disasm (branch/call instruction).
 
 ----------
 
+## **disasm-branch-off**
+
+
+Marker for branches that will NOT be taken.
+
+
+
+**Default:** '✘'  
+
+----------
+
+## **disasm-branch-on**
+
+
+Marker for branches that WILL be taken.
+
+
+
+**Default:** '✔'  
+
+----------
+
 ## **enhance-comment-color**
 
 

--- a/pwndbg/color/disasm.py
+++ b/pwndbg/color/disasm.py
@@ -13,6 +13,7 @@ from pwndbg.color import ColorConfig
 from pwndbg.color import ColorParamSpec
 from pwndbg.color import ljust_colored
 from pwndbg.color import strip
+from pwndbg.color import theme
 from pwndbg.color.message import off
 from pwndbg.color.message import on
 
@@ -21,6 +22,13 @@ c = ColorConfig(
     [
         ColorParamSpec("branch", "bold", "color for disasm (branch/call instruction)"),
     ],
+)
+
+config_branch_on = theme.add_param(
+    "disasm-branch-on", "✔", "marker for branches that WILL be taken"
+)
+config_branch_off = theme.add_param(
+    "disasm-branch-off", "✘", "marker for branches that will NOT be taken"
 )
 
 
@@ -41,9 +49,9 @@ def one_instruction(ins: PwndbgInstruction) -> str:
 
     # If we know the conditional is taken, mark it as taken.
     if ins.condition == InstructionCondition.TRUE or ins.is_conditional_jump_taken:
-        asm = on("✔ ") + asm
+        asm = on(f"{config_branch_on} ") + asm
     elif ins.condition == InstructionCondition.FALSE:
-        asm = off("✘ ") + asm
+        asm = off(f"{config_branch_off} ") + asm
     else:
         asm = f"  {asm}"
 


### PR DESCRIPTION
My terminal font doesn't have the default symbols for branches, so I took things into my own hands.

This commit adds two new config options:
- disasm-branch-on for branches that WILL be taken (default: '✔')
- disasm-branch-off for branches that will NOT be taken (default: '✘')

Happy to rename them if somebody's got a better name in mind for them.