### PR TITLE
fix(kernel): Prevent klookup crash when symbol is not found

### DIFF
--- a/pwndbg/aglib/kernel/symbol.py
+++ b/pwndbg/aglib/kernel/symbol.py
@@ -368,6 +368,8 @@ class x86_64Symbols(ArchSymbols):
         return None
 
     def qword_mov_reg_ripoff(self, disass):
+        if disass is None:
+            return None
         result = self.regex(
             "".join(disass.splitlines()),
             r".*?\bmov.*\[rip\s\+\s(0x[0-9a-f]+)\].*?(0x[0-9a-f]{16})\s\<",


### PR DESCRIPTION
Changes made:
Added a check for None in qword_mov_reg_ripoff method
Reason:
We just need to add a simple check at the beginning of the qword_mov_reg_ripoff function to handle the case where disass is None(This could be most probable).
<!--
    Please make sure to read the linting and testing instructions at
    https://pwndbg.re/pwndbg/dev/contributing/ before creating a PR.
-->
I have successfully ran lint tests as well as the kernel tests which came to be successful, please check if this is right fix.
Fixes klookup fails #3349.