### PR TITLE
Fix plist to support pointer-sized integer fields (#3448)

### DIFF
--- a/pwndbg/commands/plist.py
+++ b/pwndbg/commands/plist.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 from typing import Optional
 
+import pwndbg.aglib.arch
 import pwndbg.aglib.memory
 import pwndbg.aglib.symbol
 import pwndbg.chain
@@ -272,8 +273,19 @@ def plist(
     if next_ptr.is_optimized_out:
         print(message.error(f"{path}{sep}{next_ptr_name} has been optimized out"))
         return
-    if next_ptr.type.code != pwndbg.dbg_mod.TypeCode.POINTER:
-        print(message.error(f"{path}{sep}{next_ptr_name} is not a pointer"))
+
+    # Check if the field is a pointer type, or an integer type with pointer size
+    # (e.g., size_t, uintptr_t, unsigned long on 64-bit systems)
+    is_pointer_type = next_ptr.type.code == pwndbg.dbg_mod.TypeCode.POINTER
+    is_pointer_sized_int = (
+        next_ptr.type.code == pwndbg.dbg_mod.TypeCode.INT
+        and next_ptr.type.sizeof == pwndbg.aglib.arch.ptrsize
+    )
+
+    if not (is_pointer_type or is_pointer_sized_int):
+        print(
+            message.error(f"{path}{sep}{next_ptr_name} is not a pointer or pointer-sized integer")
+        )
         return
 
     # If the user wants a specific field to be displayed, resolve it.
@@ -359,7 +371,17 @@ def plist(
     # Here, we figure out how many bytes to subtract from *typeof(inner) so that
     # we can have a *typeof(first).
     pointee_offset = 0
-    if inner is not None and next_ptr.type.target() == inner.type:
+
+    # For pointer-sized integers (like size_t), we can't validate the target type
+    # since they don't have a target() method. We assume they point to the outer structure.
+    if is_pointer_sized_int:
+        # For integer types, we assume pointee_offset is 0 (pointing to outer structure)
+        # unless we have an inner structure, in which case the user needs to use --inner
+        # and we can't automatically determine the offset.
+        if inner is not None:
+            # We can't determine if it points to inner or outer type, so assume outer
+            pointee_offset = 0
+    elif inner is not None and next_ptr.type.target() == inner.type:
         pointee_offset = inner_offset
     elif next_ptr.type.target() == first.type:
         # We've already got everything we need for this mode.

--- a/pwndbg/commands/plist.py
+++ b/pwndbg/commands/plist.py
@@ -276,10 +276,12 @@ def plist(
 
     # Check if the field is a pointer type, or an integer type with pointer size
     # (e.g., size_t, uintptr_t, unsigned long on 64-bit systems)
-    is_pointer_type = next_ptr.type.code == pwndbg.dbg_mod.TypeCode.POINTER
+    # Strip typedefs to get the underlying type (e.g., size_t -> unsigned long)
+    underlying_type = next_ptr.type.strip_typedefs()
+    is_pointer_type = underlying_type.code == pwndbg.dbg_mod.TypeCode.POINTER
     is_pointer_sized_int = (
-        next_ptr.type.code == pwndbg.dbg_mod.TypeCode.INT
-        and next_ptr.type.sizeof == pwndbg.aglib.arch.ptrsize
+        underlying_type.code == pwndbg.dbg_mod.TypeCode.INT
+        and underlying_type.sizeof == pwndbg.aglib.arch.ptrsize
     )
 
     if not (is_pointer_type or is_pointer_sized_int):

--- a/tests/binaries/host/linked-lists.c
+++ b/tests/binaries/host/linked-lists.c
@@ -39,6 +39,16 @@ struct inner_b_node inner_b_node_c = { 2, { NULL } };
 struct inner_b_node inner_b_node_b = { 1, { &inner_b_node_c } };
 struct inner_b_node inner_b_node_a = { 0, { &inner_b_node_b } };
 
+/* Linked list using size_t for next pointer to test pointer-sized integer support. */
+#include <stdint.h>
+struct size_t_node {
+    int value;
+    size_t next;
+};
+struct size_t_node size_t_node_c = { 42, 0 };
+struct size_t_node size_t_node_b = { 21, (size_t)&size_t_node_c };
+struct size_t_node size_t_node_a = { 10, (size_t)&size_t_node_b };
+
 
 void break_here(void) {}
 int main(void)

--- a/tests/binaries/host/linked-lists.c
+++ b/tests/binaries/host/linked-lists.c
@@ -1,4 +1,5 @@
 #include <stddef.h> /* For NULL. */
+#include <stdint.h> /* For size_t. */
 
 /* Linked list in which the pointer to the next element in inside the node
  * structure itself. */
@@ -40,7 +41,6 @@ struct inner_b_node inner_b_node_b = { 1, { &inner_b_node_c } };
 struct inner_b_node inner_b_node_a = { 0, { &inner_b_node_b } };
 
 /* Linked list using size_t for next pointer to test pointer-sized integer support. */
-#include <stdint.h>
 struct size_t_node {
     int value;
     size_t next;

--- a/tests/library/dbg/tests/test_command_plist.py
+++ b/tests/library/dbg/tests/test_command_plist.py
@@ -320,20 +320,11 @@ async def test_command_plist_size_t_field(ctrl: Controller):
 
     expected_out = re.compile(
         """\
-0[xX][0-9a-fA-F]+ <size_t_node_a>:.*{\\s*
-  value = 10,?\\s*
-  next = [0-9]+,?\\s*
-}\\s*
-0[xX][0-9a-fA-F]+ <size_t_node_b>:.*{\\s*
-  value = 21,?\\s*
-  next = [0-9]+,?\\s*
-}\\s*
-0[xX][0-9a-fA-F]+ <size_t_node_c>:.*{\\s*
-  value = 42,?\\s*
-  next = (0|NULL),?\\s*
-}\
+0[xX][0-9a-fA-F]+ <size_t_node_a>:.* 10\\s*
+0[xX][0-9a-fA-F]+ <size_t_node_b>:.* 21\\s*
+0[xX][0-9a-fA-F]+ <size_t_node_c>:.* 42\\s*
 """
     )
 
-    result_str = await ctrl.execute_and_capture("plist size_t_node_a next -c 3")
+    result_str = await ctrl.execute_and_capture("plist size_t_node_a next -f value -c 3")
     assert expected_out.match(result_str) is not None

--- a/tests/library/dbg/tests/test_command_plist.py
+++ b/tests/library/dbg/tests/test_command_plist.py
@@ -309,3 +309,31 @@ async def test_command_plist_nested_indirect(ctrl: Controller):
 
     result_str = await ctrl.execute_and_capture("plist inner_a_node_a -i inner next")
     assert expected_out.match(result_str) is not None
+
+
+@pwndbg_test
+async def test_command_plist_size_t_field(ctrl: Controller):
+    """
+    Tests the plist command with size_t fields (pointer-sized integers)
+    """
+    await startup(ctrl)
+
+    expected_out = re.compile(
+        """\
+0[xX][0-9a-fA-F]+ <size_t_node_a>:.*{\\s*
+  value = 10,?\\s*
+  next = [0-9]+,?\\s*
+}\\s*
+0[xX][0-9a-fA-F]+ <size_t_node_b>:.*{\\s*
+  value = 21,?\\s*
+  next = [0-9]+,?\\s*
+}\\s*
+0[xX][0-9a-fA-F]+ <size_t_node_c>:.*{\\s*
+  value = 42,?\\s*
+  next = (0|NULL),?\\s*
+}\
+"""
+    )
+
+    result_str = await ctrl.execute_and_capture("plist size_t_node_a next")
+    assert expected_out.match(result_str) is not None

--- a/tests/library/dbg/tests/test_command_plist.py
+++ b/tests/library/dbg/tests/test_command_plist.py
@@ -317,6 +317,7 @@ async def test_command_plist_size_t_field(ctrl: Controller):
     Tests the plist command with size_t fields (pointer-sized integers)
     """
     await startup(ctrl)
+    await ctrl.execute("set dereference-limit 5")
 
     expected_out = re.compile(
         """\

--- a/tests/library/dbg/tests/test_command_plist.py
+++ b/tests/library/dbg/tests/test_command_plist.py
@@ -317,7 +317,6 @@ async def test_command_plist_size_t_field(ctrl: Controller):
     Tests the plist command with size_t fields (pointer-sized integers)
     """
     await startup(ctrl)
-    await ctrl.execute("set dereference-limit 5")
 
     expected_out = re.compile(
         """\
@@ -336,5 +335,5 @@ async def test_command_plist_size_t_field(ctrl: Controller):
 """
     )
 
-    result_str = await ctrl.execute_and_capture("plist size_t_node_a next")
+    result_str = await ctrl.execute_and_capture("plist size_t_node_a next -c 3")
     assert expected_out.match(result_str) is not None

--- a/tests/library/gdb/tests/test_command_plist.py
+++ b/tests/library/gdb/tests/test_command_plist.py
@@ -297,3 +297,30 @@ def test_command_plist_nested_indirect(start_binary):
 
     result_str = gdb.execute("plist inner_a_node_a -i inner next", to_string=True)
     assert expected_out.match(result_str) is not None
+
+
+def test_command_plist_size_t_field(start_binary):
+    """
+    Tests the plist command with size_t fields (pointer-sized integers)
+    """
+    startup(start_binary)
+
+    expected_out = re.compile(
+        """\
+0[xX][0-9a-fA-F]+ <size_t_node_a>: {\\s*
+  value = 10,\\s*
+  next = [0-9]+\\s*
+}\\s*
+0[xX][0-9a-fA-F]+ <size_t_node_b>: {\\s*
+  value = 21,\\s*
+  next = [0-9]+\\s*
+}\\s*
+0[xX][0-9a-fA-F]+ <size_t_node_c>: {\\s*
+  value = 42,\\s*
+  next = 0\\s*
+}\
+"""
+    )
+
+    result_str = gdb.execute("plist size_t_node_a next", to_string=True)
+    assert expected_out.match(result_str) is not None

--- a/tests/library/gdb/tests/test_command_plist.py
+++ b/tests/library/gdb/tests/test_command_plist.py
@@ -307,20 +307,11 @@ def test_command_plist_size_t_field(start_binary):
 
     expected_out = re.compile(
         """\
-0[xX][0-9a-fA-F]+ <size_t_node_a>: {\\s*
-  value = 10,\\s*
-  next = [0-9]+\\s*
-}\\s*
-0[xX][0-9a-fA-F]+ <size_t_node_b>: {\\s*
-  value = 21,\\s*
-  next = [0-9]+\\s*
-}\\s*
-0[xX][0-9a-fA-F]+ <size_t_node_c>: {\\s*
-  value = 42,\\s*
-  next = 0\\s*
-}\
+0[xX][0-9a-fA-F]+ <size_t_node_a>: 10\\s*
+0[xX][0-9a-fA-F]+ <size_t_node_b>: 21\\s*
+0[xX][0-9a-fA-F]+ <size_t_node_c>: 42\\s*
 """
     )
 
-    result_str = gdb.execute("plist size_t_node_a next -c 3", to_string=True)
+    result_str = gdb.execute("plist size_t_node_a next -f value -c 3", to_string=True)
     assert expected_out.match(result_str) is not None

--- a/tests/library/gdb/tests/test_command_plist.py
+++ b/tests/library/gdb/tests/test_command_plist.py
@@ -304,7 +304,6 @@ def test_command_plist_size_t_field(start_binary):
     Tests the plist command with size_t fields (pointer-sized integers)
     """
     startup(start_binary)
-    gdb.execute("set dereference-limit 5")
 
     expected_out = re.compile(
         """\
@@ -323,5 +322,5 @@ def test_command_plist_size_t_field(start_binary):
 """
     )
 
-    result_str = gdb.execute("plist size_t_node_a next", to_string=True)
+    result_str = gdb.execute("plist size_t_node_a next -c 3", to_string=True)
     assert expected_out.match(result_str) is not None

--- a/tests/library/gdb/tests/test_command_plist.py
+++ b/tests/library/gdb/tests/test_command_plist.py
@@ -304,6 +304,7 @@ def test_command_plist_size_t_field(start_binary):
     Tests the plist command with size_t fields (pointer-sized integers)
     """
     startup(start_binary)
+    gdb.execute("set dereference-limit 5")
 
     expected_out = re.compile(
         """\


### PR DESCRIPTION
## Description
Fixes #3448

The `plist` command previously rejected fields that were not pointer types, even if they were pointer-sized integers (like `size_t`, `uintptr_t`) used to store addresses.

## Changes
- Accept integer types with size equal to architecture pointer size
- Handle type validation for pointer-sized integers  
- Assume pointer-sized integers point to outer structure type

## Example
This allows `plist` to work with structs like:
```c
struct some_thing {
    size_t next;  
    size_t prev;
    int session_id;
    size_t challenge_len;
    char challenge[256];
};

Before:
pwndbg> plist head_next next
head_next->next is not a pointer

After:
pwndbg> plist head_next next
# Works! Traverses the linked list