### PR TITLE
Support system Zig in addition to the one bundled in a Python package

### DIFF
--- a/pwndbg/lib/zig.py
+++ b/pwndbg/lib/zig.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import os.path
 import pathlib
 import subprocess
@@ -71,6 +72,25 @@ _asm_header: Dict[str, str] = {
 }
 
 
+def get_zig_executable() -> str:
+    """
+    Get the path to the zig executable.
+    Precedence: ziglang module, zig in PATH.
+    """
+    try:
+        import ziglang  # type: ignore[import-untyped]
+        return os.path.join(os.path.dirname(ziglang.__file__), "zig")
+    except ImportError:
+        pass
+
+    import shutil
+    zig_in_path = shutil.which("zig")
+    if zig_in_path:
+        return zig_in_path
+
+    raise ValueError("Python module ziglang not available and zig not found in PATH")
+
+
 def _get_zig_target(arch: ArchDefinition) -> str | None:
     if arch.platform == Platform.LINUX:
         # "gnu", "gnuabin32", "gnuabi64", "gnueabi", "gnueabihf",
@@ -90,10 +110,7 @@ def _get_zig_target(arch: ArchDefinition) -> str | None:
 
 
 def flags(arch: ArchDefinition) -> List[str]:
-    try:
-        import ziglang  # type: ignore[import-untyped]
-    except ImportError:
-        raise ValueError("Can't import ziglang")
+    zig_executable = get_zig_executable()
 
     zig_target = _get_zig_target(arch)
     if zig_target is None:
@@ -102,7 +119,7 @@ def flags(arch: ArchDefinition) -> List[str]:
         )
 
     return [
-        os.path.join(os.path.dirname(ziglang.__file__), "zig"),
+        zig_executable,
         "cc",
         "-target",
         zig_target,
@@ -120,10 +137,7 @@ def asm(arch: ArchDefinition, data: str, includes: List[pathlib.Path] | None = N
 
 
 def _asm(arch_mapping: str, data: str, includes: List[pathlib.Path] | None = None) -> bytes:
-    try:
-        import ziglang
-    except ImportError:
-        raise ValueError("Can't import ziglang")
+    zig_executable = get_zig_executable()
 
     header = _asm_header.get(arch_mapping, None)
     if header is None:
@@ -148,7 +162,7 @@ def _asm(arch_mapping: str, data: str, includes: List[pathlib.Path] | None = Non
         # Build the binary with Zig
         compile_process = subprocess.run(
             [
-                os.path.join(os.path.dirname(ziglang.__file__), "zig"),
+                zig_executable,
                 "cc",
                 "-target",
                 target,
@@ -167,7 +181,7 @@ def _asm(arch_mapping: str, data: str, includes: List[pathlib.Path] | None = Non
         # Extract bytecode
         objcopy_process = subprocess.run(
             [
-                os.path.join(os.path.dirname(ziglang.__file__), "zig"),
+                zig_executable,
                 "objcopy",
                 "-O",
                 "binary",

--- a/pwndbg/lib/zig.py
+++ b/pwndbg/lib/zig.py
@@ -72,23 +72,46 @@ _asm_header: Dict[str, str] = {
 }
 
 
+ZIG_SUPPORTED_VERSION = "0.14.1"
+
+
 def get_zig_executable() -> str:
     """
     Get the path to the zig executable.
     Precedence: ziglang module, zig in PATH.
     """
+    zig_path = None
+
     try:
         import ziglang  # type: ignore[import-untyped]
-        return os.path.join(os.path.dirname(ziglang.__file__), "zig")
+        zig_path = os.path.join(os.path.dirname(ziglang.__file__), "zig")
     except ImportError:
         pass
 
-    import shutil
-    zig_in_path = shutil.which("zig")
-    if zig_in_path:
-        return zig_in_path
+    if zig_path is None:
+        import shutil
+        zig_path = shutil.which("zig")
 
-    raise ValueError("Python module ziglang not available and zig not found in PATH")
+    if zig_path is None:
+        raise ValueError("Python module ziglang not available and zig not found in PATH")
+
+    try:
+        result = subprocess.run(
+            [zig_path, "version"],
+            capture_output=True,
+            text=True,
+            timeout=1,
+        )
+        version = result.stdout.strip()
+        if version != ZIG_SUPPORTED_VERSION:
+            raise ValueError(
+                f"Unsupported Zig version: {version}. "
+                f"Only version {ZIG_SUPPORTED_VERSION} is supported."
+            )
+    except Exception as e:
+        raise ValueError(f"Failed to check Zig version at {zig_path}: {e}")
+
+    return zig_path
 
 
 def _get_zig_target(arch: ArchDefinition) -> str | None:

--- a/pwndbg/lib/zig.py
+++ b/pwndbg/lib/zig.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import os.path
 import pathlib
+import shutil
 import subprocess
 import tempfile
 from typing import Dict
@@ -10,6 +11,7 @@ from typing import List
 from typing import Literal
 from typing import Tuple
 
+import pwndbg.lib.cache
 from pwndbg.lib.arch import PWNDBG_SUPPORTED_ARCHITECTURES_TYPE
 from pwndbg.lib.arch import ArchDefinition
 from pwndbg.lib.arch import Platform
@@ -75,23 +77,19 @@ _asm_header: Dict[str, str] = {
 ZIG_SUPPORTED_VERSION = "0.14.1"
 
 
+@pwndbg.lib.cache.cache_until("forever")
 def get_zig_executable() -> str:
     """
     Get the path to the zig executable.
     Precedence: ziglang module, zig in PATH.
     """
-    zig_path = None
-
     try:
         import ziglang  # type: ignore[import-untyped]
-        zig_path = os.path.join(os.path.dirname(ziglang.__file__), "zig")
+        return os.path.join(os.path.dirname(ziglang.__file__), "zig")
     except ImportError:
         pass
 
-    if zig_path is None:
-        import shutil
-        zig_path = shutil.which("zig")
-
+    zig_path = shutil.which("zig")
     if zig_path is None:
         raise ValueError("Python module ziglang not available and zig not found in PATH")
 
@@ -100,7 +98,7 @@ def get_zig_executable() -> str:
             [zig_path, "version"],
             capture_output=True,
             text=True,
-            timeout=1,
+            timeout=15,
         )
         version = result.stdout.strip()
         if version != ZIG_SUPPORTED_VERSION:

--- a/tests/library/qemu_user/conftest.py
+++ b/tests/library/qemu_user/conftest.py
@@ -13,9 +13,9 @@ from typing import Tuple
 
 import gdb
 import pytest
-import ziglang
 
 from pwndbg.lib import tempfile
+from pwndbg.lib.zig import get_zig_executable
 
 _start_binary_called = False
 
@@ -148,9 +148,10 @@ def qemu_assembly_run():
         compiled_file = os.path.join(tmpdir, "out.elf")
 
         # Build the binary with Zig
+        zig_executable = get_zig_executable()
         compile_process = subprocess.run(
             [
-                os.path.join(os.path.dirname(ziglang.__file__), "zig"),
+                zig_executable,
                 "cc",
                 *extra_cli_args,
                 f"--target={zig_target}",

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -14,7 +14,7 @@ import time
 from enum import Enum
 from pathlib import Path
 
-import ziglang
+from pwndbg.lib.zig import get_zig_executable
 
 from .host import TestHost
 from .host import TestResult
@@ -337,11 +337,12 @@ def make_all(path: Path, jobs: int = multiprocessing.cpu_count()):
 
     print(f"[+] make -C {path} -j{jobs} all")
     try:
+        zig_executable = get_zig_executable()
         subprocess.check_call(
             [
                 "make",
                 f"-j{jobs}",
-                "ZIGCC=" + os.path.join(os.path.dirname(ziglang.__file__), "zig") + " cc",
+                f"ZIGCC={zig_executable} cc",
                 "all",
             ],
             cwd=str(path),


### PR DESCRIPTION
Add support for locating the Zig executable with the following precedence:
~1. ZIGCC environment variable - allows explicit override.~
2. ziglang module - if installed, use bundled Zig.
3. zig in PATH - fallback to system installation.

On Arch Linux we don't package the ziglang Python package. This change makes it possible for pwndbg to use the Zig executable from our zig0.14 package [0].

[0]: https://archlinux.org/packages/extra/x86_64/zig0.14/

Disclaimer: Authored with assistance from Claude Code.

<!--
    Please make sure to read the linting and testing instructions at
    https://pwndbg.re/dev/contributing/ before creating a PR.
-->
