### PR TITLE
Binja integration, add host and port setting for the XML-RPC server in Binary Ninja

### DIFF
--- a/binja_script.py
+++ b/binja_script.py
@@ -11,8 +11,10 @@ from typing import List
 from typing import Tuple
 from xmlrpc.server import SimpleXMLRPCRequestHandler
 from xmlrpc.server import SimpleXMLRPCServer
+import json
 
 import binaryninja
+from binaryninja.settings import Settings
 from binaryninja.enums import RegisterValueType
 from binaryninja.enums import VariableSourceType
 
@@ -22,13 +24,50 @@ xmlrpc.client.MININT = -(10**100)
 
 DEFAULT_HOST = '127.0.0.1'
 ENVIRONMENT_HOST_VARIABLE = "PWNDBG_BINJA_SERVER_HOST"
+SETTING_KEY_HOST = 'pwndbg.host'
 DEFAULT_PORT = 43717
 ENVIRONMENT_PORT_VARIABLE = "PWNDBG_BINJA_SERVER_PORT"
+SETTING_KEY_PORT = 'pwndbg.port'
+
 
 host = os.environ.get(ENVIRONMENT_HOST_VARIABLE, DEFAULT_HOST)
 port = int(os.environ.get(ENVIRONMENT_PORT_VARIABLE, str(DEFAULT_PORT)))
 
 logger = binaryninja.log.Logger(0, "pwndbg-integration")
+
+def plugin_register_settings():
+    """
+    Registers two setting entries for the plugin.
+    One for the host, one for the port.
+    The default values ensure backward-compatibility.
+    """
+    plugin_settings = Settings('default')
+    plugin_settings.register_group("pwndbg", 'pwndbg integration')
+    props_host = {
+        'title': "host",
+        'description':
+            'IP the XML-RPC server hosted in Binja will listen to.<br/>'
+            f'If you run pwndbg on your host, this value is likely to be {DEFAULT_HOST}<br/>'
+            'Ifyou run pwndbg on an other machine/VM, this value will be the IP of your machine running Binja on the network running the machine.<br/>'
+            'Please note that if you change this value, you probably have complex setup. So you will probably have to also change the IP of the'
+            'XML-RPC provider in you pwndbg instance (with `set bn-rpc-host IP_OF_BINJA_MACHINE`)<br/>',
+        'type':'string',
+        'default': DEFAULT_HOST,
+        'ignore': ['SettingsProjectScope', 'SettingsResourceScope'] # as per setting module documentation: if not related to analysis, ignore.
+    }
+    plugin_settings.register_setting(SETTING_KEY_HOST, json.dumps(props_host))
+
+    props_port = {
+        'title': 'port',
+        'description': 'Port of the XML-RPC server hosted in Binja',
+        'type': 'number',
+        'minValue': 0,  # Force unsigned
+        'maxValue': 65535,
+        'default': DEFAULT_PORT,
+        'ignore': ['SettingsProjectScope', 'SettingsResourceScope']
+    }
+    plugin_settings.register_setting(SETTING_KEY_PORT, json.dumps(props_port))
+
 
 
 class CustomLogHandler(SimpleXMLRPCRequestHandler):
@@ -414,6 +453,7 @@ def toggle_breakpoint(bv: binaryninja.BinaryView, addr: int) -> None:
         add_tag_at_addr(bv, addr, "pwndbg-bp", "GDB breakpoint", auto=False)
 
 
+plugin_register_settings()
 binaryninja.plugin.PluginCommand.register(
     "pwndbg\\Start integration on current view",
     "Start pwndbg integration on current view.",

--- a/binja_script.py
+++ b/binja_script.py
@@ -20,9 +20,13 @@ from binaryninja.enums import VariableSourceType
 xmlrpc.client.MAXINT = 10**100
 xmlrpc.client.MININT = -(10**100)
 
+DEFAULT_HOST = '127.0.0.1'
+ENVIRONMENT_HOST_VARIABLE = "PWNDBG_BINJA_SERVER_HOST"
+DEFAULT_PORT = 43717
+ENVIRONMENT_PORT_VARIABLE = "PWNDBG_BINJA_SERVER_PORT"
 
-host = os.environ.get("PWNDBG_BINJA_SERVER_HOST", "127.0.0.1")
-port = int(os.environ.get("PWNDBG_BINJA_SERVER_PORT", "43717"))
+host = os.environ.get(ENVIRONMENT_HOST_VARIABLE, DEFAULT_HOST)
+port = int(os.environ.get(ENVIRONMENT_PORT_VARIABLE, str(DEFAULT_PORT)))
 
 logger = binaryninja.log.Logger(0, "pwndbg-integration")
 

--- a/binja_script.py
+++ b/binja_script.py
@@ -30,8 +30,6 @@ ENVIRONMENT_PORT_VARIABLE = "PWNDBG_BINJA_SERVER_PORT"
 SETTING_KEY_PORT = 'pwndbg.port'
 
 
-host = os.environ.get(ENVIRONMENT_HOST_VARIABLE, DEFAULT_HOST)
-port = int(os.environ.get(ENVIRONMENT_PORT_VARIABLE, str(DEFAULT_PORT)))
 
 logger = binaryninja.log.Logger(0, "pwndbg-integration")
 
@@ -68,7 +66,23 @@ def plugin_register_settings():
     }
     plugin_settings.register_setting(SETTING_KEY_PORT, json.dumps(props_port))
 
+def read_host_port() -> Tuple[str, int]:
+    """
+    Reads the host and port value.
+    Retrieves from the settings. To ensure backward-compatibility, if the settings use the default value,
+    tries to read from the environment variable
 
+    Returns the tuple (host, port).
+    """
+
+    host = Settings().get_string(SETTING_KEY_HOST)
+    if host == DEFAULT_HOST:
+        host = os.environ.get(ENVIRONMENT_HOST_VARIABLE, DEFAULT_HOST)
+
+    port = Settings().get_integer(SETTING_KEY_PORT)
+    if port == DEFAULT_PORT:
+        port = int(os.environ.get(ENVIRONMENT_PORT_VARIABLE, str(DEFAULT_PORT)))
+    return host, port
 
 class CustomLogHandler(SimpleXMLRPCRequestHandler):
     def log_message(self, format: str, *args: Any):
@@ -419,6 +433,7 @@ def start_server(bv: binaryninja.BinaryView) -> None:
     handler = ServerHandler(bv)
     handler.init()
 
+    host, port = read_host_port()
     server = SimpleXMLRPCServer((host, port), requestHandler=CustomLogHandler, allow_none=True)
     server.register_introspection_functions()
 

--- a/binja_script.py
+++ b/binja_script.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import ctypes
+import json
 import os
 import sys
 import threading
@@ -11,27 +12,26 @@ from typing import List
 from typing import Tuple
 from xmlrpc.server import SimpleXMLRPCRequestHandler
 from xmlrpc.server import SimpleXMLRPCServer
-import json
 
 import binaryninja
-from binaryninja.settings import Settings
 from binaryninja.enums import RegisterValueType
 from binaryninja.enums import VariableSourceType
+from binaryninja.settings import Settings
 
 # Allow large integers to be transmitted
 xmlrpc.client.MAXINT = 10**100
 xmlrpc.client.MININT = -(10**100)
 
-DEFAULT_HOST = '127.0.0.1'
+DEFAULT_HOST = "127.0.0.1"
 ENVIRONMENT_HOST_VARIABLE = "PWNDBG_BINJA_SERVER_HOST"
-SETTING_KEY_HOST = 'pwndbg.host'
+SETTING_KEY_HOST = "pwndbg.host"
 DEFAULT_PORT = 43717
 ENVIRONMENT_PORT_VARIABLE = "PWNDBG_BINJA_SERVER_PORT"
-SETTING_KEY_PORT = 'pwndbg.port'
-
+SETTING_KEY_PORT = "pwndbg.port"
 
 
 logger = binaryninja.log.Logger(0, "pwndbg-integration")
+
 
 def plugin_register_settings():
     """
@@ -39,32 +39,35 @@ def plugin_register_settings():
     One for the host, one for the port.
     The default values ensure backward-compatibility.
     """
-    plugin_settings = Settings('default')
-    plugin_settings.register_group("pwndbg", 'pwndbg integration')
+    plugin_settings = Settings("default")
+    plugin_settings.register_group("pwndbg", "pwndbg integration")
     props_host = {
-        'title': "host",
-        'description':
-            'IP the XML-RPC server hosted in Binja will listen to.<br/>'
-            f'If you run pwndbg on your host, this value is likely to be {DEFAULT_HOST}<br/>'
-            'Ifyou run pwndbg on an other machine/VM, this value will be the IP of your machine running Binja on the network running the machine.<br/>'
-            'Please note that if you change this value, you probably have complex setup. So you will probably have to also change the IP of the'
-            'XML-RPC provider in you pwndbg instance (with `set bn-rpc-host IP_OF_BINJA_MACHINE`)<br/>',
-        'type':'string',
-        'default': DEFAULT_HOST,
-        'ignore': ['SettingsProjectScope', 'SettingsResourceScope'] # as per setting module documentation: if not related to analysis, ignore.
+        "title": "host",
+        "description": "IP the XML-RPC server hosted in Binja will listen to.<br/>"
+        f"If you run pwndbg on your host, this value is likely to be {DEFAULT_HOST}<br/>"
+        "Ifyou run pwndbg on an other machine/VM, this value will be the IP of your machine running Binja on the network running the machine.<br/>"
+        "Please note that if you change this value, you probably have complex setup. So you will probably have to also change the IP of the"
+        "XML-RPC provider in you pwndbg instance (with `set bn-rpc-host IP_OF_BINJA_MACHINE`)<br/>",
+        "type": "string",
+        "default": DEFAULT_HOST,
+        "ignore": [
+            "SettingsProjectScope",
+            "SettingsResourceScope",
+        ],  # as per setting module documentation: if not related to analysis, ignore.
     }
     plugin_settings.register_setting(SETTING_KEY_HOST, json.dumps(props_host))
 
     props_port = {
-        'title': 'port',
-        'description': 'Port of the XML-RPC server hosted in Binja',
-        'type': 'number',
-        'minValue': 0,  # Force unsigned
-        'maxValue': 65535,
-        'default': DEFAULT_PORT,
-        'ignore': ['SettingsProjectScope', 'SettingsResourceScope']
+        "title": "port",
+        "description": "Port of the XML-RPC server hosted in Binja",
+        "type": "number",
+        "minValue": 0,  # Force unsigned
+        "maxValue": 65535,
+        "default": DEFAULT_PORT,
+        "ignore": ["SettingsProjectScope", "SettingsResourceScope"],
     }
     plugin_settings.register_setting(SETTING_KEY_PORT, json.dumps(props_port))
+
 
 def read_host_port() -> Tuple[str, int]:
     """
@@ -83,6 +86,7 @@ def read_host_port() -> Tuple[str, int]:
     if port == DEFAULT_PORT:
         port = int(os.environ.get(ENVIRONMENT_PORT_VARIABLE, str(DEFAULT_PORT)))
     return host, port
+
 
 class CustomLogHandler(SimpleXMLRPCRequestHandler):
     def log_message(self, format: str, *args: Any):


### PR DESCRIPTION
Answer to issue #3406 . 
Add the settings for host and port with some helper description.

If the settings are left as default, will also check the environment variable values to ensure backward-compatibility. 

As far as I can read, there are no tests for this script, and I could find no way to properly test it, aside from running it by hand.