### PR TITLE
Allow using gdbinit without venv

### DIFF
--- a/gdbinit.py
+++ b/gdbinit.py
@@ -45,16 +45,31 @@ def get_venv_path(src_root: Path):
 
 def main() -> None:
     src_root = Path(__file__).parent.resolve()
-    venv_path = get_venv_path(src_root)
-    if not venv_path.exists():
-        print(
-            f"\nCannot find Pwndbg virtualenv directory: {venv_path}. Please (re-)run setup.sh from the Pwndbg source folder.\n"
-            "(see https://pwndbg.re/dev/setup/#installing-from-source)",
-            flush=True,
-        )
-        os._exit(1)
 
-    fixup_paths(src_root, venv_path)
+    skip_venv = False
+    try:
+        # This can fail if Pwndbg is not installed to system site-packages
+        # on our regular virtualenv setup
+        from pwndbginit.common import is_system_installation
+
+        # If Pwndbg is installed by distro package manager, skip virtualenv check
+        if is_system_installation(src_root):
+            skip_venv = True
+    except ImportError:
+        pass
+
+    if not skip_venv:
+        venv_path = get_venv_path(src_root)
+        if not venv_path.exists():
+            print(
+                f"\nCannot find Pwndbg virtualenv directory: {venv_path}. Please (re-)run setup.sh from the Pwndbg source folder.\n"
+                "(see https://pwndbg.re/dev/setup/#installing-from-source)",
+                flush=True,
+            )
+            os._exit(1)
+
+        fixup_paths(src_root, venv_path)
+
     from pwndbginit.gdbinit import main_try
 
     main_try()

--- a/pwndbginit/common.py
+++ b/pwndbginit/common.py
@@ -102,11 +102,7 @@ def update_deps(src_root: Path) -> None:
         sys.exit(return_code)
 
 
-def skip_autoupdate(src_root) -> bool:
-    no_auto_update = os.getenv("PWNDBG_NO_AUTOUPDATE") is not None
-    if no_auto_update:
-        return True
-
+def is_system_installation(src_root: Path) -> bool:
     # If pwndbg is installed in `/venv/lib/pythonX.Y/site-packages/pwndbg/`,
     # the `.pwndbg_root` file will not exist because `src_root` will point to the
     # `/venv/lib/pythonX.Y/site-packages/` directory, not the original source directory
@@ -115,6 +111,17 @@ def skip_autoupdate(src_root) -> bool:
     # and the condition will be False, allowing auto-update.
     is_system_install = not (src_root / ".pwndbg_root").exists()
     if is_system_install:
+        return True
+
+    return False
+
+
+def skip_autoupdate(src_root: Path) -> bool:
+    no_auto_update = os.getenv("PWNDBG_NO_AUTOUPDATE") is not None
+    if no_auto_update:
+        return True
+
+    if is_system_installation(src_root):
         return True
 
     return False


### PR DESCRIPTION
<!--
    Please make sure to read the linting and testing instructions at
    https://pwndbg.re/dev/contributing/ before creating a PR.
-->

+ [x] I read the contributing documentation.
+ [ ] I am providing a screenshot of the (new feature) / (fixed bug).

#3119 allows using `pwndbg` command from shell with a distro-packaged pwndbg. But using `source /usr/share/pwndbg/gdbinit.py` from `.gdbinit` still fails when no venv is created.

Using the same logic as `verify_venv` in `pwndbginit.common`:
https://github.com/pwndbg/pwndbg/blob/dca241bf82d70392e4ceb783d1af9cef20081cc2/pwndbginit/common.py#L123-L126

cc @patryk4815