### PR TITLE
Fix lldb fzf startup prompt

### DIFF
--- a/pwndbg/dbg/lldb/repl/__init__.py
+++ b/pwndbg/dbg/lldb/repl/__init__.py
@@ -393,7 +393,7 @@ def run(
             last_command = action._command
 
             if not action._prompt_silent:
-                print(f"{PROMPT}{action._command}")
+                print(f"{PROMPT.value if HAS_FZF else PROMPT}{action._command}")
 
             try:
                 if action._capture:

--- a/pwndbg/dbg/lldb/repl/fuzzy.py
+++ b/pwndbg/dbg/lldb/repl/fuzzy.py
@@ -39,7 +39,7 @@ from pwndbg.dbg.lldb import LLDB
 P = ParamSpec("P")
 T = TypeVar("T")
 
-PROMPT = ANSI("\x1b[34mpwndbg-lldb> ")
+PROMPT = ANSI("\x1b[34mpwndbg-lldb>\x1b[0m ")
 HISTORY_FILE = os.path.expanduser("~/.pwndbg_history")
 
 FZF_RUN_CMD = (


### PR DESCRIPTION
<!--
    Please make sure to read the linting and testing instructions at
    https://pwndbg.re/pwndbg/dev/contributing/ before creating a PR.
-->

When starting up, the `pwndbg-lldb> ` prompt was incorrectly formatted when `fzf` detected.

Before:
```
ANSI('\x1b[34mpwndbg-lldb> ')target create 'test'
Current executable set to 'test' (arm64)
```

After:
```
pwndbg-lldb> target create 'test'
Current executable set to 'test' (arm64)
```