### PR TITLE
Rework old and implement new compact register displays

### DIFF
--- a/docs/configuration/config.md
+++ b/docs/configuration/config.md
@@ -908,9 +908,17 @@ Whether glibc uses safe-linking.
 
 Whether to show a compact register view with columns.
 
+Values explained:
 
++ `off` - Disable compact registers (default). Every other option tries to make the register context use less rows by putting the registers into multiple columns.
++ `on` - If a register printout doesn't fit it will be added to the end of the register context.
++ `very` - Try to very hard to compress. May save more lines than on but logical register grouping may suffer.
++ `hardcut` - If a register printout doesn't fit its slot, it will simply be truncated.
 
-**Default:** off  
+See also show-compact-regs-columns, show-compact-regs-min-width and show-compact-regs-separation.
+
+**Default:** 'off'  
+**Valid values:** 'off', 'on', 'very', 'hardcut'
 
 ----------
 

--- a/docs/configuration/config.md
+++ b/docs/configuration/config.md
@@ -912,7 +912,7 @@ Values explained:
 
 + `off` - Disable compact registers (default). Every other option tries to make the register context use less rows by putting the registers into multiple columns.
 + `on` - If a register printout doesn't fit it will be added to the end of the register context.
-+ `very` - Try to very hard to compress. May save more lines than on but logical register grouping may suffer.
++ `very` - Try to very hard to compress. May save more lines than `on` but logical register grouping may suffer.
 + `hardcut` - If a register printout doesn't fit its slot, it will simply be truncated.
 
 See also show-compact-regs-columns, show-compact-regs-min-width and show-compact-regs-separation.

--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -4,10 +4,11 @@ import argparse
 import ast
 import functools
 import logging
+import math
 import os
 import sys
-import math
 from collections import defaultdict
+from enum import Enum
 from typing import Any
 from typing import Callable
 from typing import DefaultDict
@@ -36,6 +37,7 @@ import pwndbg.color.syntax_highlight as H
 import pwndbg.commands
 import pwndbg.commands.telescope
 import pwndbg.integration
+import pwndbg.lib.config
 import pwndbg.ui
 from pwndbg.aglib.arch_mod import get_thumb_mode_string
 from pwndbg.color import ColorConfig
@@ -808,8 +810,18 @@ def context(subcontext=None, enabled=None) -> None:
     reserve_lines_maybe(cmd_lines)
 
 
+class CompactRegsOptions(Enum):
+    NO = "off"
+    YES = "on"
+    VERY = "very"
+
+
 pwndbg.config.add_param(
-    "show-compact-regs", False, "whether to show a compact register view with columns"
+    "show-compact-regs",
+    CompactRegsOptions.NO.value,
+    "whether to show a compact register view with columns",
+    param_class=pwndbg.lib.config.PARAM_ENUM,
+    enum_sequence=[x.value for x in CompactRegsOptions],
 )
 pwndbg.config.add_param(
     "show-compact-regs-columns", 2, "the number of columns (0 for dynamic number of columns)"
@@ -827,27 +839,128 @@ def calculate_padding_to_align(length, align):
     return 0 if length % align == 0 else (align - (length % align))
 
 
-def compact_regs(regs: List[str], width=None, target=sys.stdout) -> List[str]:
-    columns = max(0, int(pwndbg.config.show_compact_regs_columns))
-    min_width = max(1, int(pwndbg.config.show_compact_regs_min_width))
-    separation = max(1, int(pwndbg.config.show_compact_regs_separation))
+def compact_regs_normal(
+    regs: List[str], terminal_width: int, column_width: int, columns: int, separation: int
+) -> List[str]:
+    """
+    Will try to group similar registers together, and may increase the number of rows (as opposed to compact_regs_very)
+    in order to achieve this.
 
-    if width is None:
-        _height, width = pwndbg.ui.get_window_size(target)
+    column_width does not include separation.
 
-    if columns > 0:
-        # Adjust the minimum_width (column) according to the
-        # layout depicted below, where there are "columns" columns
-        # and "columns - 1" separations.
-        #
-        # |<----------------- window width -------------------->|
-        # | column | sep. | column | sep. | ... | sep. | column |
-        #
-        # Which results in the following formula:
-        # window_width = columns * min_width + (columns - 1) * separation
-        # => min_width = (window_width - (columns - 1) * separation) / columns
-        min_width = max(min_width, (width - (columns - 1) * separation) // columns)
+    Example:
+     RAX  0xfffffffffffffdfe           R8   0                            R14  0
+     RBX  0                            R9    ⏎                           R15   ⏎
+     RCX   ⏎                           R10  0                            RBP  1
+     RDX  0                            R11  0x202                        RSP  0x7fffffffcb70 ◂— 0
+     RDI  1                            R12  0x7fffffffccb0 ◂— 1          RIP   ⏎
+     RSI  0x7fffffffccb0 ◂— 1          R13  0                            EFLAGS   ⏎
+    ↪ R9   0x7fffffffcbd0 —▸ 0x7ffff7f83e60 (_rl_orig_sigset) ◂— 0
+    ↪ R15  0x7ffff7f83e60 (_rl_orig_sigset) ◂— 0
+    ↪ RCX  0x7ffff7c90efa (__internal_syscall_cancel+138) ◂— add rsp, 0x18
+    ↪ RIP  0x7ffff7c90efa (__internal_syscall_cancel+138) ◂— add rsp, 0x18
+    ↪ EFLAGS 0x202 [ cf pf af zf sf IF df of ac ]
+    """
+    result: List[str] = []
 
+    def extract_reg_name(one_reg: str) -> str:
+        # We want the whitespace right after the name too. Also the change marker.
+        # Tricky because we want to preserve colors.
+        # state = 0 means i'm before the register name
+        # state = 1 means i'm in the register name
+        # state = 2 means i'm in the whitespace after the register name
+        state: int = 0
+        last_ws: int = -1
+        for i in range(len(one_reg)):
+            match state:
+                case 0:
+                    if one_reg[i] == change_marker or one_reg[i] == " ":
+                        state = 1
+                case 1:
+                    if one_reg[i] == " ":
+                        state = 2
+                case 2:
+                    if one_reg[i] != " ":
+                        last_ws = i - 1
+                        break
+        assert last_ws != -1
+        return one_reg[:last_ws]
+
+    will_wrap_char: str = pwndbg.color.light_gray("  ⏎")
+    wrapping_char: str = pwndbg.color.gray("↪")
+    change_marker: str = str(C.config_register_changed_marker)
+
+    line: str = ""
+    line_length: int = 0
+    nregs: int = len(regs)
+    nrows: int = math.ceil(nregs / columns)
+    pending: List[str] = []
+    for row_idx in range(nrows):
+        for column_idx in range(columns):
+            # Pad the line from the last register.
+            if column_idx != 0:
+                padding = calculate_padding_to_align(line_length, column_width + separation)
+                line += " " * padding
+                line_length += padding
+
+            reg_idx = column_idx * nrows + row_idx
+            if reg_idx >= nregs:
+                # Some columns will not have all rows filled.
+                continue
+            reg = regs[reg_idx]
+
+            # Strip the color / hightlight information the get the raw text width of the register
+            reg_length = len(pwndbg.color.strip(reg))
+
+            if reg_length > column_width:
+                # We cannot put this register here without displacing the next one, so we will
+                # print this register in a lone line at the end.
+                pending.append(reg)
+                # We want to leave a marker that we will wrap here.
+                # We extract the register name from the `reg` string which is a bit tricky.
+                # Look at the RegisterContext class for reference.
+                reg_name = extract_reg_name(reg)
+                addition = reg_name + will_wrap_char
+                line += addition
+                line_length += len(pwndbg.color.strip(addition))
+            else:
+                line += reg
+                line_length += reg_length
+
+        # Add the line.
+        result.append(line)
+        line = ""
+        line_length = 0
+
+    # Add all registers that couldn't fit into their slot.
+    if pending:
+        for pending_line in pending:
+            result.append(wrapping_char + pending_line)
+        pending.clear()
+
+    return result
+
+
+def compact_regs_very(
+    regs: List[str], terminal_width: int, column_width: int, columns: int, separation: int
+) -> List[str]:
+    """
+    Will try to group similar registers together, but will sacrifice the grouping if it can be more compact.
+
+    column_width does not include separation.
+
+    Example:
+     RAX  0xfffffffffffffdfe           R8   0                            R14  0
+     RBX  0                            R9   0x7fffffffcbd0 —▸ 0x7ffff7f83e60 (_rl_orig_sigset) ◂— 0
+     R15  0x7ffff7f83e60 (_rl_orig_sigset) ◂— 0
+     RCX  0x7ffff7c90efa (__internal_syscall_cancel+138) ◂— add rsp, 0x18
+     R10  0                            RBP  1                            RDX  0
+     R11  0x202                        RSP  0x7fffffffcb70 ◂— 0          RDI  1
+     R12  0x7fffffffccb0 ◂— 1
+     RIP  0x7ffff7c90efa (__internal_syscall_cancel+138) ◂— add rsp, 0x18
+     RSI  0x7fffffffccb0 ◂— 1          R13  0
+     EFLAGS 0x202 [ cf pf af zf sf IF df of ac ]
+    """
     result: List[str] = []
 
     line: str = ""
@@ -861,7 +974,7 @@ def compact_regs(regs: List[str], width=None, target=sys.stdout) -> List[str]:
                 # Some columns will not have all rows filled.
                 continue
             reg = regs[reg_idx]
-            
+
             # Strip the color / hightlight information the get the raw text width of the register
             reg_length = len(pwndbg.color.strip(reg))
 
@@ -872,11 +985,11 @@ def compact_regs(regs: List[str], width=None, target=sys.stdout) -> List[str]:
                 separation if line_length != 0 else 0
             )  # No separation at the start of a line
             line_length_with_padding += calculate_padding_to_align(
-                line_length_with_padding, min_width + separation
+                line_length_with_padding, column_width + separation
             )
 
             # When element does not fully fit, then start a new line
-            if line_length_with_padding + max(reg_length, min_width) > width:
+            if line_length_with_padding + max(reg_length, column_width) > terminal_width:
                 result.append(line)
 
                 line = ""
@@ -897,15 +1010,44 @@ def compact_regs(regs: List[str], width=None, target=sys.stdout) -> List[str]:
     return result
 
 
+def compact_regs(regs: List[str], width=None, target=sys.stdout) -> List[str]:
+    columns = max(0, int(pwndbg.config.show_compact_regs_columns))
+    min_width = max(1, int(pwndbg.config.show_compact_regs_min_width))
+    separation = max(1, int(pwndbg.config.show_compact_regs_separation))
+
+    if width is None:
+        _, width = pwndbg.ui.get_window_size(target)
+
+    if columns > 0:
+        # Adjust the minimum_width (column) according to the
+        # layout depicted below, where there are "columns" columns
+        # and "columns - 1" separations.
+        #
+        # |<----------------- window width -------------------->|
+        # | column | sep. | column | sep. | ... | sep. | column |
+        #
+        # Which results in the following formula:
+        # window_width = columns * min_width + (columns - 1) * separation
+        # => min_width = (window_width - (columns - 1) * separation) / columns
+        min_width = max(min_width, (width - (columns - 1) * separation) // columns)
+
+    match pwndbg.config.show_compact_regs.value:
+        case CompactRegsOptions.YES.value:
+            return compact_regs_normal(regs, width, min_width, columns, separation)
+        case CompactRegsOptions.VERY.value:
+            return compact_regs_very(regs, width, min_width, columns, separation)
+        case _:
+            assert False, "Invalid compact regs value."
+
+
 @serve_context_history
 def context_regs(target=sys.stdout, with_banner=True, width=None):
     regs = get_regs()
-    if pwndbg.config.show_compact_regs:
+    if pwndbg.config.show_compact_regs.value != CompactRegsOptions.NO.value:
         regs = compact_regs(regs, target=target, width=width)
 
     info = " / show-flags {} / show-compact-regs {}".format(
-        "on" if pwndbg.config.show_flags else "off",
-        "on" if pwndbg.config.show_compact_regs else "off",
+        "on" if pwndbg.config.show_flags else "off", pwndbg.config.show_compact_regs
     )
     banner = [pwndbg.ui.banner("registers", target=target, width=width, extra=info)]
     return banner + regs if with_banner else regs

--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -843,7 +843,7 @@ pwndbg.config.add_param(
 )
 
 
-def calculate_padding_to_align(length, align):
+def calculate_padding_to_align(length: int, align: int) -> int:
     """Calculates the number of spaces to append to reach the next alignment.
     The next alignment point is given by "x * align >= length".
     """

--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -823,9 +823,16 @@ pwndbg.config.add_param(
     "whether to show a compact register view with columns",
     param_class=pwndbg.lib.config.PARAM_ENUM,
     enum_sequence=[x.value for x in CompactRegsOptions],
-    help_docstring="""
-AAAAAAA
-"""
+    help_docstring=f"""
+Values explained:
+
++ `{CompactRegsOptions.NO.value}` - Disable compact registers (default). Every other option tries to make the register context use less rows by putting the registers into multiple columns.
++ `{CompactRegsOptions.YES.value}` - If a register printout doesn't fit it will be added to the end of the register context.
++ `{CompactRegsOptions.VERY.value}` - Try to very hard to compress. May save more lines than `{CompactRegsOptions.YES.value}` but logical register grouping may suffer.
++ `{CompactRegsOptions.HARDCUT.value}` - If a register printout doesn't fit its slot, it will simply be truncated.
+
+See also show-compact-regs-columns, show-compact-regs-min-width and show-compact-regs-separation.
+""",
 )
 pwndbg.config.add_param(
     "show-compact-regs-columns", 2, "the number of columns (0 for dynamic number of columns)"
@@ -842,8 +849,9 @@ def calculate_padding_to_align(length, align):
     """
     return 0 if length % align == 0 else (align - (length % align))
 
+
 def compact_regs_hardcut(
-        regs: List[str], terminal_width: int, column_width: int, columns: int, separation: int
+    regs: List[str], terminal_width: int, column_width: int, columns: int, separation: int
 ) -> List[str]:
     """
     If the string of any register overflows its column_width, it will be hard cut to the column_width.

--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -6,6 +6,7 @@ import functools
 import logging
 import os
 import sys
+import math
 from collections import defaultdict
 from typing import Any
 from typing import Callable
@@ -849,36 +850,45 @@ def compact_regs(regs: List[str], width=None, target=sys.stdout) -> List[str]:
 
     result: List[str] = []
 
-    line = ""
-    line_length = 0
-    for reg in regs:
-        # Strip the color / hightlight information the get the raw text width of the register
-        reg_length = len(pwndbg.color.strip(reg))
+    line: str = ""
+    line_length: int = 0
+    nregs: int = len(regs)
+    nrows: int = math.ceil(nregs / columns)
+    for row_idx in range(nrows):
+        for column_idx in range(columns):
+            reg_idx = column_idx * nrows + row_idx
+            if reg_idx >= nregs:
+                # Some columns will not have all rows filled.
+                continue
+            reg = regs[reg_idx]
+            
+            # Strip the color / hightlight information the get the raw text width of the register
+            reg_length = len(pwndbg.color.strip(reg))
 
-        # Length of line with unoccupied space and padding is required
-        # to fit the register string onto the screen / display.
-        line_length_with_padding = line_length
-        line_length_with_padding += (
-            separation if line_length != 0 else 0
-        )  # No separation at the start of a line
-        line_length_with_padding += calculate_padding_to_align(
-            line_length_with_padding, min_width + separation
-        )
+            # Length of line with unoccupied space and padding is required
+            # to fit the register string onto the screen / display.
+            line_length_with_padding = line_length
+            line_length_with_padding += (
+                separation if line_length != 0 else 0
+            )  # No separation at the start of a line
+            line_length_with_padding += calculate_padding_to_align(
+                line_length_with_padding, min_width + separation
+            )
 
-        # When element does not fully fit, then start a new line
-        if line_length_with_padding + max(reg_length, min_width) > width:
-            result.append(line)
+            # When element does not fully fit, then start a new line
+            if line_length_with_padding + max(reg_length, min_width) > width:
+                result.append(line)
 
-            line = ""
-            line_length = 0
-            line_length_with_padding = 0
+                line = ""
+                line_length = 0
+                line_length_with_padding = 0
 
-        # Add padding in front of the next printed register
-        if line_length != 0:
-            line += " " * (line_length_with_padding - line_length)
+            # Add padding in front of the next printed register
+            if line_length != 0:
+                line += " " * (line_length_with_padding - line_length)
 
-        line += reg
-        line_length = line_length_with_padding + reg_length
+            line += reg
+            line_length = line_length_with_padding + reg_length
 
     # Append last line if required
     if line_length != 0:

--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -814,6 +814,7 @@ class CompactRegsOptions(Enum):
     NO = "off"
     YES = "on"
     VERY = "very"
+    HARDCUT = "hardcut"
 
 
 pwndbg.config.add_param(
@@ -822,6 +823,9 @@ pwndbg.config.add_param(
     "whether to show a compact register view with columns",
     param_class=pwndbg.lib.config.PARAM_ENUM,
     enum_sequence=[x.value for x in CompactRegsOptions],
+    help_docstring="""
+AAAAAAA
+"""
 )
 pwndbg.config.add_param(
     "show-compact-regs-columns", 2, "the number of columns (0 for dynamic number of columns)"
@@ -837,6 +841,73 @@ def calculate_padding_to_align(length, align):
     The next alignment point is given by "x * align >= length".
     """
     return 0 if length % align == 0 else (align - (length % align))
+
+def compact_regs_hardcut(
+        regs: List[str], terminal_width: int, column_width: int, columns: int, separation: int
+) -> List[str]:
+    """
+    If the string of any register overflows its column_width, it will be hard cut to the column_width.
+
+    Example:
+     RAX  0xfffffffffffffdfe              R8   0                               R14  0
+     RBX  0                               R9   0x7fffffffcbd0 —▸ 0x7fff...     R15  0x7ffff7f83e60 (_rl_orig...
+     RCX  0x7ffff7c90efa (__intern...     R10  0                               RBP  1
+     RDX  0                               R11  0x202                           RSP  0x7fffffffcb70 ◂— 0
+     RDI  1                               R12  0x7fffffffccb0 ◂— 1             RIP  0x7ffff7c90efa (__intern...
+     RSI  0x7fffffffccb0 ◂— 1             R13  0                               EFLAGS 0x202 [ cf pf af zf sf...
+    """
+    result: List[str] = []
+
+    cut_marker = pwndbg.color.white("...")
+
+    def hardcut(reg: str) -> tuple[str, int]:
+        # Returns the cut string and the new size
+        # I don't know of a better way to do this while retaining the coloring.
+        reglen = len(reg)
+        for i in range(reglen, 0, -1):
+            candidate = reg[0:i] + cut_marker
+            candidate_len = len(pwndbg.color.strip(candidate))
+            if candidate_len <= column_width:
+                return candidate, candidate_len
+        # Shouldn't happen anyway, but we return non-zero so padding alignment
+        # can proceed.
+        return " ", 1
+
+    line: str = ""
+    line_length: int = 0
+    nregs: int = len(regs)
+    nrows: int = math.ceil(nregs / columns)
+    for row_idx in range(nrows):
+        for column_idx in range(columns):
+            # Pad the line from the last register.
+            if column_idx != 0:
+                padding = calculate_padding_to_align(line_length, column_width + separation)
+                line += " " * padding
+                line_length += padding
+
+            reg_idx = column_idx * nrows + row_idx
+            if reg_idx >= nregs:
+                # Some columns will not have all rows filled.
+                continue
+            reg = regs[reg_idx]
+
+            # Strip the color / hightlight information the get the raw text width of the register
+            reg_length = len(pwndbg.color.strip(reg))
+
+            if reg_length > column_width:
+                txt, txtlen = hardcut(reg)
+                line += txt
+                line_length += txtlen
+            else:
+                line += reg
+                line_length += reg_length
+
+        # Add the line.
+        result.append(line)
+        line = ""
+        line_length = 0
+
+    return result
 
 
 def compact_regs_normal(
@@ -1036,6 +1107,8 @@ def compact_regs(regs: List[str], width=None, target=sys.stdout) -> List[str]:
             return compact_regs_normal(regs, width, min_width, columns, separation)
         case CompactRegsOptions.VERY.value:
             return compact_regs_very(regs, width, min_width, columns, separation)
+        case CompactRegsOptions.HARDCUT.value:
+            return compact_regs_hardcut(regs, width, min_width, columns, separation)
         case _:
             assert False, "Invalid compact regs value."
 

--- a/pwndbg/ui.py
+++ b/pwndbg/ui.py
@@ -56,7 +56,7 @@ def addrsz(address) -> str:
     return pwndbg.dbg.addrsz(address)
 
 
-def get_window_size(target=sys.stdout):
+def get_window_size(target=sys.stdout) -> tuple[int, int]:
     fallback = (int(os.environ.get("LINES", 24)), int(os.environ.get("COLUMNS", 80)))
     if not target.isatty():
         return fallback


### PR DESCRIPTION
+ [x] I read the contributing documentation.
+ [x] I am providing a screenshot of the (new feature) / (fixed bug).

Changes:
+ Changed register ordering in the compact register context so it makes more sense
+ Added two new compact register modes (see screenshots, code comments and parameter description)
+ Change the default compact register mode to one of the two new ones

## Off

<img width="1387" height="401" alt="image" src="https://github.com/user-attachments/assets/1e5a5fdb-35b6-4dfd-b404-1af05c90bbec" />

## Before
`set show-compact-regs-columns 3` and `set show-compact-regs on`:
<img width="1363" height="199" alt="image" src="https://github.com/user-attachments/assets/3ecaa38a-2d87-47e0-b045-fe6976d45703" />

(not the exact same register state as "After" since I had to restart pwndbg to switch branches)

## After
`set show-compact-regs-columns 3` and `set show-compact-regs on`:
<img width="1365" height="282" alt="image" src="https://github.com/user-attachments/assets/829d7c5a-0718-4708-a8be-f6cc48e9d751" />
`set show-compact-regs very`
<img width="1376" height="202" alt="image" src="https://github.com/user-attachments/assets/f40799c9-306a-436f-92d9-e2c090f0a957" />
`set show-compact-regs hardcut`
<img width="1376" height="161" alt="image" src="https://github.com/user-attachments/assets/25496b1c-7e74-4f54-a3a4-cbc45ac2d879" />
