### PR TITLE
Fix NO_COLOR environment variable support

### DIFF
--- a/pwndbg/color/__init__.py
+++ b/pwndbg/color/__init__.py
@@ -133,6 +133,10 @@ def colorize(x: str, color: str) -> str:
     return color + terminateWith(str(x), color) + NORMAL
 
 
+def nocolor(x: str, color: str) -> str:
+    return x
+
+
 # Taken from https://stackoverflow.com/a/14693789
 ansi_escape_8bit = re.compile(
     r"(?:\x1B[@-Z\\-_]|[\x80-\x9A\x9C-\x9F]|(?:\x1B\[|\x9B)[0-?]*[ -/]*[@-~])"
@@ -148,6 +152,17 @@ disable_colors = theme.add_param(
     bool(os.environ.get("NO_COLOR")),
     "whether to color the output or not",
 )
+
+
+@pwndbg.config.trigger(disable_colors)
+def _disable_colors_trigger():
+    if disable_colors:
+        if not hasattr(colorize, 'original_code'):
+            colorize.original_code = colorize.__code__
+        colorize.__code__ = nocolor.__code__
+    else:
+        if hasattr(colorize, 'original_code'):
+            colorize.__code__ = colorize.original_code
 
 
 def generateColorFunctionInner(

--- a/pwndbg/color/__init__.py
+++ b/pwndbg/color/__init__.py
@@ -11,6 +11,7 @@ from typing import Dict
 from typing import List
 from typing import NamedTuple
 
+import pwndbg
 from pwndbg.lib.config import Parameter
 
 from . import theme
@@ -157,11 +158,11 @@ disable_colors = theme.add_param(
 @pwndbg.config.trigger(disable_colors)
 def _disable_colors_trigger():
     if disable_colors:
-        if not hasattr(colorize, 'original_code'):
+        if not hasattr(colorize, "original_code"):
             colorize.original_code = colorize.__code__
         colorize.__code__ = nocolor.__code__
     else:
-        if hasattr(colorize, 'original_code'):
+        if hasattr(colorize, "original_code"):
             colorize.__code__ = colorize.original_code
 
 


### PR DESCRIPTION
Implement proper NO_COLOR support by adding a nocolor function and configuration trigger that dynamically replaces the colorize function's behavior when colors are disabled. This approach avoids performance overhead by modifying function behavior at runtime rather than adding conditional checks to each colorize call.

Fixes #3142
