### PR TITLE
Remove regs getattr + setattr

### DIFF
--- a/docs/contributing/writing-tests.md
+++ b/docs/contributing/writing-tests.md
@@ -52,7 +52,7 @@ Using a [`pytest`](https://docs.pytest.org/en/latest/) fixture at the beginning 
 GDB will attach to a [`binary`](https://github.com/pwndbg/pwndbg/tree/dev/tests/library/gdb/conftest.py)
 or connect to a [`QEMU instance`](https://github.com/pwndbg/pwndbg/tree/dev/tests/library/qemu-user/conftest.py).
 Each test runs some commands and uses Python `assert` statements to verify correctness. We can access Pwndbg
-library code like `pwndbg.aglib.regs.rsp` as well as execute GDB commands with `gdb.execute()`.
+library code like `pwndbg.aglib.regs.sp` as well as execute GDB commands with `gdb.execute()`.
 
 We can take a look at [`tests/library/gdb/tests/test_symbol.py`](https://github.com/pwndbg/pwndbg/tree/dev/tests/library/gdb/tests/test_symbol.py)
 for an example of a simple test. Looking at a simplified version of the top-level code, we have this:
@@ -77,7 +77,7 @@ def test_hexdump(start_binary):
     pwndbg.config.hexdump_group_width.value = -1
 
     gdb.execute("set hexdump-byte-separator")
-    stack_addr = pwndbg.aglib.regs.rsp - 0x100
+    stack_addr = pwndbg.aglib.regs.sp - 0x100
 ```
 
 `pytest` will run any function that starts with `test_` as a new test, so there is no need to register your new

--- a/pwndbg/aglib/arch.py
+++ b/pwndbg/aglib/arch.py
@@ -240,7 +240,7 @@ class ArmArch(PwndbgArchitecture):
     @override
     def read_thumb_bit(self) -> Literal[0, 1]:
         # When program initially starts, cpsr may not be readable
-        if (cpsr := pwndbg.aglib.regs.cpsr) is not None:
+        if (cpsr := pwndbg.aglib.regs.read_reg("cpsr")) is not None:
             return (cpsr >> 5) & 1  # type: ignore[return-value]
 
         return 0

--- a/pwndbg/aglib/kernel/__init__.py
+++ b/pwndbg/aglib/kernel/__init__.py
@@ -338,7 +338,7 @@ class x86Ops(ArchOps):
 
     @staticmethod
     def paging_enabled() -> bool:
-        return int(pwndbg.aglib.regs.cr0) & BIT(31) != 0
+        return int(pwndbg.aglib.regs.read_reg("cr0")) & BIT(31) != 0
 
 
 class i386Ops(x86Ops):
@@ -453,7 +453,7 @@ class Aarch64Ops(ArchOps):
 
     @staticmethod
     def paging_enabled() -> bool:
-        return int(pwndbg.aglib.regs.SCTLR) & BIT(0) != 0
+        return int(pwndbg.aglib.regs.read_reg("SCTLR")) & BIT(0) != 0
 
 
 @pwndbg.lib.cache.cache_until("start")
@@ -635,7 +635,9 @@ def paging_enabled() -> bool:
         # https://starfivetech.com/uploads/u74_core_complex_manual_21G1.pdf
         # page 41, satp.MODE, bits: 60,61,62,63
         # "When satp.MODE=0x0, supervisor virtual addresses are equal to supervisor physical addresses"
-        return int(pwndbg.aglib.regs.satp) & (BIT(60) | BIT(61) | BIT(62) | BIT(63)) != 0
+        return (
+            int(pwndbg.aglib.regs.read_reg("satp")) & (BIT(60) | BIT(61) | BIT(62) | BIT(63)) != 0
+        )
     else:
         raise NotImplementedError()
 

--- a/pwndbg/aglib/kernel/paging.py
+++ b/pwndbg/aglib/kernel/paging.py
@@ -353,9 +353,9 @@ class x86_64PagingInfo(ArchPagingInfo):
 class Aarch64PagingInfo(ArchPagingInfo):
     def __init__(self):
         self.tcr_el1 = pwndbg.lib.regs.aarch64_tcr_flags
-        self.tcr_el1.value = pwndbg.aglib.regs.TCR_EL1
+        self.tcr_el1.value = pwndbg.aglib.regs.read_reg("TCR_EL1")
         id_aa64mmfr2_el1 = pwndbg.lib.regs.aarch64_mmfr_flags
-        id_aa64mmfr2_el1.value = pwndbg.aglib.regs.ID_AA64MMFR2_EL1
+        id_aa64mmfr2_el1.value = pwndbg.aglib.regs.read_reg("ID_AA64MMFR2_EL1")
         feat_lva = id_aa64mmfr2_el1.value is not None and id_aa64mmfr2_el1["VARange"] == 0b0001
         self.va_bits = 64 - self.tcr_el1["T1SZ"]  # this is prob only `vabits_actual`
         self.PAGE_OFFSET = self._PAGE_OFFSET(self.va_bits)  # physmap base address without KASLR
@@ -400,7 +400,7 @@ class Aarch64PagingInfo(ArchPagingInfo):
     @property
     @pwndbg.lib.cache.cache_until("stop")
     def kbase(self):
-        return self.kbase_helper(pwndbg.aglib.regs.vbar)
+        return self.kbase_helper(pwndbg.aglib.regs.read_reg("vbar"))
 
     @property
     @pwndbg.lib.cache.cache_until("stop")
@@ -635,9 +635,9 @@ class Aarch64PagingInfo(ArchPagingInfo):
     def pagewalk(self, target, entry) -> Tuple[PageTableLevel, ...]:
         if entry is None:
             if pwndbg.aglib.memory.is_kernel(target):
-                entry = pwndbg.aglib.regs.TTBR1_EL1
+                entry = pwndbg.aglib.regs.read_reg("TTBR1_EL1")
             else:
-                entry = pwndbg.aglib.regs.TTBR0_EL1
+                entry = pwndbg.aglib.regs.read_reg("TTBR0_EL1")
         self.entry = entry
         return self.pagewalk_helper(target, entry)
 

--- a/pwndbg/aglib/kernel/vmmap.py
+++ b/pwndbg/aglib/kernel/vmmap.py
@@ -172,7 +172,7 @@ class QemuMachine(Machine):
         if register_name.startswith("$"):
             register_name = register_name[1:]
 
-        return int(getattr(pwndbg.aglib.regs, register_name))
+        return int(pwndbg.aglib.regs.read_reg_use_handler_if_exists(register_name))
 
 
 @pwndbg.lib.cache.cache_until("stop")

--- a/pwndbg/aglib/kernel/vmmap.py
+++ b/pwndbg/aglib/kernel/vmmap.py
@@ -172,7 +172,7 @@ class QemuMachine(Machine):
         if register_name.startswith("$"):
             register_name = register_name[1:]
 
-        return int(pwndbg.aglib.regs.read_reg_use_handler_if_exists(register_name))
+        return int(pwndbg.aglib.regs.read_reg(register_name))
 
 
 @pwndbg.lib.cache.cache_until("stop")

--- a/pwndbg/aglib/objc.py
+++ b/pwndbg/aglib/objc.py
@@ -1077,8 +1077,8 @@ def try_resolve_call_at_current_pc(insn: PwndbgInstruction) -> pwndbg.lib.functi
             # TODO: Support resolution of Objective-C method calls in x86-64.
             return None
 
-        obj_ptr = getattr(pwndbg.aglib.regs, obj_reg)
-        sel_ptr = getattr(pwndbg.aglib.regs, sel_reg)
+        obj_ptr = pwndbg.aglib.regs.read_reg(obj_reg)
+        sel_ptr = pwndbg.aglib.regs.read_reg(sel_reg)
 
         obj = Object(obj_ptr)
         sel = Selector(sel_ptr)

--- a/pwndbg/aglib/regs.py
+++ b/pwndbg/aglib/regs.py
@@ -105,6 +105,16 @@ class module(ModuleType):
 
     @pwndbg.lib.cache.cache_until("stop", "prompt")
     def read_reg(self, reg: str, frame: pwndbg.dbg_mod.Frame | None = None) -> int | None:
+        """
+        Query the underlying debugger for the value of a register.
+
+        Note that in some rare cases, debuggers won't directly expose the values of some special model specific registers.
+        Although we can sometimes determine these by other indirect means, this function does not run any extra logic to handle these special cases.
+
+        Specifically, if you need to ensure you are reading the correct value of "gs", "fs", "idt", or "idt_limit", use
+        the `read_reg_use_handler_if_exists` function instead, which will invoke specific handler functions
+        as necessary to determine the values.
+        """
         return self.read_reg_uncached(reg, frame)
 
     def read_reg_uncached(self, reg: str, frame: pwndbg.dbg_mod.Frame | None = None) -> int | None:
@@ -124,15 +134,50 @@ class module(ModuleType):
         except (ValueError, pwndbg.dbg_mod.Error):
             return None
 
-    def __getattr__(self, attr: str) -> int | None:
-        return self.read_reg(attr)
+    @pwndbg.lib.cache.cache_until("stop", "prompt")
+    def read_reg_use_handler_if_exists(
+        self, reg: str, frame: pwndbg.dbg_mod.Frame | None = None
+    ) -> int | None:
+        """
+        Debuggers don't always expose the value of certain registers.
+        For example, in i386, GDB doesn't expose the values of the fs and gs registers.
+        However, in some cases we can determine the values by other means, such as by
+        invoking a syscall that fetches the value.
 
-    def __setattr__(self, attr: str, val: Any) -> None:
-        if attr in ("last", "previous"):
-            super().__setattr__(attr, val)
-        else:
-            if not pwndbg.dbg.selected_frame().reg_write(attr, int(val)):
-                raise RuntimeError(f"Attempted to write to a non-existent register '{attr}'")
+        This function will check if we have a special handler to determine a register value, and invoke it.
+        If the register doesn't require special handling, this falls back to read_reg(reg)
+
+        Currently, there are special handlers for the following registers:
+        - fsbase
+        - gsbase
+        - idt
+        - idt_limit
+        """
+        match reg:
+            case "fsbase":
+                return self.fsbase
+            case "gsbase":
+                return self.gsbase
+            case "idt":
+                return self.idt
+            case "idt_limit":
+                return self.idt_limit
+            case _:
+                return self.read_reg_uncached(reg, frame)
+
+    def write_reg(self, reg: str, value: int) -> None:
+        if not pwndbg.dbg.selected_frame().reg_write(reg, value):
+            raise RuntimeError(f"Attempted to write to a non-existent register '{reg}'")
+
+    @property
+    def pc(self) -> int | None:
+        """Get the value of the program counter register"""
+        return self.read_reg(self.current.pc)
+
+    @property
+    def sp(self) -> int | None:
+        """Get the value of the stack pointer register"""
+        return self.read_reg(self.current.stack)
 
     def __contains__(self, reg: str) -> bool:
         return reg_sets[pwndbg.aglib.arch.name].__contains__(reg)

--- a/pwndbg/aglib/regs.py
+++ b/pwndbg/aglib/regs.py
@@ -134,37 +134,6 @@ class module(ModuleType):
         except (ValueError, pwndbg.dbg_mod.Error):
             return None
 
-    @pwndbg.lib.cache.cache_until("stop", "prompt")
-    def read_reg_use_handler_if_exists(
-        self, reg: str, frame: pwndbg.dbg_mod.Frame | None = None
-    ) -> int | None:
-        """
-        Debuggers don't always expose the value of certain registers.
-        For example, in i386, GDB doesn't expose the values of the fs and gs registers.
-        However, in some cases we can determine the values by other means, such as by
-        invoking a syscall that fetches the value.
-
-        This function will check if we have a special handler to determine a register value, and invoke it.
-        If the register doesn't require special handling, this falls back to read_reg(reg)
-
-        Currently, there are special handlers for the following registers:
-        - fsbase
-        - gsbase
-        - idt
-        - idt_limit
-        """
-        match reg:
-            case "fsbase":
-                return self.fsbase
-            case "gsbase":
-                return self.gsbase
-            case "idt":
-                return self.idt
-            case "idt_limit":
-                return self.idt_limit
-            case _:
-                return self.read_reg_uncached(reg, frame)
-
     def write_reg(self, reg: str, value: int) -> None:
         if not pwndbg.dbg.selected_frame().reg_write(reg, value):
             raise RuntimeError(f"Attempted to write to a non-existent register '{reg}'")

--- a/pwndbg/aglib/regs.py
+++ b/pwndbg/aglib/regs.py
@@ -112,8 +112,7 @@ class module(ModuleType):
         Although we can sometimes determine these by other indirect means, this function does not run any extra logic to handle these special cases.
 
         Specifically, if you need to ensure you are reading the correct value of "gs", "fs", "idt", or "idt_limit", use
-        the `read_reg_use_handler_if_exists` function instead, which will invoke specific handler functions
-        as necessary to determine the values.
+        the specific helpers functions on the regs module as necessary to determine the values.
         """
         return self.read_reg_uncached(reg, frame)
 

--- a/pwndbg/aglib/regs.py
+++ b/pwndbg/aglib/regs.py
@@ -142,10 +142,19 @@ class module(ModuleType):
         """Get the value of the program counter register"""
         return self.read_reg(self.current.pc)
 
+    @pc.setter
+    def pc(self, val: int) -> None:
+        self.write_reg(self.current.pc, val)
+
     @property
     def sp(self) -> int | None:
         """Get the value of the stack pointer register"""
         return self.read_reg(self.current.stack)
+
+    @sp.setter
+    def sp(self, val: int) -> None:
+        """Get the value of the stack pointer register"""
+        self.write_reg(self.current.stack, val)
 
     def __contains__(self, reg: str) -> bool:
         return reg_sets[pwndbg.aglib.arch.name].__contains__(reg)

--- a/pwndbg/aglib/shellcode.py
+++ b/pwndbg/aglib/shellcode.py
@@ -111,15 +111,15 @@ def _ctx_registers() -> Iterator[int]:
 
     try:
         # Jump to the target address in preparation.
-        setattr(pwndbg.aglib.regs, register_set.pc, shell_starting_address)
+        pwndbg.aglib.regs.write_reg(register_set.pc, shell_starting_address)
 
         yield shell_starting_address
     finally:
         # Restore the code and the program counter and, if requested, the rest of
         # the registers.
-        setattr(pwndbg.aglib.regs, register_set.pc, starting_address)
+        pwndbg.aglib.regs.write_reg(register_set.pc, starting_address)
         for reg, val in registers.items():
-            setattr(pwndbg.aglib.regs, reg, val)
+            pwndbg.aglib.regs.write_reg(reg, val)
 
 
 async def _execute_until_addr(ec: ExecutionController, target_address: int) -> None:

--- a/pwndbg/aglib/tls.py
+++ b/pwndbg/aglib/tls.py
@@ -82,14 +82,16 @@ def find_address_with_register() -> int:
         return int(pwndbg.aglib.regs.gsbase)
     elif pwndbg.aglib.arch.name == "aarch64":
         # FIXME: cleanup/remove `TPIDR_EL0` register, it was renamed to `tpidr` since GDB13+
-        return int(pwndbg.aglib.regs.tpidr or pwndbg.aglib.regs.TPIDR_EL0 or 0)
+        return int(
+            pwndbg.aglib.regs.read_reg("tpidr") or pwndbg.aglib.regs.read_reg("TPIDR_EL0") or 0
+        )
     elif pwndbg.aglib.arch.name == "arm":
         # TODO: linux ptrace for 64bit kernel?
         # In FreeBSD tls is under `tpidruro` register.
         # In Linux, the `tpidruro` register isn't available via ptrace in the 32-bit
         # kernel but it is available for an aarch32 program running under an arm64
         # kernel via the ptrace compat interface.
-        return int(pwndbg.aglib.regs.tpidruro or 0)
+        return int(pwndbg.aglib.regs.read_reg("tpidruro") or 0)
     elif pwndbg.aglib.arch.name == "loongarch64":
-        return int(pwndbg.aglib.regs.tp or 0)
+        return int(pwndbg.aglib.regs.read_reg("tp") or 0)
     return 0

--- a/pwndbg/commands/cpsr.py
+++ b/pwndbg/commands/cpsr.py
@@ -30,6 +30,6 @@ def cpsr(cpsr_value=None) -> None:
     if cpsr_value is not None:
         reg_val = cpsr_value
     else:
-        reg_val = getattr(pwndbg.aglib.regs, reg)
+        reg_val = pwndbg.aglib.regs.read_reg(reg)
 
     print(f"{reg} {context.format_flags(reg_val, reg_flags)}")

--- a/pwndbg/commands/flags.py
+++ b/pwndbg/commands/flags.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 
+import pwndbg.aglib.regs
 import pwndbg.commands
 from pwndbg.commands import CommandCategory
 
@@ -62,7 +63,7 @@ def setflag(flag: str, value: int) -> None:
                 cleared_val = old_val & ~mask
                 new_val = cleared_val | bit_value
 
-                setattr(pwndbg.aglib.regs, flag_reg, new_val)
+                pwndbg.aglib.regs.write_reg(flag_reg, new_val)
                 print(
                     f"Set flag {flag}={value} in flag register {flag_reg} (old val={old_val:#x}, new val={new_val:#x})"
                 )

--- a/pwndbg/dbg/gdb/__init__.py
+++ b/pwndbg/dbg/gdb/__init__.py
@@ -792,7 +792,9 @@ class GDBProcess(pwndbg.dbg_mod.Process):
                 # appear to expose this in information through any command/API. Since Cortex-M has the .xpsr flags register
                 # instead of .cpsr, we will check if it's present.
                 # See: https://github.com/pwndbg/pwndbg/issues/2153
-                if match == "arm" and ("-m" in arch or pwndbg.aglib.regs.xpsr is not None):
+                if match == "arm" and (
+                    "-m" in arch or pwndbg.aglib.regs.read_reg("xpsr") is not None
+                ):
                     match = "armcm"
                 elif match.startswith("riscv:"):
                     match = match[6:]

--- a/pwndbg/dbg/lldb/__init__.py
+++ b/pwndbg/dbg/lldb/__init__.py
@@ -171,10 +171,12 @@ class LLDBFrame(pwndbg.dbg_mod.Frame):
         if name not in pwndbg.aglib.regs:
             return False
 
-        # Writing to the PC using the normal register write flow causes the
+        current_reg_set = reg_sets[pwndbg.aglib.arch.name]
+
+        # Writing to the PC (or any subregister of the PC) using the normal register write flow causes the
         # inner object to be automatically invalidated by LLDB, so we have to
         # handle jumps manually using SBFrame::SetPC.
-        if name in (reg_sets[pwndbg.aglib.arch.name].pc, "pc"):
+        if name == "pc" or current_reg_set.full_register_lookup.get(name) == current_reg_set.pc:
             ret = self.inner.SetPC(val)
             self.proc.dbg._trigger_event(pwndbg.dbg_mod.EventType.REGISTER_CHANGED)
             return ret
@@ -229,12 +231,12 @@ class LLDBFrame(pwndbg.dbg_mod.Frame):
                     # event.
                     self.proc.dbg._trigger_event(pwndbg.dbg_mod.EventType.REGISTER_CHANGED)
 
-                    # If we set the stack pointer, the inner object might have been invalidated, try
+                    # If we set the stack pointer (or a subregister of the stack pointer), the inner object might have been invalidated, try
                     # to restore it, as it should still be the selected frame.
                     if (
-                        name in (reg_sets[pwndbg.aglib.arch.name].stack, "sp")
-                        and not self.inner.IsValid()
-                    ):
+                        name == "sp"
+                        or current_reg_set.full_register_lookup.get(name) == current_reg_set.stack
+                    ) and not self.inner.IsValid():
                         self.inner = thread.GetSelectedFrame()
                         assert self.inner.GetSP() == val
 

--- a/pwndbg/dbg/lldb/__init__.py
+++ b/pwndbg/dbg/lldb/__init__.py
@@ -232,7 +232,7 @@ class LLDBFrame(pwndbg.dbg_mod.Frame):
                     # If we set the stack pointer, the inner object might have been invalidated, try
                     # to restore it, as it should still be the selected frame.
                     if (
-                        name in (reg_sets[pwndbg.aglib.arch.name].frame, "sp")
+                        name in (reg_sets[pwndbg.aglib.arch.name].stack, "sp")
                         and not self.inner.IsValid()
                     ):
                         self.inner = thread.GetSelectedFrame()

--- a/pwndbg/dbg/lldb/__init__.py
+++ b/pwndbg/dbg/lldb/__init__.py
@@ -173,10 +173,14 @@ class LLDBFrame(pwndbg.dbg_mod.Frame):
 
         current_reg_set = reg_sets[pwndbg.aglib.arch.name]
 
+        full_reg_name = name
+        if reg_info := current_reg_set.full_register_lookup.get(name):
+            full_reg_name = reg_info.name
+
         # Writing to the PC (or any subregister of the PC) using the normal register write flow causes the
         # inner object to be automatically invalidated by LLDB, so we have to
         # handle jumps manually using SBFrame::SetPC.
-        if name == "pc" or current_reg_set.full_register_lookup.get(name) == current_reg_set.pc:
+        if name == "pc" or full_reg_name == current_reg_set.pc:
             ret = self.inner.SetPC(val)
             self.proc.dbg._trigger_event(pwndbg.dbg_mod.EventType.REGISTER_CHANGED)
             return ret
@@ -234,8 +238,7 @@ class LLDBFrame(pwndbg.dbg_mod.Frame):
                     # If we set the stack pointer (or a subregister of the stack pointer), the inner object might have been invalidated, try
                     # to restore it, as it should still be the selected frame.
                     if (
-                        name == "sp"
-                        or current_reg_set.full_register_lookup.get(name) == current_reg_set.stack
+                        name == "sp" or full_reg_name == current_reg_set.stack
                     ) and not self.inner.IsValid():
                         self.inner = thread.GetSelectedFrame()
                         assert self.inner.GetSP() == val

--- a/pwndbg/emu/emulator.py
+++ b/pwndbg/emu/emulator.py
@@ -303,7 +303,7 @@ class Emulator:
             if reg in blacklisted_regs:
                 debug(DEBUG_INIT, "Skipping blacklisted register %r", reg)
                 continue
-            value = getattr(pwndbg.aglib.regs, reg)
+            value = pwndbg.aglib.regs.read_reg_use_handler_if_exists(reg)
             if None in (enum, value):
                 if reg not in blacklisted_regs:
                     debug(DEBUG_INIT, "# Could not set register %r", reg)
@@ -629,12 +629,16 @@ class Emulator:
         if arch == "armcm":
             mode |= (
                 (U.UC_MODE_MCLASS | U.UC_MODE_THUMB)
-                if (pwndbg.aglib.regs.xpsr & (1 << 24))
+                if (pwndbg.aglib.regs.read_reg("xpsr") & (1 << 24))
                 else U.UC_MODE_MCLASS
             )
 
         elif arch in ("arm", "aarch64"):
-            mode |= U.UC_MODE_THUMB if (pwndbg.aglib.regs.cpsr & (1 << 5)) else U.UC_MODE_ARM
+            mode |= (
+                U.UC_MODE_THUMB
+                if (pwndbg.aglib.regs.read_reg("cpsr") & (1 << 5))
+                else U.UC_MODE_ARM
+            )
 
         elif (
             arch == "mips"

--- a/pwndbg/emu/emulator.py
+++ b/pwndbg/emu/emulator.py
@@ -303,7 +303,7 @@ class Emulator:
             if reg in blacklisted_regs:
                 debug(DEBUG_INIT, "Skipping blacklisted register %r", reg)
                 continue
-            value = pwndbg.aglib.regs.read_reg_use_handler_if_exists(reg)
+            value = pwndbg.aglib.regs.read_reg(reg)
             if None in (enum, value):
                 if reg not in blacklisted_regs:
                     debug(DEBUG_INIT, "# Could not set register %r", reg)

--- a/pwndbg/gdblib/shellcode.py
+++ b/pwndbg/gdblib/shellcode.py
@@ -147,9 +147,9 @@ def exec_shellcode(blob, restore_context=True, capture=None, disable_breakpoints
     # Restore the code and the program counter and, if requested, the rest of
     # the registers.
     pwndbg.aglib.memory.write(starting_address, existing_code)
-    setattr(pwndbg.aglib.regs, register_set.pc, starting_address)
+    pwndbg.aglib.regs.write_reg(register_set.pc, starting_address)
     if restore_context:
         for reg, val in registers.items():
-            setattr(pwndbg.aglib.regs, reg, val)
+            pwndbg.aglib.regs.write_reg(reg, val)
 
     return captured

--- a/pwndbg/integration/binja.py
+++ b/pwndbg/integration/binja.py
@@ -599,7 +599,7 @@ class BinjaProvider(pwndbg.integration.IntegrationProvider):
     def get_stack_var_name(self, addr: int) -> str | None:
         cur = pwndbg.dbg.selected_frame()
         # there is no earlier frame so we give up
-        if addr < pwndbg.aglib.regs.read_reg("sp", frame=cur):
+        if addr < pwndbg.aglib.regs.read_reg(pwndbg.aglib.regs.stack, frame=cur):
             return None
         newest = True
         # try to find the oldest frame that's earlier than the address
@@ -608,7 +608,7 @@ class BinjaProvider(pwndbg.integration.IntegrationProvider):
             if upper is None:
                 break
 
-            upper_sp = pwndbg.aglib.regs.read_reg("sp", frame=upper)
+            upper_sp = pwndbg.aglib.regs.read_reg(pwndbg.aglib.regs.stack, frame=upper)
             if upper_sp > addr:
                 break
 

--- a/pwndbg/lib/regs.py
+++ b/pwndbg/lib/regs.py
@@ -154,47 +154,52 @@ class Reg:
 
 
 class RegisterSet:
-    #: Program counter register
     pc: str
+    """Program counter register"""
 
-    #: Stack pointer register
     stack: str
+    """Stack pointer register"""
 
-    #: Frame pointer register
     frame: str | None = None
+    """Frame pointer register"""
 
-    #: Return address register
     retaddr: Tuple[str, ...]
+    """Return address register"""
 
-    #: Flags register (eflags, cpsr)
     flags: Dict[str, BitFlags]
+    """Maps name of flag register (eflags, cpsr) to a structure detailing what the bits mean"""
 
-    #: List of native-size general-purpose registers
     gpr: Tuple[str, ...]
+    """List of native-size general-purpose registers"""
 
-    #: List of miscellaneous, valid registers
     misc: Tuple[str, ...]
+    """List of miscellaneous, valid registers"""
 
-    #: Register-based arguments for most common ABI
     args: Tuple[str, ...]
+    """Register-based arguments for most common ABI"""
 
-    #: Return value register
     retval: str | None
+    """Return value register"""
 
-    #: Common registers which should be displayed in the register context
     common: List[str] = []
+    """Common registers which should be displayed in the register context"""
 
-    #: Extra registers for kernel debugging
     kernel: KernelRegisterSet | None
+    """Extra registers for kernel debugging"""
 
-    #: All valid registers
     all: Set[str]
+    """All valid registers"""
 
-    #: Reg objects containing information on each register
     reg_definitions: Dict[str, Reg]
+    """Map of register name to Reg objects containing information on the register"""
 
-    #: Map of register name to the full register it resides in. Example mapping: "eax" -> Reg("rax")
     full_register_lookup: Dict[str, Reg]
+    """
+    Map of register name to the full register it resides in.
+    Example mapping: "eax" -> Reg("rax")
+
+    A full size register maps to itself.
+    """
 
     def __init__(
         self,

--- a/pwndbg/lib/regs.py
+++ b/pwndbg/lib/regs.py
@@ -262,6 +262,9 @@ class RegisterSet:
         # Otherwise, the values will be clobbered
         # https://github.com/pwndbg/pwndbg/pull/2337
         self.emulated_regs_order: List[UnicornRegisterWrite] = []
+        
+        # Avoid duplicates
+        seen_emulated_register: set[str] = set()
 
         for regname in itertools.chain(
             (self.pc,),
@@ -271,9 +274,10 @@ class RegisterSet:
             self.misc,
             self.gpr,
         ):
-            if regname and regname not in self.emulated_regs_order:
+            if regname and regname not in seen_emulated_register:
                 emu_reg = UnicornRegisterWrite(regname, True if regname in flags else False)
                 self.emulated_regs_order.append(emu_reg)
+                seen_emulated_register.add(regname)
 
         self.all = (
             set(self.misc)
@@ -451,7 +455,7 @@ class PseudoEmulatedRegisterFile:
 
         self.masks[full_reg_def.name] = ~new_mask & self.masks[full_reg_def.name]
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return str(
             {
                 "masks": {x: hex(y) for x, y in self.masks.items()},

--- a/tests/library/dbg/tests/test_command_canary.py
+++ b/tests/library/dbg/tests/test_command_canary.py
@@ -32,9 +32,9 @@ async def test_command_canary(ctrl: Controller, binary: str, reg_name: str, skip
 
     # The instruction that loads the canary is at the start of the function,
     # but it it not necessarily at any given fixed position, scan for it.
-    initial_reg = getattr(pwndbg.aglib.regs, reg_name)
+    initial_reg = pwndbg.aglib.regs.read_reg(reg_name)
     while True:
-        register = getattr(pwndbg.aglib.regs, reg_name)
+        register = pwndbg.aglib.regs.read_reg(reg_name)
         if register != initial_reg:
             if skips == 0:
                 break

--- a/tests/library/dbg/tests/test_command_cyclic.py
+++ b/tests/library/dbg/tests/test_command_cyclic.py
@@ -46,10 +46,10 @@ async def test_command_cyclic_register(ctrl: Controller) -> None:
 
     test_offset = 45
     pattern = cyclic(length=80, n=ptr_size)
-    test_data = int.from_bytes(
-        pattern[test_offset : test_offset + ptr_size], pwndbg.aglib.arch.endian
+    pwndbg.aglib.regs.write_reg(
+        reg_name,
+        int.from_bytes(pattern[test_offset : test_offset + ptr_size], pwndbg.aglib.arch.endian),
     )
-    setattr(pwndbg.aglib.regs, reg_name, test_data)
     out = await ctrl.execute_and_capture(f"cyclic -l ${reg_name}")
 
     assert out == (

--- a/tests/library/dbg/tests/test_command_flags.py
+++ b/tests/library/dbg/tests/test_command_flags.py
@@ -15,7 +15,7 @@ async def test_flags_command(ctrl: Controller) -> None:
 
     await ctrl.launch(REFERENCE_BINARY)
 
-    old_eflags = pwndbg.aglib.regs.eflags
+    old_eflags = pwndbg.aglib.regs.read_reg("eflags")
     if old_eflags is None:
         pytest.skip("eflags register is missing")
 
@@ -25,15 +25,15 @@ async def test_flags_command(ctrl: Controller) -> None:
     await ctrl.execute("setflag cf 1")
 
     # Verify CF is set and no other flags have changed
-    assert (old_eflags | 1) == pwndbg.aglib.regs.eflags
+    assert (old_eflags | 1) == pwndbg.aglib.regs.read_reg("eflags")
 
     await ctrl.execute("setflag cf 0")
 
     # Verify CF is not set and no other flags have changed
-    assert old_eflags == pwndbg.aglib.regs.eflags
+    assert old_eflags == pwndbg.aglib.regs.read_reg("eflags")
 
     # Test setting an invalid value
     await ctrl.execute("setflag cf 2")
 
     # Verify no flags have changed
-    assert old_eflags == pwndbg.aglib.regs.eflags
+    assert old_eflags == pwndbg.aglib.regs.read_reg("eflags")

--- a/tests/library/dbg/tests/test_command_telescope.py
+++ b/tests/library/dbg/tests/test_command_telescope.py
@@ -146,7 +146,7 @@ async def test_command_telescope_frame_bp_below_sp(ctrl: Controller) -> None:
     await launch_to(ctrl, TELESCOPE_BINARY, "break_here")
     await ctrl.execute("memoize")  # turn off cache
 
-    pwndbg.aglib.regs.sp = pwndbg.aglib.regs.read_reg(pwndbg.aglib.regs.frame) + 1
+    pwndbg.aglib.regs.write_reg("sp", pwndbg.aglib.regs.read_reg(pwndbg.aglib.regs.frame) + 1)
 
     result_str = await ctrl.execute_and_capture("telescope --frame")
 
@@ -168,7 +168,7 @@ async def test_command_telescope_frame_bp_sp_different_vmmaps(ctrl: Controller) 
     frame_reg_name = pwndbg.aglib.regs.frame
 
     pwndbg.aglib.regs.sp = pages[0].start
-    setattr(pwndbg.aglib.regs, frame_reg_name, pages[1].start)
+    pwndbg.aglib.regs.write_reg(frame_reg_name, pages[1].start)
 
     result_str = await ctrl.execute_and_capture("telescope --frame")
 

--- a/tests/library/dbg/tests/test_command_telescope.py
+++ b/tests/library/dbg/tests/test_command_telescope.py
@@ -166,8 +166,9 @@ async def test_command_telescope_frame_bp_sp_different_vmmaps(ctrl: Controller) 
 
     pages = pwndbg.aglib.vmmap.get()
     frame_reg_name = pwndbg.aglib.regs.frame
+    stack_reg_name = pwndbg.aglib.regs.stack
 
-    pwndbg.aglib.regs.sp = pages[0].start
+    pwndbg.aglib.regs.write_reg(stack_reg_name, pages[0].start)
     pwndbg.aglib.regs.write_reg(frame_reg_name, pages[1].start)
 
     result_str = await ctrl.execute_and_capture("telescope --frame")

--- a/tests/library/dbg/tests/test_command_telescope.py
+++ b/tests/library/dbg/tests/test_command_telescope.py
@@ -146,7 +146,7 @@ async def test_command_telescope_frame_bp_below_sp(ctrl: Controller) -> None:
     await launch_to(ctrl, TELESCOPE_BINARY, "break_here")
     await ctrl.execute("memoize")  # turn off cache
 
-    pwndbg.aglib.regs.write_reg("sp", pwndbg.aglib.regs.read_reg(pwndbg.aglib.regs.frame) + 1)
+    pwndbg.aglib.regs.sp = pwndbg.aglib.regs.read_reg(pwndbg.aglib.regs.frame) + 1
 
     result_str = await ctrl.execute_and_capture("telescope --frame")
 

--- a/tests/library/dbg/tests/test_commands_next.py
+++ b/tests/library/dbg/tests/test_commands_next.py
@@ -66,7 +66,7 @@ async def test_next_command_doesnt_freeze_crashed_binary(ctrl: Controller, comma
     # The nextproginstr won't step if we are already on the binary address
     # and interestingly, other commands won't step if the address can't be disassemblied
     if command == "nextproginstr":
-        pwndbg.aglib.regs.pc = 0x1234
+        pwndbg.aglib.regs.write_reg("pc", 0x1234)
 
     # This should not halt/freeze the program
     await ctrl.execute(command)

--- a/tests/library/dbg/tests/test_commands_next.py
+++ b/tests/library/dbg/tests/test_commands_next.py
@@ -66,7 +66,7 @@ async def test_next_command_doesnt_freeze_crashed_binary(ctrl: Controller, comma
     # The nextproginstr won't step if we are already on the binary address
     # and interestingly, other commands won't step if the address can't be disassemblied
     if command == "nextproginstr":
-        pwndbg.aglib.regs.write_reg("pc", 0x1234)
+        pwndbg.aglib.regs.pc = 0x1234
 
     # This should not halt/freeze the program
     await ctrl.execute(command)

--- a/tests/library/dbg/tests/test_context_commands.py
+++ b/tests/library/dbg/tests/test_context_commands.py
@@ -351,7 +351,7 @@ async def test_context_disasm_proper_render_on_mem_change_issue_1818(
         await ctrl.execute("patch $rip+5 nop;nop;nop;nop;nop")
     else:
         # Do the same, but through write API
-        pwndbg.aglib.memory.write(pwndbg.aglib.regs.rip + 5, b"\x90" * 5)
+        pwndbg.aglib.memory.write(pwndbg.aglib.regs.read_reg("rip") + 5, b"\x90" * 5)
 
     # Actual test: we expect the read memory to be different now ;)
     # (and not e.g. returned incorrectly from a not cleared cache)

--- a/tests/library/dbg/tests/test_context_commands.py
+++ b/tests/library/dbg/tests/test_context_commands.py
@@ -351,7 +351,7 @@ async def test_context_disasm_proper_render_on_mem_change_issue_1818(
         await ctrl.execute("patch $rip+5 nop;nop;nop;nop;nop")
     else:
         # Do the same, but through write API
-        pwndbg.aglib.memory.write(pwndbg.aglib.regs.read_reg("rip") + 5, b"\x90" * 5)
+        pwndbg.aglib.memory.write(pwndbg.aglib.regs.pc + 5, b"\x90" * 5)
 
     # Actual test: we expect the read memory to be different now ;)
     # (and not e.g. returned incorrectly from a not cleared cache)

--- a/tests/library/dbg/tests/test_emulate.py
+++ b/tests/library/dbg/tests/test_emulate.py
@@ -57,7 +57,7 @@ async def test_emulate_disasm_loop(ctrl: Controller) -> None:
 
     disasm_with_emu_0x400080 = [
         " ► 0x400080 <_start>       movabs rsi, string                           RSI => 0x400094 (string) ◂— xor dword ptr [rdx], esi /* '12345' */",
-        f"   0x40008a <_start+10>    mov    rdi, rsp                              RDI => {hex(pwndbg.aglib.regs.rsp)} ◂— 1",
+        f"   0x40008a <_start+10>    mov    rdi, rsp                              RDI => {hex(pwndbg.aglib.regs.read_reg("rsp"))} ◂— 1",
         "   0x40008d <_start+13>    mov    ecx, 3                                ECX => 3",
         "   0x400092 <_start+18>    rep movsb byte ptr [rdi], byte ptr [rsi]",
         "    ↓",
@@ -74,7 +74,7 @@ async def test_emulate_disasm_loop(ctrl: Controller) -> None:
 
     disasm_without_emu_0x400080 = [
         " ► 0x400080 <_start>       movabs rsi, string                           RSI => 0x400094 (string) ◂— xor dword ptr [rdx], esi /* '12345' */",
-        f"   0x40008a <_start+10>    mov    rdi, rsp                              RDI => {hex(pwndbg.aglib.regs.rsp)}",
+        f"   0x40008a <_start+10>    mov    rdi, rsp                              RDI => {hex(pwndbg.aglib.regs.read_reg("rsp"))}",
         "   0x40008d <_start+13>    mov    ecx, 3                                ECX => 3",
         "   0x400092 <_start+18>    rep movsb byte ptr [rdi], byte ptr [rsi]",
         "   0x400094 <string>       xor    dword ptr [rdx], esi",

--- a/tests/library/dbg/tests/test_emulate.py
+++ b/tests/library/dbg/tests/test_emulate.py
@@ -57,7 +57,7 @@ async def test_emulate_disasm_loop(ctrl: Controller) -> None:
 
     disasm_with_emu_0x400080 = [
         " ► 0x400080 <_start>       movabs rsi, string                           RSI => 0x400094 (string) ◂— xor dword ptr [rdx], esi /* '12345' */",
-        f"   0x40008a <_start+10>    mov    rdi, rsp                              RDI => {hex(pwndbg.aglib.regs.read_reg("rsp"))} ◂— 1",
+        f"   0x40008a <_start+10>    mov    rdi, rsp                              RDI => {hex(pwndbg.aglib.regs.sp)} ◂— 1",
         "   0x40008d <_start+13>    mov    ecx, 3                                ECX => 3",
         "   0x400092 <_start+18>    rep movsb byte ptr [rdi], byte ptr [rsi]",
         "    ↓",
@@ -74,7 +74,7 @@ async def test_emulate_disasm_loop(ctrl: Controller) -> None:
 
     disasm_without_emu_0x400080 = [
         " ► 0x400080 <_start>       movabs rsi, string                           RSI => 0x400094 (string) ◂— xor dword ptr [rdx], esi /* '12345' */",
-        f"   0x40008a <_start+10>    mov    rdi, rsp                              RDI => {hex(pwndbg.aglib.regs.read_reg("rsp"))}",
+        f"   0x40008a <_start+10>    mov    rdi, rsp                              RDI => {hex(pwndbg.aglib.regs.sp)}",
         "   0x40008d <_start+13>    mov    ecx, 3                                ECX => 3",
         "   0x400092 <_start+18>    rep movsb byte ptr [rdi], byte ptr [rsi]",
         "   0x400094 <string>       xor    dword ptr [rdx], esi",

--- a/tests/library/dbg/tests/test_windbg.py
+++ b/tests/library/dbg/tests/test_windbg.py
@@ -79,7 +79,7 @@ async def test_windbg_dX_commands(ctrl: Controller) -> None:
 
     # Try 'dq' with count equal to a register, but lets set it before ;)
     # also note that we use `data2` here
-    pwndbg.aglib.regs.eax = 4
+    pwndbg.aglib.regs.write_reg("eax", 4)
     assert (await ctrl.execute_and_capture("dq data2 $eax")) == (
         "0000000000401028     1122334455667788 0123456789abcdef\n"
         "0000000000401038     0000000000000000 ffffffffffffffff\n"
@@ -335,58 +335,67 @@ async def test_windbg_commands_x86(ctrl: Controller) -> None:
 
     await ctrl.launch(X86_BINARY)
 
+    esp = pwndbg.aglib.regs.read_reg("esp")
+
     # Prepare memory
-    pwndbg.aglib.memory.write(pwndbg.aglib.regs.esp, b"1234567890abcdef_")
-    pwndbg.aglib.memory.write(pwndbg.aglib.regs.esp + 16, b"\x00" * 16)
-    pwndbg.aglib.memory.write(pwndbg.aglib.regs.esp + 32, bytes(range(16)))
-    pwndbg.aglib.memory.write(pwndbg.aglib.regs.esp + 48, b"Z" * 16)
+    pwndbg.aglib.memory.write(esp, b"1234567890abcdef_")
+    pwndbg.aglib.memory.write(esp + 16, b"\x00" * 16)
+    pwndbg.aglib.memory.write(esp + 32, bytes(range(16)))
+    pwndbg.aglib.memory.write(esp + 48, b"Z" * 16)
 
     #################################################
     #### dX command tests
     #################################################
     db = (await ctrl.execute_and_capture("db $esp")).splitlines()
+    esp = pwndbg.aglib.regs.read_reg("esp")
     assert db == [
-        "%x     31 32 33 34 35 36 37 38 39 30 61 62 63 64 65 66" % pwndbg.aglib.regs.esp,
-        "%x     00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00" % (pwndbg.aglib.regs.esp + 16),
-        "%x     00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f" % (pwndbg.aglib.regs.esp + 32),
-        "%x     5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a" % (pwndbg.aglib.regs.esp + 48),
+        "%x     31 32 33 34 35 36 37 38 39 30 61 62 63 64 65 66" % esp,
+        "%x     00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00" % (esp + 16),
+        "%x     00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f" % (esp + 32),
+        "%x     5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a" % (esp + 48),
     ]
 
     dw = (await ctrl.execute_and_capture("dw $esp")).splitlines()
+    esp = pwndbg.aglib.regs.read_reg("esp")
     assert dw == [
-        "%x     3231 3433 3635 3837 3039 6261 6463 6665" % pwndbg.aglib.regs.esp,
-        "%x     0000 0000 0000 0000 0000 0000 0000 0000" % (pwndbg.aglib.regs.esp + 16),
-        "%x     0100 0302 0504 0706 0908 0b0a 0d0c 0f0e" % (pwndbg.aglib.regs.esp + 32),
-        "%x     5a5a 5a5a 5a5a 5a5a 5a5a 5a5a 5a5a 5a5a" % (pwndbg.aglib.regs.esp + 48),
+        "%x     3231 3433 3635 3837 3039 6261 6463 6665" % esp,
+        "%x     0000 0000 0000 0000 0000 0000 0000 0000" % (esp + 16),
+        "%x     0100 0302 0504 0706 0908 0b0a 0d0c 0f0e" % (esp + 32),
+        "%x     5a5a 5a5a 5a5a 5a5a 5a5a 5a5a 5a5a 5a5a" % (esp + 48),
     ]
 
     dd = (await ctrl.execute_and_capture("dd $esp")).splitlines()
+    esp = pwndbg.aglib.regs.read_reg("esp")
     assert dd == [
-        "%x     34333231 38373635 62613039 66656463" % pwndbg.aglib.regs.esp,
-        "%x     00000000 00000000 00000000 00000000" % (pwndbg.aglib.regs.esp + 16),
-        "%x     03020100 07060504 0b0a0908 0f0e0d0c" % (pwndbg.aglib.regs.esp + 32),
-        "%x     5a5a5a5a 5a5a5a5a 5a5a5a5a 5a5a5a5a" % (pwndbg.aglib.regs.esp + 48),
+        "%x     34333231 38373635 62613039 66656463" % esp,
+        "%x     00000000 00000000 00000000 00000000" % (esp + 16),
+        "%x     03020100 07060504 0b0a0908 0f0e0d0c" % (esp + 32),
+        "%x     5a5a5a5a 5a5a5a5a 5a5a5a5a 5a5a5a5a" % (esp + 48),
     ]
 
     dq = (await ctrl.execute_and_capture("dq $esp")).splitlines()
+    esp = pwndbg.aglib.regs.read_reg("esp")
     assert dq == [
-        "%x     3837363534333231 6665646362613039" % pwndbg.aglib.regs.esp,
-        "%x     0000000000000000 0000000000000000" % (pwndbg.aglib.regs.esp + 16),
-        "%x     0706050403020100 0f0e0d0c0b0a0908" % (pwndbg.aglib.regs.esp + 32),
-        "%x     5a5a5a5a5a5a5a5a 5a5a5a5a5a5a5a5a" % (pwndbg.aglib.regs.esp + 48),
+        "%x     3837363534333231 6665646362613039" % esp,
+        "%x     0000000000000000 0000000000000000" % (esp + 16),
+        "%x     0706050403020100 0f0e0d0c0b0a0908" % (esp + 32),
+        "%x     5a5a5a5a5a5a5a5a 5a5a5a5a5a5a5a5a" % (esp + 48),
     ]
 
     #################################################
     #### eX command tests
     #################################################
     await ctrl.execute("eb $esp 00")
-    assert pwndbg.aglib.memory.read(pwndbg.aglib.regs.esp, 1) == b"\x00"
+    assert pwndbg.aglib.memory.read(pwndbg.aglib.regs.read_reg("esp"), 1) == b"\x00"
 
     await ctrl.execute("ew $esp 4141")
-    assert pwndbg.aglib.memory.read(pwndbg.aglib.regs.esp, 2) == b"\x41\x41"
+    assert pwndbg.aglib.memory.read(pwndbg.aglib.regs.read_reg("esp"), 2) == b"\x41\x41"
 
     await ctrl.execute("ed $esp 5252525252")
-    assert pwndbg.aglib.memory.read(pwndbg.aglib.regs.esp, 4) == b"\x52" * 4
+    assert pwndbg.aglib.memory.read(pwndbg.aglib.regs.read_reg("esp"), 4) == b"\x52" * 4
 
     await ctrl.execute("eq $esp 1122334455667788")
-    assert pwndbg.aglib.memory.read(pwndbg.aglib.regs.esp, 8) == b"\x88\x77\x66\x55\x44\x33\x22\x11"
+    assert (
+        pwndbg.aglib.memory.read(pwndbg.aglib.regs.read_reg("esp"), 8)
+        == b"\x88\x77\x66\x55\x44\x33\x22\x11"
+    )

--- a/tests/library/gdb/tests/test_command_canary.py
+++ b/tests/library/gdb/tests/test_command_canary.py
@@ -31,7 +31,7 @@ def test_command_canary(start_binary, binary, reg_name):
     gdb.execute("run")
     gdb.execute("stepi")
 
-    register = getattr(pwndbg.aglib.regs, reg_name)
+    register = pwndbg.aglib.regs.read_reg(reg_name)
     canary_value, at_random = pwndbg.commands.canary.canary_value()
 
     raw = pwndbg.aglib.memory.read_pointer_width(at_random)

--- a/tests/library/gdb/tests/test_command_cyclic.py
+++ b/tests/library/gdb/tests/test_command_cyclic.py
@@ -39,8 +39,9 @@ def test_command_cyclic_register(start_binary):
     ptr_size = pwndbg.aglib.arch.ptrsize
     test_offset = 45
     pattern = cyclic(length=80, n=ptr_size)
-    pwndbg.aglib.regs.rdi = int.from_bytes(
-        pattern[test_offset : test_offset + ptr_size], pwndbg.aglib.arch.endian
+    pwndbg.aglib.regs.write_reg(
+        "rdi",
+        int.from_bytes(pattern[test_offset : test_offset + ptr_size], pwndbg.aglib.arch.endian),
     )
     out = gdb.execute("cyclic -l $rdi", to_string=True)
 
@@ -56,7 +57,7 @@ def test_command_cyclic_address(start_binary):
     """
     start_binary(REFERENCE_BINARY)
 
-    addr = pwndbg.aglib.regs.rsp
+    addr = pwndbg.aglib.regs.read_reg("rsp")
     ptr_size = pwndbg.aglib.arch.ptrsize
     test_offset = 48
     pattern = cyclic(length=80, n=ptr_size)
@@ -99,20 +100,20 @@ def test_command_cyclic_detect(start_binary):
     offset_rax = 20
     pattern_default = cyclic(length=100, n=ptr_size)
     value_rax = int.from_bytes(pattern_default[offset_rax : offset_rax + ptr_size], endian)
-    pwndbg.aglib.regs.rax = value_rax
+    pwndbg.aglib.regs.write_reg("rax", value_rax)
 
     offset_rbx_ptr = 40
-    stack_addr = pwndbg.aglib.regs.rsp
+    stack_addr = pwndbg.aglib.regs.read_reg("rsp")
     pwndbg.aglib.memory.write(
         stack_addr, pattern_default[offset_rbx_ptr : offset_rbx_ptr + ptr_size]
     )
-    pwndbg.aglib.regs.rbx = stack_addr
+    pwndbg.aglib.regs.write_reg("rbx", stack_addr)
 
     offset_rcx = 15
     alphabet_custom = b"0123456789ABCDEF"
     pattern_custom = cyclic(length=100, n=ptr_size, alphabet=alphabet_custom)
     value_rcx = int.from_bytes(pattern_custom[offset_rcx : offset_rcx + ptr_size], endian)
-    pwndbg.aglib.regs.rcx = value_rcx
+    pwndbg.aglib.regs.write_reg("rcx", value_rcx)
 
     out_default = gdb.execute("cyclic --detect", to_string=True)
 

--- a/tests/library/gdb/tests/test_command_cyclic.py
+++ b/tests/library/gdb/tests/test_command_cyclic.py
@@ -57,7 +57,7 @@ def test_command_cyclic_address(start_binary):
     """
     start_binary(REFERENCE_BINARY)
 
-    addr = pwndbg.aglib.regs.read_reg("rsp")
+    addr = pwndbg.aglib.regs.sp
     ptr_size = pwndbg.aglib.arch.ptrsize
     test_offset = 48
     pattern = cyclic(length=80, n=ptr_size)
@@ -103,7 +103,7 @@ def test_command_cyclic_detect(start_binary):
     pwndbg.aglib.regs.write_reg("rax", value_rax)
 
     offset_rbx_ptr = 40
-    stack_addr = pwndbg.aglib.regs.read_reg("rsp")
+    stack_addr = pwndbg.aglib.regs.sp
     pwndbg.aglib.memory.write(
         stack_addr, pattern_default[offset_rbx_ptr : offset_rbx_ptr + ptr_size]
     )

--- a/tests/library/gdb/tests/test_command_distance.py
+++ b/tests/library/gdb/tests/test_command_distance.py
@@ -13,12 +13,12 @@ def test_command_distance(start_binary):
     start_binary(REFERENCE_BINARY)
 
     # Test against regs
-    rsp = pwndbg.aglib.regs.rsp
+    rsp = pwndbg.aglib.regs.read_reg("rsp")
     result = gdb.execute("distance $rsp $rsp+0x10", to_string=True)
     assert result == f"{rsp:#x}->{rsp + 0x10:#x} is 0x10 bytes (0x2 words)\n"
 
     # Test if it works with symbols
-    rip = pwndbg.aglib.regs.rip
+    rip = pwndbg.aglib.regs.read_reg("rip")
 
     main = pwndbg.aglib.symbol.lookup_symbol_addr("main")
     break_here = pwndbg.aglib.symbol.lookup_symbol_addr("break_here")

--- a/tests/library/gdb/tests/test_command_distance.py
+++ b/tests/library/gdb/tests/test_command_distance.py
@@ -13,12 +13,12 @@ def test_command_distance(start_binary):
     start_binary(REFERENCE_BINARY)
 
     # Test against regs
-    rsp = pwndbg.aglib.regs.read_reg("rsp")
+    rsp = pwndbg.aglib.regs.sp
     result = gdb.execute("distance $rsp $rsp+0x10", to_string=True)
     assert result == f"{rsp:#x}->{rsp + 0x10:#x} is 0x10 bytes (0x2 words)\n"
 
     # Test if it works with symbols
-    rip = pwndbg.aglib.regs.read_reg("rip")
+    rip = pwndbg.aglib.regs.pc
 
     main = pwndbg.aglib.symbol.lookup_symbol_addr("main")
     break_here = pwndbg.aglib.symbol.lookup_symbol_addr("break_here")

--- a/tests/library/gdb/tests/test_command_flags.py
+++ b/tests/library/gdb/tests/test_command_flags.py
@@ -12,7 +12,7 @@ REFERENCE_BINARY = get_binary("reference-binary.native.out")
 def test_flags_command(start_binary):
     start_binary(REFERENCE_BINARY)
 
-    old_eflags = pwndbg.aglib.regs.eflags
+    old_eflags = pwndbg.aglib.regs.read_reg("eflags")
 
     # Verify CF is not set
     assert old_eflags & 0x1 == 0
@@ -20,15 +20,15 @@ def test_flags_command(start_binary):
     gdb.execute("setflag cf 1")
 
     # Verify CF is set and no other flags have changed
-    assert (old_eflags | 1) == pwndbg.aglib.regs.eflags
+    assert (old_eflags | 1) == pwndbg.aglib.regs.read_reg("eflags")
 
     gdb.execute("setflag cf 0")
 
     # Verify CF is not set and no other flags have changed
-    assert old_eflags == pwndbg.aglib.regs.eflags
+    assert old_eflags == pwndbg.aglib.regs.read_reg("eflags")
 
     # Test setting an invalid value
     gdb.execute("setflag cf 2")
 
     # Verify no flags have changed
-    assert old_eflags == pwndbg.aglib.regs.eflags
+    assert old_eflags == pwndbg.aglib.regs.read_reg("eflags")

--- a/tests/library/gdb/tests/test_command_telescope.py
+++ b/tests/library/gdb/tests/test_command_telescope.py
@@ -72,7 +72,7 @@ def test_telescope_command_with_address_as_count(start_binary):
     start_binary(TELESCOPE_BINARY)
 
     out = gdb.execute("telescope 2", to_string=True).splitlines()
-    rsp = pwndbg.aglib.regs.rsp
+    rsp = pwndbg.aglib.regs.read_reg("rsp")
 
     assert len(out) == 2
     assert out[0] == "00:0000│ rsp %#x ◂— 1" % rsp
@@ -85,7 +85,7 @@ def test_telescope_command_with_address_as_count_and_reversed_flag(start_binary)
     start_binary(TELESCOPE_BINARY)
 
     out = gdb.execute("telescope -r 2", to_string=True).splitlines()
-    rsp = pwndbg.aglib.regs.rsp
+    rsp = pwndbg.aglib.regs.read_reg("rsp")
 
     assert out == ["00:0000│     %#x ◂— 0" % (rsp - 8), "01:0008│ rsp %#x ◂— 1" % rsp]
 
@@ -99,9 +99,10 @@ def test_command_telescope_reverse_skipped_records_shows_input_address(start_bin
     gdb.execute("break break_here")
     gdb.execute("run")
     gdb.execute("up")
-    pwndbg.aglib.memory.write(pwndbg.aglib.regs.rsp - 8 * 3, b"\x00" * 8 * 4)
+    rsp = pwndbg.aglib.regs.read_reg("rsp")
+    pwndbg.aglib.memory.write(rsp - 8 * 3, b"\x00" * 8 * 4)
 
-    expected_value = hex(pwndbg.aglib.regs.rsp)
+    expected_value = hex(rsp)
     result_str = gdb.execute("telescope -r $rsp", to_string=True)
     result_lines = result_str.strip("\n").split("\n")
 
@@ -137,7 +138,7 @@ def test_command_telescope_frame_bp_below_sp(start_binary):
     gdb.execute("run")
     gdb.execute("memoize")  # turn off cache
 
-    pwndbg.aglib.regs.sp = pwndbg.aglib.regs.read_reg(pwndbg.aglib.regs.frame) + 1
+    pwndbg.aglib.regs.write_reg("sp", pwndbg.aglib.regs.read_reg(pwndbg.aglib.regs.frame) + 1)
 
     result_str = gdb.execute("telescope --frame", to_string=True)
 
@@ -156,8 +157,8 @@ def test_command_telescope_frame_bp_sp_different_vmmaps(start_binary):
 
     pages = pwndbg.aglib.vmmap.get()
 
-    pwndbg.aglib.regs.sp = pages[0].start
-    pwndbg.aglib.regs.bp = pages[1].start
+    pwndbg.aglib.regs.write_reg("sp", pages[0].start)
+    pwndbg.aglib.regs.write_reg("bp", pages[1].start)
 
     result_str = gdb.execute("telescope --frame", to_string=True)
 

--- a/tests/library/gdb/tests/test_command_telescope.py
+++ b/tests/library/gdb/tests/test_command_telescope.py
@@ -138,7 +138,7 @@ def test_command_telescope_frame_bp_below_sp(start_binary):
     gdb.execute("run")
     gdb.execute("memoize")  # turn off cache
 
-    pwndbg.aglib.regs.write_reg("sp", pwndbg.aglib.regs.read_reg(pwndbg.aglib.regs.frame) + 1)
+    pwndbg.aglib.regs.sp = pwndbg.aglib.regs.read_reg(pwndbg.aglib.regs.frame) + 1
 
     result_str = gdb.execute("telescope --frame", to_string=True)
 
@@ -157,7 +157,7 @@ def test_command_telescope_frame_bp_sp_different_vmmaps(start_binary):
 
     pages = pwndbg.aglib.vmmap.get()
 
-    pwndbg.aglib.regs.write_reg("sp", pages[0].start)
+    pwndbg.aglib.regs.sp = pages[0].start
     pwndbg.aglib.regs.write_reg("bp", pages[1].start)
 
     result_str = gdb.execute("telescope --frame", to_string=True)

--- a/tests/library/gdb/tests/test_command_telescope.py
+++ b/tests/library/gdb/tests/test_command_telescope.py
@@ -72,7 +72,7 @@ def test_telescope_command_with_address_as_count(start_binary):
     start_binary(TELESCOPE_BINARY)
 
     out = gdb.execute("telescope 2", to_string=True).splitlines()
-    rsp = pwndbg.aglib.regs.read_reg("rsp")
+    rsp = pwndbg.aglib.regs.sp
 
     assert len(out) == 2
     assert out[0] == "00:0000│ rsp %#x ◂— 1" % rsp
@@ -85,7 +85,7 @@ def test_telescope_command_with_address_as_count_and_reversed_flag(start_binary)
     start_binary(TELESCOPE_BINARY)
 
     out = gdb.execute("telescope -r 2", to_string=True).splitlines()
-    rsp = pwndbg.aglib.regs.read_reg("rsp")
+    rsp = pwndbg.aglib.regs.sp
 
     assert out == ["00:0000│     %#x ◂— 0" % (rsp - 8), "01:0008│ rsp %#x ◂— 1" % rsp]
 
@@ -99,7 +99,7 @@ def test_command_telescope_reverse_skipped_records_shows_input_address(start_bin
     gdb.execute("break break_here")
     gdb.execute("run")
     gdb.execute("up")
-    rsp = pwndbg.aglib.regs.read_reg("rsp")
+    rsp = pwndbg.aglib.regs.sp
     pwndbg.aglib.memory.write(rsp - 8 * 3, b"\x00" * 8 * 4)
 
     expected_value = hex(rsp)

--- a/tests/library/gdb/tests/test_command_xor.py
+++ b/tests/library/gdb/tests/test_command_xor.py
@@ -17,7 +17,7 @@ def test_command_xor_with_gdb_execute(start_binary):
     """
     start_binary(REFERENCE_BINARY)
 
-    before = pwndbg.aglib.regs.rsp
+    before = pwndbg.aglib.regs.read_reg("rsp")
     pwndbg.aglib.memory.write(before, b"aaaaaaaa")
     gdb.execute("xor $rsp ' ' 4")
     after = pwndbg.aglib.memory.read(before, 8)
@@ -30,7 +30,7 @@ def test_command_xor_with_int(start_binary):
     """
     start_binary(REFERENCE_BINARY)
 
-    before = pwndbg.aglib.regs.rsp
+    before = pwndbg.aglib.regs.read_reg("rsp")
     assert isinstance(before, int)
     pwndbg.aglib.memory.write(before, b"aaaaaaaa")
     gdb.execute(f"xor {before} ' ' 4")
@@ -44,7 +44,7 @@ def test_command_xor_with_hex(start_binary):
     """
     start_binary(REFERENCE_BINARY)
 
-    before = pwndbg.aglib.regs.rsp
+    before = pwndbg.aglib.regs.read_reg("rsp")
     before_hex = hex(before)
     assert isinstance(before_hex, str)
     pwndbg.aglib.memory.write(before, b"aaaaaaaa")
@@ -56,7 +56,7 @@ def test_command_xor_with_hex(start_binary):
 def test_command_memfrob(start_binary):
     start_binary(REFERENCE_BINARY)
 
-    before = pwndbg.aglib.regs.rsp
+    before = pwndbg.aglib.regs.read_reg("rsp")
     pwndbg.aglib.memory.write(before, b"aaaaaaaa")
     memfrob(before, 4)
     after = pwndbg.aglib.memory.read(before, 8)

--- a/tests/library/gdb/tests/test_command_xor.py
+++ b/tests/library/gdb/tests/test_command_xor.py
@@ -17,7 +17,7 @@ def test_command_xor_with_gdb_execute(start_binary):
     """
     start_binary(REFERENCE_BINARY)
 
-    before = pwndbg.aglib.regs.read_reg("rsp")
+    before = pwndbg.aglib.regs.sp
     pwndbg.aglib.memory.write(before, b"aaaaaaaa")
     gdb.execute("xor $rsp ' ' 4")
     after = pwndbg.aglib.memory.read(before, 8)
@@ -30,7 +30,7 @@ def test_command_xor_with_int(start_binary):
     """
     start_binary(REFERENCE_BINARY)
 
-    before = pwndbg.aglib.regs.read_reg("rsp")
+    before = pwndbg.aglib.regs.sp
     assert isinstance(before, int)
     pwndbg.aglib.memory.write(before, b"aaaaaaaa")
     gdb.execute(f"xor {before} ' ' 4")
@@ -44,7 +44,7 @@ def test_command_xor_with_hex(start_binary):
     """
     start_binary(REFERENCE_BINARY)
 
-    before = pwndbg.aglib.regs.read_reg("rsp")
+    before = pwndbg.aglib.regs.sp
     before_hex = hex(before)
     assert isinstance(before_hex, str)
     pwndbg.aglib.memory.write(before, b"aaaaaaaa")
@@ -56,7 +56,7 @@ def test_command_xor_with_hex(start_binary):
 def test_command_memfrob(start_binary):
     start_binary(REFERENCE_BINARY)
 
-    before = pwndbg.aglib.regs.read_reg("rsp")
+    before = pwndbg.aglib.regs.sp
     pwndbg.aglib.memory.write(before, b"aaaaaaaa")
     memfrob(before, 4)
     after = pwndbg.aglib.memory.read(before, 8)

--- a/tests/library/gdb/tests/test_commands_next.py
+++ b/tests/library/gdb/tests/test_commands_next.py
@@ -50,7 +50,7 @@ def test_command_nextproginstr(start_binary):
     gdb.execute("continue")
 
     # Sanity check that we are in libc
-    assert "libc" in pwndbg.aglib.vmmap.find(pwndbg.aglib.regs.rip).objfile
+    assert "libc" in pwndbg.aglib.vmmap.find(pwndbg.aglib.regs.read_reg("rip")).objfile
 
     # Execute nextproginstr and see if we came back to the same vmmap page
     gdb.execute("nextproginstr")
@@ -68,7 +68,7 @@ def test_next_command_doesnt_freeze_crashed_binary(start_binary, command):
     # The nextproginstr won't step if we are already on the binary address
     # and interestingly, other commands won't step if the address can't be disassemblied
     if command == "nextproginstr":
-        pwndbg.aglib.regs.pc = 0x1234
+        pwndbg.aglib.regs.write_reg("pc", 0x1234)
 
     # This should not halt/freeze the program
     gdb.execute(command, to_string=True)

--- a/tests/library/gdb/tests/test_commands_next.py
+++ b/tests/library/gdb/tests/test_commands_next.py
@@ -50,7 +50,7 @@ def test_command_nextproginstr(start_binary):
     gdb.execute("continue")
 
     # Sanity check that we are in libc
-    assert "libc" in pwndbg.aglib.vmmap.find(pwndbg.aglib.regs.read_reg("rip")).objfile
+    assert "libc" in pwndbg.aglib.vmmap.find(pwndbg.aglib.regs.pc).objfile
 
     # Execute nextproginstr and see if we came back to the same vmmap page
     gdb.execute("nextproginstr")
@@ -68,7 +68,7 @@ def test_next_command_doesnt_freeze_crashed_binary(start_binary, command):
     # The nextproginstr won't step if we are already on the binary address
     # and interestingly, other commands won't step if the address can't be disassemblied
     if command == "nextproginstr":
-        pwndbg.aglib.regs.write_reg("pc", 0x1234)
+        pwndbg.aglib.regs.pc = 0x1234
 
     # This should not halt/freeze the program
     gdb.execute(command, to_string=True)

--- a/tests/library/gdb/tests/test_context_commands.py
+++ b/tests/library/gdb/tests/test_context_commands.py
@@ -328,7 +328,7 @@ def test_context_disasm_proper_render_on_mem_change_issue_1818(start_binary, pat
         gdb.execute("patch $rip nop;nop;nop;nop;nop", to_string=True)
     else:
         # Do the same, but through write API
-        pwndbg.aglib.memory.write(pwndbg.aglib.regs.rip, b"\x90" * 5)
+        pwndbg.aglib.memory.write(pwndbg.aglib.regs.read_reg("rip"), b"\x90" * 5)
 
     # Actual test: we expect the read memory to be different now ;)
     # (and not e.g. returned incorrectly from a not cleared cache)

--- a/tests/library/gdb/tests/test_context_commands.py
+++ b/tests/library/gdb/tests/test_context_commands.py
@@ -328,7 +328,7 @@ def test_context_disasm_proper_render_on_mem_change_issue_1818(start_binary, pat
         gdb.execute("patch $rip nop;nop;nop;nop;nop", to_string=True)
     else:
         # Do the same, but through write API
-        pwndbg.aglib.memory.write(pwndbg.aglib.regs.read_reg("rip"), b"\x90" * 5)
+        pwndbg.aglib.memory.write(pwndbg.aglib.regs.pc, b"\x90" * 5)
 
     # Actual test: we expect the read memory to be different now ;)
     # (and not e.g. returned incorrectly from a not cleared cache)

--- a/tests/library/gdb/tests/test_hexdump.py
+++ b/tests/library/gdb/tests/test_hexdump.py
@@ -41,7 +41,7 @@ def test_hexdump(start_binary):
 
     # TODO: Setting theme options with Python isn't working
     gdb.execute("set hexdump-byte-separator")
-    stack_addr = pwndbg.aglib.regs.rsp - 0x100
+    stack_addr = pwndbg.aglib.regs.read_reg("rsp") - 0x100
 
     expected = [
         f"""+0000 0x{stack_addr:x}  6161616261616161 6161616461616163 │aaaabaaa│caaadaaa│
@@ -64,7 +64,7 @@ def test_hexdump(start_binary):
 
 def test_hexdump_collapse_lines(start_binary):
     start_binary(BINARY)
-    sp = pwndbg.aglib.regs.rsp
+    sp = pwndbg.aglib.regs.read_reg("rsp")
 
     pwndbg.aglib.memory.write(sp, b"abcdefgh\x01\x02\x03\x04\x05\x06\x07\x08" * 16)
 
@@ -90,7 +90,7 @@ def test_hexdump_saved_address_and_offset(start_binary):
     # TODO There is no way to verify repetition: the last_address and offset are reset
     # before each command
     start_binary(BINARY)
-    sp = pwndbg.aglib.regs.rsp
+    sp = pwndbg.aglib.regs.read_reg("rsp")
 
     SIZE = 21
 
@@ -112,7 +112,7 @@ def test_hexdump_limit_check(start_binary):
     Tests that the hexdump command respects the hexdump-limit-mb settings.
     """
     start_binary(BINARY)
-    sp = pwndbg.aglib.regs.rsp
+    sp = pwndbg.aglib.regs.read_reg("rsp")
 
     # Default limit is 10 MB
     default_limit_mb = 10
@@ -162,7 +162,7 @@ def test_hexdump_limit_check(start_binary):
 
 def test_hexdump_code_py_format(start_binary):
     start_binary(BINARY)
-    sp = pwndbg.aglib.regs.rsp
+    sp = pwndbg.aglib.regs.read_reg("rsp")
 
     pwndbg.aglib.memory.write(sp, b"abcdefgh\x01\x02\x03\x04\x05\x06\x07\x08" * 16)
 
@@ -180,7 +180,7 @@ def test_hexdump_code_py_format(start_binary):
 
 def test_hexdump_code_c_format(start_binary):
     start_binary(BINARY)
-    sp = pwndbg.aglib.regs.rsp
+    sp = pwndbg.aglib.regs.read_reg("rsp")
 
     pwndbg.aglib.memory.write(sp, b"abcdefgh\x01\x02\x03\x04\x05\x06\x07\x08" * 16)
 

--- a/tests/library/gdb/tests/test_hexdump.py
+++ b/tests/library/gdb/tests/test_hexdump.py
@@ -41,7 +41,7 @@ def test_hexdump(start_binary):
 
     # TODO: Setting theme options with Python isn't working
     gdb.execute("set hexdump-byte-separator")
-    stack_addr = pwndbg.aglib.regs.read_reg("rsp") - 0x100
+    stack_addr = pwndbg.aglib.regs.sp - 0x100
 
     expected = [
         f"""+0000 0x{stack_addr:x}  6161616261616161 6161616461616163 │aaaabaaa│caaadaaa│
@@ -64,7 +64,7 @@ def test_hexdump(start_binary):
 
 def test_hexdump_collapse_lines(start_binary):
     start_binary(BINARY)
-    sp = pwndbg.aglib.regs.read_reg("rsp")
+    sp = pwndbg.aglib.regs.sp
 
     pwndbg.aglib.memory.write(sp, b"abcdefgh\x01\x02\x03\x04\x05\x06\x07\x08" * 16)
 
@@ -90,7 +90,7 @@ def test_hexdump_saved_address_and_offset(start_binary):
     # TODO There is no way to verify repetition: the last_address and offset are reset
     # before each command
     start_binary(BINARY)
-    sp = pwndbg.aglib.regs.read_reg("rsp")
+    sp = pwndbg.aglib.regs.sp
 
     SIZE = 21
 
@@ -112,7 +112,7 @@ def test_hexdump_limit_check(start_binary):
     Tests that the hexdump command respects the hexdump-limit-mb settings.
     """
     start_binary(BINARY)
-    sp = pwndbg.aglib.regs.read_reg("rsp")
+    sp = pwndbg.aglib.regs.sp
 
     # Default limit is 10 MB
     default_limit_mb = 10
@@ -162,7 +162,7 @@ def test_hexdump_limit_check(start_binary):
 
 def test_hexdump_code_py_format(start_binary):
     start_binary(BINARY)
-    sp = pwndbg.aglib.regs.read_reg("rsp")
+    sp = pwndbg.aglib.regs.sp
 
     pwndbg.aglib.memory.write(sp, b"abcdefgh\x01\x02\x03\x04\x05\x06\x07\x08" * 16)
 
@@ -180,7 +180,7 @@ def test_hexdump_code_py_format(start_binary):
 
 def test_hexdump_code_c_format(start_binary):
     start_binary(BINARY)
-    sp = pwndbg.aglib.regs.read_reg("rsp")
+    sp = pwndbg.aglib.regs.sp
 
     pwndbg.aglib.memory.write(sp, b"abcdefgh\x01\x02\x03\x04\x05\x06\x07\x08" * 16)
 

--- a/tests/library/gdb/tests/test_memory.py
+++ b/tests/library/gdb/tests/test_memory.py
@@ -50,7 +50,7 @@ def test_memory_peek_poke(start_binary):
     assert pwndbg.aglib.memory.poke(0) is False
     assert pwndbg.aglib.memory.peek(0) is None
 
-    stack_addr = pwndbg.aglib.regs.rsp
+    stack_addr = pwndbg.aglib.regs.read_reg("rsp")
 
     for v in range(256):
         data = bytearray([v, 0, 0, 0])

--- a/tests/library/gdb/tests/test_memory.py
+++ b/tests/library/gdb/tests/test_memory.py
@@ -50,7 +50,7 @@ def test_memory_peek_poke(start_binary):
     assert pwndbg.aglib.memory.poke(0) is False
     assert pwndbg.aglib.memory.peek(0) is None
 
-    stack_addr = pwndbg.aglib.regs.read_reg("rsp")
+    stack_addr = pwndbg.aglib.regs.sp
 
     for v in range(256):
         data = bytearray([v, 0, 0, 0])

--- a/tests/library/gdb/tests/test_windbg.py
+++ b/tests/library/gdb/tests/test_windbg.py
@@ -313,58 +313,66 @@ def test_windbg_commands_x86(start_binary):
     """
     start_binary(X86_BINARY)
 
+    esp = pwndbg.aglib.regs.read_reg("esp")
     # Prepare memory
-    pwndbg.aglib.memory.write(pwndbg.aglib.regs.esp, b"1234567890abcdef_")
-    pwndbg.aglib.memory.write(pwndbg.aglib.regs.esp + 16, b"\x00" * 16)
-    pwndbg.aglib.memory.write(pwndbg.aglib.regs.esp + 32, bytes(range(16)))
-    pwndbg.aglib.memory.write(pwndbg.aglib.regs.esp + 48, b"Z" * 16)
+    pwndbg.aglib.memory.write(esp, b"1234567890abcdef_")
+    pwndbg.aglib.memory.write(esp + 16, b"\x00" * 16)
+    pwndbg.aglib.memory.write(esp + 32, bytes(range(16)))
+    pwndbg.aglib.memory.write(esp + 48, b"Z" * 16)
 
     #################################################
     #### dX command tests
     #################################################
     db = gdb.execute("db $esp", to_string=True).splitlines()
+    esp = pwndbg.aglib.regs.read_reg("esp")
     assert db == [
-        "%x     31 32 33 34 35 36 37 38 39 30 61 62 63 64 65 66" % pwndbg.aglib.regs.esp,
-        "%x     00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00" % (pwndbg.aglib.regs.esp + 16),
-        "%x     00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f" % (pwndbg.aglib.regs.esp + 32),
-        "%x     5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a" % (pwndbg.aglib.regs.esp + 48),
+        "%x     31 32 33 34 35 36 37 38 39 30 61 62 63 64 65 66" % esp,
+        "%x     00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00" % (esp + 16),
+        "%x     00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f" % (esp + 32),
+        "%x     5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a" % (esp + 48),
     ]
 
     dw = gdb.execute("dw $esp", to_string=True).splitlines()
+    esp = pwndbg.aglib.regs.read_reg("esp")
     assert dw == [
-        "%x     3231 3433 3635 3837 3039 6261 6463 6665" % pwndbg.aglib.regs.esp,
-        "%x     0000 0000 0000 0000 0000 0000 0000 0000" % (pwndbg.aglib.regs.esp + 16),
-        "%x     0100 0302 0504 0706 0908 0b0a 0d0c 0f0e" % (pwndbg.aglib.regs.esp + 32),
-        "%x     5a5a 5a5a 5a5a 5a5a 5a5a 5a5a 5a5a 5a5a" % (pwndbg.aglib.regs.esp + 48),
+        "%x     3231 3433 3635 3837 3039 6261 6463 6665" % esp,
+        "%x     0000 0000 0000 0000 0000 0000 0000 0000" % (esp + 16),
+        "%x     0100 0302 0504 0706 0908 0b0a 0d0c 0f0e" % (esp + 32),
+        "%x     5a5a 5a5a 5a5a 5a5a 5a5a 5a5a 5a5a 5a5a" % (esp + 48),
     ]
 
     dd = gdb.execute("dd $esp", to_string=True).splitlines()
+    esp = pwndbg.aglib.regs.read_reg("esp")
     assert dd == [
-        "%x     34333231 38373635 62613039 66656463" % pwndbg.aglib.regs.esp,
-        "%x     00000000 00000000 00000000 00000000" % (pwndbg.aglib.regs.esp + 16),
-        "%x     03020100 07060504 0b0a0908 0f0e0d0c" % (pwndbg.aglib.regs.esp + 32),
-        "%x     5a5a5a5a 5a5a5a5a 5a5a5a5a 5a5a5a5a" % (pwndbg.aglib.regs.esp + 48),
+        "%x     34333231 38373635 62613039 66656463" % esp,
+        "%x     00000000 00000000 00000000 00000000" % (esp + 16),
+        "%x     03020100 07060504 0b0a0908 0f0e0d0c" % (esp + 32),
+        "%x     5a5a5a5a 5a5a5a5a 5a5a5a5a 5a5a5a5a" % (esp + 48),
     ]
 
     dq = gdb.execute("dq $esp", to_string=True).splitlines()
+    esp = pwndbg.aglib.regs.read_reg("esp")
     assert dq == [
-        "%x     3837363534333231 6665646362613039" % pwndbg.aglib.regs.esp,
-        "%x     0000000000000000 0000000000000000" % (pwndbg.aglib.regs.esp + 16),
-        "%x     0706050403020100 0f0e0d0c0b0a0908" % (pwndbg.aglib.regs.esp + 32),
-        "%x     5a5a5a5a5a5a5a5a 5a5a5a5a5a5a5a5a" % (pwndbg.aglib.regs.esp + 48),
+        "%x     3837363534333231 6665646362613039" % esp,
+        "%x     0000000000000000 0000000000000000" % (esp + 16),
+        "%x     0706050403020100 0f0e0d0c0b0a0908" % (esp + 32),
+        "%x     5a5a5a5a5a5a5a5a 5a5a5a5a5a5a5a5a" % (esp + 48),
     ]
 
     #################################################
     #### eX command tests
     #################################################
     gdb.execute("eb $esp 00")
-    assert pwndbg.aglib.memory.read(pwndbg.aglib.regs.esp, 1) == b"\x00"
+    assert pwndbg.aglib.memory.read(pwndbg.aglib.regs.read_reg("esp"), 1) == b"\x00"
 
     gdb.execute("ew $esp 4141")
-    assert pwndbg.aglib.memory.read(pwndbg.aglib.regs.esp, 2) == b"\x41\x41"
+    assert pwndbg.aglib.memory.read(pwndbg.aglib.regs.read_reg("esp"), 2) == b"\x41\x41"
 
     gdb.execute("ed $esp 5252525252")
-    assert pwndbg.aglib.memory.read(pwndbg.aglib.regs.esp, 4) == b"\x52" * 4
+    assert pwndbg.aglib.memory.read(pwndbg.aglib.regs.read_reg("esp"), 4) == b"\x52" * 4
 
     gdb.execute("eq $esp 1122334455667788")
-    assert pwndbg.aglib.memory.read(pwndbg.aglib.regs.esp, 8) == b"\x88\x77\x66\x55\x44\x33\x22\x11"
+    assert (
+        pwndbg.aglib.memory.read(pwndbg.aglib.regs.read_reg("esp"), 8)
+        == b"\x88\x77\x66\x55\x44\x33\x22\x11"
+    )

--- a/tests/library/qemu_system/tests/test_commands_kernel.py
+++ b/tests/library/qemu_system/tests/test_commands_kernel.py
@@ -288,9 +288,9 @@ def test_command_pagewalk():
     pgd_ptr = "$cr3"
     if pwndbg.aglib.arch.name == "aarch64":
         if pwndbg.aglib.memory.is_kernel(address):
-            pgd_ptr = pwndbg.aglib.regs.TTBR1_EL1
+            pgd_ptr = pwndbg.aglib.regs.read_reg("TTBR1_EL1")
         else:
-            pgd_ptr = pwndbg.aglib.regs.TTBR0_EL1
+            pgd_ptr = pwndbg.aglib.regs.read_reg("TTBR0_EL1")
     res2 = gdb.execute(f"pagewalk {hex(address)} --pgd {pgd_ptr}", to_string=True).splitlines()[-1]
     assert res == res2
     # test non nonexistent address


### PR DESCRIPTION
This fixes the failing tests that reverted #3441. I had missed some cases of using `setattr(pwndbg,aglib.regs, name, val)`, which didn't crash as it simply added an attribute to the regs object. These are now replaced with `pwndbg.aglib.regs.write_reg(name, val)`

Recap of the PR:

This PR removes the `__getattr__` and `__setattr__` methods of the `pwndbg.aglib.regs` module, which were used to fetch and set the values of registers. To unify the API, reads now all use `pwndbg.aglib.regs.read_reg(reg_name)`, and writes use `pwndbg.aglib.regs.write_reg(reg_name, val)`

Two special getter (and setter) properties are added to the object, pc and sp. This means you can still do `pwndbg.aglib.regs.pc` and `pwndbg.agilb.regs.sp` to read from these special registers, which is very common in the codebase. By specifically handling them, we also gain the advantage of resolving the name of the actual stack pointer (like `rsp`) before forwarding the request to the underlying debugger, instead of depending on the debugger to convert `sp -> rsp`.
