### PR TITLE
Fix aarch64_be disassembly

### DIFF
--- a/pwndbg/aglib/arch.py
+++ b/pwndbg/aglib/arch.py
@@ -20,6 +20,8 @@ from capstone import CS_MODE_16
 from capstone import CS_MODE_32
 from capstone import CS_MODE_64
 from capstone import CS_MODE_ARM
+from capstone import CS_MODE_BIG_ENDIAN
+from capstone import CS_MODE_LITTLE_ENDIAN
 from capstone import CS_MODE_LOONGARCH64
 from capstone import CS_MODE_MCLASS
 from capstone import CS_MODE_MIPS32
@@ -65,6 +67,12 @@ def get_pwndbg_architecture(name: PWNDBG_SUPPORTED_ARCHITECTURES_TYPE) -> Pwndbg
         return None
 
     return registered_architectures[name]
+
+
+CAPSTONE_ENDIAN_MAPPING: Dict[EndianType, int] = {
+    "little": CS_MODE_LITTLE_ENDIAN,
+    "big": CS_MODE_BIG_ENDIAN,
+}
 
 
 class PwndbgArchitecture(ArchDefinition):
@@ -156,6 +164,9 @@ class PwndbgArchitecture(ArchDefinition):
         Return tuple of (CAPSTONE ARCH, CAPSTONE MODE) used to instantiate the Capstone disassembler for this architecture.
         """
         return None
+
+    def get_capstone_endianness(self) -> int:
+        return CAPSTONE_ENDIAN_MAPPING[self.endian]
 
     def read_thumb_bit(self) -> Literal[0, 1, None]:
         """
@@ -273,6 +284,10 @@ class AArch64Arch(PwndbgArchitecture):
     @override
     def get_capstone_constants(self, address: int) -> Tuple[int, int]:
         return (CS_ARCH_AARCH64, CS_MODE_ARM)
+
+    @override
+    def get_capstone_endianness(self) -> int:
+        return CS_MODE_LITTLE_ENDIAN
 
 
 class PowerPCArch(PwndbgArchitecture):

--- a/pwndbg/aglib/disasm/disassembly.py
+++ b/pwndbg/aglib/disasm/disassembly.py
@@ -40,11 +40,6 @@ from pwndbg.color import message
 from pwndbg.dbg import EventType
 from pwndbg.lib.arch import PWNDBG_SUPPORTED_ARCHITECTURES_TYPE
 
-CapstoneEndian = {
-    "little": CS_MODE_LITTLE_ENDIAN,
-    "big": CS_MODE_BIG_ENDIAN,
-}
-
 CapstoneSyntax = {"intel": CS_OPT_SYNTAX_INTEL, "att": CS_OPT_SYNTAX_ATT}
 
 force_register_alias = pwndbg.config.add_param(
@@ -147,7 +142,7 @@ def get_previous_instruction(
 def get_disassembler(cs_info: Tuple[int, int]):
     arch, mode = cs_info
 
-    mode |= CapstoneEndian[pwndbg.aglib.arch.endian]
+    mode |= pwndbg.aglib.arch.get_capstone_endianness()
 
     cs = Cs(arch, mode)
 

--- a/tests/library/qemu_user/conftest.py
+++ b/tests/library/qemu_user/conftest.py
@@ -23,6 +23,7 @@ QEMU_PORT: str | None = None
 
 COMPILATION_TARGETS_TYPE = Literal[
     "aarch64",
+    "aarch64_be",
     "arm",
     "riscv32",
     "riscv64",
@@ -43,6 +44,7 @@ COMPILATION_TARGETS: list[COMPILATION_TARGETS_TYPE] = list(
 # Tuple contains (Zig target,extra_cli_args,qemu_suffix),
 COMPILE_AND_RUN_INFO: Dict[COMPILATION_TARGETS_TYPE, Tuple[str, Tuple[str, ...], str]] = {
     "aarch64": ("aarch64-freestanding", (), "aarch64"),
+    "aarch64_be": ("aarch64_be-freestanding", (), "aarch64_be"),
     "arm": ("arm-freestanding", (), "arm"),
     "riscv32": ("riscv32-freestanding", (), "riscv32"),
     "riscv64": ("riscv64-freestanding", (), "riscv64"),

--- a/tests/library/qemu_user/tests/test_aarch64.py
+++ b/tests/library/qemu_user/tests/test_aarch64.py
@@ -164,6 +164,38 @@ def test_aarch64_syscall_annotation(qemu_assembly_run):
         assert i.syscall_name == "exit"
 
 
+def test_aarch64_be_disassembly(qemu_assembly_run):
+    """
+    Make sure disassembly of big-endian aarch64 is correct.
+    aarch64 instructions are always little-endian. The endianness refers to memory/register data layout.
+    """
+
+    qemu_assembly_run(EXIT_SYSCALL, "aarch64_be")
+
+    # Verify that it shows up in the output
+    dis = gdb.execute("context disasm", to_string=True)
+    dis = pwndbg.color.strip(dis)
+
+    expected = (
+        "LEGEND: STACK | HEAP | CODE | DATA | WX | RODATA\n"
+        "─────────────────────[ DISASM / aarch64 / set emulate on ]──────────────────────\n"
+        " ► 0x1010120 <_start>       mov    x0, #0            X0 => 0\n"
+        "   0x1010124 <_start+4>     mov    x8, #0x5d         X8 => 0x5d\n"
+        "   0x1010128 <_start+8>     svc    #0 <SYS_exit>\n"
+        "   0x101012c <_start+12>    nop    \n"
+        "   0x1010130 <_start+16>    nop    \n"
+        "   0x1010134 <_start+20>    nop    \n"
+        "   0x1010138 <_start+24>    nop    \n"
+        "   0x101013c <_start+28>    nop    \n"
+        "   0x1010140 <_start+32>    nop    \n"
+        "   0x1010144 <_start+36>    nop    \n"
+        "   0x1010148 <_start+40>    nop    \n"
+        "────────────────────────────────────────────────────────────────────────────────\n"
+    )
+
+    assert dis == expected
+
+
 CONDITIONAL_JUMPS = f"""
 {AARCH64_PREAMBLE}
 mov x2, 0b1010


### PR DESCRIPTION
In `aarch64_be`, the endianness refers to byte order of data. However, the instructions are always little-endian.

https://developer.arm.com/documentation/102376/0200/Alignment-and-endianness/Endianness

<img width="599" height="100" alt="image" src="https://github.com/user-attachments/assets/5fa10439-6633-4f0b-9468-387a37ecc58b" />

This fixes the constant that we pass to Capstone, to make disassembly always little-endian for aarch64. Without this, byte order was flipped while disassembling, resulting in incorrect disassembly.

Adds a test to check for this as well.