### PR TITLE
Don't install vendored GDB and LLDB in setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -215,7 +215,7 @@ pip install uv
 
 # Install dependencies
 echo "Installing dependencies.."
-uv sync --extra gdb --extra lldb --quiet
+uv sync --quiet
 
 if [ -z "$UPDATE_MODE" ]; then
     if grep -qs '^[^#]*source.*pwndbg/gdbinit.py' ~/.gdbinit; then


### PR DESCRIPTION
<!--
    Please make sure to read the linting and testing instructions at
    https://pwndbg.re/dev/contributing/ before creating a PR.
-->

+ [x] I read the contributing documentation.
+ [ ] I am providing a screenshot of the (new feature) / (fixed bug).

setup.sh will create a venv and use gdbinit to launch pwndbg, without installing the pwndbg and pwndbg-lldb commands.

With the gdbinit approach, users will use the system GDB and LLDB, instead of the ones installed in venv.

So installing these binaries in venv is a waste of time, bandwidth and disk space for users.

Feel free to blame me if I'm wrong. :P