### PR TITLE
Fixing caching and eventing

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -1,0 +1,1 @@
+set debug-events on

--- a/.gdbinit
+++ b/.gdbinit
@@ -1,1 +1,0 @@
-set debug-events on

--- a/docs/configuration/config.md
+++ b/docs/configuration/config.md
@@ -387,18 +387,6 @@ Path to the editor for editing custom structures.
 
 ----------
 
-## **debug-events**
-<small style="color: lightgray;">(only in GDB)</small>
-
-
-Display internal event debugging info.
-
-
-
-**Default:** off  
-
-----------
-
 ## **decompiler**
 
 
@@ -430,6 +418,17 @@ Max number of pointers to dereference in a chain.
 
 
 **Default:** 5  
+
+----------
+
+## **dev-debug-events**
+
+
+Display internal event debugging info.
+
+
+
+**Default:** off  
 
 ----------
 

--- a/pwndbg/__init__.py
+++ b/pwndbg/__init__.py
@@ -19,3 +19,6 @@ __version__ = pwndbg.lib.version.__version__
 """Pwndbg version."""
 version = __version__
 """Pwndbg version."""
+
+# Don't know where else to put this xd
+config.add_param("dev-debug-events", False, "display internal event debugging info")

--- a/pwndbg/aglib/disasm/disassembly.py
+++ b/pwndbg/aglib/disasm/disassembly.py
@@ -72,9 +72,6 @@ next_addresses_cache: Set[int] = set()
 # Register GDB event listeners for all stop events
 @pwndbg.dbg.event_handler(EventType.STOP)
 def enhance_cache_listener() -> None:
-    # Clear the register value cache to ensure we get the correct program counter value
-    pwndbg.aglib.regs.read_reg.cache.clear()
-
     if pwndbg.aglib.regs.pc not in next_addresses_cache:
         # Clear the enhanced instruction cache to ensure we don't use stale values
         computed_instruction_cache.clear()

--- a/pwndbg/aglib/regs.py
+++ b/pwndbg/aglib/regs.py
@@ -23,6 +23,7 @@ import pwndbg
 import pwndbg.aglib
 import pwndbg.aglib.proc
 import pwndbg.aglib.remote
+import pwndbg.dbg_mod
 import pwndbg.lib.cache
 from pwndbg.dbg_mod import EventType
 from pwndbg.lib.regs import BitFlags
@@ -37,19 +38,8 @@ def regs_in_frame(frame: pwndbg.dbg_mod.Frame) -> pwndbg.dbg_mod.Registers:
 
 
 @pwndbg.aglib.proc.OnlyWhenRunning
-def get_register(
-    name: str, frame: pwndbg.dbg_mod.Frame | None = None
-) -> pwndbg.dbg_mod.Value | None:
-    if frame is None:
-        frame = pwndbg.dbg.selected_frame()
-        if frame is None:
-            # `read_reg` will return None when it catches this exception. This
-            # mirrors how a `gdb.error` causes `read_reg` to return `None` in
-            # gdblib when no frame is selected.
-            raise pwndbg.dbg_mod.Error("No currently selected frame to read registers from")
-
+def get_register(name: str, frame: pwndbg.dbg_mod.Frame) -> pwndbg.dbg_mod.Value | None:
     regs = regs_in_frame(frame)
-
     value = regs.by_name(name)
     return value if value is not None else regs.by_name(name.upper())
 
@@ -101,20 +91,7 @@ class module(ModuleType):
     previous: Dict[str, int] = {}
     last: Dict[str, int] = {}
 
-    @pwndbg.lib.cache.cache_until("stop", "prompt")
-    def read_reg(self, reg: str, frame: pwndbg.dbg_mod.Frame | None = None) -> int | None:
-        """
-        Query the underlying debugger for the value of a register.
-
-        Note that in some rare cases, debuggers won't directly expose the values of some special model specific registers.
-        Although we can sometimes determine these by other indirect means, this function does not run any extra logic to handle these special cases.
-
-        Specifically, if you need to ensure you are reading the correct value of "gs", "fs", "idt", or "idt_limit", use
-        the specific helpers functions on the regs module as necessary to determine the values.
-        """
-        return self.read_reg_uncached(reg, frame)
-
-    def read_reg_uncached(self, reg: str, frame: pwndbg.dbg_mod.Frame | None = None) -> int | None:
+    def read_reg_uncached_in_frame(self, reg: str, frame: pwndbg.dbg_mod.Frame) -> int | None:
         reg = reg.lstrip("$")
         try:
             value = get_register(reg, frame)
@@ -138,6 +115,39 @@ class module(ModuleType):
             return int(value) & mask
         except (ValueError, pwndbg.dbg_mod.Error):
             return None
+
+    def read_reg_uncached(self, reg: str) -> int | None:
+        frame = pwndbg.dbg.selected_frame()
+        if frame is None:
+            return None
+        return self.read_reg_uncached_in_frame(reg, frame)
+
+    @pwndbg.lib.cache.cache_until("stop")
+    def read_reg_in_frame(self, reg: str, frame: pwndbg.dbg_mod.Frame) -> int | None:
+        """
+        Same as read_reg() except for the provided frame, rather than the currently
+        selected frame.
+        """
+        return self.read_reg_uncached_in_frame(reg, frame)
+
+    def read_reg(self, reg: str) -> int | None:
+        """
+        Query the underlying debugger for the value of a register.
+
+        Note that in some rare cases, debuggers won't directly expose the values of some special model specific registers.
+        Although we can sometimes determine these by other indirect means, this function does not run any extra logic to handle these special cases.
+
+        Specifically, if you need to ensure you are reading the correct value of "gs", "fs", "idt", or "idt_limit", use
+        the specific helpers functions on the regs module as necessary to determine the values.
+
+        Use read_reg_in_frame() if you have a `frame` object, its faster.
+        """
+        # Adding a cache_until decorator to read_reg() is semantically incorrect since it will return
+        # the same register value even if the frame changes.
+        frame = pwndbg.dbg.selected_frame()
+        if frame is None:
+            return None
+        return self.read_reg_in_frame(reg, frame)
 
     def write_reg(self, reg: str, value: int) -> None:
         if not pwndbg.dbg.selected_frame().reg_write(reg, value):
@@ -267,7 +277,10 @@ class module(ModuleType):
         Requires ptrace'ing the child directory if i386."""
 
         if pwndbg.aglib.arch.name == "x86-64":
-            reg_value = get_register(regname)
+            frame = pwndbg.dbg.selected_frame()
+            if frame is None:
+                return 0
+            reg_value = get_register(regname, frame)
             return int(reg_value) if reg_value is not None else 0
 
         # We can't really do anything if the process is remote.

--- a/pwndbg/aglib/regs.py
+++ b/pwndbg/aglib/regs.py
@@ -32,7 +32,7 @@ from pwndbg.lib.regs import RegisterSet
 from pwndbg.lib.regs import reg_sets
 
 
-@pwndbg.lib.cache.cache_until("stop", "prompt")
+@pwndbg.lib.cache.cache_until("stop")
 def regs_in_frame(frame: pwndbg.dbg_mod.Frame) -> pwndbg.dbg_mod.Registers:
     return frame.regs()
 

--- a/pwndbg/commands/integration.py
+++ b/pwndbg/commands/integration.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 
+import pwndbg
 import pwndbg.aglib.regs
 import pwndbg.commands
 import pwndbg.integration

--- a/pwndbg/commands/integration.py
+++ b/pwndbg/commands/integration.py
@@ -5,6 +5,7 @@ import argparse
 import pwndbg
 import pwndbg.aglib.regs
 import pwndbg.commands
+import pwndbg.dbg_mod
 import pwndbg.integration
 from pwndbg.commands import CommandCategory
 

--- a/pwndbg/dbg_mod/__init__.py
+++ b/pwndbg/dbg_mod/__init__.py
@@ -27,6 +27,9 @@ dbg: Debugger = None
 
 T = TypeVar("T")
 
+# Increased by one on every stop event.
+number_of_stops_since_birth: int = 0
+
 
 @contextlib.contextmanager
 def selection(target: T, get_current: Callable[[], T], select: Callable[[T], None]):
@@ -285,6 +288,15 @@ class Frame:
         The index of this stack frame on the thread's stack. Index zero is the most
         fresh frame.
         """
+        raise NotImplementedError()
+
+    def __hash__(self) -> int:
+        """
+        The hash value of this stack frame. Needs to guarantee uniqueness both within
+        a stop and *accross time* so caches can work properly.
+        """
+        # Looking at how the debugger implements the frame equality check can help you
+        # figure this out.
         raise NotImplementedError()
 
 

--- a/pwndbg/dbg_mod/__init__.py
+++ b/pwndbg/dbg_mod/__init__.py
@@ -172,6 +172,16 @@ class SymbolLookupType(Enum):
 
 
 class Frame:
+    """
+    A lightweight object referencing a stack frame in a given thread.
+
+    It does not hold state, it allows us to ask the debugger for state
+    (registers, symbols etc.) associated with this stack frame.
+
+    This is a very short-lived object and easily becomes invalid so do not
+    store it, and especially not between debugger stops.
+    """
+
     def lookup_symbol(
         self,
         name: str,
@@ -267,6 +277,13 @@ class Frame:
         Whether this frame is the same as the given frame. Two frames are the
         same if they point to the same stack frame and have the same execution
         context.
+        """
+        raise NotImplementedError()
+
+    def idx(self) -> int:
+        """
+        The index of this stack frame on the thread's stack. Index zero is the most
+        fresh frame.
         """
         raise NotImplementedError()
 

--- a/pwndbg/dbg_mod/__init__.py
+++ b/pwndbg/dbg_mod/__init__.py
@@ -1087,6 +1087,24 @@ class EventType(Enum):
     `objfile`s."""
 
 
+class EventHandlerPriority(Enum):
+    """
+    Determines the order in which event handlers are called when
+    a given event is triggered.
+    """
+
+    # If you wish to add another priority, feel free to. Prefer descriptive names
+    # like "CACHE_CLEAR" to something generic like "LOW" or "HIGH" which doesn't
+    # make it obvious which handlers are registered with this priority.
+    # Make sure that the values are defined in increasing order!!
+    # (https://docs.python.org/3/library/enum.html#enum.EnumType.__iter__)
+    CACHE_CLEAR = 0
+    """The first thing we want to do is clear the cache, so we aren't working on stale
+    data."""
+    STANDARD = 100
+    """The default value."""
+
+
 class Debugger:
     """
     The base class representing a debugger.
@@ -1167,11 +1185,18 @@ class Debugger:
         """
         raise NotImplementedError()
 
-    def event_handler(self, ty: EventType) -> Callable[[Callable[..., T]], Callable[..., T]]:
+    def event_handler(
+        self, event_type: EventType, priority: EventHandlerPriority = EventHandlerPriority.STANDARD
+    ) -> Callable[[Callable[..., None]], Callable[..., None]]:
         """
         Sets up the given function to be called when an event of the given type
         gets fired. Returns a callable that corresponds to the wrapped function.
-        This function my be used as a decorator.
+        The wrapped function must return None.
+
+        You may control the order in which the handlers for a specific event will
+        be called by setting the `priority` argument.
+
+        This function may be used as a decorator.
         """
         raise NotImplementedError()
 

--- a/pwndbg/dbg_mod/__init__.py
+++ b/pwndbg/dbg_mod/__init__.py
@@ -1052,35 +1052,38 @@ class CommandHandle:
 class EventType(Enum):
     """
     Events that can be listened for and reacted to in a debugger.
-
-    The events types listed here are defined as follows:
-        - `START`: This event is fired some time between the creation of or
-          attachment to the process to be debugged, and the start of its
-          execution.
-        - `STOP`: This event is fired after execution of the process has been
-          suspended, but before control is returned to the user for interactive
-          debugging.
-        - `EXIT`: This event is fired after the process being debugged has been
-          detached from or has finished executing.
-        - `MEMORY_CHANGED`: This event is fired when the user interactively makes
-          changes to the memory of the process being debugged.
-        - `REGISTER_CHANGED`: Like `MEMORY_CHANGED`, but for registers.
-        - `CONTINUE`: This event is fired after the user has requested for
-          process execution to continue after it had been previously suspended.
-        - `NEW_MODULE`: This event is fired when a new application module has
-          been encountered by the debugger. This usually happens when a new
-          application module is loaded into the memory space of the process being
-          debugged. In GDB terminology, these are called `objfile`s.
     """
-
     SUSPEND_ALL = -1
+
     START = 0
+    """This event is fired some time between the creation of or attachment to the
+    process to be debugged, and the start of its execution."""
+
     STOP = 1
+    """This event is fired after execution of the process has been suspended, but
+    before control is returned to the user for interactive debugging."""
+
     EXIT = 2
+    """This event is fired after the process being debugged has been
+    detached from or has finished executing."""
+
     MEMORY_CHANGED = 3
+    """This event is fired when the user interactively makes changes to the memory
+    of the process being debugged."""
+
     REGISTER_CHANGED = 4
+    """This event is fired when the user interactively makes changes to the registers
+    of the process being debugged."""
+
     CONTINUE = 5
+    """This event is fired after the user has requested for process execution to continue
+    after it had been previously suspended."""
+
     NEW_MODULE = 6
+    """This event is fired when a new application module has been encountered by the
+    debugger. This usually happens when a new application module is loaded into the
+    memory space of the process being debugged. In GDB terminology, these are called
+    `objfile`s."""
 
 
 class Debugger:

--- a/pwndbg/dbg_mod/__init__.py
+++ b/pwndbg/dbg_mod/__init__.py
@@ -1053,6 +1053,7 @@ class EventType(Enum):
     """
     Events that can be listened for and reacted to in a debugger.
     """
+
     SUSPEND_ALL = -1
 
     START = 0

--- a/pwndbg/dbg_mod/gdb/__init__.py
+++ b/pwndbg/dbg_mod/gdb/__init__.py
@@ -250,6 +250,11 @@ class GDBFrame(pwndbg.dbg_mod.Frame):
 
         return self.inner == other.inner
 
+    @override
+    def idx(self) -> int:
+        # https://sourceware.org/gdb/current/onlinedocs/gdb.html/Frames-In-Python.html#Frames-In-Python:~:text=Frame%2Elevel
+        return self.inner.level()
+
 
 class GDBThread(pwndbg.dbg_mod.Thread):
     def __init__(self, inner: gdb.InferiorThread):

--- a/pwndbg/dbg_mod/gdb/__init__.py
+++ b/pwndbg/dbg_mod/gdb/__init__.py
@@ -6,6 +6,7 @@ from contextlib import contextmanager
 from contextlib import nullcontext
 from os import environ
 from pathlib import Path
+from random import randint
 from typing import Any
 from typing import Coroutine
 from typing import Generator
@@ -143,6 +144,8 @@ class GDBRegisters(pwndbg.dbg_mod.Registers):
 class GDBFrame(pwndbg.dbg_mod.Frame):
     def __init__(self, inner: gdb.Frame):
         self.inner = inner
+        # caching the hash since calculating it involves some string operations
+        self._hash: int | None = None
 
     @override
     def lookup_symbol(
@@ -205,7 +208,17 @@ class GDBFrame(pwndbg.dbg_mod.Frame):
 
     @override
     def sp(self) -> int:
-        return int(self.regs().by_name("sp"))
+        # We're gonna use a little trick to prevent an expensive register read.
+        # e.g. `str(self.inner) == "{stack=0x7fffffffe030,code=0x00007ffff7fe0880,!special}"`
+        # See gdb/python/py-frame.c:frapy_str() and gdb/frame.c:frame_id::to_string()
+        # They really could just expose .stack() as an API...
+        str_id = str(self.inner)
+        if "stack=0x" in str_id:
+            return int(str_id.partition("stack=")[2].partition(",")[0], 16)
+        else:
+            # We got "!stack", "stack=<unavailable>", "stack=<sentinel>" or "stack=<outer>".
+            # Not sure what sp will actually resolve to here...
+            return int(self.regs().by_name("sp"))
 
     @override
     def parent(self) -> pwndbg.dbg_mod.Frame | None:
@@ -255,15 +268,97 @@ class GDBFrame(pwndbg.dbg_mod.Frame):
         # https://sourceware.org/gdb/current/onlinedocs/gdb.html/Frames-In-Python.html#Frames-In-Python:~:text=Frame%2Elevel
         return self.inner.level()
 
+    def _frame_id(self) -> tuple[int, int, int, int]:
+        """
+        Returns a tuple which recovers the frame_id struct of the GDB frame object (self.inner).
+        We cannot recover only frame_id.user_created_p.
+
+        Format is (stack_addr, code_addr, special_addr, artificial_depth).
+
+        The status fields are returned implicitly in the following:
+            stack_addr == -1 means stack_status == FID_STACK_INVALID
+            stack_addr == -2 means stack_status == FID_STACK_UNAVAILABLE
+            stack_addr == -3 means stack_status == FID_STACK_SENTINEL
+            stack_addr == -4 means stack_status == FID_STACK_OUTER
+            code_addr == -1 means code_addr_p == 0
+            special_addr == -1 means special_addr_p == 0
+        Note that artificial_depth == 0 means invalid.
+        """
+        # See gdb/frame-id.h and gdb/frame.c:frame_id::to_string().
+
+        # Here is an example of what is can look like:
+        # "{stack=0x7fffffffe030,code=0x00007ffff7fe0880,!special}"
+        frame_id_str: str = str(self.inner)
+
+        # Get rid of curly braces and split into individual fields.
+        splitted: list[str] = frame_id_str[1:-1].split(",")
+
+        stack_addr: int
+        code_addr: int
+        special_addr: int
+        artificial_addr: int
+
+        match splitted[0]:
+            case "!stack":
+                stack_addr = -1
+            case "stack=<unavailable>":
+                stack_addr = -2
+            case "stack=<sentinel>":
+                stack_addr = -3
+            case "stack=<outer>":
+                stack_addr = -4
+            case _:
+                # We have an actual address (len("stack=") == 6)
+                stack_addr = int(splitted[0][6:], 16)
+
+        if splitted[1] == "!code":
+            code_addr = -1
+        else:
+            # len("code=") == 5
+            code_addr = int(splitted[1][5:], 16)
+
+        if splitted[2] == "!special":
+            special_addr = -1
+        else:
+            # len("special=") == 8
+            special_addr = int(splitted[2][8:], 16)
+
+        if len(splitted) == 3:
+            artificial_addr = -1
+        else:
+            # len("artificial=") == 11
+            artificial_addr = int(splitted[3][11:], 16)
+
+        return (stack_addr, code_addr, special_addr, artificial_addr)
+
     @override
     def __hash__(self) -> int:
+        if self._hash is not None:
+            return self._hash
+
         # GDB implements the equality comparison in gdb/python/py-frame.c:frapy_richcompare()
-        # Unfortunately it doesn't expose frame_id and frame_id_is_next.
-        # Thus, we are rolling our own hash (see the LLDB implementation for rationale).
-        # Since GDB doesn't provide us with a way to get the thread id, we're just going to use the
-        # the SP because it should be unique between threads.
-        # FIXME: self.sp() might be slow, can we do something better?
-        return self.idx() + (pwndbg.dbg_mod.number_of_stops_since_birth << 16) + (self.sp() << 32)
+        # and gdb/frame.c:frame_id::operator==().
+        # The frame_id is not exposed to the python API, but we can exploit str(self.inner)
+        # to recover it. (though still don't have frame_id_is_next, but oh well..)
+        # This is much faster than reading the stack pointer from the inferior, and will give
+        # more accurate results as well.
+        stack_addr, code_addr, special_addr, artificial_depth = self._frame_id()
+        # stack_addr == -1 (FID_STACK_INVALID) acts as NaN, so we have to be unique
+        if stack_addr == -1:
+            self._hash = randint(0, 1 << 63)
+            return self._hash
+
+        # I don't want to make assumptions on the sizes of all these fields so I will just build up a
+        # string and use the string's hash. Using "|" for domain separation.
+        self._hash = hash(
+            f"{stack_addr}|{code_addr}|{special_addr}|{artificial_depth}|"
+            # Still using idx() for good measure (maybe it helps with the lack of frame_id_is_next?)
+            # Still using number_of_stops_since_birth because I want to guarantee that same frames at
+            # different times return different hashes.
+            f"{self.idx()}|{pwndbg.dbg_mod.number_of_stops_since_birth << 16}"
+        )
+
+        return self._hash
 
 
 class GDBThread(pwndbg.dbg_mod.Thread):

--- a/pwndbg/dbg_mod/gdb/__init__.py
+++ b/pwndbg/dbg_mod/gdb/__init__.py
@@ -255,6 +255,18 @@ class GDBFrame(pwndbg.dbg_mod.Frame):
         # https://sourceware.org/gdb/current/onlinedocs/gdb.html/Frames-In-Python.html#Frames-In-Python:~:text=Frame%2Elevel
         return self.inner.level()
 
+    @override
+    def __hash__(self) -> int:
+        # GDB implements the equality comparison in gdb/python/py-frame.c:frapy_richcompare()
+        # Unfortunately it doesn't expose frame_id and frame_id_is_next.
+        # Thus, we are rolling our own hash (see the LLDB implementation as well).
+        # Since GDB doesn't provide us with a way to get the thread id, we're just going to use the
+        # the SP (with a bit cut off the top :p) because it should be unique between threads.
+        # FIXME: self.sp() might be slow, can we do something better?
+        return (
+            self.idx() + (pwndbg.dbg_mod.number_of_stops_since_birth << 16) + (self.sp() << 32)
+        ) & 0xFFFFFFFFFFFFFFFF
+
 
 class GDBThread(pwndbg.dbg_mod.Thread):
     def __init__(self, inner: gdb.InferiorThread):

--- a/pwndbg/dbg_mod/gdb/__init__.py
+++ b/pwndbg/dbg_mod/gdb/__init__.py
@@ -24,10 +24,12 @@ from typing_extensions import Set
 from typing_extensions import override
 
 import pwndbg
+import pwndbg.dbg_mod
 import pwndbg.gdblib
 import pwndbg.gdblib.events
 import pwndbg.lib.memory
 from pwndbg.aglib import load_aglib
+from pwndbg.dbg_mod import EventHandlerPriority
 from pwndbg.dbg_mod import selection
 from pwndbg.gdblib import gdb_version
 from pwndbg.gdblib import load_gdblib
@@ -1688,24 +1690,26 @@ class GDB(pwndbg.dbg_mod.Debugger):
 
     @override
     def event_handler(
-        self, ty: pwndbg.dbg_mod.EventType
-    ) -> Callable[[Callable[..., T]], Callable[..., T]]:
+        self,
+        event_type: pwndbg.dbg_mod.EventType,
+        priority: EventHandlerPriority = EventHandlerPriority.STANDARD,
+    ) -> Callable[[Callable[..., None]], Callable[..., None]]:
         # Make use of the existing gdblib event handlers.
-        if ty == pwndbg.dbg_mod.EventType.EXIT:
+        if event_type == pwndbg.dbg_mod.EventType.EXIT:
             return pwndbg.gdblib.events.exit
-        elif ty == pwndbg.dbg_mod.EventType.CONTINUE:
+        elif event_type == pwndbg.dbg_mod.EventType.CONTINUE:
             return pwndbg.gdblib.events.cont
-        elif ty == pwndbg.dbg_mod.EventType.START:
+        elif event_type == pwndbg.dbg_mod.EventType.START:
             return pwndbg.gdblib.events.start
-        elif ty == pwndbg.dbg_mod.EventType.STOP:
+        elif event_type == pwndbg.dbg_mod.EventType.STOP:
             return pwndbg.gdblib.events.stop
-        elif ty == pwndbg.dbg_mod.EventType.NEW_MODULE:
+        elif event_type == pwndbg.dbg_mod.EventType.NEW_MODULE:
             return pwndbg.gdblib.events.new_objfile
-        elif ty == pwndbg.dbg_mod.EventType.MEMORY_CHANGED:
+        elif event_type == pwndbg.dbg_mod.EventType.MEMORY_CHANGED:
             return pwndbg.gdblib.events.mem_changed
-        elif ty == pwndbg.dbg_mod.EventType.REGISTER_CHANGED:
+        elif event_type == pwndbg.dbg_mod.EventType.REGISTER_CHANGED:
             return pwndbg.gdblib.events.reg_changed
-        elif ty == pwndbg.dbg_mod.EventType.SUSPEND_ALL:
+        elif event_type == pwndbg.dbg_mod.EventType.SUSPEND_ALL:
             raise RuntimeError("invalid usage, this event is not supported")
 
     @override

--- a/pwndbg/dbg_mod/gdb/__init__.py
+++ b/pwndbg/dbg_mod/gdb/__init__.py
@@ -28,8 +28,8 @@ import pwndbg.dbg_mod
 import pwndbg.gdblib
 import pwndbg.gdblib.events
 import pwndbg.lib.memory
-from pwndbg.aglib import load_aglib
 from pwndbg.dbg_mod import EventHandlerPriority
+from pwndbg.dbg_mod import EventType
 from pwndbg.dbg_mod import selection
 from pwndbg.gdblib import gdb_version
 from pwndbg.gdblib import load_gdblib
@@ -187,6 +187,8 @@ class GDBFrame(pwndbg.dbg_mod.Frame):
 
     @override
     def reg_write(self, name: str, val: int) -> bool:
+        import pwndbg.aglib
+
         if name not in pwndbg.aglib.regs:
             return False
 
@@ -289,32 +291,7 @@ class GDBMemoryMap(pwndbg.dbg_mod.MemoryMap):
 BPWP_DEFERRED_DELETE: Set[GDBStopPoint] = set()
 BPWP_DEFERRED_ENABLE: Set[GDBStopPoint] = set()
 BPWP_DEFERRED_DISABLE: Set[GDBStopPoint] = set()
-
-
-@pwndbg.gdblib.events.stop
-def _bpwp_process_deferred():
-    for to_enable in BPWP_DEFERRED_ENABLE:
-        to_enable.inner.enabled = True
-    for to_disable in BPWP_DEFERRED_DISABLE:
-        to_disable.inner.enabled = False
-    for to_delete in BPWP_DEFERRED_DELETE:
-        to_delete.inner.delete()
-    _bpwp_clear_deferred()
-
-
-@pwndbg.gdblib.events.start
-@pwndbg.gdblib.events.exit
-def _bpwp_clear_deferred():
-    for elem in BPWP_DEFERRED_DELETE:
-        elem._clear()
-    for elem in BPWP_DEFERRED_ENABLE:
-        elem._clear()
-    for elem in BPWP_DEFERRED_DISABLE:
-        elem._clear()
-
-    BPWP_DEFERRED_DELETE.clear()
-    BPWP_DEFERRED_ENABLE.clear()
-    BPWP_DEFERRED_DISABLE.clear()
+# See pwndbg/dbg_mod/gdb/hooks.py !
 
 
 class BreakpointAdapter(gdb.Breakpoint):
@@ -1359,15 +1336,15 @@ class GDBValue(pwndbg.dbg_mod.Value):
             raise pwndbg.dbg_mod.Error(e)
 
 
-def _gdb_event_class_from_event_type(ty: pwndbg.dbg_mod.EventType) -> Any:
+def _gdb_event_registry_from_event_type(ty: EventType) -> gdb.EventRegistry[Any]:
     """
-    Returns the GDB event class that corresponds to the given event type.
+    Returns the GDB event registry that corresponds to the given event type.
     """
-    if ty == pwndbg.dbg_mod.EventType.EXIT:
+    if ty == EventType.EXIT:
         return gdb.events.exited
-    elif ty == pwndbg.dbg_mod.EventType.CONTINUE:
+    elif ty == EventType.CONTINUE:
         return gdb.events.cont
-    elif ty == pwndbg.dbg_mod.EventType.START:
+    elif ty == EventType.START:
         # Pwndbg installs this one when it loads the GDB event support module.
         #
         # We should never run this function before it gets loaded, but, if this
@@ -1377,15 +1354,15 @@ def _gdb_event_class_from_event_type(ty: pwndbg.dbg_mod.EventType) -> Any:
             gdb.events, "start"
         ), "gdb.events.start is missing. Did the Pwndbg GDB event code not get loaded?"
         return gdb.events.start
-    elif ty == pwndbg.dbg_mod.EventType.STOP:
+    elif ty == EventType.STOP:
         return gdb.events.stop
-    elif ty == pwndbg.dbg_mod.EventType.NEW_MODULE:
+    elif ty == EventType.NEW_MODULE:
         return gdb.events.new_objfile
-    elif ty == pwndbg.dbg_mod.EventType.MEMORY_CHANGED:
+    elif ty == EventType.MEMORY_CHANGED:
         return gdb.events.memory_changed
-    elif ty == pwndbg.dbg_mod.EventType.REGISTER_CHANGED:
+    elif ty == EventType.REGISTER_CHANGED:
         return gdb.events.register_changed
-    elif ty == pwndbg.dbg_mod.EventType.SUSPEND_ALL:
+    elif ty == EventType.SUSPEND_ALL:
         assert hasattr(
             gdb.events, "suspend_all"
         ), "gdb.events.suspend_all is missing. Did the Pwndbg GDB event code not get loaded?"
@@ -1456,11 +1433,16 @@ class GDB(pwndbg.dbg_mod.Debugger):
 
         pwnlib.update.disabled = True
 
+        from pwndbg.aglib import load_aglib
         from pwndbg.commands import load_commands
 
         load_gdblib()
         load_aglib()
         load_commands()
+
+        # Register event hooks.
+        # (We can't do them in this file because pwndbg.dbg isn't initialized yet.)
+        from pwndbg.dbg_mod.gdb import hooks as hooks
 
         # Importing `pwndbg.gdblib.prompt` ends up importing code that has the
         # side effect of setting a command up. Because command setup requires
@@ -1684,33 +1666,23 @@ class GDB(pwndbg.dbg_mod.Debugger):
         return True
 
     @override
-    def has_event_type(self, ty: pwndbg.dbg_mod.EventType) -> bool:
+    def has_event_type(self, ty: EventType) -> bool:
         # Currently GDB supports all event types.
         return True
 
     @override
     def event_handler(
         self,
-        event_type: pwndbg.dbg_mod.EventType,
+        event_type: EventType,
         priority: EventHandlerPriority = EventHandlerPriority.STANDARD,
     ) -> Callable[[Callable[..., None]], Callable[..., None]]:
-        # Make use of the existing gdblib event handlers.
-        if event_type == pwndbg.dbg_mod.EventType.EXIT:
-            return pwndbg.gdblib.events.exit
-        elif event_type == pwndbg.dbg_mod.EventType.CONTINUE:
-            return pwndbg.gdblib.events.cont
-        elif event_type == pwndbg.dbg_mod.EventType.START:
-            return pwndbg.gdblib.events.start
-        elif event_type == pwndbg.dbg_mod.EventType.STOP:
-            return pwndbg.gdblib.events.stop
-        elif event_type == pwndbg.dbg_mod.EventType.NEW_MODULE:
-            return pwndbg.gdblib.events.new_objfile
-        elif event_type == pwndbg.dbg_mod.EventType.MEMORY_CHANGED:
-            return pwndbg.gdblib.events.mem_changed
-        elif event_type == pwndbg.dbg_mod.EventType.REGISTER_CHANGED:
-            return pwndbg.gdblib.events.reg_changed
-        elif event_type == pwndbg.dbg_mod.EventType.SUSPEND_ALL:
-            raise RuntimeError("invalid usage, this event is not supported")
+        import pwndbg.gdblib.events
+
+        event_registry: gdb.EventRegistry[Any] = _gdb_event_registry_from_event_type(event_type)
+        decorator = pwndbg.gdblib.events.event_handler_factory(
+            event_registry, event_type.name, priority
+        )
+        return decorator
 
     @override
     @contextmanager
@@ -1718,12 +1690,12 @@ class GDB(pwndbg.dbg_mod.Debugger):
         pwndbg.gdblib.prompt.context_shown = True
 
     @override
-    def suspend_events(self, ty: pwndbg.dbg_mod.EventType) -> None:
-        pwndbg.gdblib.events.pause(_gdb_event_class_from_event_type(ty))
+    def suspend_events(self, ty: EventType) -> None:
+        pwndbg.gdblib.events.pause(_gdb_event_registry_from_event_type(ty))
 
     @override
-    def resume_events(self, ty: pwndbg.dbg_mod.EventType) -> None:
-        pwndbg.gdblib.events.unpause(_gdb_event_class_from_event_type(ty))
+    def resume_events(self, ty: EventType) -> None:
+        pwndbg.gdblib.events.unpause(_gdb_event_registry_from_event_type(ty))
 
     @override
     def set_sysroot(self, sysroot: str) -> bool:

--- a/pwndbg/dbg_mod/gdb/__init__.py
+++ b/pwndbg/dbg_mod/gdb/__init__.py
@@ -1695,10 +1695,7 @@ class GDB(pwndbg.dbg_mod.Debugger):
         import pwndbg.gdblib.events
 
         event_registry: gdb.EventRegistry[Any] = _gdb_event_registry_from_event_type(event_type)
-        decorator = pwndbg.gdblib.events.event_handler_factory(
-            event_registry, event_type.name, priority
-        )
-        return decorator
+        return pwndbg.gdblib.events.event_handler_factory(event_registry, event_type.name, priority)
 
     @override
     @contextmanager

--- a/pwndbg/dbg_mod/gdb/__init__.py
+++ b/pwndbg/dbg_mod/gdb/__init__.py
@@ -1355,35 +1355,36 @@ def _gdb_event_registry_from_event_type(ty: EventType) -> gdb.EventRegistry[Any]
     """
     Returns the GDB event registry that corresponds to the given event type.
     """
-    if ty == EventType.EXIT:
-        return gdb.events.exited
-    elif ty == EventType.CONTINUE:
-        return gdb.events.cont
-    elif ty == EventType.START:
-        # Pwndbg installs this one when it loads the GDB event support module.
-        #
-        # We should never run this function before it gets loaded, but, if this
-        # ever changes by mistake, we want the mistake to be caught early, with
-        # a clear error.
-        assert hasattr(
-            gdb.events, "start"
-        ), "gdb.events.start is missing. Did the Pwndbg GDB event code not get loaded?"
-        return gdb.events.start
-    elif ty == EventType.STOP:
-        return gdb.events.stop
-    elif ty == EventType.NEW_MODULE:
-        return gdb.events.new_objfile
-    elif ty == EventType.MEMORY_CHANGED:
-        return gdb.events.memory_changed
-    elif ty == EventType.REGISTER_CHANGED:
-        return gdb.events.register_changed
-    elif ty == EventType.SUSPEND_ALL:
-        assert hasattr(
-            gdb.events, "suspend_all"
-        ), "gdb.events.suspend_all is missing. Did the Pwndbg GDB event code not get loaded?"
-        return gdb.events.suspend_all
-
-    raise NotImplementedError(f"unknown event type {ty}")
+    match ty:
+        case EventType.EXIT:
+            return gdb.events.exited
+        case EventType.CONTINUE:
+            return gdb.events.cont
+        case EventType.START:
+            # Pwndbg installs this one when it loads the GDB event support module.
+            #
+            # We should never run this function before it gets loaded, but, if this
+            # ever changes by mistake, we want the mistake to be caught early, with
+            # a clear error.
+            assert hasattr(
+                gdb.events, "start"
+            ), "gdb.events.start is missing. Did the Pwndbg GDB event code not get loaded?"
+            return gdb.events.start
+        case EventType.STOP:
+            return gdb.events.stop
+        case EventType.NEW_MODULE:
+            return gdb.events.new_objfile
+        case EventType.MEMORY_CHANGED:
+            return gdb.events.memory_changed
+        case EventType.REGISTER_CHANGED:
+            return gdb.events.register_changed
+        case EventType.SUSPEND_ALL:
+            assert hasattr(
+                gdb.events, "suspend_all"
+            ), "gdb.events.suspend_all is missing. Did the Pwndbg GDB event code not get loaded?"
+            return gdb.events.suspend_all
+        case _:
+            raise NotImplementedError(f"unknown event type {ty}")
 
 
 class GDB(pwndbg.dbg_mod.Debugger):

--- a/pwndbg/dbg_mod/gdb/__init__.py
+++ b/pwndbg/dbg_mod/gdb/__init__.py
@@ -285,6 +285,8 @@ class GDBFrame(pwndbg.dbg_mod.Frame):
         Note that artificial_depth == 0 means invalid.
         """
         # See gdb/frame-id.h and gdb/frame.c:frame_id::to_string().
+        # This obviously isn't guaranteed to be stable, but looking at the blame
+        # of to_string() it has been.
 
         # Here is an example of what is can look like:
         # "{stack=0x7fffffffe030,code=0x00007ffff7fe0880,!special}"
@@ -334,6 +336,7 @@ class GDBFrame(pwndbg.dbg_mod.Frame):
     @override
     def __hash__(self) -> int:
         if self._hash is not None:
+            # The object is immutable, so this works.
             return self._hash
 
         # GDB implements the equality comparison in gdb/python/py-frame.c:frapy_richcompare()
@@ -355,7 +358,7 @@ class GDBFrame(pwndbg.dbg_mod.Frame):
             # Still using idx() for good measure (maybe it helps with the lack of frame_id_is_next?)
             # Still using number_of_stops_since_birth because I want to guarantee that same frames at
             # different times return different hashes.
-            f"{self.idx()}|{pwndbg.dbg_mod.number_of_stops_since_birth << 16}"
+            f"{self.idx()}|{pwndbg.dbg_mod.number_of_stops_since_birth}"
         )
 
         return self._hash

--- a/pwndbg/dbg_mod/gdb/__init__.py
+++ b/pwndbg/dbg_mod/gdb/__init__.py
@@ -259,13 +259,11 @@ class GDBFrame(pwndbg.dbg_mod.Frame):
     def __hash__(self) -> int:
         # GDB implements the equality comparison in gdb/python/py-frame.c:frapy_richcompare()
         # Unfortunately it doesn't expose frame_id and frame_id_is_next.
-        # Thus, we are rolling our own hash (see the LLDB implementation as well).
+        # Thus, we are rolling our own hash (see the LLDB implementation for rationale).
         # Since GDB doesn't provide us with a way to get the thread id, we're just going to use the
-        # the SP (with a bit cut off the top :p) because it should be unique between threads.
+        # the SP because it should be unique between threads.
         # FIXME: self.sp() might be slow, can we do something better?
-        return (
-            self.idx() + (pwndbg.dbg_mod.number_of_stops_since_birth << 16) + (self.sp() << 32)
-        ) & 0xFFFFFFFFFFFFFFFF
+        return self.idx() + (pwndbg.dbg_mod.number_of_stops_since_birth << 16) + (self.sp() << 32)
 
 
 class GDBThread(pwndbg.dbg_mod.Thread):

--- a/pwndbg/dbg_mod/gdb/hooks.py
+++ b/pwndbg/dbg_mod/gdb/hooks.py
@@ -11,8 +11,37 @@ import pwndbg.aglib.typeinfo
 import pwndbg.gdblib.events
 from pwndbg.dbg_mod import EventHandlerPriority
 from pwndbg.dbg_mod import EventType
+from pwndbg.dbg_mod.gdb import BPWP_DEFERRED_DELETE
+from pwndbg.dbg_mod.gdb import BPWP_DEFERRED_DISABLE
+from pwndbg.dbg_mod.gdb import BPWP_DEFERRED_ENABLE
 
 # TODO: Combine these `update_*` hook callbacks into one method
+
+
+@pwndbg.dbg.event_handler(EventType.STOP)
+def bpwp_process_deferred() -> None:
+    for to_enable in BPWP_DEFERRED_ENABLE:
+        to_enable.inner.enabled = True
+    for to_disable in BPWP_DEFERRED_DISABLE:
+        to_disable.inner.enabled = False
+    for to_delete in BPWP_DEFERRED_DELETE:
+        to_delete.inner.delete()
+    bpwp_clear_deferred()
+
+
+@pwndbg.dbg.event_handler(EventType.START)
+@pwndbg.dbg.event_handler(EventType.EXIT)
+def bpwp_clear_deferred() -> None:
+    for elem in BPWP_DEFERRED_DELETE:
+        elem._clear()
+    for elem in BPWP_DEFERRED_ENABLE:
+        elem._clear()
+    for elem in BPWP_DEFERRED_DISABLE:
+        elem._clear()
+
+    BPWP_DEFERRED_DELETE.clear()
+    BPWP_DEFERRED_ENABLE.clear()
+    BPWP_DEFERRED_DISABLE.clear()
 
 
 @pwndbg.dbg.event_handler(EventType.NEW_MODULE)
@@ -74,24 +103,37 @@ pwndbg.lib.cache.connect_clear_caching_events(
         # if the user does an operation to modify memory or registers while the program is stopped.
         # We don't do this for the other events, because they hopefully don't change memory or
         # registers
+        CacheUntilEvent.EXIT: (
+            pwndbg.dbg.event_handler(EventType.EXIT, EventHandlerPriority.CACHE_CLEAR),
+        ),
+        CacheUntilEvent.OBJFILE: (
+            pwndbg.dbg.event_handler(EventType.NEW_MODULE, EventHandlerPriority.CACHE_CLEAR),
+        ),
+        CacheUntilEvent.START: (
+            pwndbg.dbg.event_handler(EventType.START, EventHandlerPriority.CACHE_CLEAR),
+        ),
         CacheUntilEvent.STOP: (
-            pwndbg.gdblib.events.stop,
-            pwndbg.gdblib.events.mem_changed,
-            pwndbg.gdblib.events.reg_changed,
+            pwndbg.dbg.event_handler(EventType.STOP, EventHandlerPriority.CACHE_CLEAR),
+            pwndbg.dbg.event_handler(EventType.MEMORY_CHANGED, EventHandlerPriority.CACHE_CLEAR),
+            pwndbg.dbg.event_handler(EventType.REGISTER_CHANGED, EventHandlerPriority.CACHE_CLEAR),
         ),
-        CacheUntilEvent.EXIT: (pwndbg.gdblib.events.exit,),
-        CacheUntilEvent.OBJFILE: (pwndbg.gdblib.events.new_objfile,),
-        CacheUntilEvent.START: (pwndbg.gdblib.events.start,),
         CacheUntilEvent.CONT: (
-            pwndbg.gdblib.events.cont,
-            pwndbg.gdblib.events.mem_changed,
-            pwndbg.gdblib.events.reg_changed,
+            pwndbg.dbg.event_handler(EventType.CONTINUE, EventHandlerPriority.CACHE_CLEAR),
+            pwndbg.dbg.event_handler(EventType.MEMORY_CHANGED, EventHandlerPriority.CACHE_CLEAR),
+            pwndbg.dbg.event_handler(EventType.REGISTER_CHANGED, EventHandlerPriority.CACHE_CLEAR),
         ),
-        CacheUntilEvent.THREAD: (pwndbg.gdblib.events.thread,),
-        CacheUntilEvent.PROMPT: (pwndbg.gdblib.events.before_prompt,),
+        CacheUntilEvent.THREAD: (
+            pwndbg.gdblib.events.event_handler_factory(
+                gdb.events.new_thread, "THREAD", EventHandlerPriority.CACHE_CLEAR
+            ),
+        ),
+        CacheUntilEvent.PROMPT: (
+            pwndbg.gdblib.events.event_handler_factory(
+                gdb.events.before_prompt, "PROMPT", EventHandlerPriority.CACHE_CLEAR
+            ),
+        ),
         CacheUntilEvent.FOREVER: (),
-    },
-    priority=EventHandlerPriority.CACHE_CLEAR,
+    }
 )
 
 

--- a/pwndbg/dbg_mod/gdb/hooks.py
+++ b/pwndbg/dbg_mod/gdb/hooks.py
@@ -8,6 +8,7 @@ import pwndbg.aglib.file
 import pwndbg.aglib.memory
 import pwndbg.aglib.strings
 import pwndbg.aglib.typeinfo
+import pwndbg.dbg_mod
 import pwndbg.gdblib.events
 from pwndbg.dbg_mod import EventHandlerPriority
 from pwndbg.dbg_mod import EventType
@@ -87,6 +88,7 @@ def on_start() -> None:
 @pwndbg.dbg.event_handler(EventType.STOP)
 def on_stop() -> None:
     pwndbg.aglib.strings.update_length()
+    pwndbg.dbg_mod.number_of_stops_since_birth += 1
 
 
 @pwndbg.dbg.event_handler(EventType.EXIT)

--- a/pwndbg/dbg_mod/gdb/hooks.py
+++ b/pwndbg/dbg_mod/gdb/hooks.py
@@ -129,11 +129,6 @@ pwndbg.lib.cache.connect_clear_caching_events(
                 gdb.events.new_thread, "THREAD", EventHandlerPriority.CACHE_CLEAR
             ),
         ),
-        CacheUntilEvent.PROMPT: (
-            pwndbg.gdblib.events.event_handler_factory(
-                gdb.events.before_prompt, "PROMPT", EventHandlerPriority.CACHE_CLEAR
-            ),
-        ),
         CacheUntilEvent.FOREVER: (),
     }
 )

--- a/pwndbg/dbg_mod/lldb/__init__.py
+++ b/pwndbg/dbg_mod/lldb/__init__.py
@@ -328,12 +328,14 @@ class LLDBFrame(pwndbg.dbg_mod.Frame):
         # I think a (number of stops, thread index, frame index) tuple uniquely identifies a stack frame.
         # There probably won't be >= 65,536 stack frames in a thread stack, or
         # >= 65,536 threads in a process.
-        # We cut off int values larger than 64 bits so python can hopefully optimize this a bit.
+        # The `pwndbg.dbg_mod.number_of_stops_since_birth` part might not be necessary, because
+        # if you are comparing frames from different stops that means your code is buggy; but it
+        # lets me sleep at night better.
         return (
             self.idx()
             + (self.inner.thread.idx << 16)
             + (pwndbg.dbg_mod.number_of_stops_since_birth << 32)
-        ) & 0xFFFFFFFFFFFFFFFF
+        )
 
 
 class LLDBThread(pwndbg.dbg_mod.Thread):

--- a/pwndbg/dbg_mod/lldb/__init__.py
+++ b/pwndbg/dbg_mod/lldb/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import bisect
 import collections
 import enum
+import functools
 import os
 import random
 import re
@@ -2202,14 +2203,26 @@ class LLDB(pwndbg.dbg_mod.Debugger):
         # not a decorator itself - it returns a decorator which is then
         # immediately applied to the function.
         def decorator(fn: Callable[..., None]) -> Callable[..., None]:
-            # This is only executed once.
+            if pwndbg.config.dev_debug_events:
+                print("Connecting", fn.__name__, event_type.name)
+
             if event_type not in self.event_handlers:
                 self.event_handlers[event_type] = {priority: []}
             elif priority not in self.event_handlers[event_type]:
                 self.event_handlers[event_type][priority] = []
 
-            self.event_handlers[event_type][priority].append(fn)
-            return fn
+            # Wrap the function for dev instrumentation
+            @functools.wraps(fn)
+            def _dev_wrapper(*a, **kw) -> None:
+                if pwndbg.config.dev_debug_events:
+                    sys.stdout.write(
+                        f"{event_type.name} ({priority.name}) {fn.__module__}.{fn.__qualname__}\n"
+                    )
+
+                return fn(*a, **kw)
+
+            self.event_handlers[event_type][priority].append(_dev_wrapper)
+            return _dev_wrapper
 
         return decorator
 

--- a/pwndbg/dbg_mod/lldb/__init__.py
+++ b/pwndbg/dbg_mod/lldb/__init__.py
@@ -2259,19 +2259,19 @@ class LLDB(pwndbg.dbg_mod.Debugger):
             # This event has been suspended.
             return
 
-        # Run the handlers in order of their priority.
-        # We should optimize this by using a Dict[EventType, List[Tuple[EventHandlerPriority, Callable[..., None]]]]
-        # type for self.event_handlers, and sort it only once after everything is registered.
-        for prio in EventHandlerPriority:
-            handlers = self.event_handlers[ty].get(prio, [])
-            for handler in handlers:
-                try:
+        try:
+            # Run the handlers in order of their priority.
+            # We should optimize this by using a Dict[EventType, List[Tuple[EventHandlerPriority, Callable[..., None]]]]
+            # type for self.event_handlers, and sort it only once after everything is registered.
+            for prio in EventHandlerPriority:
+                handlers = self.event_handlers[ty].get(prio, [])
+                for handler in handlers:
                     handler()
-                except Exception as e:
-                    from pwndbg.exception import handle as pwndbg_exception
+        except Exception as e:
+            from pwndbg.exception import handle as pwndbg_exception
 
-                    pwndbg_exception()
-                    raise e
+            pwndbg_exception()
+            raise e
 
     @override
     def set_sysroot(self, sysroot: str) -> bool:

--- a/pwndbg/dbg_mod/lldb/__init__.py
+++ b/pwndbg/dbg_mod/lldb/__init__.py
@@ -28,8 +28,10 @@ from typing_extensions import override
 
 import pwndbg
 import pwndbg.color.message as M
+import pwndbg.dbg_mod
 import pwndbg.lib.memory
 from pwndbg.aglib import load_aglib
+from pwndbg.dbg_mod import EventHandlerPriority
 from pwndbg.dbg_mod import selection
 from pwndbg.lib.arch import ArchDefinition
 from pwndbg.lib.arch import Platform
@@ -1913,7 +1915,9 @@ class LLDB(pwndbg.dbg_mod.Debugger):
 
     # We keep track of all installed event handlers here. The REPL will trigger
     # them by means of the `_trigger_event()` method.
-    event_handlers: Dict[pwndbg.dbg_mod.EventType, List[Callable[..., T]]]
+    event_handlers: Dict[
+        pwndbg.dbg_mod.EventType, Dict[EventHandlerPriority, List[Callable[..., None]]]
+    ]
 
     # Event types may be suspended. We keep track of that here.
     suspended_events: Dict[pwndbg.dbg_mod.EventType, bool]
@@ -2188,14 +2192,17 @@ class LLDB(pwndbg.dbg_mod.Debugger):
 
     @override
     def event_handler(
-        self, ty: pwndbg.dbg_mod.EventType
-    ) -> Callable[[Callable[..., T]], Callable[..., T]]:
-        def decorator(fn: Callable[..., T]) -> Callable[..., T]:
-            if ty not in self.event_handlers:
-                self.event_handlers[ty] = []
+        self,
+        event_type: pwndbg.dbg_mod.EventType,
+        priority: EventHandlerPriority = EventHandlerPriority.STANDARD,
+    ) -> Callable[[Callable[..., None]], Callable[..., None]]:
+        def decorator(fn: Callable[..., None]) -> Callable[..., None]:
+            if event_type not in self.event_handlers:
+                self.event_handlers[event_type] = {priority: []}
+            elif priority not in self.event_handlers[event_type]:
+                self.event_handlers[event_type][priority] = []
 
-            # [...] incompatible type "Callable[..., T]"; expected "Callable[..., T]"
-            self.event_handlers[ty].append(fn)  # type: ignore[arg-type]
+            self.event_handlers[event_type][priority].append(fn)
             return fn
 
         return decorator
@@ -2233,14 +2240,19 @@ class LLDB(pwndbg.dbg_mod.Debugger):
             # This event has been suspended.
             return
 
-        for handler in self.event_handlers[ty]:
-            try:
-                handler()
-            except Exception as e:
-                from pwndbg.exception import handle as pwndbg_exception
+        # Run the handlers in order of their priority.
+        # We should optimize this by using a Dict[EventType, List[Tuple[EventHandlerPriority, Callable[..., None]]]]
+        # type for self.event_handlers, and sort it only once after everything is registered.
+        for prio in EventHandlerPriority:
+            handlers = self.event_handlers[ty].get(prio, [])
+            for handler in handlers:
+                try:
+                    handler()
+                except Exception as e:
+                    from pwndbg.exception import handle as pwndbg_exception
 
-                pwndbg_exception()
-                raise e
+                    pwndbg_exception()
+                    raise e
 
     @override
     def set_sysroot(self, sysroot: str) -> bool:

--- a/pwndbg/dbg_mod/lldb/__init__.py
+++ b/pwndbg/dbg_mod/lldb/__init__.py
@@ -309,6 +309,32 @@ class LLDBFrame(pwndbg.dbg_mod.Frame):
         # https://lldb.llvm.org/python_api/lldb.SBFrame.html#lldb.SBFrame.idx
         return self.inner.idx
 
+    @override
+    def __hash__(self) -> int:
+        # There is a GetFrameID API [1], but it isn't really documented
+        # and looking at its implementation [2] does not fill me with confidence.
+        # Looking at the SBFrame equality check [3], it uses StackFrame.GetStackID()
+        # [4] which updates and returns StackFrame.m_id the comparison of which is
+        # implemented here [5]. But I don't see how it guarantees that two frames at
+        # the same stack and pc but at different times will be different. Maybe it
+        # just doesn't?
+        # In any case the StackID class doesn't expose an integer, so we are rolling
+        # our own thing.
+        # [1] https://lldb.llvm.org/python_api/lldb.SBFrame.html#lldb.SBFrame.GetFrameID
+        # [2] https://github.com/llvm/llvm-project/blob/1deee91bf52ca15e47b59a2929e5e5a323f4864c/lldb/source/API/SBFrame.cpp#L255
+        # [3] https://github.com/llvm/llvm-project/blob/1deee91bf52ca15e47b59a2929e5e5a323f4864c/lldb/source/API/SBFrame.cpp#L585
+        # [4] https://github.com/llvm/llvm-project/blob/1deee91bf52ca15e47b59a2929e5e5a323f4864c/lldb/source/Target/StackFrame.cpp#L154
+        # [5] https://github.com/llvm/llvm-project/blob/1deee91bf52ca15e47b59a2929e5e5a323f4864c/lldb/source/Target/StackID.cpp#L53
+        # I think a (number of stops, thread index, frame index) tuple uniquely identifies a stack frame.
+        # There probably won't be >= 65,536 stack frames in a thread stack, or
+        # >= 65,536 threads in a process.
+        # We cut off int values larger than 64 bits so python can hopefully optimize this a bit.
+        return (
+            self.idx()
+            + (self.inner.thread.idx << 16)
+            + (pwndbg.dbg_mod.number_of_stops_since_birth << 32)
+        ) & 0xFFFFFFFFFFFFFFFF
+
 
 class LLDBThread(pwndbg.dbg_mod.Thread):
     inner: lldb.SBThread

--- a/pwndbg/dbg_mod/lldb/__init__.py
+++ b/pwndbg/dbg_mod/lldb/__init__.py
@@ -1983,7 +1983,9 @@ class LLDB(pwndbg.dbg_mod.Debugger):
 
         pwndbg.commands.comments.init()
 
-        import pwndbg.dbg_mod.lldb.hooks
+        # Register event hooks.
+        # (We can't do them in this file because pwndbg.dbg isn't initialized yet.)
+        from pwndbg.dbg_mod.lldb import hooks as hooks
 
     def relay_exceptions(self) -> None:
         """
@@ -2196,7 +2198,11 @@ class LLDB(pwndbg.dbg_mod.Debugger):
         event_type: pwndbg.dbg_mod.EventType,
         priority: EventHandlerPriority = EventHandlerPriority.STANDARD,
     ) -> Callable[[Callable[..., None]], Callable[..., None]]:
+        # Note that event_handler is actually a decorator factory and
+        # not a decorator itself - it returns a decorator which is then
+        # immediately applied to the function.
         def decorator(fn: Callable[..., None]) -> Callable[..., None]:
+            # This is only executed once.
             if event_type not in self.event_handlers:
                 self.event_handlers[event_type] = {priority: []}
             elif priority not in self.event_handlers[event_type]:

--- a/pwndbg/dbg_mod/lldb/__init__.py
+++ b/pwndbg/dbg_mod/lldb/__init__.py
@@ -304,6 +304,11 @@ class LLDBFrame(pwndbg.dbg_mod.Frame):
 
         return self.inner == other.inner
 
+    @override
+    def idx(self) -> int:
+        # https://lldb.llvm.org/python_api/lldb.SBFrame.html#lldb.SBFrame.idx
+        return self.inner.idx
+
 
 class LLDBThread(pwndbg.dbg_mod.Thread):
     inner: lldb.SBThread

--- a/pwndbg/dbg_mod/lldb/hooks.py
+++ b/pwndbg/dbg_mod/lldb/hooks.py
@@ -69,7 +69,6 @@ pwndbg.lib.cache.connect_clear_caching_events(
             pwndbg.dbg.event_handler(EventType.MEMORY_CHANGED, EventHandlerPriority.CACHE_CLEAR),
             pwndbg.dbg.event_handler(EventType.REGISTER_CHANGED, EventHandlerPriority.CACHE_CLEAR),
         ),
-        CacheUntilEvent.PROMPT: (),
         CacheUntilEvent.FOREVER: (),
     },
 )
@@ -93,9 +92,6 @@ def renew_show_context():
 
 
 def prompt_hook():
-    # Clear the prompt cache manually.
-    pwndbg.lib.cache.clear_cache(CacheUntilEvent.PROMPT)
-
     dbg: LLDB = pwndbg.dbg
     ctx_suspend_once = dbg.should_suspend_ctx
     global should_show_context

--- a/pwndbg/dbg_mod/lldb/hooks.py
+++ b/pwndbg/dbg_mod/lldb/hooks.py
@@ -11,6 +11,7 @@ import pwndbg.aglib.kernel
 import pwndbg.aglib.memory
 import pwndbg.aglib.strings
 import pwndbg.aglib.typeinfo
+import pwndbg.dbg_mod
 import pwndbg.lib.cache
 from pwndbg.dbg_mod import EventHandlerPriority
 from pwndbg.dbg_mod import EventType
@@ -39,6 +40,7 @@ def on_start() -> None:
 @pwndbg.dbg.event_handler(EventType.STOP)
 def on_stop() -> None:
     pwndbg.aglib.strings.update_length()
+    pwndbg.dbg_mod.number_of_stops_since_birth += 1
 
 
 @pwndbg.dbg.event_handler(EventType.EXIT)

--- a/pwndbg/dbg_mod/lldb/hooks.py
+++ b/pwndbg/dbg_mod/lldb/hooks.py
@@ -12,6 +12,7 @@ import pwndbg.aglib.memory
 import pwndbg.aglib.strings
 import pwndbg.aglib.typeinfo
 import pwndbg.lib.cache
+from pwndbg.dbg_mod import EventHandlerPriority
 from pwndbg.dbg_mod import EventType
 from pwndbg.dbg_mod.lldb import LLDB
 from pwndbg.lib.cache import CacheUntilEvent
@@ -63,6 +64,7 @@ pwndbg.lib.cache.connect_clear_caching_events(
         CacheUntilEvent.PROMPT: (),
         CacheUntilEvent.FOREVER: (),
     },
+    priority=EventHandlerPriority.CACHE_CLEAR,
 )
 
 # As we don't have support for MEMORY_CHANGED, REGISTER_CHANGED, or NEW_THREAD

--- a/pwndbg/dbg_mod/lldb/hooks.py
+++ b/pwndbg/dbg_mod/lldb/hooks.py
@@ -48,23 +48,28 @@ def on_exit() -> None:
 
 pwndbg.lib.cache.connect_clear_caching_events(
     {
-        CacheUntilEvent.EXIT: (pwndbg.dbg.event_handler(EventType.EXIT),),
-        CacheUntilEvent.OBJFILE: (pwndbg.dbg.event_handler(EventType.NEW_MODULE),),
-        CacheUntilEvent.START: (pwndbg.dbg.event_handler(EventType.START),),
+        CacheUntilEvent.EXIT: (
+            pwndbg.dbg.event_handler(EventType.EXIT, EventHandlerPriority.CACHE_CLEAR),
+        ),
+        CacheUntilEvent.OBJFILE: (
+            pwndbg.dbg.event_handler(EventType.NEW_MODULE, EventHandlerPriority.CACHE_CLEAR),
+        ),
+        CacheUntilEvent.START: (
+            pwndbg.dbg.event_handler(EventType.START, EventHandlerPriority.CACHE_CLEAR),
+        ),
         CacheUntilEvent.STOP: (
-            pwndbg.dbg.event_handler(EventType.STOP),
-            pwndbg.dbg.event_handler(EventType.MEMORY_CHANGED),
-            pwndbg.dbg.event_handler(EventType.REGISTER_CHANGED),
+            pwndbg.dbg.event_handler(EventType.STOP, EventHandlerPriority.CACHE_CLEAR),
+            pwndbg.dbg.event_handler(EventType.MEMORY_CHANGED, EventHandlerPriority.CACHE_CLEAR),
+            pwndbg.dbg.event_handler(EventType.REGISTER_CHANGED, EventHandlerPriority.CACHE_CLEAR),
         ),
         CacheUntilEvent.CONT: (
-            pwndbg.dbg.event_handler(EventType.CONTINUE),
-            pwndbg.dbg.event_handler(EventType.MEMORY_CHANGED),
-            pwndbg.dbg.event_handler(EventType.REGISTER_CHANGED),
+            pwndbg.dbg.event_handler(EventType.CONTINUE, EventHandlerPriority.CACHE_CLEAR),
+            pwndbg.dbg.event_handler(EventType.MEMORY_CHANGED, EventHandlerPriority.CACHE_CLEAR),
+            pwndbg.dbg.event_handler(EventType.REGISTER_CHANGED, EventHandlerPriority.CACHE_CLEAR),
         ),
         CacheUntilEvent.PROMPT: (),
         CacheUntilEvent.FOREVER: (),
     },
-    priority=EventHandlerPriority.CACHE_CLEAR,
 )
 
 # As we don't have support for MEMORY_CHANGED, REGISTER_CHANGED, or NEW_THREAD

--- a/pwndbg/dbg_mod/lldb/hooks.py
+++ b/pwndbg/dbg_mod/lldb/hooks.py
@@ -11,8 +11,10 @@ import pwndbg.aglib.kernel
 import pwndbg.aglib.memory
 import pwndbg.aglib.strings
 import pwndbg.aglib.typeinfo
+import pwndbg.lib.cache
 from pwndbg.dbg_mod import EventType
 from pwndbg.dbg_mod.lldb import LLDB
+from pwndbg.lib.cache import CacheUntilEvent
 
 
 @pwndbg.dbg.event_handler(EventType.NEW_MODULE)
@@ -43,25 +45,23 @@ def on_exit() -> None:
     pwndbg.aglib.file.reset_remote_files()
 
 
-import pwndbg.lib.cache
-
 pwndbg.lib.cache.connect_clear_caching_events(
     {
-        "exit": (pwndbg.dbg.event_handler(EventType.EXIT),),
-        "objfile": (pwndbg.dbg.event_handler(EventType.NEW_MODULE),),
-        "start": (pwndbg.dbg.event_handler(EventType.START),),
-        "stop": (
+        CacheUntilEvent.EXIT: (pwndbg.dbg.event_handler(EventType.EXIT),),
+        CacheUntilEvent.OBJFILE: (pwndbg.dbg.event_handler(EventType.NEW_MODULE),),
+        CacheUntilEvent.START: (pwndbg.dbg.event_handler(EventType.START),),
+        CacheUntilEvent.STOP: (
             pwndbg.dbg.event_handler(EventType.STOP),
             pwndbg.dbg.event_handler(EventType.MEMORY_CHANGED),
             pwndbg.dbg.event_handler(EventType.REGISTER_CHANGED),
         ),
-        "cont": (
+        CacheUntilEvent.CONT: (
             pwndbg.dbg.event_handler(EventType.CONTINUE),
             pwndbg.dbg.event_handler(EventType.MEMORY_CHANGED),
             pwndbg.dbg.event_handler(EventType.REGISTER_CHANGED),
         ),
-        "prompt": (),
-        "forever": (),
+        CacheUntilEvent.PROMPT: (),
+        CacheUntilEvent.FOREVER: (),
     },
 )
 
@@ -72,9 +72,7 @@ pwndbg.lib.cache.connect_clear_caching_events(
 # TODO: Implement missing event types and re-enable the cache types that depend on them.
 #
 # FIXME: `stop` and `cont` have been enabled for performance reasons, but aren't 100% correct.
-pwndbg.lib.cache.IS_CACHING_DISABLED_FOR["stop"] = False
-pwndbg.lib.cache.IS_CACHING_DISABLED_FOR["thread"] = True
-pwndbg.lib.cache.IS_CACHING_DISABLED_FOR["cont"] = False
+pwndbg.lib.cache.IS_CACHING_DISABLED_FOR = CacheUntilEvent.THREAD
 
 should_show_context = False
 
@@ -87,7 +85,7 @@ def renew_show_context():
 
 def prompt_hook():
     # Clear the prompt cache manually.
-    pwndbg.lib.cache.clear_cache("prompt")
+    pwndbg.lib.cache.clear_cache(CacheUntilEvent.PROMPT)
 
     dbg: LLDB = pwndbg.dbg
     ctx_suspend_once = dbg.should_suspend_ctx

--- a/pwndbg/dbg_mod/lldb/repl/__init__.py
+++ b/pwndbg/dbg_mod/lldb/repl/__init__.py
@@ -174,22 +174,22 @@ class EventRelay(EventHandler):
     there's a bit of work we have to do to properly convey certain events.
     """
 
-    def __init__(self, dbg: LLDB):
+    def __init__(self, dbg: LLDB) -> None:
         self.dbg = dbg
         self.ignore_resumed = 0
 
-    def _set_ignore_resumed(self, count: int):
+    def _set_ignore_resumed(self, count: int) -> None:
         """
         Don't relay next given number of resumed events.
         """
         self.ignore_resumed += count
 
     @override
-    def created(self):
+    def created(self) -> None:
         self.dbg._trigger_event(EventType.START)
 
     @override
-    def suspended(self, event: lldb.SBEvent):
+    def suspended(self, event: lldb.SBEvent) -> None:
         # The event might have originated from a different source than the user
         # currently has selected. Move focus to the where the event happened.
         #
@@ -211,7 +211,7 @@ class EventRelay(EventHandler):
         self.dbg._trigger_event(EventType.STOP)
 
     @override
-    def resumed(self):
+    def resumed(self) -> None:
         if self.ignore_resumed > 0:
             self.ignore_resumed -= 1
             return
@@ -219,11 +219,11 @@ class EventRelay(EventHandler):
         self.dbg._trigger_event(EventType.CONTINUE)
 
     @override
-    def exited(self):
+    def exited(self) -> None:
         self.dbg._trigger_event(EventType.EXIT)
 
     @override
-    def modules_loaded(self):
+    def modules_loaded(self) -> None:
         self.dbg._trigger_event(EventType.NEW_MODULE)
 
 

--- a/pwndbg/gdblib/__init__.py
+++ b/pwndbg/gdblib/__init__.py
@@ -32,7 +32,6 @@ def load_gdblib() -> None:
     import pwndbg.gdblib.bpoint
     import pwndbg.gdblib.functions
     import pwndbg.gdblib.got
-    import pwndbg.gdblib.hooks
     import pwndbg.gdblib.prompt
     import pwndbg.gdblib.symbol
     import pwndbg.gdblib.tui

--- a/pwndbg/gdblib/bpoint.py
+++ b/pwndbg/gdblib/bpoint.py
@@ -17,7 +17,7 @@ class Breakpoint(gdb.Breakpoint):
 
     def stop(self) -> bool:
         # Clear the cache for the stop event.
-        pwndbg.lib.cache.clear_cache("stop")
+        pwndbg.lib.cache.clear_cache(pwndbg.lib.cache.CacheUntilEvent.STOP)
         return self.should_stop()
 
     def should_stop(self) -> bool:

--- a/pwndbg/gdblib/events.py
+++ b/pwndbg/gdblib/events.py
@@ -23,7 +23,6 @@ import gdb
 from typing_extensions import ParamSpec
 
 import pwndbg
-import pwndbg.dbg_mod.gdb
 import pwndbg.lib.config
 from pwndbg import config
 from pwndbg.color import message
@@ -32,8 +31,6 @@ from pwndbg.dbg_mod import EventHandlerPriority
 DISABLED = "disabled"
 DISABLED_DEADLOCK = "disabled-deadlock"
 ENABLED = "enabled"
-
-debug = config.add_param("debug-events", False, "display internal event debugging info")
 
 gdb_workaround_stop_event = config.add_param(
     "gdb-workaround-stop-event",
@@ -293,7 +290,7 @@ def event_handler_factory(
     def decorator(fn: Callable[..., None]) -> Callable[..., None]:
         # This is only executed once.
 
-        if debug:
+        if pwndbg.config.dev_debug_events:
             print("Connecting", fn.__name__, event_name)
 
         should_connect: bool = False
@@ -305,9 +302,9 @@ def event_handler_factory(
         # Wrap the function for dev instrumentation
         @functools.wraps(fn)
         def _dev_wrapper(*a, **kw) -> None:
-            if debug:
+            if pwndbg.config.dev_debug_events:
                 sys.stdout.write(
-                    f"{event_name} ({priority.name}) {fn.__module__}.{fn.__name__} {a!r}\n"
+                    f"{event_name} ({priority.name}) {fn.__module__}.{fn.__qualname__}\n"
                 )
 
             return fn(*a, **kw)
@@ -331,7 +328,7 @@ def event_handler_factory(
 
 
 def log_objfiles(ofile: gdb.NewObjFileEvent | None = None) -> None:
-    if not (debug and ofile):
+    if not (pwndbg.config.dev_debug_events and ofile):
         return None
 
     name = ofile.new_objfile.filename

--- a/pwndbg/gdblib/events.py
+++ b/pwndbg/gdblib/events.py
@@ -6,6 +6,7 @@ by using a decorator.
 
 from __future__ import annotations
 
+import functools
 import sys
 from collections import defaultdict
 from collections import deque
@@ -22,6 +23,8 @@ import gdb
 from typing_extensions import ParamSpec
 
 import pwndbg
+import pwndbg.dbg_mod.gdb
+import pwndbg.lib.config
 from pwndbg import config
 from pwndbg.color import message
 from pwndbg.dbg_mod import EventHandlerPriority
@@ -95,6 +98,7 @@ class StartEvent:
         self.on_new_objfile()
 
 
+# Monkeypatching GDB hihi
 gdb.events.start = StartEvent()
 gdb.events.suspend_all = object()
 
@@ -249,7 +253,7 @@ def wrap_safe_event_handler(event_handler: Callable[P, T], event_type: Any) -> C
 
 # In order to support reloading, we must be able to re-fire
 # all 'objfile' and 'stop' events.
-registered: Dict[Any, Dict[EventHandlerPriority, List[Callable[..., None]]]] = {
+registered: Dict[gdb.EventRegistry[Any], Dict[EventHandlerPriority, List[Callable[..., None]]]] = {
     gdb.events.exited: {},
     gdb.events.cont: {},
     gdb.events.new_objfile: {},
@@ -261,93 +265,69 @@ registered: Dict[Any, Dict[EventHandlerPriority, List[Callable[..., None]]]] = {
     gdb.events.register_changed: {},
 }
 
-# Registered events are wrapped and aren't directly connected to GDB
-# This is a map from event to the actual handler connected to GDB
-connected = {}
-
 # Keys are gdb.events.*
 paused = defaultdict(bool)
 
 
-def pause(event_registry) -> None:
+def pause(event_registry: gdb.EventRegistry[Any]) -> None:
     paused[event_registry] = True
 
 
-def unpause(event_registry) -> None:
+def unpause(event_registry: gdb.EventRegistry[Any]) -> None:
     paused[event_registry] = False
 
 
-def connect(
-    func: Callable[[], None],
-    event_handler: Any,
-    name: str = "",
-    priority: EventHandlerPriority = EventHandlerPriority.STANDARD,
-) -> Callable[[], None]:
-    if debug:
-        print("Connecting", func.__name__, event_handler)
+def event_handler_factory(
+    event_registry: gdb.EventRegistry[Any], event_name: str, priority: EventHandlerPriority
+) -> Callable[[Callable[..., None]], Callable[..., None]]:
+    """
+    Essentially the implementation of pwndbg.dbg_mod.gdb.event_handler().
 
-    @wraps(func)
-    def caller(*a: Any, **kw: Any) -> None:
-        if paused[event_handler] or paused[gdb.events.suspend_all]:
-            return None
+    Takes a gdb.EventRegistry because that contains some events that pwndbg.dbg_mod.EventType
+    doesn't.
+
+    Read the first few paragraphs of:
+    https://sourceware.org/gdb/current/onlinedocs/gdb.html/Events-In-Python.html#Events-In-Python
+    """
+
+    def decorator(fn: Callable[..., None]) -> Callable[..., None]:
+        # This is only executed once.
 
         if debug:
-            sys.stdout.write(f"{name!r} ({priority.name}) {func.__module__}.{func.__name__} {a!r}\n")
+            print("Connecting", fn.__name__, event_name)
 
-        try:
-            # Don't pass the event along to the decorated function.
-            # This is because there are functions with multiple event decorators
-            func()
-        except Exception as e:
-            import pwndbg.exception
+        should_connect: bool = False
 
-            pwndbg.exception.handle()
-            raise e
+        if not registered[event_registry]:
+            # We've never seen this type of event before.
+            should_connect = True
 
-    registered[event_handler].setdefault(priority, []).append(caller)
-    if event_handler not in connected:
-        handle = partial(invoke_event, event_handler)
-        handle = wrap_safe_event_handler(handle, event_handler)
+        # Wrap the function for dev instrumentation
+        @functools.wraps(fn)
+        def _dev_wrapper(*a, **kw) -> None:
+            if debug:
+                sys.stdout.write(
+                    f"{event_name} ({priority.name}) {fn.__module__}.{fn.__name__} {a!r}\n"
+                )
 
-        event_handler.connect(handle)
-        connected[event_handler] = handle
-    return func
+            return fn(*a, **kw)
 
+        # Register this event handler with us.
+        registered[event_registry].setdefault(priority, []).append(_dev_wrapper)
 
-def exit(func: Callable[[], None], **kwargs: Any) -> Callable[[], None]:
-    return connect(func, gdb.events.exited, "exit", **kwargs)
+        if should_connect:
+            # We actually need to tell gdb to run `invoke_event` when
+            # the appropriate event is invoked. Then inside `invoke_event`
+            # we will call all `registered` functions.
 
+            wrapped_invoke_event = partial(invoke_event, event_registry)
+            wrapped_invoke_event = wrap_safe_event_handler(wrapped_invoke_event, event_registry)
 
-def cont(func: Callable[[], None], **kwargs: Any) -> Callable[[], None]:
-    return connect(func, gdb.events.cont, "cont", **kwargs)
+            event_registry.connect(wrapped_invoke_event)
 
+        return _dev_wrapper
 
-def new_objfile(func: Callable[[], None], **kwargs: Any) -> Callable[[], None]:
-    return connect(func, gdb.events.new_objfile, "obj", **kwargs)
-
-
-def stop(func: Callable[[], None], **kwargs: Any) -> Callable[[], None]:
-    return connect(func, gdb.events.stop, "stop", **kwargs)
-
-
-def start(func: Callable[[], None], **kwargs: Any) -> Callable[[], None]:
-    return connect(func, gdb.events.start, "start", **kwargs)
-
-
-def thread(func: Callable[[], None], **kwargs: Any) -> Callable[[], None]:
-    return connect(func, gdb.events.new_thread, "thread", **kwargs)
-
-
-def before_prompt(func: Callable[[], None], **kwargs: Any) -> Callable[[], None]:
-    return connect(func, gdb.events.before_prompt, "before_prompt", **kwargs)
-
-
-def reg_changed(func: Callable[[], None], **kwargs: Any) -> Callable[[], None]:
-    return connect(func, gdb.events.register_changed, "reg_changed", **kwargs)
-
-
-def mem_changed(func: Callable[[], None], **kwargs: Any) -> Callable[[], None]:
-    return connect(func, gdb.events.memory_changed, "mem_changed", **kwargs)
+    return decorator
 
 
 def log_objfiles(ofile: gdb.NewObjFileEvent | None = None) -> None:
@@ -364,13 +344,28 @@ def log_objfiles(ofile: gdb.NewObjFileEvent | None = None) -> None:
 gdb.events.new_objfile.connect(log_objfiles)
 
 
-# invoke all registered handlers of a certain event type
-def invoke_event(event: Any, *args: Any, **kwargs: Any) -> None:
-    handlers = registered.get(event)
-    if handlers is not None:
+def invoke_event(event_registry: gdb.EventRegistry[Any], event_data: Any = None) -> None:
+    """
+    Invoke all registered handlers for a certain event_registry.
+    event_data may be None if we manually ran this function.
+    """
+    if paused[event_registry] or paused[gdb.events.suspend_all]:
+        return
+
+    handlers = registered.get(event_registry)
+    if handlers is None:
+        return
+
+    try:
+        # Run all the event handlers for this event from lowest to highest priority.
         for prio in EventHandlerPriority:
-            for f in handlers.get(prio, []):
-                f(*args, **kwargs)
+            for func in handlers.get(prio, []):
+                func()
+    except Exception as e:
+        import pwndbg.exception
+
+        pwndbg.exception.handle()
+        raise e
 
 
 def after_reload(fire_start: bool = True) -> None:

--- a/pwndbg/gdblib/events.py
+++ b/pwndbg/gdblib/events.py
@@ -9,8 +9,6 @@ from __future__ import annotations
 import sys
 from collections import defaultdict
 from collections import deque
-from enum import Enum
-from enum import auto
 from functools import partial
 from functools import wraps
 from typing import Any
@@ -26,6 +24,7 @@ from typing_extensions import ParamSpec
 import pwndbg
 from pwndbg import config
 from pwndbg.color import message
+from pwndbg.dbg_mod import EventHandlerPriority
 
 DISABLED = "disabled"
 DISABLED_DEADLOCK = "disabled-deadlock"
@@ -248,18 +247,9 @@ def wrap_safe_event_handler(event_handler: Callable[P, T], event_type: Any) -> C
     return _inner_handler
 
 
-class HandlerPriority(Enum):
-    """
-    A priority level for an event handler, ordered from highest to lowest priority.
-    """
-
-    CACHE_CLEAR = auto()
-    LOW = auto()
-
-
 # In order to support reloading, we must be able to re-fire
 # all 'objfile' and 'stop' events.
-registered: Dict[Any, Dict[HandlerPriority, List[Callable[..., Any]]]] = {
+registered: Dict[Any, Dict[EventHandlerPriority, List[Callable[..., None]]]] = {
     gdb.events.exited: {},
     gdb.events.cont: {},
     gdb.events.new_objfile: {},
@@ -288,11 +278,11 @@ def unpause(event_registry) -> None:
 
 
 def connect(
-    func: Callable[[], T],
+    func: Callable[[], None],
     event_handler: Any,
     name: str = "",
-    priority: HandlerPriority = HandlerPriority.LOW,
-) -> Callable[[], T]:
+    priority: EventHandlerPriority = EventHandlerPriority.STANDARD,
+) -> Callable[[], None]:
     if debug:
         print("Connecting", func.__name__, event_handler)
 
@@ -302,7 +292,7 @@ def connect(
             return None
 
         if debug:
-            sys.stdout.write(f"{name!r} {func.__module__}.{func.__name__} {a!r}\n")
+            sys.stdout.write(f"{name!r} ({priority.name}) {func.__module__}.{func.__name__} {a!r}\n")
 
         try:
             # Don't pass the event along to the decorated function.
@@ -324,39 +314,39 @@ def connect(
     return func
 
 
-def exit(func: Callable[[], T], **kwargs: Any) -> Callable[[], T]:
+def exit(func: Callable[[], None], **kwargs: Any) -> Callable[[], None]:
     return connect(func, gdb.events.exited, "exit", **kwargs)
 
 
-def cont(func: Callable[[], T], **kwargs: Any) -> Callable[[], T]:
+def cont(func: Callable[[], None], **kwargs: Any) -> Callable[[], None]:
     return connect(func, gdb.events.cont, "cont", **kwargs)
 
 
-def new_objfile(func: Callable[[], T], **kwargs: Any) -> Callable[[], T]:
+def new_objfile(func: Callable[[], None], **kwargs: Any) -> Callable[[], None]:
     return connect(func, gdb.events.new_objfile, "obj", **kwargs)
 
 
-def stop(func: Callable[[], T], **kwargs: Any) -> Callable[[], T]:
+def stop(func: Callable[[], None], **kwargs: Any) -> Callable[[], None]:
     return connect(func, gdb.events.stop, "stop", **kwargs)
 
 
-def start(func: Callable[[], T], **kwargs: Any) -> Callable[[], T]:
+def start(func: Callable[[], None], **kwargs: Any) -> Callable[[], None]:
     return connect(func, gdb.events.start, "start", **kwargs)
 
 
-def thread(func: Callable[[], T], **kwargs: Any) -> Callable[[], T]:
+def thread(func: Callable[[], None], **kwargs: Any) -> Callable[[], None]:
     return connect(func, gdb.events.new_thread, "thread", **kwargs)
 
 
-def before_prompt(func: Callable[[], T], **kwargs: Any) -> Callable[[], T]:
+def before_prompt(func: Callable[[], None], **kwargs: Any) -> Callable[[], None]:
     return connect(func, gdb.events.before_prompt, "before_prompt", **kwargs)
 
 
-def reg_changed(func: Callable[[], T], **kwargs: Any) -> Callable[[], T]:
+def reg_changed(func: Callable[[], None], **kwargs: Any) -> Callable[[], None]:
     return connect(func, gdb.events.register_changed, "reg_changed", **kwargs)
 
 
-def mem_changed(func: Callable[[], T], **kwargs: Any) -> Callable[[], T]:
+def mem_changed(func: Callable[[], None], **kwargs: Any) -> Callable[[], None]:
     return connect(func, gdb.events.memory_changed, "mem_changed", **kwargs)
 
 
@@ -378,7 +368,7 @@ gdb.events.new_objfile.connect(log_objfiles)
 def invoke_event(event: Any, *args: Any, **kwargs: Any) -> None:
     handlers = registered.get(event)
     if handlers is not None:
-        for prio in HandlerPriority:
+        for prio in EventHandlerPriority:
             for f in handlers.get(prio, []):
                 f(*args, **kwargs)
 

--- a/pwndbg/gdblib/hooks.py
+++ b/pwndbg/gdblib/hooks.py
@@ -9,6 +9,7 @@ import pwndbg.aglib.memory
 import pwndbg.aglib.strings
 import pwndbg.aglib.typeinfo
 import pwndbg.gdblib.events
+from pwndbg.dbg_mod import EventHandlerPriority
 from pwndbg.dbg_mod import EventType
 
 # TODO: Combine these `update_*` hook callbacks into one method
@@ -90,7 +91,7 @@ pwndbg.lib.cache.connect_clear_caching_events(
         CacheUntilEvent.PROMPT: (pwndbg.gdblib.events.before_prompt,),
         CacheUntilEvent.FOREVER: (),
     },
-    priority=pwndbg.gdblib.events.HandlerPriority.CACHE_CLEAR,
+    priority=EventHandlerPriority.CACHE_CLEAR,
 )
 
 

--- a/pwndbg/gdblib/hooks.py
+++ b/pwndbg/gdblib/hooks.py
@@ -65,6 +65,7 @@ def on_exit() -> None:
 
 
 import pwndbg.lib.cache
+from pwndbg.lib.cache import CacheUntilEvent
 
 pwndbg.lib.cache.connect_clear_caching_events(
     {
@@ -72,22 +73,22 @@ pwndbg.lib.cache.connect_clear_caching_events(
         # if the user does an operation to modify memory or registers while the program is stopped.
         # We don't do this for the other events, because they hopefully don't change memory or
         # registers
-        "stop": (
+        CacheUntilEvent.STOP: (
             pwndbg.gdblib.events.stop,
             pwndbg.gdblib.events.mem_changed,
             pwndbg.gdblib.events.reg_changed,
         ),
-        "exit": (pwndbg.gdblib.events.exit,),
-        "objfile": (pwndbg.gdblib.events.new_objfile,),
-        "start": (pwndbg.gdblib.events.start,),
-        "cont": (
+        CacheUntilEvent.EXIT: (pwndbg.gdblib.events.exit,),
+        CacheUntilEvent.OBJFILE: (pwndbg.gdblib.events.new_objfile,),
+        CacheUntilEvent.START: (pwndbg.gdblib.events.start,),
+        CacheUntilEvent.CONT: (
             pwndbg.gdblib.events.cont,
             pwndbg.gdblib.events.mem_changed,
             pwndbg.gdblib.events.reg_changed,
         ),
-        "thread": (pwndbg.gdblib.events.thread,),
-        "prompt": (pwndbg.gdblib.events.before_prompt,),
-        "forever": (),
+        CacheUntilEvent.THREAD: (pwndbg.gdblib.events.thread,),
+        CacheUntilEvent.PROMPT: (pwndbg.gdblib.events.before_prompt,),
+        CacheUntilEvent.FOREVER: (),
     },
     priority=pwndbg.gdblib.events.HandlerPriority.CACHE_CLEAR,
 )

--- a/pwndbg/gdblib/prompt.py
+++ b/pwndbg/gdblib/prompt.py
@@ -13,7 +13,6 @@ import pwndbg.commands.context
 import pwndbg.decorators
 import pwndbg.gdblib.events
 import pwndbg.gdblib.functions
-import pwndbg.lib.cache
 import pwndbg.profiling
 from pwndbg.color import disable_colors
 from pwndbg.color import message

--- a/pwndbg/gdblib/ptmalloc2_tracking.py
+++ b/pwndbg/gdblib/ptmalloc2_tracking.py
@@ -64,6 +64,7 @@ import pwndbg.aglib.typeinfo
 import pwndbg.aglib.vmmap
 import pwndbg.lib.cache
 from pwndbg.color import message
+from pwndbg.lib.cache import CacheUntilEvent
 
 LIBC_NAME = "libc.so.6"
 MALLOC_NAME = "malloc"
@@ -158,7 +159,7 @@ class FreeChunkWatchpoint(gdb.Breakpoint):
         super().__init__(loc, type=gdb.BP_WATCHPOINT, internal=True)
 
     def stop(self):
-        pwndbg.lib.cache.clear_cache("stop")
+        pwndbg.lib.cache.clear_cache(CacheUntilEvent.STOP)
         if not in_program_code_stack():
             # Untracked.
             return False
@@ -394,7 +395,7 @@ class MallocEnterBreakpoint(gdb.Breakpoint):
         self.tracker = tracker
 
     def stop(self) -> bool:
-        pwndbg.lib.cache.clear_cache("stop")
+        pwndbg.lib.cache.clear_cache(CacheUntilEvent.STOP)
         requested_size = pwndbg.arguments.argument(0)
         if self.tracker.is_performing_memory_management():
             # This call was made from inside another memory management call.
@@ -412,7 +413,7 @@ class CallocEnterBreakpoint(gdb.Breakpoint):
         self.tracker = tracker
 
     def stop(self) -> bool:
-        pwndbg.lib.cache.clear_cache("stop")
+        pwndbg.lib.cache.clear_cache(CacheUntilEvent.STOP)
 
         num_elements = pwndbg.arguments.argument(0)
         element_size = pwndbg.arguments.argument(1)
@@ -452,7 +453,7 @@ class AllocExitBreakpoint(gdb.FinishBreakpoint):
         self.name = name
 
     def stop(self) -> bool:
-        pwndbg.lib.cache.clear_cache("stop")
+        pwndbg.lib.cache.clear_cache(CacheUntilEvent.STOP)
         if not in_program_code_stack():
             # Untracked.
             self.tracker.exit_memory_management()
@@ -487,7 +488,7 @@ class ReallocEnterBreakpoint(gdb.Breakpoint):
         self.tracker = tracker
 
     def stop(self) -> bool:
-        pwndbg.lib.cache.clear_cache("stop")
+        pwndbg.lib.cache.clear_cache(CacheUntilEvent.STOP)
 
         freed_pointer = pwndbg.arguments.argument(0)
         requested_size = pwndbg.arguments.argument(1)
@@ -527,7 +528,7 @@ class ReallocExitBreakpoint(gdb.FinishBreakpoint):
         self.tracker = tracker
 
     def stop(self):
-        pwndbg.lib.cache.clear_cache("stop")
+        pwndbg.lib.cache.clear_cache(CacheUntilEvent.STOP)
         if not in_program_code_stack():
             # Untracked.
             self.tracker.exit_memory_management()
@@ -574,7 +575,7 @@ class FreeEnterBreakpoint(gdb.Breakpoint):
         self.tracker = tracker
 
     def stop(self) -> bool:
-        pwndbg.lib.cache.clear_cache("stop")
+        pwndbg.lib.cache.clear_cache(CacheUntilEvent.STOP)
         ptr = pwndbg.arguments.argument(0)
         if self.tracker.is_performing_memory_management():
             # This call was made from inside another memory management call.
@@ -598,7 +599,7 @@ class FreeExitBreakpoint(gdb.FinishBreakpoint):
         self.tracker = tracker
 
     def stop(self):
-        pwndbg.lib.cache.clear_cache("stop")
+        pwndbg.lib.cache.clear_cache(CacheUntilEvent.STOP)
         if not in_program_code_stack():
             # Untracked.
             self.tracker.exit_memory_management()

--- a/pwndbg/integration/binja.py
+++ b/pwndbg/integration/binja.py
@@ -598,7 +598,7 @@ class BinjaProvider(pwndbg.integration.IntegrationProvider):
     def get_stack_var_name(self, addr: int) -> str | None:
         cur = pwndbg.dbg.selected_frame()
         # there is no earlier frame so we give up
-        if addr < pwndbg.aglib.regs.read_reg(pwndbg.aglib.regs.stack, frame=cur):
+        if addr < pwndbg.aglib.regs.read_reg_in_frame(pwndbg.aglib.regs.stack, cur):
             return None
         newest = True
         # try to find the oldest frame that's earlier than the address
@@ -607,7 +607,7 @@ class BinjaProvider(pwndbg.integration.IntegrationProvider):
             if upper is None:
                 break
 
-            upper_sp = pwndbg.aglib.regs.read_reg(pwndbg.aglib.regs.stack, frame=upper)
+            upper_sp = pwndbg.aglib.regs.read_reg_in_frame(pwndbg.aglib.regs.stack, upper)
             if upper_sp > addr:
                 break
 
@@ -617,7 +617,7 @@ class BinjaProvider(pwndbg.integration.IntegrationProvider):
         regs = [
             (name, val)
             for name in pwndbg.aglib.regs.common
-            if (val := pwndbg.aglib.regs.read_reg(name, frame=cur)) is not None
+            if (val := pwndbg.aglib.regs.read_reg_in_frame(name, cur)) is not None
         ]
         # put stack pointer and frame pointer at the front
         regs.sort(

--- a/pwndbg/lib/cache.py
+++ b/pwndbg/lib/cache.py
@@ -7,7 +7,7 @@ new library/objfile are loaded, etc.
 from __future__ import annotations
 
 from collections import UserDict
-from enum import Enum
+from enum import IntFlag
 from functools import wraps
 from typing import Any
 from typing import Callable
@@ -94,9 +94,14 @@ class _CacheUntilEvent:
 
 
 # fmt: off
-class CacheUntilEvent(Enum):
+class CacheUntilEvent(IntFlag):
     """
-    Some of these are explained in pwndbg.dbg_mod.EventType .
+    Not necessarily 1:1 with pwndbg.dbg_mod.EventTypes , but
+    read the definition of that enum to get an idea of how these
+    work.
+
+    Notably, STOP is also triggered when the user changes debugee
+    memory or register state.
     """
     STOP    = 0b00000001
     EXIT    = 0b00000010

--- a/pwndbg/lib/cache.py
+++ b/pwndbg/lib/cache.py
@@ -134,6 +134,11 @@ IS_CACHING_DISABLED_FOR: Dict[str, bool] = {
 
 
 def cache_until(*event_names: str) -> Callable[[Callable[P, T]], CachedFunction[T]]:
+    """
+    All possible values of the function arguments must be hashable
+    (so e.g. `frame: Frame | None = None` is not allowed).
+    The return value of the function should not be mutable, must not be mutated.
+    """
     if any(event_name not in _ALL_CACHE_EVENT_NAMES for event_name in event_names):
         raise ValueError(
             f"Unknown event name[s] passed to the `cache_until` decorator: {event_names}.\n"

--- a/pwndbg/lib/cache.py
+++ b/pwndbg/lib/cache.py
@@ -76,14 +76,16 @@ class _CacheUntilEvent:
     def __init__(self) -> None:
         self.caches: List[Cache] = []
 
-    def connect_event_hooks(self, event_hooks: Tuple[Any, ...], **kwargs: Any) -> None:
+    def connect_event_hooks(self, event_hooks: Tuple[Any, ...]) -> None:
         """
         A given _CacheUntilEvent object may require multiple debugger events
         to be handled properly. E.g. our `stop` cache needs to be handled
         by `stop`, `mem_changed` and `reg_changed` events.
         """
         for event_hook in event_hooks:
-            event_hook(self.clear, **kwargs)
+            # This will just run a decorator (which will return a function, but
+            # that return value is not used here).
+            event_hook(self.clear)
 
     def clear(self) -> None:
         for cache in self.caches:
@@ -149,12 +151,12 @@ def events_to_event_set(event_list: List[CacheUntilEvent]) -> EventSet:
     return res
 
 
-def connect_clear_caching_events(event_dicts: Dict[CacheUntilEvent, Tuple[Any, ...]], **kwargs: Any) -> None:
+def connect_clear_caching_events(event_dicts: Dict[CacheUntilEvent, Tuple[Any, ...]]) -> None:
     """
     Connect given debugger event hooks to corresponding _CacheUntilEvent instances
     """
     for event_name, event_hooks in event_dicts.items():
-        _ALL_CACHE_UNTIL_EVENTS[event_name].connect_event_hooks(event_hooks, **kwargs)
+        _ALL_CACHE_UNTIL_EVENTS[event_name].connect_event_hooks(event_hooks)
 
 
 # A singleton used to mark a cache miss

--- a/pwndbg/lib/cache.py
+++ b/pwndbg/lib/cache.py
@@ -111,8 +111,7 @@ class CacheUntilEvent(IntFlag):
     START   = 0b00001000
     CONT    = 0b00010000
     THREAD  = 0b00100000
-    PROMPT  = 0b01000000
-    FOREVER = 0b10000000
+    FOREVER = 0b01000000
 
 # fmt: on
 
@@ -127,7 +126,6 @@ _ALL_CACHE_UNTIL_EVENTS: Dict[CacheUntilEvent, _CacheUntilEvent] = {
     CacheUntilEvent.START: _CacheUntilEvent(),
     CacheUntilEvent.CONT: _CacheUntilEvent(),
     CacheUntilEvent.THREAD: _CacheUntilEvent(),
-    CacheUntilEvent.PROMPT: _CacheUntilEvent(),
     CacheUntilEvent.FOREVER: _CacheUntilEvent(),
 }
 
@@ -138,7 +136,6 @@ _NAME_TO_EVENT: Dict[str, CacheUntilEvent] = {
     "start": CacheUntilEvent.START,
     "cont": CacheUntilEvent.CONT,
     "thread": CacheUntilEvent.THREAD,
-    "prompt": CacheUntilEvent.PROMPT,
     "forever": CacheUntilEvent.FOREVER,
 }
 _ALL_CACHE_EVENT_NAMES = tuple(_NAME_TO_EVENT.keys())

--- a/pwndbg/lib/cache.py
+++ b/pwndbg/lib/cache.py
@@ -213,8 +213,12 @@ def cache_until(*event_names: str) -> Callable[[Callable[P, T]], CachedFunction[
                 try:
                     cached_value: Any = cache.get(key, _NOT_FOUND_IN_CACHE)
                 except TypeError:
-                    # skip caching unhashable arguments
-                    return func(*a, **kw)
+                    print("Unhashable argument passed to a cache_until decorated function.")
+                    print("Make the argument hashable or refactor.")
+                    print(f"Function: {func.__module__}.{func.__qualname__}", )
+                    print(f"Arguments: {repr(key)}")
+                    assert False, "Unhashable argument passed to a cache_until decorated function."
+
                 if cached_value is not _NOT_FOUND_IN_CACHE:
                     return cached_value
 

--- a/pwndbg/lib/cache.py
+++ b/pwndbg/lib/cache.py
@@ -7,6 +7,7 @@ new library/objfile are loaded, etc.
 from __future__ import annotations
 
 from collections import UserDict
+from enum import Enum
 from functools import wraps
 from typing import Any
 from typing import Callable
@@ -36,7 +37,7 @@ class DebugCacheDict(UserDict):  # type: ignore[type-arg]
         self.hits = 0
         self.misses = 0
         self.func = func
-        self.name = f'{func.__module__.split(".")[-1]}.{func.__name__}'
+        self.name = f"{func.__module__.split('.')[-1]}.{func.__name__}"
 
     def __getitem__(self, key: Tuple[Any, ...]) -> Any:
         if debug & DEBUG_GET and (not debug_name or debug_name in self.name):
@@ -67,6 +68,7 @@ Cache = Union[Dict[Tuple[Any, ...], Any], DebugCacheDict]
 
 class CachedFunction(Protocol[T]):
     cache: Cache
+
     def __call__(self, *args: Any, **kwargs: Any) -> T: ...
 
 
@@ -91,22 +93,60 @@ class _CacheUntilEvent:
         self.caches.append(cache)
 
 
-_ALL_CACHE_UNTIL_EVENTS: Dict[str, _CacheUntilEvent] = {
-    "stop": _CacheUntilEvent(),
-    "exit": _CacheUntilEvent(),
-    "objfile": _CacheUntilEvent(),
-    "start": _CacheUntilEvent(),
-    "cont": _CacheUntilEvent(),
-    "thread": _CacheUntilEvent(),
-    "prompt": _CacheUntilEvent(),
-    "forever": _CacheUntilEvent(),
-}
-_ALL_CACHE_EVENT_NAMES = tuple(_ALL_CACHE_UNTIL_EVENTS.keys())
-
-
-def connect_clear_caching_events(event_dicts: Dict[str, Tuple[Any, ...]], **kwargs: Any) -> None:
+# fmt: off
+class CacheUntilEvent(Enum):
     """
-    Connect given debugger event hooks to correspoonding _CacheUntilEvent instances
+    Some of these are explained in pwndbg.dbg_mod.EventType .
+    """
+    STOP    = 0b00000001
+    EXIT    = 0b00000010
+    OBJFILE = 0b00000100
+    START   = 0b00001000
+    CONT    = 0b00010000
+    THREAD  = 0b00100000
+    PROMPT  = 0b01000000
+    FOREVER = 0b10000000
+
+# fmt: on
+
+# OR (|) events together to make a set
+EventSet = int
+
+
+_ALL_CACHE_UNTIL_EVENTS: Dict[CacheUntilEvent, _CacheUntilEvent] = {
+    CacheUntilEvent.STOP: _CacheUntilEvent(),
+    CacheUntilEvent.EXIT: _CacheUntilEvent(),
+    CacheUntilEvent.OBJFILE: _CacheUntilEvent(),
+    CacheUntilEvent.START: _CacheUntilEvent(),
+    CacheUntilEvent.CONT: _CacheUntilEvent(),
+    CacheUntilEvent.THREAD: _CacheUntilEvent(),
+    CacheUntilEvent.PROMPT: _CacheUntilEvent(),
+    CacheUntilEvent.FOREVER: _CacheUntilEvent(),
+}
+
+_NAME_TO_EVENT: Dict[str, CacheUntilEvent] = {
+    "stop": CacheUntilEvent.STOP,
+    "exit": CacheUntilEvent.EXIT,
+    "objfile": CacheUntilEvent.OBJFILE,
+    "start": CacheUntilEvent.START,
+    "cont": CacheUntilEvent.CONT,
+    "thread": CacheUntilEvent.THREAD,
+    "prompt": CacheUntilEvent.PROMPT,
+    "forever": CacheUntilEvent.FOREVER,
+}
+_ALL_CACHE_EVENT_NAMES = tuple(_NAME_TO_EVENT.keys())
+
+
+def events_to_event_set(event_list: List[CacheUntilEvent]) -> EventSet:
+    res = 0
+    for an_event in event_list:
+        res |= an_event.value
+    return res
+
+
+def connect_clear_caching_events(event_dicts: Dict[CacheUntilEvent, Tuple[Any, ...]], **kwargs: Any) -> None:
+    """
+    Connect given debugger event hooks to corresponding _CacheUntilEvent instances
     """
     for event_name, event_hooks in event_dicts.items():
         _ALL_CACHE_UNTIL_EVENTS[event_name].connect_event_hooks(event_hooks, **kwargs)
@@ -117,20 +157,17 @@ _NOT_FOUND_IN_CACHE = object()
 _KWARGS_SEPARATOR = object()
 
 # Global value whether the results from cache are returned or not
+# Used for debugging (by pwndbg.commands.memoize).
 IS_CACHING = True
 
 
 # Global value that allows disabling of individual cache types.
-IS_CACHING_DISABLED_FOR: Dict[str, bool] = {
-    "stop": False,
-    "exit": False,
-    "objfile": False,
-    "start": False,
-    "cont": False,
-    "thread": False,
-    "prompt": False,
-    "forever": False,
-}
+# This should only be set by the debugger at bring-up time. Thus
+# it should be possible to perform this check at decoration time
+# rather than at runtime and get a nice performance improvement, but
+# I'm not sure how to do this safely exactly.
+# The value is an event set (an OR (|) of different events)
+IS_CACHING_DISABLED_FOR: EventSet = 0
 
 
 def cache_until(*event_names: str) -> Callable[[Callable[P, T]], CachedFunction[T]]:
@@ -145,6 +182,10 @@ def cache_until(*event_names: str) -> Callable[[Callable[P, T]], CachedFunction[
             f"Expected: {_ALL_CACHE_EVENT_NAMES}"
         )
 
+    # We could require that CacheUntilEvent's be passed instead of strings as cache_until arguments.
+    event_list: List[CacheUntilEvent] = [_NAME_TO_EVENT[event_name] for event_name in event_names]
+    event_set: EventSet = events_to_event_set(event_list)
+
     def inner(func: Callable[P, T]) -> CachedFunction[T]:
         if hasattr(func, "cache"):
             raise ValueError(
@@ -156,7 +197,7 @@ def cache_until(*event_names: str) -> Callable[[Callable[P, T]], CachedFunction[
 
         @wraps(func)
         def decorator(*a: P.args, **kw: P.kwargs) -> T:
-            if IS_CACHING and not any((IS_CACHING_DISABLED_FOR[e] for e in event_names)):
+            if IS_CACHING and (event_set & IS_CACHING_DISABLED_FOR) == 0:
                 key: Tuple[Any, ...] = (a, _KWARGS_SEPARATOR, *kw.items())
 
                 # Check if the value is in the cache; if we have a cache miss,
@@ -189,10 +230,10 @@ def cache_until(*event_names: str) -> Callable[[Callable[P, T]], CachedFunction[
         # ^ now the decorator is a CachedFunction
 
         # Register the cache for the given event so it can be cleared
-        for event_name in event_names:
-            _ALL_CACHE_UNTIL_EVENTS[event_name].add_cache(cache)
+        for an_event in event_list:
+            _ALL_CACHE_UNTIL_EVENTS[an_event].add_cache(cache)
 
-        return decorator # type: ignore[return-value]
+        return decorator  # type: ignore[return-value]
 
     return inner
 
@@ -202,5 +243,7 @@ def clear_caches() -> None:
         cache.clear()
 
 
-def clear_cache(cache_name: str) -> None:
-    _ALL_CACHE_UNTIL_EVENTS[cache_name].clear()
+def clear_cache(cache_event: CacheUntilEvent) -> None:
+    # I could imagine this being a hot path, so I don't want to do the
+    # `str -> CacheUntilEvent` conversion here.
+    _ALL_CACHE_UNTIL_EVENTS[cache_event].clear()

--- a/pwndbg/lib/cache.py
+++ b/pwndbg/lib/cache.py
@@ -177,7 +177,7 @@ IS_CACHING_DISABLED_FOR: EventSet = 0
 def cache_until(*event_names: str) -> Callable[[Callable[P, T]], CachedFunction[T]]:
     """
     All possible values of the function arguments must be hashable
-    (so e.g. `frame: Frame | None = None` is not allowed).
+    (so e.g. `var: MyUnhashableType | None = None` is not allowed, but may fail rarely).
     The return value of the function should not be mutable, must not be mutated.
     """
     if any(event_name not in _ALL_CACHE_EVENT_NAMES for event_name in event_names):

--- a/pwndbg/lib/regs.py
+++ b/pwndbg/lib/regs.py
@@ -28,21 +28,19 @@ from pwndbg.lib.arch import PWNDBG_SUPPORTED_ARCHITECTURES_TYPE
 #
 # Instances of VisitableRegister will call the methods of RegisterContextProtocol to do their logic.
 
+
 class RegisterContextProtocol(Protocol):
-    def flag_register_context(self, reg: str, bit_flags: BitFlags) -> str | None:
-        ...
+    def flag_register_context(self, reg: str, bit_flags: BitFlags) -> str | None: ...
 
-    def addressing_register_context(self, reg: str, is_virtual: bool) -> str | None:
-        ...
+    def addressing_register_context(self, reg: str, is_virtual: bool) -> str | None: ...
 
-    def segment_registers_context(self,regs: list[str]) -> str | None:
-        ...
+    def segment_registers_context(self, regs: list[str]) -> str | None: ...
 
 
 # Represents a register or a set of registers that can be printed in the context register view
 class VisitableRegister(Protocol):
-    def context(self, rc: RegisterContextProtocol) -> str | None:
-        ...
+    def context(self, rc: RegisterContextProtocol) -> str | None: ...
+
 
 class BitFlags(VisitableRegister):
     # this is intentionally uninitialized -- arm uses the same self.flags structuture for different registers

--- a/pwndbg/lib/zig.py
+++ b/pwndbg/lib/zig.py
@@ -85,6 +85,7 @@ def get_zig_executable() -> str:
     """
     try:
         import ziglang  # type: ignore[import-untyped]
+
         return os.path.join(os.path.dirname(ziglang.__file__), "zig")
     except ImportError:
         pass

--- a/tests/library/dbg/tests/test_cache.py
+++ b/tests/library/dbg/tests/test_cache.py
@@ -117,11 +117,11 @@ async def test_cache_registers_account_frame(ctrl: Controller) -> None:
     import pwndbg.aglib.regs
 
     await launch_to(ctrl, TELESCOPE_BINARY, "break_here")
-    # Get the value of sp in the freshest stack frame
-    sp = pwndbg.aglib.regs.sp
+    # Get the value of pc in the freshest stack frame
+    pc1 = pwndbg.aglib.regs.pc
 
-    # Get the value of sp in a higher stack frame
+    # Get the value of pc in a higher stack frame
     await ctrl.execute("up")
-    sp2 = pwndbg.aglib.regs.sp
+    pc2 = pwndbg.aglib.regs.pc
 
-    assert sp != sp2
+    assert pc1 != pc2

--- a/tests/library/dbg/tests/test_cache.py
+++ b/tests/library/dbg/tests/test_cache.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 from ....host import Controller
 from . import get_binary
 from . import pwndbg_test
+from . import launch_to
 
 BINARY = get_binary("reference-binary.native.out")
+TELESCOPE_BINARY = get_binary("telescope_binary.native.out")
 
 
 @pwndbg_test
@@ -105,3 +107,22 @@ async def test_cache_clear_has_priority(ctrl: Controller) -> None:
     foo()
     foo()
     assert actions == ["foo", "on_stop", "foo"]
+
+
+@pwndbg_test
+async def test_cache_registers_account_frame(ctrl: Controller) -> None:
+    # Test that the registers don't get cached without an associated frame
+    # and thus reuse a stale value.
+    # https://github.com/pwndbg/pwndbg/issues/3508
+    import pwndbg.aglib.regs
+
+    await launch_to(ctrl, TELESCOPE_BINARY, "break_here")
+    # Get the value of sp in the freshest stack frame
+    sp = pwndbg.aglib.regs.sp
+
+    # Get the value of sp in a higher stack frame
+    await ctrl.execute("up")
+    sp2 = pwndbg.aglib.regs.sp
+
+    assert sp != sp2
+

--- a/tests/library/dbg/tests/test_cache.py
+++ b/tests/library/dbg/tests/test_cache.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from ....host import Controller
 from . import get_binary
-from . import pwndbg_test
 from . import launch_to
+from . import pwndbg_test
 
 BINARY = get_binary("reference-binary.native.out")
 TELESCOPE_BINARY = get_binary("telescope_binary.native.out")
@@ -125,4 +125,3 @@ async def test_cache_registers_account_frame(ctrl: Controller) -> None:
     sp2 = pwndbg.aglib.regs.sp
 
     assert sp != sp2
-


### PR DESCRIPTION
+ [x] Refactor caching to use integers instead of strings
    + Optimizes a hot codepath with an `&` instead of an `any` + list comprehension
    + Stricter typing
+ [x] Removed the cache clear from enhance_cache_listener
+ [x] Added event handler priority as a debugger agnostic concept
    + (to be clear, caching was broken on LLDB before, now its not)
    + Was a blocker for https://github.com/pwndbg/pwndbg/issues/3508 , https://github.com/pwndbg/pwndbg/issues/2713, and more?
+ [x] Refactor the GDB event system
    + The previous thing was impossible to do without this, now it resembles LLDB's system more
    + Comments should hopefully clear this up for the unfortunate soul who has to go through this decorator hell
+ [x] Add `idx` to `Frame`
+ [x] Add hashing to `Frame`
+ [x] Refactor `.read_reg` to cache with a frame
+ [x] add a test for this^^
+ [x] Delete the `prompt` CacheUntilEvent
+ [x] Enforce that all cached arguments are hashable

Closes: https://github.com/pwndbg/pwndbg/issues/3508 ,  https://github.com/pwndbg/pwndbg/issues/3428 . Unblocks https://github.com/pwndbg/pwndbg/pull/3497 , https://github.com/pwndbg/pwndbg/issues/2713