### PR TITLE
Fix `nix develop` for lldb

### DIFF
--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -81,6 +81,10 @@ in
         pkgs.lldb_20
       ];
     shellHook = ''
+      # lldb looks for the `debugserver` binary in `DEVELOPER_DIR`,
+      # but nixpkgs does not provide `debugserver` there
+      unset DEVELOPER_DIR
+
       export PWNDBG_NO_AUTOUPDATE=1
       export PWNDBG_NO_UV=1
       export PWNDBG_VENV_PATH="${pyEnv}"


### PR DESCRIPTION
Before:
<img width="543" height="218" alt="image" src="https://github.com/user-attachments/assets/abd6629b-278f-4966-9ad4-a48a97d04ff1" />


After:
<img width="563" height="230" alt="image" src="https://github.com/user-attachments/assets/a4d2128b-4b7d-4029-a1db-5a54dc2de48c" />
