### PR TITLE
fix get_file() checking relative paths

### DIFF
--- a/pwndbg/aglib/file.py
+++ b/pwndbg/aglib/file.py
@@ -82,10 +82,6 @@ def get_file(path: str, try_local_path: bool = False) -> str:
         The local path to the file
     """
     has_target_prefix = path.startswith("target:")
-    has_good_prefix = path.startswith(("/", "./", "../")) or has_target_prefix
-    if not has_good_prefix:
-        raise OSError("get_file called with incorrect path", errno.ENOENT)
-
     if has_target_prefix:
         path = path[7:]  # len('target:') == 7
 

--- a/tests/library/gdb/tests/test_file.py
+++ b/tests/library/gdb/tests/test_file.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import os
 import tempfile
+
 from pwndbg.aglib.file import get
+
 
 def test_get():
     # Test different relative and absolute file path prefixes

--- a/tests/library/gdb/tests/test_file.py
+++ b/tests/library/gdb/tests/test_file.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import os
+import tempfile
+
+# We must import the function under test after all the mocks are imported
+from pwndbg.aglib.file import get
+
+def test_get():
+    # Test different relative and absolute file path prefixes
+    cwd = os.getcwd()
+    test_file_prefixes = ["/", "./", f"../{os.path.basename(cwd)}/", ""]
+    with tempfile.TemporaryDirectory(dir=cwd) as tempdir:
+        path = os.path.join(tempdir, "test_file")
+        with open(path, "w") as f:
+            f.write("test")
+        for test_prefix in test_file_prefixes:
+            test_path = path if test_prefix == "/" else test_prefix + os.path.relpath(path)
+            assert get(test_path) == b"test"

--- a/tests/library/gdb/tests/test_file.py
+++ b/tests/library/gdb/tests/test_file.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 import os
 import tempfile
-
-# We must import the function under test after all the mocks are imported
 from pwndbg.aglib.file import get
 
 def test_get():


### PR DESCRIPTION
This PR fixes issues mentioned in #2659. Delete the path prefix checks in `get_file()` since POSIX standards do not require a `./` or `../` in front of relative paths. Invalid paths should/will be caught by their respective file open operations.
