### PR TITLE
Add option to enable register aliases in disassembly

### DIFF
--- a/docs/configuration/config.md
+++ b/docs/configuration/config.md
@@ -443,6 +443,20 @@ Replacing constant operands with their symbol in the disassembly.
 
 ----------
 
+## **disasm-reg-alias**
+
+
+Force the disassembly to use register aliases (e.g. aarch64 x29 -> fp).
+
+The register aliasing is done by capstone, see:
+https://github.com/capstone-engine/capstone/blob/next/docs/cs_v6_release_guide.md#:~:text=None.-,Register%20alias,-Register%20alias%20
+
+Enabling this may make disassembly slower.
+
+**Default:** off  
+
+----------
+
 ## **disasm-telescope-depth**
 
 

--- a/pwndbg/aglib/disasm/disassembly.py
+++ b/pwndbg/aglib/disasm/disassembly.py
@@ -46,6 +46,18 @@ CapstoneEndian = {
 
 CapstoneSyntax = {"intel": CS_OPT_SYNTAX_INTEL, "att": CS_OPT_SYNTAX_ATT}
 
+force_register_alias = pwndbg.config.add_param(
+    "disasm-reg-alias",
+    False,
+    "force the disassembly to use register aliases (e.g. aarch64 x29 -> fp)",
+    param_class=pwndbg.lib.config.PARAM_BOOLEAN,
+    help_docstring="""\
+The register aliasing is done by capstone, see:
+https://github.com/capstone-engine/capstone/blob/next/docs/cs_v6_release_guide.md#:~:text=None.-,Register%20alias,-Register%20alias%20
+
+Enabling this may make disassembly slower.
+""",
+)
 
 # Caching strategy:
 # To ensure we don't have stale register/memory information in our cached PwndbgInstruction,
@@ -109,6 +121,8 @@ def get_disassembler(cs_info: Tuple[int, int]):
     flavor = pwndbg.dbg.x86_disassembly_flavor()
     try:
         cs.syntax = CapstoneSyntax[flavor]
+        if force_register_alias:
+            cs.syntax |= CS_OPT_SYNTAX_CS_REG_ALIAS
     except CsError:
         pass
     cs.detail = True

--- a/pwndbg/aglib/disasm/disassembly.py
+++ b/pwndbg/aglib/disasm/disassembly.py
@@ -324,7 +324,9 @@ def near(
     Disasms instructions near given `address`. Passing `emulate` makes use of
     unicorn engine to emulate instructions to predict branches that will be taken.
     `show_prev_insns` makes this show previously cached instructions
-    (this is mostly used by context's disasm display, so user see what was previously)
+
+    This allows us to maintain a context of surrounding instructions while
+    single-stepping instructions.
     """
 
     pc = pwndbg.aglib.regs.pc


### PR DESCRIPTION
aarch64 example:

with disabled (default):
<img width="246" height="31" alt="image" src="https://github.com/user-attachments/assets/2bb7c001-f949-43ab-a8af-d6b47223b30d" />
with enabled:
<img width="245" height="26" alt="image" src="https://github.com/user-attachments/assets/3e26bfca-c511-4b1b-8e75-41a62591a1d9" />
