### PR TITLE
Apply readline import fix to unit tests

### DIFF
--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+import importlib.abc
+import sys
+
+
+class RemoveReadlineFinder(importlib.abc.MetaPathFinder):
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname == "readline":
+            raise ImportError("readline module disabled in unit tests")
+        return None
+
+
+sys.meta_path.insert(0, RemoveReadlineFinder())


### PR DESCRIPTION
Running `unit-tests.sh` with Python 3.13 in a freshly cloned repository on Arch Linux results in the following test failure:

```sh
FAILED tests/unit_tests/test_readline.py::test_readline_not_imported - AssertionError: assert 'readline' not in {'__future__': <module '__future__' from '/usr/lib/python...
```

I believe this is because pwndbg.exception imports pdb (ipdb is not available), and in Python 3.13, pdb imports rlcompleter, which imports readline.

To address this, apply the readline import fix from pwndbginit/gdbpatches.py to the suite via a conftest module. Related:
https://github.com/pwndbg/pwndbg/pull/2622

Disclaimer: Authored with assistance from Claude Code.

<!--
    Please make sure to read the linting and testing instructions at
    https://pwndbg.re/dev/contributing/ before creating a PR.
-->
