### PR TITLE
Fix handling of missing DYLD Shared Cache

### DIFF
--- a/pwndbg/aglib/macho.py
+++ b/pwndbg/aglib/macho.py
@@ -637,7 +637,7 @@ class DyldSharedCache:
         return DyldSharedCacheHashSet(ptr)
 
 
-@pwndbg.lib.cache.cache_until("exit")
+@pwndbg.lib.cache.cache_until("exit", ignore_for=[None])
 def shared_cache() -> DyldSharedCache | None:
     """
     Base address of the Darwin shared cache.
@@ -659,12 +659,16 @@ def shared_cache() -> DyldSharedCache | None:
     [1]: https://github.com/apple-oss-distributions/objc4/blob/f126469408dc82bd3f327217ae678fd0e6e3b37c/runtime/objc-opt.mm#L434
     [2]: https://github.com/apple-oss-distributions/dyld/blob/main/doc/dyld4.md#libdylddylib
     """
-    base = int(
-        pwndbg.dbg.selected_inferior().evaluate_expression(
-            "(const void*)_dyld_get_shared_cache_range()"
-        )
-    )
+    if pwndbg.aglib.symbol.lookup_symbol("_dyld_get_shared_cache_range") is None:
+        return None
 
+    base = pwndbg.dbg.selected_inferior().evaluate_expression(
+        "(const void*)_dyld_get_shared_cache_range()"
+    )
+    if base.is_optimized_out:
+        return None
+
+    base = int(base)
     if base == 0:
         return None
 

--- a/pwndbg/lib/cache.py
+++ b/pwndbg/lib/cache.py
@@ -126,8 +126,7 @@ IS_CACHING_DISABLED_FOR: Dict[str, bool] = {
     "forever": False,
 }
 
-
-def cache_until(*event_names: str) -> Callable[[Callable[P, T]], Callable[P, T]]:
+def cache_until(*event_names: str, ignore_for: List[Any] | None = None) -> Callable[[Callable[P, T]], Callable[P, T]]:
     if any(event_name not in _ALL_CACHE_EVENT_NAMES for event_name in event_names):
         raise ValueError(
             f"Unknown event name[s] passed to the `cache_until` decorator: {event_names}.\n"
@@ -166,7 +165,9 @@ def cache_until(*event_names: str) -> Callable[[Callable[P, T]], Callable[P, T]]
                 if isinstance(value, list):
                     print(f"Should not cache mutable types! {func.__name__}")
 
-                cache[key] = value
+                if ignore_for is None or value not in ignore_for:
+                    # Only cache if we were not requested to ignore this value.
+                    cache[key] = value
 
                 return value
 


### PR DESCRIPTION
During early execution, the DYLD Shared Cache may not be available. This can manifest as the `_dyld_get_shared_cache_range` being communicated to us as having been optimized out. This PR makes it so that that case is properly handled.

Additionally, this PR adds an optional list of ignored values to `pwndbg.lib.cache.cache_until`, so that caching is not performed if they are returned, and the cached function is allowed to run again, which is used by the shared cache function, to allow it to be retried later on. An alternative to this would be to cache until `"stop"`, but that would not entirely capture the fact that, once that value is found, it stays the same for the entire lifetime of the process.