### PR TITLE
bump flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1753750875,
-        "narHash": "sha256-J1P0aQymehe8AHsID9wwoMjbaYrIB2eH5HftoXhF9xk=",
+        "lastModified": 1757034884,
+        "narHash": "sha256-PgLSZDBEWUHpfTRfFyklmiiLBE1i1aGCtz4eRA3POao=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "871381d997e4a063f25a3994ce8a9ac595246610",
+        "rev": "ca77296380960cd497a765102eeb1356eb80fed0",
         "type": "github"
       },
       "original": {
@@ -29,11 +29,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742689179,
-        "narHash": "sha256-kDXV6r6pQp6sxBKKxXqcTGPdiH63m8WA+IvzHhdZlEg=",
+        "lastModified": 1757296493,
+        "narHash": "sha256-6nzSZl28IwH2Vx8YSmd3t6TREHpDbKlDPK+dq1LKIZQ=",
         "owner": "pyproject-nix",
         "repo": "build-system-pkgs",
-        "rev": "5c2a1faadc4015d50eb9919a8e20c112f3765fc2",
+        "rev": "5b8e37fe0077db5c1df3a5ee90a651345f085d38",
         "type": "github"
       },
       "original": {
@@ -49,11 +49,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754287816,
-        "narHash": "sha256-kDt0HB89oWTlTQMnTwDxx3BlRHK1AdAJ1kMcVYGuccs=",
+        "lastModified": 1757246327,
+        "narHash": "sha256-6pNlGhwOIMfhe/RLjHdpXveKS4FyLHvlGe+KtjDild4=",
         "owner": "pyproject-nix",
         "repo": "pyproject.nix",
-        "rev": "efe944d0902f406c28b4e8662312292a37e4de87",
+        "rev": "8d77f342d66ad1601cdb9d97e9388b69f64d4c8e",
         "type": "github"
       },
       "original": {
@@ -80,11 +80,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1753067819,
-        "narHash": "sha256-vjLTZCgMWvfep8eKZL25T8pBb4MyBjswfyAlHTyJaoY=",
+        "lastModified": 1756973152,
+        "narHash": "sha256-9JcKAA7T9J98LWdcxbXvmf+amQG3ZErxqQnBjEJI04I=",
         "owner": "pyproject-nix",
         "repo": "uv2nix",
-        "rev": "5b7b7a8808c031fa8e13d8e949a2af3c2c12a1c6",
+        "rev": "64298e806f4a5f63a51c625edc100348138491aa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Main changes:
- lldb               20.1.6 -> 20.1.8
- python3            3.13.5 -> 3.13.6
- qemu               10.0.2 -> 10.0.3

Full Diff:

```console
(pwndbg) psondej@m4 ~/projekty/pwndbg $ nvd diff ./result1-devshell ./result2-devshell
<<< result1-devshell
>>> result2-devshell
Version changes:
[U*]  #01  bash               5.3p0 -> 5.3p3
[U.]  #02  bundler            2.6.9 -> 2.7.1
[C*]  #03  clang              19.1.7, 19.1.7-lib, 20.1.6-lib -> 19.1.7, 19.1.7-lib, 20.1.8-lib
[U*]  #04  go                 1.24.5 -> 1.24.6
[U.]  #05  gst-plugins-base   1.26.0 -> 1.26.3
[U.]  #06  gstreamer          1.26.0 -> 1.26.3
[U.]  #07  libpng-apng        1.6.47 -> 1.6.49
[U.]  #08  libxml2            2.14.4-unstable-2025-06-20 -> 2.14.5
[U*]  #09  lldb               20.1.6, 20.1.6-dev -> 20.1.8, 20.1.8-dev
[C.]  #10  llvm               19.1.7, 19.1.7-lib, 20.1.6-lib -> 19.1.7, 19.1.7-lib, 20.1.8-lib
[U.]  #11  markdown-it-py     3.0.0 -> 4.0.0
[U.]  #12  nettle             3.10.1 -> 3.10.2
[U*]  #13  nghttp2            1.65.0, 1.65.0-dev, 1.65.0-lib -> 1.66.0, 1.66.0-dev, 1.66.0-lib
[U.]  #14  packaging          24.2 -> 25.0
[U*]  #15  parallel           20250722 -> 20250822
[U.]  #16  pluggy             1.5.0 -> 1.6.0
[U*]  #17  publicsuffix-list  0-unstable-2025-06-10 -> 0-unstable-2025-07-22
[U.]  #18  pygments           2.19.1 -> 2.19.2
[U.]  #19  python3            3.13.5 -> 3.13.6
[U*]  #20  qemu               10.0.2 -> 10.0.3
[U.]  #21  rich               13.9.4 -> 14.1.0
[U.]  #22  spice              0.15.2 -> 0.16.0
[U.]  #23  trove-classifiers  2025.3.19.19 -> 2025.8.26.11
[U.]  #24  typing-extensions  4.12.2 -> 4.15.0
[U.]  #25  unbound            1.23.0-lib -> 1.23.1-lib
[U.]  #26  wolfssl-all        5.7.6-lib -> 5.8.2-lib
Added packages:
[A.]  #1  libx11    1.8.12
[A.]  #2  libxau    1.0.12
[A.]  #3  libxdmcp  1.1.5
[A.]  #4  libxext   1.3.6
Removed packages:
[R.]  #1  libX11    1.8.12
[R.]  #2  libXau    1.0.12
[R.]  #3  libXdmcp  1.1.5
[R.]  #4  libXext   1.3.6
Closure size: 285 -> 285 (271 paths added, 271 paths removed, delta +0, disk usage +482.9KiB).
(pwndbg) psondej@m4 ~/projekty/pwndbg $ nvd diff ./result1-gdb ./result2-gdb
<<< result1-gdb
>>> result2-gdb
Version changes:
[U*]  #1  bash                   5.3p0 -> 5.3p3
[U.]  #2  libxml2                2.14.4-unstable-2025-06-20 -> 2.14.5
[U.]  #3  nss-cacert             3.113.1 -> 3.114
[U.]  #4  python3                3.13.5 -> 3.13.6
[U.]  #5  python3.13-certifi     2025.06.15 -> 2025.07.14
[U.]  #6  python3.13-paramiko    3.5.1 -> 4.0.0
[U.]  #7  python3.13-pygments    2.19.1 -> 2.19.2
[U.]  #8  python3.13-setuptools  80.7.1 -> 80.9.0
[U.]  #9  python3.13-urllib3     2.4.0 -> 2.5.0
Closure size: 117 -> 117 (117 paths added, 117 paths removed, delta +0, disk usage +57.1KiB).
(pwndbg) psondej@m4 ~/projekty/pwndbg $ nvd diff ./result1-lldb ./result2-lldb
<<< result1-lldb
>>> result2-lldb
Version changes:
[U*]  #01  bash                   5.3p0 -> 5.3p3
[U.]  #02  clang                  20.1.6-lib -> 20.1.8-lib
[U.]  #03  libxml2                2.14.4-unstable-2025-06-20 -> 2.14.5
[U*]  #04  lldb                   20.1.6 -> 20.1.8
[U.]  #05  llvm                   20.1.6-lib -> 20.1.8-lib
[U.]  #06  nss-cacert             3.113.1 -> 3.114
[U.]  #07  python3                3.13.5 -> 3.13.6
[U.]  #08  python3.13-certifi     2025.06.15 -> 2025.07.14
[U.]  #09  python3.13-paramiko    3.5.1 -> 4.0.0
[U.]  #10  python3.13-pygments    2.19.1 -> 2.19.2
[U.]  #11  python3.13-setuptools  80.7.1 -> 80.9.0
[U.]  #12  python3.13-urllib3     2.4.0 -> 2.5.0
Closure size: 113 -> 113 (113 paths added, 113 paths removed, delta +0, disk usage +61.8KiB).

```