### PR TITLE
Adding last_signal to config_context_sections

### DIFF
--- a/docs/configuration/config.md
+++ b/docs/configuration/config.md
@@ -360,7 +360,7 @@ Which context sections are displayed (controls order).
 
 
 
-**Default:** 'regs disasm code ghidra stack backtrace expressions threads heap_tracker'  
+**Default:** 'last_signal regs disasm code ghidra stack backtrace expressions threads heap_tracker'  
 
 ----------
 

--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -164,7 +164,7 @@ config_output = pwndbg.config.add_param(
 )
 config_context_sections = pwndbg.config.add_param(
     "context-sections",
-    "regs disasm code ghidra stack backtrace expressions threads heap_tracker",
+    "last_signal regs disasm code ghidra stack backtrace expressions threads heap_tracker",
     "which context sections are displayed (controls order)",
 )
 config_max_threads_display = pwndbg.config.add_param(

--- a/tests/library/dbg/tests/test_context_commands.py
+++ b/tests/library/dbg/tests/test_context_commands.py
@@ -92,8 +92,10 @@ async def test_empty_context_sections(ctrl: Controller, sections: str) -> None:
 
     await ctrl.launch(USE_FDS_BINARY)
 
-    # Sanity check
-    default_ctx_sects = "regs disasm code ghidra stack backtrace expressions threads heap_tracker"
+    # Sanity checkdefault_ctx_sects
+    default_ctx_sects = (
+        "last_signal regs disasm code ghidra stack backtrace expressions threads heap_tracker"
+    )
     assert pwndbg.config.context_sections.value == default_ctx_sects
     assert (await ctrl.execute_and_capture("context")) != ""
 


### PR DESCRIPTION
<!--
    Please make sure to read the linting and testing instructions at
    https://pwndbg.re/dev/contributing/ before creating a PR.
-->

+ [x] I read the contributing documentation.
+ [x] I am providing a screenshot of the (new feature) / (fixed bug).

This PR makes last_signal section to be displayed by default in context. Previously, you had to add something like
`set context-sections regs last_signal disasm code ghidra stack backtrace expressions threads heap_tracker`
to .gdbinit.
It's a followup to https://github.com/pwndbg/pwndbg/pull/3531
Before:

<img width="1556" height="813" alt="before" src="https://github.com/user-attachments/assets/befce0f0-d3fa-42c9-b8e0-62d79d73e176" />

After:

<img width="1556" height="813" alt="after" src="https://github.com/user-attachments/assets/ae4c5731-c2ac-4d5a-b67a-a13337203027" />
