### PR TITLE
drop ppc64 big-endian portable release

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -12,7 +12,6 @@ jobs:
           pwndbg-gdb-cross-arm32-tarball,
           pwndbg-gdb-cross-riscv64-tarball,
           pwndbg-gdb-cross-s390x-tarball,
-          pwndbg-gdb-cross-ppc64-tarball,
           pwndbg-gdb-cross-ppc64le-tarball,
           pwndbg-gdb-cross-x86_32-tarball,
           pwndbg-gdb-cross-loong64-tarball,
@@ -21,7 +20,6 @@ jobs:
           pwndbg-lldb-cross-arm32-tarball,
           pwndbg-lldb-cross-riscv64-tarball,
           pwndbg-lldb-cross-s390x-tarball,
-#          pwndbg-lldb-cross-ppc64-tarball,  # broken lldb compilation
           pwndbg-lldb-cross-ppc64le-tarball,
           pwndbg-lldb-cross-x86_32-tarball,
           pwndbg-lldb-cross-loong64-tarball,

--- a/flake.nix
+++ b/flake.nix
@@ -108,17 +108,6 @@
             (
               final: prev:
               nixpkgs.lib.optionalAttrs
-                (prev.stdenv.targetPlatform.isPower64 && prev.stdenv.targetPlatform.isBigEndian)
-                {
-                  # ncurses is broken with gcc14+
-                  ncurses = prev.ncurses.override {
-                    stdenv = prev.gcc13Stdenv;
-                  };
-                }
-            )
-            (
-              final: prev:
-              nixpkgs.lib.optionalAttrs
                 (prev.stdenv.targetPlatform.isPower64 && prev.stdenv.targetPlatform.isLittleEndian)
                 {
                   # new boost is broken: https://github.com/NixOS/nixpkgs/issues/382179

--- a/flake.nix
+++ b/flake.nix
@@ -54,7 +54,6 @@
         "arm64" = "aarch64-multiplatform";
         "riscv64" = "riscv64";
         "s390x" = "s390x";
-        "ppc64" = "ppc64"; # broken lldb compilation ;(
         "ppc64le" = "powernv";
         "loong64" = "loongarch64-linux";
       };


### PR DESCRIPTION
For reference, see: [golang/go#34850](https://github.com/golang/go/issues/34850)

We will stop distributing our **pwndbg-portable** release for **ppc64 (big-endian)**.  
Maintaining ppc64 is increasingly difficult as many dependencies have dropped support, and there have been no actively supported distributions for ppc64 since around 2020.

We will continue to support the **ppc64le** portable release.

Currently, I propose supporting portable releases according to the following tiers:

### Tier 1 (most popular)
- x86_64
- aarch64

### Tier 2 (less popular)
- loongarch64
- riscv64

### Tier 3 (older or less common)
- ppc64le
- s390x
- armv7l
- i686 (x86 32-bit)

> In a few years, we may need to drop support for **i686 (x86 32-bit)** as most popular distributions have already dropped it.
