### PR TITLE
Make the pull request template more explicit

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,3 +2,6 @@
     Please make sure to read the linting and testing instructions at
     https://pwndbg.re/dev/contributing/ before creating a PR.
 -->
+
++ [ ] I read the contributing documentation.
++ [ ] I am providing a screenshot of the (new feature) / (fixed bug).

--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,6 @@ result*
 
 # Vim
 *.swp
+
+# lsp configuration
+pyrightconfig.json


### PR DESCRIPTION
Thougts?

Realistically not all contributions are screenshottable, but the ones that get spammed generally are.