### PR TITLE
Fix branch checkmark appearing on certain s390x unconditional jumps

### DIFF
--- a/pwndbg/aglib/disasm/instruction.py
+++ b/pwndbg/aglib/disasm/instruction.py
@@ -46,9 +46,9 @@ from capstone.riscv import RISCV_INS_JAL
 from capstone.riscv import RISCV_INS_JALR
 from capstone.sparc import SPARC_INS_JMPL
 from capstone.systemz import SYSTEMZ_INS_B
-from capstone.systemz import SYSTEMZ_INS_BR
 from capstone.systemz import SYSTEMZ_INS_BAL
 from capstone.systemz import SYSTEMZ_INS_BALR
+from capstone.systemz import SYSTEMZ_INS_BR
 from capstone.systemz import SYSTEMZ_INS_BRAS
 from capstone.systemz import SYSTEMZ_INS_BRASL
 from capstone.x86 import X86_INS_CALL
@@ -96,7 +96,7 @@ UNCONDITIONAL_JUMP_INSTRUCTIONS: Dict[int, Set[int]] = {
         SYSTEMZ_INS_BAL,
         SYSTEMZ_INS_BALR,
         SYSTEMZ_INS_BRAS,
-        SYSTEMZ_INS_BRASL
+        SYSTEMZ_INS_BRASL,
     },
     CS_ARCH_LOONGARCH: {
         LOONGARCH_INS_B,

--- a/pwndbg/aglib/disasm/instruction.py
+++ b/pwndbg/aglib/disasm/instruction.py
@@ -46,8 +46,11 @@ from capstone.riscv import RISCV_INS_JAL
 from capstone.riscv import RISCV_INS_JALR
 from capstone.sparc import SPARC_INS_JMPL
 from capstone.systemz import SYSTEMZ_INS_B
+from capstone.systemz import SYSTEMZ_INS_BR
 from capstone.systemz import SYSTEMZ_INS_BAL
 from capstone.systemz import SYSTEMZ_INS_BALR
+from capstone.systemz import SYSTEMZ_INS_BRAS
+from capstone.systemz import SYSTEMZ_INS_BRASL
 from capstone.x86 import X86_INS_CALL
 from capstone.x86 import X86_INS_JMP
 from capstone.x86 import X86Op
@@ -87,7 +90,14 @@ UNCONDITIONAL_JUMP_INSTRUCTIONS: Dict[int, Set[int]] = {
         RISCV_INS_C_JR,
     },
     CS_ARCH_PPC: {PPC_INS_B, PPC_INS_BA, PPC_INS_BL, PPC_INS_BLA},
-    CS_ARCH_SYSTEMZ: {SYSTEMZ_INS_B, SYSTEMZ_INS_BAL, SYSTEMZ_INS_BALR},
+    CS_ARCH_SYSTEMZ: {
+        SYSTEMZ_INS_B,
+        SYSTEMZ_INS_BR,
+        SYSTEMZ_INS_BAL,
+        SYSTEMZ_INS_BALR,
+        SYSTEMZ_INS_BRAS,
+        SYSTEMZ_INS_BRASL
+    },
     CS_ARCH_LOONGARCH: {
         LOONGARCH_INS_B,
         LOONGARCH_INS_BL,

--- a/pwndbg/aglib/disasm/instruction.py
+++ b/pwndbg/aglib/disasm/instruction.py
@@ -51,6 +51,8 @@ from capstone.systemz import SYSTEMZ_INS_BALR
 from capstone.systemz import SYSTEMZ_INS_BR
 from capstone.systemz import SYSTEMZ_INS_BRAS
 from capstone.systemz import SYSTEMZ_INS_BRASL
+from capstone.systemz import SYSTEMZ_INS_J
+from capstone.systemz import SYSTEMZ_INS_JL
 from capstone.x86 import X86_INS_CALL
 from capstone.x86 import X86_INS_JMP
 from capstone.x86 import X86Op
@@ -91,6 +93,8 @@ UNCONDITIONAL_JUMP_INSTRUCTIONS: Dict[int, Set[int]] = {
     },
     CS_ARCH_PPC: {PPC_INS_B, PPC_INS_BA, PPC_INS_BL, PPC_INS_BLA},
     CS_ARCH_SYSTEMZ: {
+        SYSTEMZ_INS_J,
+        SYSTEMZ_INS_JL,
         SYSTEMZ_INS_B,
         SYSTEMZ_INS_BR,
         SYSTEMZ_INS_BAL,


### PR DESCRIPTION
Addresses #3298 - previously, we didn't specify that certain branch instructions were unconditional, so the ✘ or ✔ was appearing for unconditional branches.