### PR TITLE
Fix vmmap indicator overwriting address prefix

### DIFF
--- a/pwndbg/color/memory.py
+++ b/pwndbg/color/memory.py
@@ -109,8 +109,8 @@ def get(
         text = pwndbg.lib.pretty_print.int_to_string(address)
 
     if prefix:
-        # Replace first N characters with the provided prefix
-        text = prefix + text[len(prefix) :]
+        # Prepend the prefix before the text
+        text = prefix + " " + text
 
     return color(text)
 


### PR DESCRIPTION
## Summary
Fixes the issue where the backtrace indicator (►) overwrites the `0x` prefix in addresses when using `vmmap kernel` or similar commands, making it difficult to copy-paste addresses.

## Problem
When displaying filtered vmmap results with indicators, the prefix was replacing the first N characters of the address instead of prepending to it:
- **Before**: `►xffffffff81000000`
- **After**: `► 0xffffffff81000000`

## Changes
Modified `pwndbg/color/memory.py` in the `get()` function (line 111-113):
- Changed from replacing first N characters with prefix
- To prepending prefix with a space before the address text

## Impact
- Addresses are now easily copy-pasteable
- Maintains visual indicator for filtered results
- No breaking changes to existing functionality

## Testing
The fix ensures that when a prefix is provided, it's prepended with a space rather than overwriting the address prefix.

Fixes #3412