### PR TITLE
lldb: fix lookup symbol for specific objfile

### DIFF
--- a/pwndbg/dbg/lldb/__init__.py
+++ b/pwndbg/dbg/lldb/__init__.py
@@ -1405,7 +1405,10 @@ class LLDBProcess(pwndbg.dbg_mod.Process):
         variables_types: Dict[Tuple[int, str], LLDBType] = {}
 
         if type in (pwndbg.dbg_mod.SymbolLookupType.VARIABLE, pwndbg.dbg_mod.SymbolLookupType.ANY):
-            variables: lldb.SBValueList = (objfile or self.target).FindGlobalVariables(name, 0)
+            if objfile:
+                variables: lldb.SBValueList = objfile.FindGlobalVariables(self.target, name, 0)
+            else:
+                variables: lldb.SBValueList = self.target.FindGlobalVariables(name, 0)
             var: lldb.SBValue
             for var in variables:
                 # LLDB[1] is attempting to resolve a TLS variable, but it fails with the following error:

--- a/pwndbg/dbg/lldb/__init__.py
+++ b/pwndbg/dbg/lldb/__init__.py
@@ -1405,10 +1405,11 @@ class LLDBProcess(pwndbg.dbg_mod.Process):
         variables_types: Dict[Tuple[int, str], LLDBType] = {}
 
         if type in (pwndbg.dbg_mod.SymbolLookupType.VARIABLE, pwndbg.dbg_mod.SymbolLookupType.ANY):
+            variables: lldb.SBValueList
             if objfile:
-                variables: lldb.SBValueList = objfile.FindGlobalVariables(self.target, name, 0)
+                variables = objfile.FindGlobalVariables(self.target, name, 0)
             else:
-                variables: lldb.SBValueList = self.target.FindGlobalVariables(name, 0)
+                variables = self.target.FindGlobalVariables(name, 0)
             var: lldb.SBValue
             for var in variables:
                 # LLDB[1] is attempting to resolve a TLS variable, but it fails with the following error:


### PR DESCRIPTION
Before this can crash with error:
```
File /nix/store/73a8xvjj9y1ac3h08500g2clq00j64nf-pwndbg-env/lib/python3.13/site-packages/pwndbg/dbg/lldb/__init__.py:1408, in LLDBProcess._iter_symbols(self, name, type, objfile)
   1405 variables_types: Dict[Tuple[int, str], LLDBType] = {}
   1407 if type in (pwndbg.dbg_mod.SymbolLookupType.VARIABLE, pwndbg.dbg_mod.SymbolLookupType.ANY):
-> 1408     variables: lldb.SBValueList = (objfile or self.target).FindGlobalVariables(name, 0)
   1409     var: lldb.SBValue
   1410     for var in variables:
   1411         # LLDB[1] is attempting to resolve a TLS variable, but it fails with the following error:
   1412         # [1] https://github.com/llvm/llvm-project/blob/1dfa34c8e1f28963f059e05ce89ebf1f76ebbddc/lldb/source/Expression/DWARFExpression.cpp#L2198
   (...)
   1415
   1416         # <address>, <variable_name>

TypeError: SBModule.FindGlobalVariables() missing 1 required positional argument: 'max_matches'
```