### PR TITLE
Fix Page.__str__ function crash

### DIFF
--- a/pwndbg/lib/memory.py
+++ b/pwndbg/lib/memory.py
@@ -160,7 +160,7 @@ class Page:
         )
 
     def __str__(self) -> str:
-        if pwndbg.config.vmmap_prefer_relpaths:
+        if pwndbg.config.vmmap_prefer_relpaths and self.objfile:
             rel = relpath(self.objfile)
             # Keep the origin path when relative paths are longer than absolute ones.
             objfile = self.objfile if len(rel) > len(self.objfile) else rel


### PR DESCRIPTION
Fix #3022 - this caused any place that invoked the Page.__str__ function to crash: (1) vmmap-add, and (2) `xinfo`, sometimes when debugging remote processes when the `.objfile` property was empty.