### PR TITLE
Fix xinfo and argument parsing in general

### DIFF
--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -26,7 +26,9 @@ import pwndbg.aglib.heap
 import pwndbg.aglib.kernel
 import pwndbg.aglib.proc
 import pwndbg.aglib.qemu
+import pwndbg.aglib.typeinfo
 import pwndbg.color.message as message
+import pwndbg.dbg_mod
 import pwndbg.exception
 import pwndbg.integration
 from pwndbg.aglib.heap.ptmalloc import DebugSymsHeap
@@ -657,7 +659,10 @@ def fix_int_reraise_arg(arg) -> int:
     """fix_int_reraise wrapper for evaluating command arguments"""
     try:
         fixed = fix_reraise_arg(arg)
-        return int(fixed)
+        fixed_ptr = fixed.cast(
+            pwndbg.aglib.typeinfo.pvoid
+        )  # Fixes issues with function ptrs (e.g. passing in `malloc`).
+        return int(fixed_ptr)
     except pwndbg.dbg_mod.Error as e:
         raise argparse.ArgumentTypeError(
             f"couldn't convert '{arg}' ({fixed.type.name_to_human_readable}) to int: {e}"

--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -658,11 +658,16 @@ def fix_int_reraise(*a, **kw) -> int:
 def fix_int_reraise_arg(arg) -> int:
     """fix_int_reraise wrapper for evaluating command arguments"""
     try:
-        fixed = fix_reraise_arg(arg)
-        fixed_ptr = fixed.cast(
-            pwndbg.aglib.typeinfo.pvoid
-        )  # Fixes issues with function ptrs (e.g. passing in `malloc`).
-        return int(fixed_ptr)
+        fixed: pwndbg.dbg_mod.Value = fix_reraise_arg(arg)
+        if fixed.type.code == pwndbg.dbg_mod.TypeCode.FUNC:
+            # Fixes issues with function ptrs (e.g. passing in `malloc`).
+            func_addr = fixed.address
+            if func_addr is None:
+                raise argparse.ArgumentTypeError(
+                    f"couldn't convert '{arg}' ({fixed.type.name_to_human_readable}) to int: Function is not addressable."
+                )
+            return int(func_addr)
+        return int(fixed)
     except pwndbg.dbg_mod.Error as e:
         raise argparse.ArgumentTypeError(
             f"couldn't convert '{arg}' ({fixed.type.name_to_human_readable}) to int: {e}"

--- a/pwndbg/commands/xinfo.py
+++ b/pwndbg/commands/xinfo.py
@@ -103,10 +103,7 @@ def xinfo_default(page: Page, addr: int) -> None:
 
 @pwndbg.commands.Command(parser, category=CommandCategory.MEMORY)
 @pwndbg.commands.OnlyWhenRunning
-def xinfo(address=None) -> None:
-    address = address.cast(
-        pwndbg.aglib.typeinfo.pvoid
-    )  # Fixes issues with function ptrs (xinfo malloc)
+def xinfo(address: int) -> None:
     addr = int(address)
     addr &= pwndbg.aglib.arch.ptrmask
 

--- a/pwndbg/commands/xinfo.py
+++ b/pwndbg/commands/xinfo.py
@@ -104,16 +104,15 @@ def xinfo_default(page: Page, addr: int) -> None:
 @pwndbg.commands.Command(parser, category=CommandCategory.MEMORY)
 @pwndbg.commands.OnlyWhenRunning
 def xinfo(address: int) -> None:
-    addr = int(address)
-    addr &= pwndbg.aglib.arch.ptrmask
+    address &= pwndbg.aglib.arch.ptrmask
 
-    page = pwndbg.aglib.vmmap.find(addr)
+    page = pwndbg.aglib.vmmap.find(address)
 
     if page is None:
-        print(f"\n  Virtual address {addr:#x} is not mapped.")
+        print(f"\n  Virtual address {address:#x} is not mapped.")
         return
 
-    print(f"Extended information for virtual address {mem_color.get(addr)}:")
+    print(f"Extended information for virtual address {mem_color.get(address)}:")
 
     print("\n  Containing mapping:")
     print(mem_color.get(address, text=str(page)))
@@ -121,9 +120,9 @@ def xinfo(address: int) -> None:
     print("\n  Offset information:")
 
     if page.is_stack:
-        xinfo_stack(page, addr)
+        xinfo_stack(page, address)
     else:
-        xinfo_default(page, addr)
+        xinfo_default(page, address)
 
     if page.is_memory_mapped_file:
-        xinfo_mmap_file(page, addr)
+        xinfo_mmap_file(page, address)


### PR DESCRIPTION
It seems the subcommand PR invalidated some assumptions (the assumptions suck) and broke xinfo.

### Before
```
pwndbg> xinfo 0x7ffff7df0ca8
╭─────────────────────────────── Traceback (most recent call last) ────────────────────────────────╮
│ pwndbg/pwndbg/commands/__init__.py:464 in __call__                               │
│                                                                                                  │
│    461 │                                                                                         │
│    462 │   def __call__(self, *args: Any, **kwargs: Any) -> str | None:                          │
│    463 │   │   try:                                                                              │
│ ❱  464 │   │   │   return self.function(*args, **kwargs)                                         │
│    465 │   │   except TypeError:                                                                 │
│    466 │   │   │   print(f"{self.command_name}: {self.description}")                             │
│    467 │   │   │   pwndbg.exception.handle(self.function.__name__)                               │
│                                                                                                  │
│ pwndbg/pwndbg/commands/__init__.py:781 in _OnlyWhenRunning                       │
│                                                                                                  │
│    778 │   def _OnlyWhenRunning(*a: P.args, **kw: P.kwargs) -> Optional[T]:                      │
│    779 │   │   # TODO: Properly support OnlyWhenRunning without `gdblib`.                        │
│    780 │   │   if pwndbg.aglib.proc.alive():                                                     │
│ ❱  781 │   │   │   return function(*a, **kw)                                                     │
│    782 │   │   else:                                                                             │
│    783 │   │   │   log.error(f"{func_name(function)}: The program is not being run.")            │
│    784 │   │   │   return None                                                                   │
│                                                                                                  │
│ pwndbg/pwndbg/commands/xinfo.py:107 in xinfo                                     │
│                                                                                                  │
│   104 @pwndbg.commands.Command(parser, category=CommandCategory.MEMORY)                          │
│   105 @pwndbg.commands.OnlyWhenRunning                                                           │
│   106 def xinfo(address=None) -> None:                                                           │
│ ❱ 107 │   address = address.cast(                                                                │
│   108 │   │   pwndbg.aglib.typeinfo.pvoid                                                        │
│   109 │   )  # Fixes issues with function ptrs (xinfo malloc)                                    │
│   110 │   addr = int(address)                                                                    │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
AttributeError: 'int' object has no attribute 'cast'
If that is an issue, you can report it on https://github.com/pwndbg/pwndbg/issues
(Please don't forget to search if it hasn't been reported before)
To generate the report and open a browser, you may run `bugreport --run-browser`
PS: Pull requests are welcome
pwndbg> xinfo malloc
usage: xinfo [-h] [address]
xinfo: error: argument address: couldn't convert 'malloc' (void *(size_t)) to int: Cannot convert value to long.
pwndbg> 
```

### After 
```
pwndbg> xinfo 0x7ffff7df0ca8
Extended information for virtual address 0x7ffff7df0ca8:

  Containing mapping:
    0x7ffff7def000     0x7ffff7f54000 r-xp   165000   28000 libc.so.6

  Offset information:
         Mapped Area 0x7ffff7df0ca8 = 0x7ffff7def000 + 0x1ca8
         File (Base) 0x7ffff7df0ca8 = 0x7ffff7dc7000 + 0x29ca8
      File (Segment) 0x7ffff7df0ca8 = 0x7ffff7def000 + 0x1ca8
         File (Disk) 0x7ffff7df0ca8 = libc.so.6 + 0x29ca8

 Containing ELF sections:
               .text 0x7ffff7df0ca8 = 0x7ffff7def400 + 0x18a8
pwndbg> xinfo malloc
Extended information for virtual address 0x7ffff7e69b50:

  Containing mapping:
    0x7ffff7def000     0x7ffff7f54000 r-xp   165000   28000 libc.so.6

  Offset information:
         Mapped Area 0x7ffff7e69b50 = 0x7ffff7def000 + 0x7ab50
         File (Base) 0x7ffff7e69b50 = 0x7ffff7dc7000 + 0xa2b50
      File (Segment) 0x7ffff7e69b50 = 0x7ffff7def000 + 0x7ab50
         File (Disk) 0x7ffff7e69b50 = libc.so.6 + 0xa2b50

 Containing ELF sections:
               .text 0x7ffff7e69b50 = 0x7ffff7def400 + 0x7a750
```