### PR TITLE
re-adds handling for `lines is None` in `nearpc`

### DIFF
--- a/pwndbg/aglib/kernel/symbol.py
+++ b/pwndbg/aglib/kernel/symbol.py
@@ -275,7 +275,7 @@ class ArchSymbols:
         self.bpf_map_heuristic_func = "bpf_map_free_id"
         self.current_task_heuristic_func = "common_cpu_up"
 
-    def disass(self, name, lines=None):
+    def disass(self, name, lines=5):
         sym = pwndbg.aglib.symbol.lookup_symbol(name)
         if sym is None:
             return None

--- a/pwndbg/aglib/nearpc.py
+++ b/pwndbg/aglib/nearpc.py
@@ -88,7 +88,7 @@ opcode_separator_bytes = pwndbg.config.add_param(
 
 def nearpc(
     pc: int = None,
-    lines: int = None,
+    lines: int = 5,  # consistent with previous nearpc_lines
     back_lines: int = 0,
     total_lines: int = None,
     emulate=False,


### PR DESCRIPTION
closes #3417 

the cause was that #3357 removed handling for `lines == None`, this PR simply adds it back