### PR TITLE
Replace pwndbg.aglib.regs[x] with pwndbg.aglib.regs.read_reg(x)

### DIFF
--- a/profiling/benchmark.py
+++ b/profiling/benchmark.py
@@ -143,7 +143,7 @@ parser.add_argument("name", type=str, help="Name placed into output pstats filen
 @pwndbg.commands.Command(parser, category=pwndbg.commands.CommandCategory.DEV)
 def benchmark_large_telescope(name: str):
     # Telescope entire stack
-    stack_page = pwndbg.aglib.vmmap.find(pwndbg.aglib.regs[pwndbg.aglib.regs.stack])
+    stack_page = pwndbg.aglib.vmmap.find(pwndbg.aglib.regs.read_reg(pwndbg.aglib.regs.stack))
     start = stack_page.start
     len = stack_page.memsz
     

--- a/pwndbg/aglib/disasm/arch.py
+++ b/pwndbg/aglib/disasm/arch.py
@@ -453,8 +453,8 @@ class DisassemblyAssistant:
             # which is relevent if we are writing to this register.
             # However, the information can still be useful for display purposes.
             if DEBUG_ENHANCEMENT:
-                print(f"Read value from process register: {pwndbg.aglib.regs[regname]}")
-            return pwndbg.aglib.regs[regname]
+                print(f"Read value from process register: {pwndbg.aglib.regs.read_reg(regname)}")
+            return pwndbg.aglib.regs.read_reg(regname)
         elif (reg_value := self.manual_register_values.read_register(regname)) is not None:
             # If we manually tracked the value of this register while disassembling, we can read from it.
             return reg_value

--- a/pwndbg/aglib/disasm/arm.py
+++ b/pwndbg/aglib/disasm/arm.py
@@ -243,7 +243,7 @@ class ArmDisassemblyAssistant(pwndbg.aglib.disasm.arch.DisassemblyAssistant):
             instruction.groups.remove(CS_GRP_CALL)
 
         # Disable Unicorn while in IT instruction blocks since Unicorn cannot be paused in it.
-        flags_value = pwndbg.aglib.regs[self.flags_reg]
+        flags_value = pwndbg.aglib.regs.read_reg(self.flags_reg)
         it_state = itstate_from_cpsr(flags_value)
 
         if (instruction.id == ARM_INS_IT or it_state != 0) and emu:
@@ -326,7 +326,7 @@ class ArmDisassemblyAssistant(pwndbg.aglib.disasm.arch.DisassemblyAssistant):
             parts.append("%#x" % op.mem.disp)
 
         if op.mem.index != 0:
-            index = pwndbg.aglib.regs[instruction.cs_insn.reg_name(op.mem.index)]
+            index = pwndbg.aglib.regs.read_reg(instruction.cs_insn.reg_name(op.mem.index))
             scale = op.mem.scale
             parts.append(f"{index}*{scale:#x}")
 

--- a/pwndbg/aglib/disasm/disassembly.py
+++ b/pwndbg/aglib/disasm/disassembly.py
@@ -402,7 +402,7 @@ def near(
     # Copy register values to the enhancer for use in manual register tracking
     if assistant.supports_manual_emulation and address == pc:
         for reg in pwndbg.aglib.regs.current.common:
-            if (reg_value := pwndbg.aglib.regs[reg]) is not None:
+            if (reg_value := pwndbg.aglib.regs.read_reg(reg)) is not None:
                 assistant.manual_register_values.write_register(reg, reg_value)
 
     # Start at the current instruction using emulation if available.

--- a/pwndbg/aglib/disasm/x86.py
+++ b/pwndbg/aglib/disasm/x86.py
@@ -428,7 +428,7 @@ class X86DisassemblyAssistant(pwndbg.aglib.disasm.arch.DisassemblyAssistant):
             if arith:
                 sz += " + "
 
-            index = pwndbg.aglib.regs[instruction.cs_insn.reg_name(index)]
+            index = pwndbg.aglib.regs.read_reg(instruction.cs_insn.reg_name(index))
             sz += f"{index}*{op.mem.scale:#x}"
             arith = True
 

--- a/pwndbg/aglib/kernel/paging.py
+++ b/pwndbg/aglib/kernel/paging.py
@@ -275,7 +275,7 @@ class x86_64PagingInfo(ArchPagingInfo):
     @property
     @pwndbg.lib.cache.cache_until("stop")
     def paging_level(self) -> int:
-        return 4 if (pwndbg.aglib.regs["cr4"] & (1 << 12)) == 0 else 5
+        return 4 if (pwndbg.aglib.regs.read_reg("cr4") & (1 << 12)) == 0 else 5
 
     @pwndbg.lib.cache.cache_until("stop")
     def markers(self) -> Tuple[Tuple[str, int], ...]:
@@ -335,12 +335,12 @@ class x86_64PagingInfo(ArchPagingInfo):
                     page.objfile = self.KERNELBSS
                 else:
                     page.objfile = self.KERNELRO
-            if pwndbg.aglib.regs[pwndbg.aglib.regs.stack] in page:
+            if pwndbg.aglib.regs.read_reg(pwndbg.aglib.regs.stack) in page:
                 page.objfile = "kernel [stack]"
 
     def pagewalk(self, target, entry) -> Tuple[PageTableLevel, ...]:
         if entry is None:
-            entry = pwndbg.aglib.regs["cr3"]
+            entry = pwndbg.aglib.regs.read_reg("cr3")
         return self.pagewalk_helper(target, entry)
 
     def pageentry_flags(self, is_last) -> BitFlags:
@@ -612,7 +612,7 @@ class Aarch64PagingInfo(ArchPagingInfo):
                     page.objfile = self.KERNELBSS
                 else:
                     page.objfile = self.KERNELRO
-            if pwndbg.aglib.regs[pwndbg.aglib.regs.stack] in page:
+            if pwndbg.aglib.regs.read_reg(pwndbg.aglib.regs.stack) in page:
                 page.objfile = "kernel [stack]"
 
     @property

--- a/pwndbg/aglib/kernel/symbol.py
+++ b/pwndbg/aglib/kernel/symbol.py
@@ -575,4 +575,4 @@ class Aarch64Symbols(ArchSymbols):
         return self.qword_adrp_add_const(disass)
 
     def _current_task(self):
-        return pwndbg.aglib.regs["sp_el0"]
+        return pwndbg.aglib.regs.read_reg("sp_el0")

--- a/pwndbg/aglib/nearpc.py
+++ b/pwndbg/aglib/nearpc.py
@@ -235,7 +235,7 @@ def nearpc(
 
                 base = operand.mem.base
                 if base > 0:
-                    address += pwndbg.aglib.regs[instr.reg_name(base)]
+                    address += pwndbg.aglib.regs.read_reg(instr.reg_name(base))
 
                 vmmap = pwndbg.aglib.vmmap.get()
                 page = next((page for page in vmmap if address in page), None)

--- a/pwndbg/aglib/regs.py
+++ b/pwndbg/aglib/regs.py
@@ -134,14 +134,6 @@ class module(ModuleType):
             if not pwndbg.dbg.selected_frame().reg_write(attr, int(val)):
                 raise RuntimeError(f"Attempted to write to a non-existent register '{attr}'")
 
-    @pwndbg.lib.cache.cache_until("stop", "prompt")
-    def __getitem__(self, item: Any) -> int | None:
-        if not isinstance(item, str):
-            print("Unknown register type: %r" % (item))
-            return None
-
-        return self.read_reg(item)
-
     def __contains__(self, reg: str) -> bool:
         return reg_sets[pwndbg.aglib.arch.name].__contains__(reg)
 
@@ -200,7 +192,7 @@ class module(ModuleType):
 
     def items(self) -> Generator[Tuple[str, Any], None, None]:
         for regname in self.all:
-            yield regname, self[regname]
+            yield regname, self.read_reg(regname)
 
     reg_sets = reg_sets
 
@@ -208,7 +200,7 @@ class module(ModuleType):
     def changed(self) -> List[str]:
         delta: List[str] = []
         for reg, value in self.previous.items():
-            if self[reg] != value:
+            if self.read_reg(reg) != value:
                 delta.append(reg)
         return delta
 
@@ -278,7 +270,7 @@ sys.modules[__name__] = module(__name__, "")
 def update_last() -> None:
     M: module = cast(module, sys.modules[__name__])
     M.previous = M.last
-    M.last = {k: M[k] for k in M.common}
+    M.last = {k: M.read_reg(k) for k in M.common}
     # TODO: Uncomment this once the LLDB command port PR for `context` is merged
     # if pwndbg.config.show_retaddr_reg:
     #    M.last.update({k: M[k] for k in M.retaddr})

--- a/pwndbg/aglib/shellcode.py
+++ b/pwndbg/aglib/shellcode.py
@@ -32,7 +32,7 @@ def _get_syscall_return_value():
 
     register_set = pwndbg.lib.regs.reg_sets[pwndbg.aglib.arch.name]
     # FIXME: `retval` is syscall abi? or sysv abi?
-    return pwndbg.aglib.regs[register_set.retval]
+    return pwndbg.aglib.regs.read_reg(register_set.retval)
 
 
 async def exec_syscall(

--- a/pwndbg/commands/binja_functions.py
+++ b/pwndbg/commands/binja_functions.py
@@ -131,7 +131,7 @@ def bn_eval(expr: gdb.Value) -> int:
 
     magic_vars = {}
     for r in pwndbg.aglib.regs.current:
-        v = pwndbg.aglib.regs[r]
+        v = pwndbg.aglib.regs.read_reg(r)
         if v is not None:
             magic_vars[r] = v
     magic_vars["piebase"] = pwndbg.aglib.proc.binary_base_addr

--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -953,7 +953,7 @@ class RegisterContext:
         return f"{m}{regname}"
 
     def get_register_value(self, reg):
-        val = pwndbg.aglib.regs[reg]
+        val = pwndbg.aglib.regs.read_reg(reg)
         if val is None:
             print(message.warn(f"Unknown register: {reg!r}"))
             return None

--- a/pwndbg/commands/cyclic.py
+++ b/pwndbg/commands/cyclic.py
@@ -42,7 +42,7 @@ def detect_register_patterns(alphabet, length, timeout) -> None:
     all_register_names = register_set.all
 
     for reg_name in all_register_names:
-        value = pwndbg.aglib.regs[reg_name]
+        value = pwndbg.aglib.regs.read_reg(reg_name)
         if value is None:
             continue
 

--- a/pwndbg/commands/flags.py
+++ b/pwndbg/commands/flags.py
@@ -55,7 +55,7 @@ def setflag(flag: str, value: int) -> None:
                     print(f"Maximum value for flag is {max_val} (size={size})")
                     return
 
-                old_val = int(pwndbg.aglib.regs[flag_reg])
+                old_val = int(pwndbg.aglib.regs.read_reg(flag_reg))
                 mask = max_val << bit
                 bit_value = value << bit
 

--- a/pwndbg/commands/ida.py
+++ b/pwndbg/commands/ida.py
@@ -163,8 +163,8 @@ def _ida_local(name: str) -> int | None:
         if offset == -1:
             raise ValueError("ida.GetMemberOffset(%r) == -1" % local_name)
         if saved_baseptr != -1 and pwndbg.aglib.regs.frame is not None:
-            return pwndbg.aglib.regs[pwndbg.aglib.regs.frame] + offset - saved_baseptr
-        return pwndbg.aglib.regs[pwndbg.aglib.regs.stack] + offset
+            return pwndbg.aglib.regs.read_reg(pwndbg.aglib.regs.frame) + offset - saved_baseptr
+        return pwndbg.aglib.regs.read_reg(pwndbg.aglib.regs.stack) + offset
     return None
 
 

--- a/pwndbg/commands/msr.py
+++ b/pwndbg/commands/msr.py
@@ -59,8 +59,8 @@ def x86_msr_read(msr: int) -> None:
     async def ctrl(ec: pwndbg.dbg_mod.ExecutionController):
         sc = pwndbg.aglib.asm.asm(f"mov ecx, {msr}; rdmsr")
         async with pwndbg.aglib.shellcode.exec_shellcode(ec, sc):
-            edx = int(pwndbg.aglib.regs["edx"]) << 32
-            eax = int(pwndbg.aglib.regs["eax"])
+            edx = int(pwndbg.aglib.regs.read_reg("edx")) << 32
+            eax = int(pwndbg.aglib.regs.read_reg("eax"))
             ret = edx + eax
             print(f"{hex(msr)}:\t{hex(ret)}")
 

--- a/pwndbg/commands/telescope.py
+++ b/pwndbg/commands/telescope.py
@@ -143,7 +143,7 @@ def telescope(
             print("The frame register is not defined for this architecture.")
             return
         sp = pwndbg.aglib.regs.sp
-        bp = pwndbg.aglib.regs[pwndbg.aglib.regs.frame]
+        bp = pwndbg.aglib.regs.read_reg(pwndbg.aglib.regs.frame)
         if sp > bp:
             print("Cannot display stack frame because base pointer is below stack pointer")
             return
@@ -169,7 +169,7 @@ def telescope(
     # Map of address to register string
     reg_values: DefaultDict[int, List[str]] = collections.defaultdict(list)
     for reg in pwndbg.aglib.regs.common:
-        reg_values[pwndbg.aglib.regs[reg]].append(reg)
+        reg_values[pwndbg.aglib.regs.read_reg(reg)].append(reg)
 
     if not inverse:
         start = address
@@ -228,7 +228,7 @@ def telescope(
 
     bp = None
     if print_framepointer_offset and pwndbg.aglib.regs.frame is not None:
-        bp = pwndbg.aglib.regs[pwndbg.aglib.regs.frame]
+        bp = pwndbg.aglib.regs.read_reg(pwndbg.aglib.regs.frame)
 
     for i, addr in enumerate(range(start, stop, step)):
         if not pwndbg.aglib.memory.peek(addr):

--- a/pwndbg/commands/xinfo.py
+++ b/pwndbg/commands/xinfo.py
@@ -31,7 +31,7 @@ def xinfo_stack(page: Page, addr: int) -> None:
     # well as offsets to current stack and base pointer (if used by debuggee)
 
     sp = pwndbg.aglib.regs.sp
-    frame = pwndbg.aglib.regs[pwndbg.aglib.regs.frame]
+    frame = pwndbg.aglib.regs.read_reg(pwndbg.aglib.regs.frame)
     frame_mapping = pwndbg.aglib.vmmap.find(frame)
 
     print_line("Stack Top", addr, page.vaddr, addr - page.vaddr, "+")

--- a/pwndbg/gdblib/shellcode.py
+++ b/pwndbg/gdblib/shellcode.py
@@ -28,7 +28,7 @@ def _get_syscall_return_value():
     """
 
     register_set = pwndbg.lib.regs.reg_sets[pwndbg.aglib.arch.name]
-    return pwndbg.aglib.regs[register_set.retval]
+    return pwndbg.aglib.regs.read_reg(register_set.retval)
 
 
 def exec_syscall(
@@ -82,7 +82,7 @@ def exec_shellcode(blob, restore_context=True, capture=None, disable_breakpoints
     register_set = pwndbg.lib.regs.reg_sets[pwndbg.aglib.arch.name]
     preserve_set = register_set.gpr + register_set.args + (register_set.pc, register_set.stack)
 
-    registers = {reg: pwndbg.aglib.regs[reg] for reg in preserve_set}
+    registers = {reg: pwndbg.aglib.regs.read_reg(reg) for reg in preserve_set}
     starting_address = registers[register_set.pc]
 
     # Make sure the blob fits in the rest of the space we have in this page.

--- a/pwndbg/ghidra.py
+++ b/pwndbg/ghidra.py
@@ -46,7 +46,7 @@ def decompile(func=None):
         raise Exception("r2pipe or rzpipe not available, but required for r2/rz->ghidra bridge")
 
     if pwndbg.aglib.qemu.is_qemu_kernel():
-        pc = pwndbg.aglib.regs[pwndbg.aglib.regs.current.pc]
+        pc = pwndbg.aglib.regs.read_reg(pwndbg.aglib.regs.current.pc)
         if func is None:
             func = pwndbg.aglib.symbol.resolve_addr(pc)
             if func is not None:
@@ -56,7 +56,7 @@ def decompile(func=None):
 
     if not func:
         func = (
-            hex(pwndbg.aglib.regs[pwndbg.aglib.regs.current.pc])
+            hex(pwndbg.aglib.regs.read_reg(pwndbg.aglib.regs.current.pc))
             if pwndbg.aglib.proc.alive
             else "main"
         )
@@ -72,7 +72,7 @@ def decompile(func=None):
 
     # If not running there is no current pc to mark
     if pwndbg.aglib.proc.alive:
-        pc = pwndbg.aglib.regs[pwndbg.aglib.regs.current.pc]
+        pc = pwndbg.aglib.regs.read_reg(pwndbg.aglib.regs.current.pc)
 
         closest = 0
         for off in (a.get("offset", 0) for a in src.get("annotations", [])):

--- a/tests/library/dbg/tests/test_command_telescope.py
+++ b/tests/library/dbg/tests/test_command_telescope.py
@@ -124,7 +124,7 @@ async def test_command_telescope_frame(ctrl: Controller) -> None:
     await launch_to(ctrl, TELESCOPE_BINARY, "break_here")
 
     rsp = hex(pwndbg.aglib.regs.sp)
-    rbp = hex(pwndbg.aglib.regs[pwndbg.aglib.regs.frame])
+    rbp = hex(pwndbg.aglib.regs.read_reg(pwndbg.aglib.regs.frame))
 
     result_str = await ctrl.execute_and_capture("telescope --frame")
     result_lines = result_str.strip().split("\n")
@@ -143,7 +143,7 @@ async def test_command_telescope_frame_bp_below_sp(ctrl: Controller) -> None:
     await launch_to(ctrl, TELESCOPE_BINARY, "break_here")
     await ctrl.execute("memoize")  # turn off cache
 
-    pwndbg.aglib.regs.sp = pwndbg.aglib.regs[pwndbg.aglib.regs.frame] + 1
+    pwndbg.aglib.regs.sp = pwndbg.aglib.regs.read_reg(pwndbg.aglib.regs.frame) + 1
 
     result_str = await ctrl.execute_and_capture("telescope --frame")
 

--- a/tests/library/dbg/tests/test_windbg.py
+++ b/tests/library/dbg/tests/test_windbg.py
@@ -302,7 +302,7 @@ async def test_windbg_eX_commands(ctrl: Controller) -> None:
     ### Test write & output on partial write
     #########################################
     # e.g. when we make a write to the last stack address
-    stack_ea = pwndbg.aglib.regs[pwndbg.aglib.regs.stack]
+    stack_ea = pwndbg.aglib.regs.read_reg(pwndbg.aglib.regs.stack)
     stack_page = pwndbg.aglib.vmmap.find(stack_ea)
 
     # Last possible address on stack where we can perform an 8-byte write

--- a/tests/library/gdb/tests/test_command_telescope.py
+++ b/tests/library/gdb/tests/test_command_telescope.py
@@ -118,7 +118,7 @@ def test_command_telescope_frame(start_binary):
     gdb.execute("run")
 
     rsp = hex(pwndbg.aglib.regs.sp)
-    rbp = hex(pwndbg.aglib.regs[pwndbg.aglib.regs.frame])
+    rbp = hex(pwndbg.aglib.regs.read_reg(pwndbg.aglib.regs.frame))
 
     result_str = gdb.execute("telescope --frame", to_string=True)
     result_lines = result_str.strip().split("\n")
@@ -137,7 +137,7 @@ def test_command_telescope_frame_bp_below_sp(start_binary):
     gdb.execute("run")
     gdb.execute("memoize")  # turn off cache
 
-    pwndbg.aglib.regs.sp = pwndbg.aglib.regs[pwndbg.aglib.regs.frame] + 1
+    pwndbg.aglib.regs.sp = pwndbg.aglib.regs.read_reg(pwndbg.aglib.regs.frame) + 1
 
     result_str = gdb.execute("telescope --frame", to_string=True)
 

--- a/tests/library/gdb/tests/test_windbg.py
+++ b/tests/library/gdb/tests/test_windbg.py
@@ -290,7 +290,7 @@ def test_windbg_eX_commands(start_binary):
     ### Test write & output on partial write
     #########################################
     # e.g. when we make a write to the last stack address
-    stack_ea = pwndbg.aglib.regs[pwndbg.aglib.regs.stack]
+    stack_ea = pwndbg.aglib.regs.read_reg(pwndbg.aglib.regs.stack)
     stack_page = pwndbg.aglib.vmmap.find(stack_ea)
 
     # Last possible address on stack where we can perform an 8-byte write


### PR DESCRIPTION
Currently, there are 3 ways to read registers:
1. `pwndbg.aglib.regs.x`        -  the `__getattr__` property
2. `pwndbg.aglib.regs["x"]`    - the `__getitem__` property
3. `pwndbg.aglib.regs.read_reg("x")`

This PR replaces all occurrences of  `pwndbg.aglib.regs["x"]` with `pwndbg,aglib.regs.read_reg("x")`.

A future PR will remove the first method, `__getattr__`, but it requires more than just changing object accesses, since we have some "special" properties on the regs module to override logic for fetching a specific register, such as `fs_base`, and some places in the codebase uses `getattr(pwndbg.aglib.regs,reg_name)` in order to invoke the special handlers in case they exist for the given register.

https://github.com/pwndbg/pwndbg/blob/f035e158a019a0dbed26fe2e228517c3ac41a123/pwndbg/aglib/kernel/vmmap.py#L175

https://github.com/pwndbg/pwndbg/blob/f035e158a019a0dbed26fe2e228517c3ac41a123/pwndbg/aglib/regs.py#L223