### PR TITLE
Clean up Dockerfile comments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,10 @@
 # This dockerfile was created for development & testing purposes, for APT-based distro.
 #
-# Build as:             docker build -t pwndbg .
+# Build as:
+#   docker build -f Dockerfile -t pwndbg .
 #
-# For testing use:      docker run --rm -it --cap-add=SYS_PTRACE --security-opt seccomp=unconfined pwndbg bash
-#
-# For development, mount the directory so the host changes are reflected into container:
-#   docker run -it --cap-add=SYS_PTRACE --security-opt seccomp=unconfined -v `pwd`:/pwndbg pwndbg bash
-#
+# To run use (we mount the directory so the host changes are reflected into container):
+#   docker run -it --cap-add=SYS_PTRACE --security-opt seccomp=unconfined -v $(pwd):/pwndbg pwndbg bash
 
 ARG image=mcr.microsoft.com/devcontainers/base:jammy
 FROM $image AS base

--- a/Dockerfile.arch
+++ b/Dockerfile.arch
@@ -1,12 +1,10 @@
 # This dockerfile was created for development & testing purposes, for Pacman-based distro.
 #
-# Build as:             docker build -f Dockerfile.arch -t pwndbg .
+# Build as:
+#   docker build -f Dockerfile.arch -t pwndbg-arch .
 #
-# For testing use:      docker run --rm -it --cap-add=SYS_PTRACE --security-opt seccomp=unconfined pwndbg bash
-#
-# For development, mount the directory so the host changes are reflected into container:
-#   docker run -it --cap-add=SYS_PTRACE --security-opt seccomp=unconfined -v `pwd`:/pwndbg pwndbg bash
-#
+# To run use (we mount the directory so the host changes are reflected into container):
+#   docker run -it --cap-add=SYS_PTRACE --security-opt seccomp=unconfined -v $(pwd):/pwndbg pwndbg-arch bash
 
 ARG image=archlinux:latest
 FROM $image

--- a/Dockerfile.dnf
+++ b/Dockerfile.dnf
@@ -1,12 +1,10 @@
 # This dockerfile was created for development & testing purposes, for DNF-based distro.
 #
-# Build as:             docker build -f Dockerfile.dnf -t pwndbg .
+# Build as:
+#   docker build -f Dockerfile.dnf -t pwndbg-deb .
 #
-# For testing use:      docker run --rm -it --cap-add=SYS_PTRACE --security-opt seccomp=unconfined pwndbg bash
-#
-# For development, mount the directory so the host changes are reflected into container:
-#   docker run -it --cap-add=SYS_PTRACE --security-opt seccomp=unconfined -v `pwd`:/pwndbg pwndbg bash
-#
+# To run use (we mount the directory so the host changes are reflected into container):
+#   docker run -it --cap-add=SYS_PTRACE --security-opt seccomp=unconfined -v $(pwd):/pwndbg pwndbg-deb bash
 
 ARG image=fedora:41
 FROM $image


### PR DESCRIPTION
There are three changes:
1. Get rid of the "For testing use:" line
   + It personally confused me. I was trying to test some failing test and later realized I actually want the "For development" line. I don't really know of a use-case for the "testing" command, so I think its better to remove it to reduce confusion.
2. Changed the tags to be different
   + Not too uncommonly I want to debug a test on different distributions. If I run the commands as-is the image will be rebuilt which takes ten thousand years.
3. Use `$(pwd)` instead of backticks. The former works on bash zsh and fish, while the latter doesn't work on fish which means I have to fix-up the command every time which is annoying. 