### PR TITLE
Install script sudo check edge case

### DIFF
--- a/docs/install.sh
+++ b/docs/install.sh
@@ -137,8 +137,12 @@ else
             ${*}
         }
     else
-        echoinfo "Requesting 'sudo' privileges. You may be prompted for your password..."
-        sudo -v
+        # Before prompting, check if the user can run sudo without password,
+        # or if the credentials are already cached
+        if ! sudo -n true 2>/dev/null; then
+            echoinfo "Requesting 'sudo' privileges. You may be prompted for your password..."
+            sudo -v
+        fi
     fi
 fi
 

--- a/docs/install.sh
+++ b/docs/install.sh
@@ -139,7 +139,7 @@ else
     else
         # Before prompting, check if the user can run sudo without password,
         # or if the credentials are already cached
-        if ! sudo -n true 2>/dev/null; then
+        if ! sudo -n true 2> /dev/null; then
             echoinfo "Requesting 'sudo' privileges. You may be prompted for your password..."
             sudo -v
         fi


### PR DESCRIPTION
This fixes an edge case that prevents the install.sh script from succeeding when a user has passwordless user access AND has other sudo rules applied to them that required password access.

By default, sudo will avoid reprompting for passwords constantly - once you enter your sudo password once, it will not asked again for a couple minutes on subsequent calls to sudo.

For convenience, the install script explicitly runs `sudo -v` early on. This will prompt for the password, and cache the credentials for a couple minutes. This is done to avoid the password prompt being hidden within the other output when sudo is used later. However, this call to `sudo -v` blocked the script from succeeding in the following case:

Sudo config:
```
%sudo    (ALL : ALL) ALL
user    (ALL : ALL) NOPASSWD: ALL
```

User was part of `sudo` group in the container, but has no password set. However, through the second rule, they have passwordless sudo. This means all calls to `sudo command_here` run with no prompt. However, interestingly, with this configuration, `sudo -v` still prompts for a password, since it finds the first rule in the config applies to the user and it necessitates passwords 

Since `sudo -v` prompts for a password, but the user has no password set, the command fails and the script fails early.


This adds a check to avoid running `sudo -v` in cases where this applies (user can run sudo with no password).
