### PR TITLE
Fix DYLD Shared Cache

### DIFF
--- a/pwndbg/aglib/macho.py
+++ b/pwndbg/aglib/macho.py
@@ -637,7 +637,7 @@ class DyldSharedCache:
         return DyldSharedCacheHashSet(ptr)
 
 
-@pwndbg.lib.cache.cache_until("exit")
+@pwndbg.lib.cache.cache_until("exit", ignore_for=[None])
 def shared_cache() -> DyldSharedCache | None:
     """
     Base address of the Darwin shared cache.
@@ -659,12 +659,16 @@ def shared_cache() -> DyldSharedCache | None:
     [1]: https://github.com/apple-oss-distributions/objc4/blob/f126469408dc82bd3f327217ae678fd0e6e3b37c/runtime/objc-opt.mm#L434
     [2]: https://github.com/apple-oss-distributions/dyld/blob/main/doc/dyld4.md#libdylddylib
     """
-    base = int(
-        pwndbg.dbg.selected_inferior().evaluate_expression(
-            "(const void*)_dyld_get_shared_cache_range()"
-        )
-    )
+    if pwndbg.aglib.symbol.lookup_symbol("_dyld_get_shared_cache_range") is None:
+        return None
 
+    base = pwndbg.dbg.selected_inferior().evaluate_expression(
+        "(const void*)_dyld_get_shared_cache_range()"
+    )
+    if base.is_optimized_out:
+        return None
+
+    base = int(base)
     if base == 0:
         return None
 

--- a/pwndbg/aglib/macho.py
+++ b/pwndbg/aglib/macho.py
@@ -10,6 +10,7 @@ from typing import TypeVar
 
 import pwndbg
 import pwndbg.aglib.memory
+import pwndbg.aglib.symbol
 
 
 def _uleb128(ptr: int) -> Tuple[int, int]:
@@ -637,7 +638,10 @@ class DyldSharedCache:
         return DyldSharedCacheHashSet(ptr)
 
 
-@pwndbg.lib.cache.cache_until("exit", ignore_for=[None])
+_global_new_variable_id = 0
+
+
+@pwndbg.lib.cache.cache_until("objfile")
 def shared_cache() -> DyldSharedCache | None:
     """
     Base address of the Darwin shared cache.
@@ -662,8 +666,14 @@ def shared_cache() -> DyldSharedCache | None:
     if pwndbg.aglib.symbol.lookup_symbol("_dyld_get_shared_cache_range") is None:
         return None
 
+    # Due to bug: https://github.com/llvm/llvm-project/issues/84806#issuecomment-1995055683
+    # we have to create new variable on each call
+    global _global_new_variable_id
+    _global_new_variable_id += 1
+    var = f"$_pwndbg_internal_shared_cache_size{_global_new_variable_id}"
+
     base = pwndbg.dbg.selected_inferior().evaluate_expression(
-        "(const void*)_dyld_get_shared_cache_range()"
+        f"size_t {var} = 0; (const void*)_dyld_get_shared_cache_range(&{var})"
     )
     if base.is_optimized_out:
         return None

--- a/pwndbg/lib/cache.py
+++ b/pwndbg/lib/cache.py
@@ -126,7 +126,8 @@ IS_CACHING_DISABLED_FOR: Dict[str, bool] = {
     "forever": False,
 }
 
-def cache_until(*event_names: str, ignore_for: List[Any] | None = None) -> Callable[[Callable[P, T]], Callable[P, T]]:
+
+def cache_until(*event_names: str) -> Callable[[Callable[P, T]], Callable[P, T]]:
     if any(event_name not in _ALL_CACHE_EVENT_NAMES for event_name in event_names):
         raise ValueError(
             f"Unknown event name[s] passed to the `cache_until` decorator: {event_names}.\n"
@@ -165,9 +166,7 @@ def cache_until(*event_names: str, ignore_for: List[Any] | None = None) -> Calla
                 if isinstance(value, list):
                     print(f"Should not cache mutable types! {func.__name__}")
 
-                if ignore_for is None or value not in ignore_for:
-                    # Only cache if we were not requested to ignore this value.
-                    cache[key] = value
+                cache[key] = value
 
                 return value
 

--- a/pwndbg/lib/cache.py
+++ b/pwndbg/lib/cache.py
@@ -126,8 +126,7 @@ IS_CACHING_DISABLED_FOR: Dict[str, bool] = {
     "forever": False,
 }
 
-
-def cache_until(*event_names: str) -> Callable[[Callable[P, T]], Callable[P, T]]:
+def cache_until(*event_names: str, ignore_for: List[Any] | None = None) -> Callable[[Callable[P, T]], Callable[P, T]]:
     if any(event_name not in _ALL_CACHE_EVENT_NAMES for event_name in event_names):
         raise ValueError(
             f"Unknown event name[s] passed to the `cache_until` decorator: {event_names}.\n"
@@ -166,7 +165,9 @@ def cache_until(*event_names: str) -> Callable[[Callable[P, T]], Callable[P, T]]
                 if isinstance(value, list):
                     print(f"Should not cache mutable types! {func.__name__}")
 
-                cache[key] = value
+                if ignore_for is None or value not in ignore_for:
+                    # Only cache if we were not requested to ignore this value.
+                    cache[key] = value
 
                 return value
 

--- a/pwndbg/lib/memory.py
+++ b/pwndbg/lib/memory.py
@@ -33,6 +33,9 @@ def format_address(vaddr: int, memsz: int, permstr: str, offset: int, objfile: s
     "Format the given address as a string."
 
     width = 2 + 2 * pwndbg.aglib.arch.ptrsize
+    if memsz > 0x100000000:
+        return f"{vaddr:#{width}x} {vaddr + memsz:#{width}x} {permstr} {memsz:8x} {offset:6x} {objfile or ''}"
+
     return f"{vaddr:#{width}x} {vaddr + memsz:#{width}x} {permstr} {memsz:8x} {offset:7x} {objfile or ''}"
 
 


### PR DESCRIPTION
This PR also include changes from: https://github.com/pwndbg/pwndbg/pull/3302

Old version of `_dyld_get_shared_cache_range` was wrong from begging, this func has required first argument.
And lldb21+ now checks if "evaluation" is in proper state:
<img width="880" height="542" alt="image" src="https://github.com/user-attachments/assets/1ca5df8f-ca90-44c8-927a-ae2e14e63a71" />

Closes:
- https://github.com/pwndbg/pwndbg/issues/3281