### PR TITLE
Fix 3289: Prevent 'None+offset' symbol formatting

### DIFF
--- a/pwndbg/aglib/symbol.py
+++ b/pwndbg/aglib/symbol.py
@@ -113,4 +113,7 @@ def resolve_addr(addr: int) -> str | None:
     if symbol_name:
         return symbol_name
 
-    return pwndbg.integration.provider.get_symbol(addr)
+    symbol = pwndbg.integration.provider.get_symbol(addr)
+    if symbol is None:
+        return None
+    return symbol

--- a/pwndbg/integration/binja.py
+++ b/pwndbg/integration/binja.py
@@ -396,18 +396,24 @@ class BinjaProvider(pwndbg.integration.IntegrationProvider):
             return sym
         func: Tuple[str, int] | None = _bn.get_func_info(l2r(addr))
         if func is not None:
-            diff = addr - r2l(func[1])
+            name, base = func
+            if name is None:
+                return None
+            diff = addr - r2l(base)
             if diff:
-                return f"{func[0]}{diff:+}"
+                return f"{name}{diff:+}"
             else:
-                return func[0]
+                return name
         dv: Tuple[str, int] | None = _bn.get_data_info(l2r(addr))
         if dv is not None:
-            diff = addr - r2l(dv[1])
+            name, base = dv
+            if name is None:
+                return None
+            diff = addr - r2l(base)
             if diff:
-                return f"{dv[0]}{addr - r2l(dv[1]):+}"
+                return f"{name}{diff:+}"
             else:
-                return dv[0]
+                return name
         return None
 
     @pwndbg.decorators.suppress_errors(fallback=())

--- a/pwndbg/integration/ida.py
+++ b/pwndbg/integration/ida.py
@@ -575,7 +575,13 @@ class IdaProvider(pwndbg.integration.IntegrationProvider):
         if exe:
             exe_map = pwndbg.aglib.vmmap.find(exe.address)
             if exe_map and addr in exe_map:
-                return Name(addr) or GetFuncOffset(addr) or None
+                name = Name(addr)
+                offset = GetFuncOffset(addr)
+
+                if name is None:
+                    return None
+
+                return name or offset or None
         return None
 
     @pwndbg.decorators.suppress_errors(fallback=())


### PR DESCRIPTION
This PR resolves [Issue #3289](https://github.com/pwndbg/pwndbg/issues/3289) by ensuring that symbol resolution never formats None as a symbol name.

- I broke up the (name, base) tuples in both BinjaProvider and IdaProvider for readability and explicit None checks. This makes the logic easier to follow and ensures future contributors can clearly see where symbol names are validated before formatting.
- Added guards in Binja/Ida Provider to avoid formatting None as symbol name
- Added top-level check in resolve_addr for added robustness
