### PR TITLE
Drop debug info requirement for kernel section markers

### DIFF
--- a/pwndbg/aglib/kernel/vmmap.py
+++ b/pwndbg/aglib/kernel/vmmap.py
@@ -32,7 +32,7 @@ class KernelVmmap:
         self.pages = pages
         self.sections = None
         self.pi = pwndbg.aglib.kernel.arch_paginginfo()
-        if self.pi and pwndbg.aglib.kernel.has_debug_symbols():
+        if self.pi:
             self.sections = self.pi.markers()
 
     def get_name(self, addr: int) -> str:


### PR DESCRIPTION
I think all of this info is actually available after this PR https://github.com/pwndbg/pwndbg/pull/3116

Removing this debug check appears to work for me for x86_64 (although i did not look too carefully to see if it was actually correct, but it looked okay). Did not check aarch64 but based on the code it should be fine.