### PR TITLE
Fix debugger-aware parsing for int arguments in subcommands

### DIFF
--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -228,15 +228,22 @@ class CommandObj:
         # We want to run all integer and otherwise-unspecified arguments
         # through fix() so that GDB parses it.
         # FIXME: this is weird
-        for action in self.parser._actions:
-            if isinstance(action, argparse._SubParsersAction):
-                action.type = str
-            if action.dest == "help":
-                continue
-            if action.type is int:
-                action.type = fix_int_reraise_arg
-            elif action.type is None:
-                action.type = fix_reraise_arg
+        def process_actions(actions):
+            """Recursively process actions, including subparsers"""
+            for action in actions:
+                if isinstance(action, argparse._SubParsersAction):
+                    action.type = str
+                    # Recursively process each subparser's actions
+                    for subparser in action.choices.values():
+                        process_actions(subparser._actions)
+                if action.dest == "help":
+                    continue
+                if action.type is int:
+                    action.type = fix_int_reraise_arg
+                elif action.type is None:
+                    action.type = fix_reraise_arg
+
+        process_actions(self.parser._actions)
 
         assert (
             self.parser.formatter_class is argparse.HelpFormatter


### PR DESCRIPTION
Issue #3418 Fix subcommand int parameters to accept hex values and debugger expressions.

Subcommand arguments with `type=int` only accepted decimal values. Regular command arguments worked fine, but subcommands failed:
<img width="902" height="501" alt="vmware_YxH2XOexeL" src="https://github.com/user-attachments/assets/69e99272-b95a-4b91-98bd-d90ef52d44bc" />

Made initialize_parser() recursive to process subparser actions. When encountering a _SubParsersAction, iterate through its subparsers and apply the same type=int → fix_int_reraise_arg replacement.

<img width="911" height="483" alt="vmware_VsiF04OXaz" src="https://github.com/user-attachments/assets/7179aa72-d3fa-4a37-a910-48218a790e2f" />
