### PR TITLE
Gracefully handle scenarios when kversion string is not found

### DIFF
--- a/pwndbg/aglib/kernel/__init__.py
+++ b/pwndbg/aglib/kernel/__init__.py
@@ -171,13 +171,18 @@ def kversion() -> str:
     except Exception:
         pass
     mapping = first_kernel_ro_page()
+    if mapping is None:
+        return None
     version_addr = next(pwndbg.search.search(b"Linux version", mappings=[mapping]), None)
     return pwndbg.aglib.memory.string(version_addr).decode("ascii").strip()
 
 
 @pwndbg.lib.cache.cache_until("start")
-def krelease() -> Tuple[int, ...]:
-    match = re.search(r"Linux version (\d+)\.(\d+)(?:\.(\d+))?", kversion())
+def krelease() -> Tuple[int, ...] | None:
+    _kversion = kversion()
+    if _kversion is None:
+        return None
+    match = re.search(r"Linux version (\d+)\.(\d+)(?:\.(\d+))?", _kversion)
     if match:
         return tuple(int(x) for x in match.groups() if x)
     raise Exception("Linux version tuple not found")

--- a/pwndbg/aglib/kernel/buddydump.py
+++ b/pwndbg/aglib/kernel/buddydump.py
@@ -77,6 +77,8 @@ def find_zone_offsets() -> Tuple[int, int, int, int, int]:
 def load_buddydump_typeinfo():
     if pwndbg.aglib.typeinfo.lookup_types("struct pglist_data") is not None:
         return
+    if pwndbg.aglib.kernel.symbol.kversion_cint() is None:
+        return
     nmtypes = pwndbg.aglib.kernel.symbol.nmtypes()
     nzones = pwndbg.aglib.kernel.symbol.nzones()
     nnodes = pwndbg.aglib.kernel.num_numa_nodes()

--- a/pwndbg/aglib/kernel/slab.py
+++ b/pwndbg/aglib/kernel/slab.py
@@ -548,6 +548,8 @@ def kmem_cache_pad_sz(kconfig) -> Tuple[int, int]:
 
 
 def kmem_cache_structs(node_cache_pad):
+    if pwndbg.aglib.kernel.symbol.kversion_cint() is None:
+        return
     result = f"#define KVERSION {pwndbg.aglib.kernel.symbol.kversion_cint()}\n"
     if "CONFIG_SLUB_CPU_PARTIAL" in pwndbg.aglib.kernel.kconfig():
         result += "#define CONFIG_SLUB_CPU_PARTIAL\n"
@@ -630,6 +632,8 @@ def kmem_cache_structs(node_cache_pad):
 
 def load_slab_typeinfo():
     if pwndbg.aglib.typeinfo.lookup_types("struct kmem_cache") is not None:
+        return
+    if pwndbg.aglib.kernel.symbol.kversion_cint() is None:
         return
     pwndbg.aglib.kernel.symbol.load_common_structs()
     kconfig = pwndbg.aglib.kernel.kconfig()

--- a/pwndbg/aglib/kernel/symbol.py
+++ b/pwndbg/aglib/kernel/symbol.py
@@ -99,10 +99,12 @@ def npcplist() -> int:
     return 0
 
 
-def kversion_cint(kversion=None):
+def kversion_cint(kversion: Tuple[int, int, int] = None):
     if kversion is None:
         kversion = pwndbg.aglib.kernel.krelease()
-        x, y, z = kversion
+    if kversion is None or len(kversion) != 3:
+        return None
+    x, y, z = kversion
     return ((x) * 65536) + ((y) * 256) + (z)
 
 
@@ -159,7 +161,7 @@ enum pageflags {
 
 
 def load_common_structs():
-    if pwndbg.aglib.kernel.has_debug_info():
+    if pwndbg.aglib.kernel.has_debug_info() or not kversion_cint():
         return
     if pwndbg.aglib.typeinfo.lookup_types("struct page") is not None:
         return

--- a/pwndbg/lib/kernel/kconfig.py
+++ b/pwndbg/lib/kernel/kconfig.py
@@ -94,7 +94,8 @@ class Kconfig(UserDict):  # type: ignore[type-arg]
 
     @property
     def CONFIG_SLUB_TINY(self) -> bool:
-        if pwndbg.aglib.kernel.krelease() < (6, 2): # config added after v6.2
+        krelease = pwndbg.aglib.kernel.krelease()
+        if krelease is not None and krelease < (6, 2): # config added after v6.2
             return False
         return pwndbg.aglib.symbol.lookup_symbol("deactivate_slab") is None
 
@@ -140,7 +141,10 @@ class Kconfig(UserDict):  # type: ignore[type-arg]
     @property
     def CONFIG_KASAN_GENERIC(self) -> bool:
         # TODO: have a kernel build that tests this
-        if pwndbg.aglib.kernel.krelease() > (6, 1) or pwndbg.aglib.kernel.krelease() < (5, 11):
+        krelease = pwndbg.aglib.kernel.krelease()
+        if krelease is None:
+            return False
+        if krelease > (6, 1) or krelease < (5, 11):
             return pwndbg.aglib.symbol.lookup_symbol("kasan_cache_create") is not None
         return pwndbg.aglib.symbol.lookup_symbol("__kasan_cache_create") is not None
 


### PR DESCRIPTION
`first_kernel_ro_page` may return `None` if `ptrace_scope` is enabled or kernel has not finished initialization.