### PR TITLE
feat: Add `fmtarg` command for exploiting Format String Bugs 

### DIFF
--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -973,3 +973,4 @@ def load_commands() -> None:
     import pwndbg.commands.windbg
     import pwndbg.commands.xinfo
     import pwndbg.commands.xor
+    import pwndbg.commands.fmtarg

--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -903,6 +903,7 @@ def load_commands() -> None:
     import pwndbg.commands.commpage
     import pwndbg.commands.config
     import pwndbg.commands.context
+    import pwndbg.commands.cppheap
     import pwndbg.commands.cpsr
     import pwndbg.commands.cyclic
     import pwndbg.commands.dev
@@ -911,6 +912,7 @@ def load_commands() -> None:
     import pwndbg.commands.dumpargs
     import pwndbg.commands.elf
     import pwndbg.commands.flags
+    import pwndbg.commands.fmtarg
     import pwndbg.commands.gdt
     import pwndbg.commands.ghidra
     import pwndbg.commands.godbg
@@ -973,4 +975,3 @@ def load_commands() -> None:
     import pwndbg.commands.windbg
     import pwndbg.commands.xinfo
     import pwndbg.commands.xor
-    import pwndbg.commands.fmtarg

--- a/pwndbg/commands/fmtarg.py
+++ b/pwndbg/commands/fmtarg.py
@@ -1,19 +1,20 @@
 # fmtarg command. Check EOF for license
+from __future__ import annotations
+
 import argparse
 from typing import Tuple
-import pwndbg.commands
-import pwndbg.chain
+
 import pwndbg.aglib.arch
 import pwndbg.aglib.memory
-import pwndbg.aglib.stack
 import pwndbg.aglib.regs
+import pwndbg.aglib.stack
+import pwndbg.chain
+import pwndbg.commands
 from pwndbg.commands import CommandCategory
 
 parser = argparse.ArgumentParser()
 parser.description = "Dump arguments for format string exploits."
-parser.add_argument(
-    "n", nargs="?", type=int, default=16, help="Number of arguments to print"
-)
+parser.add_argument("n", nargs="?", type=int, default=16, help="Number of arguments to print")
 
 
 @pwndbg.commands.Command(parser, category=CommandCategory.MISC)
@@ -23,7 +24,7 @@ def fmtarg(n=16):
     Show first n arguments as used in a format string
     """
 
-    n += 1 # to show first n arguments including the formatstring.
+    n += 1  # to show first n arguments including the formatstring.
     index_width = len(str(n)) + 2
     ret_addrs = set(pwndbg.aglib.stack.callstack())
 
@@ -41,7 +42,7 @@ def fmtarg(n=16):
         loc, arg = argument(i)
         annotation = " [RETADDR]" if arg in ret_addrs else ""
         index = str(i).center(index_width)
-        if type(loc) == str:
+        if isinstance(loc, str):
             loc = loc.upper()
             loc = loc.ljust(longest_reg_len + 2)
             print("%s│ %s%s%s" % (index, loc, pwndbg.chain.format(arg), annotation))

--- a/pwndbg/commands/fmtarg.py
+++ b/pwndbg/commands/fmtarg.py
@@ -1,0 +1,55 @@
+# fmtarg command. Check EOF for license
+import argparse
+import pwndbg.commands
+import pwndbg.chain
+import pwndbg.aglib.arch
+import pwndbg.aglib.memory
+import pwndbg.aglib.stack
+import pwndbg.aglib.regs
+from pwndbg.commands import CommandCategory
+
+parser = argparse.ArgumentParser()
+parser.description = "Dump arguments for format string exploits."
+parser.add_argument(
+    "n", nargs="?", type=int, default=16, help="Number of arguments to print"
+)
+
+
+@pwndbg.commands.Command(parser, category=CommandCategory.MISC)
+@pwndbg.commands.OnlyWhenRunning
+def fmtarg(n=16):
+    """
+    Show first n arguments as used in a format string, following
+    System V AMD64 calling convention.
+    """
+
+    # System V AMD64 calling convention: rsi, rdx, rcx, r8, r9
+    regs64 = ["rsi", "rdx", "rcx", "r8", "r9"]
+
+    if pwndbg.aglib.arch.name != "x86-64":
+        print("Only x86-64 supported right now")
+        return
+
+    ptrsize = pwndbg.aglib.arch.ptrsize
+    rsp = pwndbg.aglib.regs.rsp
+    assert rsp is not None
+    # figure out how wide the index column should be
+    index_width = len(str(n))
+    ret_addrs = set(pwndbg.aglib.stack.callstack())
+
+    for i, reg in enumerate(regs64):
+        if i >= n:
+            return
+        val = pwndbg.aglib.regs[reg]
+        reg = reg.upper()
+        # Align index, register name, and formatted value
+        print(f"{i+1:{index_width}d} │ {reg:<4} {pwndbg.chain.format(val)}")
+
+    for i in range(6, n):
+        addr = rsp + (i - 6) * ptrsize
+        val = pwndbg.aglib.memory.u(addr)
+
+        annotation = " [RETADDR]" if val in ret_addrs else ""
+        print(f"{i:{index_width}d} │ {pwndbg.chain.format(addr)}{annotation}")
+
+

--- a/pwndbg/commands/fmtarg.py
+++ b/pwndbg/commands/fmtarg.py
@@ -1,5 +1,6 @@
 # fmtarg command. Check EOF for license
 import argparse
+from typing import Tuple
 import pwndbg.commands
 import pwndbg.chain
 import pwndbg.aglib.arch
@@ -19,37 +20,53 @@ parser.add_argument(
 @pwndbg.commands.OnlyWhenRunning
 def fmtarg(n=16):
     """
-    Show first n arguments as used in a format string, following
-    System V AMD64 calling convention.
+    Show first n arguments as used in a format string
     """
 
-    # System V AMD64 calling convention: rsi, rdx, rcx, r8, r9
-    regs64 = ["rsi", "rdx", "rcx", "r8", "r9"]
-
-    if pwndbg.aglib.arch.name != "x86-64":
-        print("Only x86-64 supported right now")
-        return
-
-    ptrsize = pwndbg.aglib.arch.ptrsize
-    rsp = pwndbg.aglib.regs.rsp
-    assert rsp is not None
-    # figure out how wide the index column should be
-    index_width = len(str(n))
+    n += 1 # to show first n arguments including the formatstring.
+    index_width = len(str(n)) + 2
     ret_addrs = set(pwndbg.aglib.stack.callstack())
 
-    for i, reg in enumerate(regs64):
-        if i >= n:
-            return
-        val = pwndbg.aglib.regs[reg]
-        reg = reg.upper()
-        # Align index, register name, and formatted value
-        print(f"{i+1:{index_width}d} │ {reg:<4} {pwndbg.chain.format(val)}")
+    abi = pwndbg.aglib.arch.function_abi
+    if abi is None:
+        raise pwndbg.dbg_mod.Error(
+            f"Function ABI not defined for current architecture, {pwndbg.aglib.arch.function_abi}"
+        )
 
-    for i in range(6, n):
-        addr = rsp + (i - 6) * ptrsize
-        val = pwndbg.aglib.memory.u(addr)
+    regs = abi.register_arguments
+    longest_reg = max(regs, key=len)
+    longest_reg_len = len(longest_reg)
 
-        annotation = " [RETADDR]" if val in ret_addrs else ""
-        print(f"{i:{index_width}d} │ {pwndbg.chain.format(addr)}{annotation}")
+    for i in range(n):
+        loc, arg = argument(i)
+        annotation = " [RETADDR]" if arg in ret_addrs else ""
+        index = str(i).center(index_width)
+        if type(loc) == str:
+            loc = loc.upper()
+            loc = loc.ljust(longest_reg_len + 2)
+            print("%s│ %s%s%s" % (index, loc, pwndbg.chain.format(arg), annotation))
+        else:
+            print("%s│ %s%s" % (index, pwndbg.chain.format(loc), annotation))
 
 
+def argument(n: int) -> Tuple[int | str, int]:
+    """
+    Returns the nth argument, as if $pc were a 'call' or 'bl' type
+    instruction.
+    Works only for ABIs that use registers for arguments.
+    """
+    abi = pwndbg.aglib.arch.function_abi
+    if abi is None:
+        raise pwndbg.dbg_mod.Error(
+            f"Function ABI not defined for current architecture, {pwndbg.aglib.arch.function_abi}"
+        )
+    regs = abi.register_arguments
+
+    if n < len(regs):
+        return regs[n], getattr(pwndbg.aglib.regs, regs[n])
+
+    n -= len(regs)
+
+    sp = pwndbg.aglib.regs.sp + (n * pwndbg.aglib.arch.ptrsize)
+
+    return sp, pwndbg.aglib.memory.read_pointer_width(sp)


### PR DESCRIPTION
# Fmtarg

Community discussion: https://github.com/pwndbg/pwndbg/discussions/3323

## Description

The `fmtarg` command displays the argument index for use in formatstring exploits.

TL;DR, see image:


<img width="813" height="522" alt="image" src="https://github.com/user-attachments/assets/025b4972-7ac4-44a9-905f-5752847c5f68" />

Also shows annotations for return addresses for ease of exploitation:

<img width="900" height="139" alt="image" src="https://github.com/user-attachments/assets/e0625295-2938-4bf2-9def-79802bdcfa9a" />

## Supported Architectures

Supports all architectures handled by `pwndbg`
