### PR TITLE
Bug fix: variable accidentally overwritten

### DIFF
--- a/pwndbg/color/syntax_highlight.py
+++ b/pwndbg/color/syntax_highlight.py
@@ -70,8 +70,8 @@ def _pygments_get_lexer_for_filename(filename, code, **options):
     matched_lexer = ""
     fn = os.path.basename(filename)
     for name, _, filenames, _ in pygments.lexers.get_all_lexers(plugins=False):
-        for filename in filenames:
-            if _fn_matches(fn, filename):
+        for candidate_filename in filenames:
+            if _fn_matches(fn, candidate_filename):
                 if one_match:
                     # already seen one match, this is a second match
                     one_match = False


### PR DESCRIPTION
A loop variable had the same name as the variable in the function, accidentally overwriting it.

A couple lines down, at https://github.com/pwndbg/pwndbg/blob/42e8af33d2411109f39078e82b20cbc7a852f478/pwndbg/color/syntax_highlight.py#L85-L86

the variable "filename" is used again. This was accidentally cobbled by the for loop variable.

This was causing some file types to not get syntax highlighting.