### PR TITLE
Fix warnings with `cyclic --n 4 --detect` on 64 bit host

### DIFF
--- a/pwndbg/commands/cyclic.py
+++ b/pwndbg/commands/cyclic.py
@@ -49,7 +49,7 @@ def detect_register_patterns(alphabet, length, timeout) -> None:
         try:
             signal.alarm(timeout)
             value_bytes = value.to_bytes(ptr_size, endian)
-            offset = cyclic_find(value_bytes, alphabet=alphabet, n=length)
+            offset = cyclic_find(value_bytes[:length], alphabet=alphabet, n=length)
             if offset != -1:
                 found_patterns.append((reg_name, value, offset))
         except TimeoutException:


### PR DESCRIPTION
The register values were always read in register sizes causing 8 bytes to be passed to `cyclic_find` while setting `n=4`.

This triggers a truncation warning in `cyclic_find`, so truncate the input ourselves.