### PR TITLE
Use qGDBServerVersion for QEMU version detection

### DIFF
--- a/pwndbg/aglib/qemu.py
+++ b/pwndbg/aglib/qemu.py
@@ -4,8 +4,37 @@ Determine whether the target is being run under QEMU.
 
 from __future__ import annotations
 
+import re
+
 import pwndbg
 import pwndbg.lib.cache
+
+_QEMU_VERSION_RE = re.compile(r"(\d+)\.(\d+)(?:\.(\d+))?")
+
+
+def _parse_qgdbserverversion(response: bytes) -> tuple[int, ...] | None:
+    if not response or response.startswith(b"E"):
+        return None
+
+    text = response.decode(errors="ignore").strip()
+    if not text:
+        return None
+
+    match = _QEMU_VERSION_RE.search(text)
+    if not match:
+        return None
+
+    return tuple(int(part) for part in match.groups() if part is not None)
+
+
+@pwndbg.lib.cache.cache_until("stop")
+def qemu_gdbserver_version() -> tuple[int, ...] | None:
+    inferior = pwndbg.dbg.selected_inferior()
+    if not inferior.is_remote():
+        return None
+
+    response = inferior.send_remote("qGDBServerVersion")
+    return _parse_qgdbserverversion(response)
 
 
 @pwndbg.lib.cache.cache_until("stop")
@@ -13,6 +42,9 @@ def is_qemu() -> bool:
     inferior = pwndbg.dbg.selected_inferior()
     if not inferior.is_remote():
         return False
+
+    if qemu_gdbserver_version() is not None:
+        return True
 
     # Examples:
     #
@@ -60,7 +92,14 @@ def is_qemu_kernel() -> bool:
 
 def is_old_qemu_user() -> bool:
     # qemu-user <8.1
-    return is_qemu_usermode() and not exec_file_supported()
+    if not is_qemu_usermode():
+        return False
+
+    version = qemu_gdbserver_version()
+    if version is not None:
+        return version < (8, 1)
+
+    return not exec_file_supported()
 
 
 @pwndbg.lib.cache.cache_until("stop")

--- a/pwndbg/aglib/qemu.py
+++ b/pwndbg/aglib/qemu.py
@@ -29,6 +29,9 @@ def _parse_qgdbserverversion(response: bytes) -> tuple[int, ...] | None:
 
 @pwndbg.lib.cache.cache_until("stop")
 def qemu_gdbserver_version() -> tuple[int, ...] | None:
+    """
+    Returns QEMU version. Works since QEMU 10.1.0
+    """
     inferior = pwndbg.dbg.selected_inferior()
     if not inferior.is_remote():
         return None

--- a/tests/unit_tests/test_qemu.py
+++ b/tests/unit_tests/test_qemu.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from pwndbg.aglib.qemu import _parse_qgdbserverversion
+
+
+def test_parse_qgdbserverversion_empty():
+    assert _parse_qgdbserverversion(b"") is None
+    assert _parse_qgdbserverversion(b"E00") is None
+
+
+def test_parse_qgdbserverversion_without_version():
+    assert _parse_qgdbserverversion(b"QEMU gdbserver version") is None
+
+
+def test_parse_qgdbserverversion_with_full_version():
+    assert _parse_qgdbserverversion(b"QEMU gdbserver version: 10.1.0") == (10, 1, 0)
+    assert _parse_qgdbserverversion(b"10.1.2-rc1") == (10, 1, 2)
+
+
+def test_parse_qgdbserverversion_with_partial_version():
+    assert _parse_qgdbserverversion(b"qemu 10.1") == (10, 1)


### PR DESCRIPTION
## Summary:

  - Add a cached qGDBServerVersion query + parser for QEMU version detection.
  - Use the new packet for QEMU detection and version checks, but still keep legacy fallbacks.

  ## Tests That I Ran:
  - ./lint.sh
```
$ ./lint.sh
+ LINT_FILES='pwndbg pwndbginit tests *.py scripts'
...snip...
uv run --group dev --group lint --group tests --extra gdb --extra lldb mypy pwndbg pwndbginit tests/host
Success: no issues found in 264 source files
```
  - ./unit-tests.sh
```
$ ./unit-tests.sh
===================== test session starts ======================
platform linux -- Python 3.12.3, pytest-8.0.2, pluggy-1.6.0
rootdir: /home/rob/src/github.com/pwndbg
plugins: cov-4.1.0
collected 49 items                                             

tests/unit_tests/test_arch.py .                          [  2%]
tests/unit_tests/test_bit_math.py .....                  [ 12%]
tests/unit_tests/test_functions.py ....                  [ 20%]
tests/unit_tests/test_hex2ptr.py ...                     [ 26%]
tests/unit_tests/test_memory.py ..                       [ 30%]
tests/unit_tests/test_qemu.py ....                       [ 38%]
tests/unit_tests/test_regs.py ......                     [ 51%]
tests/unit_tests/test_which.py ...                       [ 57%]
tests/unit_tests/test_zig_asm.py ..................sss   [100%]

=========== 46 passed, 3 skipped in 60.90s (0:01:00) ===========
```

  ## Issue: 

 - Fixes #3501


  ## Checklist:

  - [x] I read the contributing documentation.
  - [x] I am providing a screenshot of the (new feature) / (fixed
    bug).
     - QEMU 8 and QEMU 10 screenshots of behavior provided in a comment below.
