### PR TITLE
Improve load_custom_structure message

### DIFF
--- a/pwndbg/commands/cymbol.py
+++ b/pwndbg/commands/cymbol.py
@@ -289,7 +289,7 @@ def load_custom_structure(custom_structure_name: str, custom_structure_path: str
         return  # generate_debug_symbols prints on failures
     pwndbg.dbg.selected_inferior().add_symbol_file(pwndbg_debug_symbols_output_file)
     loaded_symbols[custom_structure_name] = pwndbg_debug_symbols_output_file
-    print(message.success("Symbols are loaded!"))
+    print(message.success(f"Loaded custom symbols! (from {custom_structure_path})"))
 
 
 @OnlyWhenStructFileExists


### PR DESCRIPTION
Fixes #3472. Makes the "Symbols are loaded!" message less confusing by changing it to: "Loaded custom symbols! (from {path})" so that the user can inspect what were the symbols loaded.

Before:
<img width="1590" height="456" alt="image" src="https://github.com/user-attachments/assets/22755a98-c1a1-4196-ac17-603b9044633d" />

After:
<img width="895" height="230" alt="image" src="https://github.com/user-attachments/assets/bfdb442b-6105-42c3-86bd-bb160f7a30fb" />
