### PR TITLE
Fix our CI on macOS intel

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -24,7 +24,7 @@ jobs:
         os: [
           ubuntu-latest,  # x86_64-linux
           ubuntu-24.04-arm,  # aarch64-linux
-          macos-13,  # x86_64-darwin
+          macos-15-intel,  # x86_64-darwin
           macos-15,  # aarch64-darwin
         ]
     runs-on: ${{ matrix.os }}
@@ -59,7 +59,7 @@ jobs:
         os: [
           ubuntu-latest,  # x86_64-linux
           ubuntu-24.04-arm,  # aarch64-linux
-          macos-13,  # x86_64-darwin
+          macos-15-intel,  # x86_64-darwin
           macos-15,  # aarch64-darwin
         ]
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -99,7 +99,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [
-          macos-13,  # x86_64-darwin
+          macos-15-intel,  # x86_64-darwin
           macos-15,  # aarch64-darwin
         ]
         attribute: [


### PR DESCRIPTION
see: https://github.com/actions/runner-images/issues/13046

> For users that require the x86_64 (Intel) environment, we are also introducing a new label to migrate to: macos-15-intel. The new label will run on macOS 15 and will be available from now until August 2027. This will be the last available x86_64 image from Actions, and after that date the x86_64 architecture will not be supported on GitHub Actions. 

** until August 2027. ... after that date the x86_64 architecture will not be supported on GitHub Action **