### PR TITLE
Replacing `main_module_name` calls with `pwndbg.aglib.proc.exe`

### DIFF
--- a/pwndbg/commands/attachp.py
+++ b/pwndbg/commands/attachp.py
@@ -230,7 +230,7 @@ def attachp(
 ) -> None:
     # As a default, the user may want to attach to a binary name taken from currently loaded file name
     if target is None:
-        bin_path = pwndbg.dbg.selected_inferior().main_module_name()
+        bin_path = pwndbg.aglib.proc.exe
         if bin_path is None:
             print(
                 message.error(

--- a/pwndbg/commands/kbase.py
+++ b/pwndbg/commands/kbase.py
@@ -37,11 +37,10 @@ def kbase(rebase=False) -> None:
     if not rebase:
         return
 
-    symbol_file = pwndbg.dbg.selected_inferior().main_module_name()
+    symbol_file = pwndbg.aglib.proc.exe
 
     if symbol_file:
         if pwndbg.dbg.is_gdblib_available():
-            gdb.execute("symbol-file")
             gdb.execute(f"add-symbol-file {symbol_file} {hex(base)}")
         else:
             print(M.error("Adding symbol not supported in LLDB yet"))

--- a/pwndbg/ghidra.py
+++ b/pwndbg/ghidra.py
@@ -108,7 +108,7 @@ def decompile(func=None):
         if pwndbg.dbg.is_gdblib_available():
             src_filename = pwndbg.gdblib.symbol.selected_frame_source_absolute_filename()
         if not src_filename:
-            filename = pwndbg.dbg.selected_inferior().main_module_name()
+            filename = pwndbg.aglib.proc.exe
             src_filename = filename + ".c" if os.path.basename(filename).find(".") < 0 else filename
         source = H.syntax_highlight(source, src_filename)
 

--- a/pwndbg/radare2.py
+++ b/pwndbg/radare2.py
@@ -23,7 +23,7 @@ def r2pipe():
 
     Returns a r2pipe.open handle.
     """
-    filename = pwndbg.dbg.selected_inferior().main_module_name()
+    filename = pwndbg.aglib.proc.exe
     if not filename:
         raise Exception("Could not find objfile to create a r2pipe for")
 

--- a/pwndbg/rizin.py
+++ b/pwndbg/rizin.py
@@ -21,7 +21,7 @@ def rzpipe():
     Raises Exception if anything goes fatally wrong.
     Returns a rzpipe.open handle.
     """
-    filename = pwndbg.dbg.selected_inferior().main_module_name()
+    filename = pwndbg.aglib.proc.exe
     if not filename:
         raise Exception("Could not find objfile to create a rzpipe for")
 


### PR DESCRIPTION
`pwndbg.aglib.proc.exe` is currently an "alias" of `pwndbg.dbg.selected_inferior().main_module_name()`