### PR TITLE
Exit on uv install error with info msg

### DIFF
--- a/pwndbginit/common.py
+++ b/pwndbginit/common.py
@@ -93,6 +93,13 @@ def update_deps(src_root: Path) -> None:
             print(stdout)
     else:
         print(stderr, file=sys.stderr)
+        print("\x1b[31mERROR: Pwndbg failed to update with the above uv error.\x1b[0m")
+        print(
+            "\x1b[31m"
+            "ERROR: Re-run with PWNDBG_NO_AUTOUPDATE=1 if you intend to run without an update."
+            "\x1b[0m"
+        )
+        sys.exit(return_code)
 
 
 def skip_autoupdate(src_root) -> bool:


### PR DESCRIPTION
Handles a case where user have permission erorrs

```
$ gdb ./a
Detected outdated Pwndbg dependencies (uv.lock). Updating.
test
warning: `VIRTUAL_ENV=/home/user/venv-ctfs` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead
Resolved 149 packages in 1ms
   Building pwndbg @ file:///home/user/pwndbg
  × Failed to build `pwndbg @ file:///home/user/pwndbg`
  ├─▶ Failed to resolve requirements from `build-system.requires`
  ├─▶ No solution found when resolving: `hatchling`
  ├─▶ Failed to write to the client cache
  ╰─▶ Permission denied (os error 13) at path
      "/home/user/.cache/uv/simple-v17/pypi/.tmpDnKF8u"
pwndbg: loaded 212 pwndbg commands. Type pwndbg [filter] for a list.
pwndbg: created 9 GDB functions (can be used with print/break). Type help function to see them.
Reading symbols from ./a...

This GDB supports auto-downloading debuginfo from the following URLs:
  <https://debuginfod.ubuntu.com>
Debuginfod has been disabled.
To make this setting permanent, add 'set debuginfod enabled off' to .gdbinit.
(No debugging symbols found in ./a)
------- tip of the day (disable with set show-tips off) -------
break-if-taken and break-if-not-taken commands sets breakpoints after a given jump instruction was taken or not
pwndbg> quit
```

<!--
    Please make sure to read the linting and testing instructions at
    https://pwndbg.re/dev/contributing/ before creating a PR.
-->

+ [x] I read the contributing documentation.
+ [x] I am providing a screenshot of the (new feature) / (fixed bug).
