### PR TITLE
Fix cachedir on Windows

### DIFF
--- a/pwndbg/lib/tempfile.py
+++ b/pwndbg/lib/tempfile.py
@@ -31,7 +31,7 @@ def cachedir(namespace: str | None = None) -> str:
         cachehome = os.getenv("LOCALAPPDATA")
     else:
         cachehome = os.getenv("XDG_CACHE_HOME") or os.path.join(os.getenv("HOME", ""), ".cache")
-    cachedir = os.path.join(cachehome, "pwndbg")
+    cachedir = os.path.join(cachehome or tempfile.gettempdir(), "pwndbg")
     if namespace:
         cachedir = os.path.join(cachedir, namespace)
     os.makedirs(cachedir, exist_ok=True)

--- a/pwndbg/lib/tempfile.py
+++ b/pwndbg/lib/tempfile.py
@@ -5,6 +5,7 @@ Common helper and cache for pwndbg tempdir
 from __future__ import annotations
 
 import os
+import sys
 import tempfile
 
 import pwndbg.lib.cache
@@ -22,11 +23,14 @@ def tempdir() -> str:
 def cachedir(namespace: str | None = None) -> str:
     """
     Returns and potentially creates a persistent safe cachedir location
-    based on XDG_CACHE_HOME or ~/.cache
+    based on XDG_CACHE_HOME or ~/.cache or LOCALAPPDATA (Windows)
 
     Optionally creates a sub namespace inside the pwndbg cache folder.
     """
-    cachehome = os.getenv("XDG_CACHE_HOME") or os.path.join(os.getenv("HOME", ""), ".cache")
+    if sys.platform == "win32":
+        cachehome = os.getenv("LOCALAPPDATA")
+    else:
+        cachehome = os.getenv("XDG_CACHE_HOME") or os.path.join(os.getenv("HOME", ""), ".cache")
     cachedir = os.path.join(cachehome, "pwndbg")
     if namespace:
         cachedir = os.path.join(cachedir, namespace)


### PR DESCRIPTION
This PR fixes the `cachedir` function on Windows. Previously, it defaulted to `C:\Windows\System32`, which made it unusable. With this fix, `LOCALAPPDATA` is correctly used to store application-specific data.

Tested with:
```py
Python 3.11.6 (tags/v3.11.6:8b6ee5b, Oct  2 2023, 14:57:12) [MSC v.1935 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> import pwndbg.lib.tempfile
>>> pwndbg.lib.tempfile.cachedir("onegadget")
'C:\\Users\\xxx\\AppData\\Local\\pwndbg\\onegadget'
>>>
```
