### PR TITLE
Fix `gdb.execute(.., to_string=True)` in `ipi` context

### DIFF
--- a/pwndbg/commands/ipython_interactive.py
+++ b/pwndbg/commands/ipython_interactive.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import sys
 from contextlib import contextmanager
+from typing import Iterator
 
 import gdb
 
@@ -16,7 +17,7 @@ from pwndbg.commands import CommandCategory
 
 
 @contextmanager
-def switch_to_ipython_env():
+def switch_to_ipython_env() -> Iterator[None]:
     saved_excepthook = sys.excepthook
     try:
         saved_ps = sys.ps1, sys.ps2

--- a/pwndbg/commands/ipython_interactive.py
+++ b/pwndbg/commands/ipython_interactive.py
@@ -17,15 +17,19 @@ from pwndbg.commands import CommandCategory
 
 @contextmanager
 def switch_to_ipython_env():
-    """We need to change stdout/stderr to the default ones, otherwise we can't use tab or autocomplete"""
-    # Save GDB's excepthook
     saved_excepthook = sys.excepthook
-    # Switch to default stdout/stderr
-    with pwndbg.lib.stdio.stdio:
-        yield
-    # Restore Python's default ps1, ps2, and excepthook for GDB's `pi` command
-    sys.ps1 = ">>> "
-    sys.ps2 = "... "
+    try:
+        saved_ps = sys.ps1, sys.ps2
+    except AttributeError:
+        saved_ps = None
+    yield
+    # Restore Python's default `ps1`, `ps2`, and `excepthook`
+    # to ensure proper behavior of the GDB repl.
+    if saved_ps is not None:
+        sys.ps1, sys.ps2 = saved_ps
+    else:
+        del sys.ps1
+        del sys.ps2
     sys.excepthook = saved_excepthook
 
 


### PR DESCRIPTION

##  Fix `gdb.execute(.., to_string=True)` in `ipi` context:

Before:
<img width="391" height="110" alt="image" src="https://github.com/user-attachments/assets/a959d2a0-486a-4aef-92a2-9cc2a9972d43" />

After:
<img width="407" height="154" alt="image" src="https://github.com/user-attachments/assets/dc8668c9-e8a0-47ef-8f6f-15539461af76" />
