### PR TITLE
fix kmem-trace invalid obj hex print

### DIFF
--- a/pwndbg/commands/kmem_trace.py
+++ b/pwndbg/commands/kmem_trace.py
@@ -96,7 +96,7 @@ class KmemTracepointsData:
             cache = pwndbg.aglib.kernel.slab.find_containing_slab_cache(objaddr)
             name = cache.name
         except Exception:
-            self.results.append(M.warn(f"{prefix} invalid SLUB object @ {objaddr}"))
+            self.results.append(M.warn(f"{prefix} invalid SLUB object @ {objaddr:#x}"))
             return
         result = self._format_kmem_tracepoint_output(prefix, name, "obj", objaddr)
         self.add_result(result)


### PR DESCRIPTION
i got this:
<img width="673" height="69" alt="image" src="https://github.com/user-attachments/assets/f966afee-c4a3-43b8-b45d-ab1e7a77640a" />

so.