### PR TITLE
Fix aglib.kernel.try_usymbol size value

### DIFF
--- a/pwndbg/aglib/kernel/symbol.py
+++ b/pwndbg/aglib/kernel/symbol.py
@@ -40,21 +40,27 @@ def migratetype_names() -> Tuple[str, ...]:
 
 
 # try getting value of a symbol as an unsigned integer
-def try_usymbol(name: str, size=pwndbg.aglib.kernel.ptr_size) -> int:
+def try_usymbol(name: str, size=None) -> int:
     if not pwndbg.aglib.kernel.has_debug_symbols():
         return None
     try:
         if pwndbg.aglib.kernel.has_debug_info():
             return pwndbg.aglib.symbol.lookup_symbol_value(name)
+
         symbol = pwndbg.aglib.symbol.lookup_symbol_addr(name)
         if symbol is None:
             return None
+
+        if size is None:
+            size = pwndbg.aglib.kernel.ptr_size()
+
         if size == 8:
             return pwndbg.aglib.memory.u(symbol)
         if size == 16:
             return pwndbg.aglib.memory.u16(symbol)
         if size == 32:
             return pwndbg.aglib.memory.u32(symbol)
+
         return pwndbg.aglib.memory.u64(symbol)
     except Exception:
         # for kpti


### PR DESCRIPTION
We used the `pwndbg.aglib.kerne.ptr_size` incorrectly as a default value for the `size` argument of `pwndbg.aglib.kernel.try_usymbol`.

The `pwndbg.aglib.kernel.ptr_size` is a function:
```py
In [3]: pwndbg.aglib.kernel.ptr_size??
Signature: pwndbg.aglib.kernel.ptr_size() -> 'int'
Docstring: <no docstring>
Source:
def ptr_size() -> int:
    ops = arch_ops()
    if ops:
        return ops.ptr_size
    else:
        raise NotImplementedError()
File:      ~/pwndbg/pwndbg/aglib/kernel/__init__.py
Type:      function
```

And it wasn't evaluated.

Please note that we also cannot do just `size=kernel.ptr_size()` as an argument because if we would do so, it would be evaluated only once when the function is defined. This is just how Python works.

Here is a screenshot showing how it failed to do its job:
<img width="656" height="588" alt="Image" src="https://github.com/user-attachments/assets/2279eeb5-a6ff-4995-a90c-a615e16a472d" />

+ [x] I read the contributing documentation.
+ [x] I am providing a screenshot of the (new feature) / (fixed bug).
