### PR TITLE
fix: also look in $XDG_CONFIG_HOME (defaults to ~/.config for gdbinit)

### DIFF
--- a/pwndbg/dbg/gdb/__init__.py
+++ b/pwndbg/dbg/gdb/__init__.py
@@ -4,6 +4,7 @@ import re
 from asyncio import CancelledError
 from contextlib import contextmanager
 from contextlib import nullcontext
+from os import environ
 from pathlib import Path
 from typing import Any
 from typing import Coroutine
@@ -1384,7 +1385,10 @@ class GDB(pwndbg.dbg_mod.Debugger):
         if disable_any:
             return
 
-        home_file = Path("~/.gdbinit").expanduser().resolve()
+        config_home = environ.get("XDG_CONFIG_HOME", Path("~/.config").expanduser().resolve())
+        home_file = (Path(config_home) / "gdb" / "gdbinit").resolve()
+        if not home_file.exists():
+            home_file = Path("~/.gdbinit").expanduser().resolve()
         local_file = Path("./.gdbinit").resolve()
 
         def load_source(file_path: str):
@@ -1395,7 +1399,7 @@ class GDB(pwndbg.dbg_mod.Debugger):
 
         is_home_loaded = False
         if not disable_home and home_file.exists():
-            load_source("~/.gdbinit")
+            load_source(str(home_file))
             is_home_loaded = True
 
         disable_local = not gdb.parameter("auto-load local-gdbinit")


### PR DESCRIPTION
<!--
    Please make sure to read the linting and testing instructions at
    https://pwndbg.re/dev/contributing/ before creating a PR.
-->

+ [x] I read the contributing documentation.
+ [x] I am providing a screenshot of the (new feature) / (fixed bug).

before:
<img width="1915" height="1079" alt="before" src="https://github.com/user-attachments/assets/82479a55-f2c0-4039-a999-413a32d1544f" />

after:
<img width="1919" height="1079" alt="after" src="https://github.com/user-attachments/assets/1e00e0d5-664f-415a-bce1-598086259d0f" />

