### PR TITLE
Improve function call detection

### DIFF
--- a/pwndbg/arguments.py
+++ b/pwndbg/arguments.py
@@ -33,6 +33,17 @@ from pwndbg.lib.arch import Platform
 from pwndbg.lib.functions import format_flags_argument
 
 
+# Sometimes function calls are not invoked with a "call instruction",
+# such as with tail-recursion or in PLT stubs
+def fallback_check_for_function_call(instruction: PwndbgInstruction) -> bool:
+    if instruction.is_unconditional_jump and instruction.target_string:
+        # Check if it is to the start of a function
+        # Otherwise, the symbol would contain +constant
+        # Like `main+132`
+        return "+" not in instruction.target_string
+    return False
+
+
 def get(instruction: PwndbgInstruction) -> List[Tuple[pwndbg.lib.functions.Argument, int]]:
     """
     Returns an array containing the arguments to the current function,
@@ -47,7 +58,7 @@ def get(instruction: PwndbgInstruction) -> List[Tuple[pwndbg.lib.functions.Argum
     if instruction.address != pwndbg.aglib.regs.pc:
         return []
 
-    if instruction.call_like:
+    if instruction.call_like or (fallback_check_for_function_call(instruction)):
         abi = pwndbg.aglib.arch.function_abi
 
         if abi is None:


### PR DESCRIPTION
This implements the idea suggested in #3214 to show function call arguments in more cases. If an unconditional branch goes to a symbol, we infer that it is a function call.

Currently, function call arguments are shown for instructions explicitly denoted as call instructions - x86 `CALL`, arm `bl`, etc. Function calls can be invoked other branch types, however, such as in tail recursion and in PLT stubs.

<img width="837" height="97" alt="image" src="https://github.com/user-attachments/assets/36b8b0c9-3815-4ed9-af26-527ab2090ac8" />

cc @k4lizen 