### PR TITLE
LLDB: Print process status information on exit

### DIFF
--- a/pwndbg/dbg/lldb/repl/__init__.py
+++ b/pwndbg/dbg/lldb/repl/__init__.py
@@ -108,7 +108,7 @@ def print_hint(msg: str, *args):
 
 def print_info(msg: str, *args):
     """
-    Print an informative message in the style of the LLDB CLI.
+    Print an information message in the style of the LLDB CLI.
     """
     print(message.info("info:"), msg, *args)
 

--- a/pwndbg/dbg/lldb/repl/__init__.py
+++ b/pwndbg/dbg/lldb/repl/__init__.py
@@ -71,12 +71,6 @@ from pwndbg.dbg.lldb.pset import pget
 from pwndbg.dbg.lldb.pset import pset
 from pwndbg.dbg.lldb.repl.io import IODriver
 from pwndbg.dbg.lldb.repl.io import get_io_driver
-from pwndbg.dbg.lldb.repl.proc import EventHandler
-from pwndbg.dbg.lldb.repl.proc import LaunchResultConnected
-from pwndbg.dbg.lldb.repl.proc import LaunchResultEarlyExit
-from pwndbg.dbg.lldb.repl.proc import LaunchResultError
-from pwndbg.dbg.lldb.repl.proc import LaunchResultSuccess
-from pwndbg.dbg.lldb.repl.proc import ProcessDriver
 from pwndbg.lib.tips import color_tip
 from pwndbg.lib.tips import get_tip_of_the_day
 
@@ -89,6 +83,42 @@ else:
     from pwndbg.dbg.lldb.repl.readline import PROMPT
     from pwndbg.dbg.lldb.repl.readline import enable_readline
     from pwndbg.dbg.lldb.repl.readline import wrap_with_history
+
+
+def print_error(msg: str, *args):
+    """
+    Print an error message in the style of the LLDB CLI.
+    """
+    print(message.error("error:"), msg, *args)
+
+
+def print_warn(msg: str, *args):
+    """
+    Print a warning message in the style of the LLDB CLI.
+    """
+    print(message.warn("warn:"), msg, *args)
+
+
+def print_hint(msg: str, *args):
+    """
+    Print a hint message in the style of the LLDB CLI.
+    """
+    print(message.hint("hint:"), msg, *args)
+
+
+def print_info(msg: str, *args):
+    """
+    Print an informative message in the style of the LLDB CLI.
+    """
+    print(message.info("info:"), msg, *args)
+
+
+from pwndbg.dbg.lldb.repl.proc import EventHandler
+from pwndbg.dbg.lldb.repl.proc import LaunchResultConnected
+from pwndbg.dbg.lldb.repl.proc import LaunchResultEarlyExit
+from pwndbg.dbg.lldb.repl.proc import LaunchResultError
+from pwndbg.dbg.lldb.repl.proc import LaunchResultSuccess
+from pwndbg.dbg.lldb.repl.proc import ProcessDriver
 
 show_tip = pwndbg.config.add_param(
     "show-tips", True, "whether to display the tip of the day on startup"
@@ -264,27 +294,6 @@ class PwndbgController:
         output of the command being available.
         """
         return OneShotAwaitable(YieldExecDirect(command, True, False))
-
-
-def print_error(msg: str, *args):
-    """
-    Print an error message in the style of the LLDB CLI.
-    """
-    print(message.error("error:"), msg, *args)
-
-
-def print_warn(msg: str, *args):
-    """
-    Print a warning message in the style of the LLDB CLI.
-    """
-    print(message.warn("warn:"), msg, *args)
-
-
-def print_hint(msg: str, *args):
-    """
-    Print a hint message in the style of the LLDB CLI.
-    """
-    print(message.hint("hint:"), msg, *args)
 
 
 @wrap_with_history

--- a/pwndbg/dbg/lldb/repl/proc.py
+++ b/pwndbg/dbg/lldb/repl/proc.py
@@ -13,6 +13,7 @@ import lldb
 import pwndbg
 from pwndbg.dbg.lldb import YieldContinue
 from pwndbg.dbg.lldb import YieldSingleStep
+from pwndbg.dbg.lldb.repl import print_info
 from pwndbg.dbg.lldb.repl.io import IODriver
 from pwndbg.dbg.lldb.repl.io import IODriverPlainText
 
@@ -321,6 +322,18 @@ class ProcessDriver:
 
                         if fire_events:
                             self.eh.exited()
+
+                        if new_state == lldb.eStateExited:
+                            proc = lldb.SBProcess.GetProcessFromEvent(event)
+                            desc = (
+                                "" if not proc.exit_description else f" ({proc.exit_description})"
+                            )
+                            print_info(f"process exited with status {proc.exit_state}{desc}")
+                        elif new_state == lldb.eStateCrashed:
+                            print_info("process crashed")
+                        elif new_state == lldb.eStateDetached:
+                            print_info("process detached")
+
                         result = _PollResultExited(new_state)
                         break
 


### PR DESCRIPTION
This PR makes it so that the Pwndbg LLDB CLI prints process status information on exit, along with any extra information LLDB provides us. It's kind of silly that this wasn't a thing up until now, but I guess using `-v` constantly made me forget at some point that this information was never given outside of verbose mode.

<img width="940" height="171" alt="image" src="https://github.com/user-attachments/assets/8b388ed5-0b58-4798-937d-93a0a0d4ed83" />

<img width="2160" height="131" alt="image" src="https://github.com/user-attachments/assets/684d7506-d47a-4f2f-84f6-349c0475dab5" />
