### PR TITLE
Make pwndbg.dbg.selected_inferior() raise an exception instead of returning None

### DIFF
--- a/pwndbg/aglib/typeinfo.py
+++ b/pwndbg/aglib/typeinfo.py
@@ -46,8 +46,10 @@ ssize_t: pwndbg.dbg_mod.Type
 
 
 def lookup_types(*types: str) -> pwndbg.dbg_mod.Type:
-    process = pwndbg.dbg.selected_inferior()
-    assert process, "tried to initialize typeinfo with no inferior"
+    try:
+        process = pwndbg.dbg.selected_inferior()
+    except pwndbg.dbg_mod.NoInferior:
+        raise AssertionError("Tried to initialize typeinfo with no inferior")
     for type_str in types:
         t = process.types_with_name(type_str)
         if len(t) > 0:

--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -26,6 +26,7 @@ import pwndbg.aglib.heap
 import pwndbg.aglib.kernel
 import pwndbg.aglib.proc
 import pwndbg.aglib.qemu
+import pwndbg.aglib.symbol
 import pwndbg.aglib.typeinfo
 import pwndbg.color.message as message
 import pwndbg.dbg_mod
@@ -440,7 +441,9 @@ class CommandObj:
 
     def invoke(self, argument: str, from_tty: bool) -> None:
         """Invoke the command with an argument string"""
-        if not pwndbg.dbg.selected_inferior():
+        try:
+            _ = pwndbg.dbg.selected_inferior()
+        except pwndbg.dbg_mod.NoInferior:
             log.error("Pwndbg commands require a target binary to be selected")
             return
 
@@ -614,10 +617,12 @@ def fix(
         return arg
 
     frame = pwndbg.dbg.selected_frame()
-    target: pwndbg.dbg_mod.Frame | pwndbg.dbg_mod.Process = (
-        frame if frame else pwndbg.dbg.selected_inferior()
-    )
-    assert target, "Reached command expression evaluation with no frame or inferior"
+    try:
+        target: pwndbg.dbg_mod.Frame | pwndbg.dbg_mod.Process = (
+            frame if frame else pwndbg.dbg.selected_inferior()
+        )
+    except pwndbg.dbg_mod.NoInferior:
+        raise AssertionError("Reached command expression evaluation with no frame or inferior")
 
     # Try to evaluate the expression in the local, or, failing that, global
     # context.
@@ -987,10 +992,12 @@ def sloppy_gdb_parse(s: str) -> int | str:
     """
 
     frame = pwndbg.dbg.selected_frame()
-    target: pwndbg.dbg_mod.Frame | pwndbg.dbg_mod.Process = (
-        frame if frame else pwndbg.dbg.selected_inferior()
-    )
-    assert target, "Reached command expression evaluation with no frame or inferior"
+    try:
+        target: pwndbg.dbg_mod.Frame | pwndbg.dbg_mod.Process = (
+            frame if frame else pwndbg.dbg.selected_inferior()
+        )
+    except pwndbg.dbg_mod.NoInferior:
+        raise AssertionError("Reached command expression evaluation with no frame or inferior")
 
     try:
         val = pwndbg.aglib.symbol.lookup_symbol(s) or target.evaluate_expression(s)

--- a/pwndbg/commands/integration.py
+++ b/pwndbg/commands/integration.py
@@ -17,6 +17,7 @@ import pwndbg.color as color
 import pwndbg.color.memory as color_mem
 import pwndbg.color.message as message
 import pwndbg.commands
+import pwndbg.dbg_mod
 import pwndbg.integration
 import pwndbg.lib.config
 import pwndbg.lib.tempfile
@@ -439,15 +440,27 @@ def soft_connection_check(also_sync: bool) -> bool:
     return True
 
 
+def check_alive(error_msg: str) -> bool:
+    try:
+        inf = pwndbg.dbg.selected_inferior()
+
+        if not inf.alive():
+            # A bit hacky but whatever.
+            raise pwndbg.dbg_mod.NoInferior
+
+        return True
+    except pwndbg.dbg_mod.NoInferior:
+        print(message.error(error_msg))
+        return False
+
+
 def jump(addr: Optional[int]) -> None:
     if not pwndbg.integration.manager.is_connected():
         print(message.error("Not connected to a decompiler."))
         print(message.hint("Try `di connect`."))
         return
 
-    # Check if the process is alive
-    if (inf := pwndbg.dbg.selected_inferior()) is None or not inf.alive():
-        print(message.error("Can only jump to address while the process is alive."))
+    if not check_alive("Can only jump to address while the process is alive."):
         return
 
     if addr is None:
@@ -477,10 +490,9 @@ def sync(fail_quietly: bool) -> None:
         if not soft_connection_check(also_sync=False):
             return
 
-    # Check if the process is alive
-    if (inf := pwndbg.dbg.selected_inferior()) is None or not inf.alive():
-        if not fail_quietly:
-            print(message.notice("Can only sync with the debugger while the process is alive."))
+    if not check_alive(
+        "" if fail_quietly else "Can only sync with the debugger while the process is alive."
+    ):
         return
 
     print("Syncing symbols. It may take a while.")
@@ -593,9 +605,7 @@ def list_(list_all: bool) -> None:
     if not soft_connection_check(also_sync=True):
         return
 
-    # Check if the process is alive
-    if (inf := pwndbg.dbg.selected_inferior()) is None or not inf.alive():
-        print(message.error("Can only list function variables if the process is alive."))
+    if not check_alive("Can only list function variables if the process is alive."):
         return
 
     if list_all:

--- a/pwndbg/commands/kmem_trace.py
+++ b/pwndbg/commands/kmem_trace.py
@@ -11,6 +11,7 @@ import pwndbg.arguments
 import pwndbg.color as color
 import pwndbg.color.message as message
 import pwndbg.commands.context
+import pwndbg.dbg_mod
 import pwndbg.lib.cache
 from pwndbg.dbg_mod import BreakpointLocation
 from pwndbg.dbg_mod import DebuggerType
@@ -209,12 +210,9 @@ class KmemTracepoints:
 
     @staticmethod
     def palloc_handler(sp: pwndbg.dbg_mod.StopPoint) -> bool:
-        inf = pwndbg.dbg.selected_inferior()
-        assert inf
-
         self = get_kmem_tracepoints()
         order = pwndbg.arguments.argument(1)
-        inf.trace_ret(KmemTracepoints._palloc_handler, True)
+        pwndbg.dbg.selected_inferior().trace_ret(KmemTracepoints._palloc_handler, True)
         self.data.order = order
         return False
 
@@ -228,7 +226,6 @@ class KmemTracepoints:
 
     def register_breakpoints(self, verbose, trace_all):
         inf = pwndbg.dbg.selected_inferior()
-        assert inf
         self.results = []
         self.data = KmemTracepointsData(verbose, trace_all)
         if self.slab_tracepoints_enabled:

--- a/pwndbg/commands/kmem_trace.py
+++ b/pwndbg/commands/kmem_trace.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import threading
+from typing import Tuple
 
 import pwndbg.aglib
 import pwndbg.aglib.kernel
@@ -168,7 +169,7 @@ class KmemTracepoints:
         self.slab_tracepoints_enabled = True
         self.buddy_tracepoints_enabled = True
 
-    def resolve_names(self, names):
+    def resolve_names(self, names: Tuple[str, ...]) -> list[int]:
         result = []
         for name in names:
             addr = pwndbg.aglib.symbol.lookup_symbol_addr(name)

--- a/pwndbg/dbg_mod/__init__.py
+++ b/pwndbg/dbg_mod/__init__.py
@@ -68,7 +68,7 @@ class Error(Exception):
 
 
 class NoInferior(Exception):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__("The debugger couldn't find a selected inferior.")
 
 

--- a/pwndbg/dbg_mod/__init__.py
+++ b/pwndbg/dbg_mod/__init__.py
@@ -67,6 +67,11 @@ class Error(Exception):
     pass
 
 
+class NoInferior(Exception):
+    def __init__(self):
+        super().__init__("The debugger couldn't find a selected inferior.")
+
+
 class DisassembledInstruction(TypedDict):
     addr: int
     asm: str
@@ -1194,9 +1199,14 @@ class Debugger:
         """
         raise NotImplementedError()
 
-    def selected_inferior(self) -> Process | None:
+    def selected_inferior(self) -> Process:
         """
         The inferior process currently being focused on in this interactive session.
+
+        Raises:
+            pwndbg.dbg_mod.NoInferior: If the debugger couldn't return an inferior. If
+                there is an alive Process (i.e. you are under @pwndbg.commands.OnlyWhenRunning)
+                this will not be raised.
         """
         raise NotImplementedError()
 

--- a/pwndbg/dbg_mod/gdb/__init__.py
+++ b/pwndbg/dbg_mod/gdb/__init__.py
@@ -1782,7 +1782,7 @@ class GDB(pwndbg.dbg_mod.Debugger):
         return existing_commands
 
     @override
-    def selected_inferior(self) -> pwndbg.dbg_mod.Process | None:
+    def selected_inferior(self) -> pwndbg.dbg_mod.Process:
         return GDBProcess(gdb.selected_inferior())
 
     @override

--- a/pwndbg/dbg_mod/lldb/__init__.py
+++ b/pwndbg/dbg_mod/lldb/__init__.py
@@ -24,6 +24,7 @@ from typing import Optional
 from typing import Sequence
 from typing import Tuple
 from typing import TypeVar
+from typing import cast
 
 import lldb
 from typing_extensions import override
@@ -2132,14 +2133,17 @@ class LLDB(pwndbg.dbg_mod.Debugger):
     def lex_args(self, command_line: str) -> List[str]:
         return shlex.split(command_line)
 
-    def _any_inferior(self) -> LLDBProcess | None:
+    def _any_inferior(self) -> LLDBProcess:
         """
         Pick the first inferior in the debugger, if any is present.
+
+        Raises:
+            pwndbg.dbg_mod.NoInferior: If we couldn't find an inferior.
         """
         target_count = self.debugger.GetNumTargets()
         if target_count == 0:
             # No targets are available.
-            return None
+            raise pwndbg.dbg_mod.NoInferior()
         if target_count > 1:
             # We don't support multiple targets.
             raise RuntimeError("Multiple LLDB targets are not supported")
@@ -2150,12 +2154,12 @@ class LLDB(pwndbg.dbg_mod.Debugger):
         process = target.GetProcess()
         if not process.IsValid():
             # No process we can use.
-            return None
+            raise pwndbg.dbg_mod.NoInferior()
 
         return LLDBProcess(self, process, target, self._current_process_is_gdb_remote)
 
     @override
-    def selected_inferior(self) -> pwndbg.dbg_mod.Process | None:
+    def selected_inferior(self) -> pwndbg.dbg_mod.Process:
         if len(self.exec_states) == 0:
             # The Debugger-agnostic API treats existence of an inferior the same
             # as it being selected, as multiple inferiors are not supported, so
@@ -2169,14 +2173,14 @@ class LLDB(pwndbg.dbg_mod.Debugger):
         if p.IsValid() and t.IsValid():
             return LLDBProcess(self, p, t, self._current_process_is_gdb_remote)
 
-        return None
+        raise pwndbg.dbg_mod.NoInferior()
 
     def _any_thread(self) -> LLDBThread | None:
         """
         Pick the first thread we can get our hands on, preferring the selected
         thread, if any is selected.
         """
-        inferior: LLDBProcess = self.selected_inferior()
+        inferior: LLDBProcess = cast(LLDBProcess, self.selected_inferior())
         if inferior is None:
             return None
 

--- a/pwndbg/dbg_mod/lldb/__init__.py
+++ b/pwndbg/dbg_mod/lldb/__init__.py
@@ -2143,7 +2143,7 @@ class LLDB(pwndbg.dbg_mod.Debugger):
         target_count = self.debugger.GetNumTargets()
         if target_count == 0:
             # No targets are available.
-            raise pwndbg.dbg_mod.NoInferior()
+            raise pwndbg.dbg_mod.NoInferior
         if target_count > 1:
             # We don't support multiple targets.
             raise RuntimeError("Multiple LLDB targets are not supported")
@@ -2154,7 +2154,7 @@ class LLDB(pwndbg.dbg_mod.Debugger):
         process = target.GetProcess()
         if not process.IsValid():
             # No process we can use.
-            raise pwndbg.dbg_mod.NoInferior()
+            raise pwndbg.dbg_mod.NoInferior
 
         return LLDBProcess(self, process, target, self._current_process_is_gdb_remote)
 
@@ -2173,7 +2173,7 @@ class LLDB(pwndbg.dbg_mod.Debugger):
         if p.IsValid() and t.IsValid():
             return LLDBProcess(self, p, t, self._current_process_is_gdb_remote)
 
-        raise pwndbg.dbg_mod.NoInferior()
+        raise pwndbg.dbg_mod.NoInferior
 
     def _any_thread(self) -> LLDBThread | None:
         """

--- a/pwndbg/dbg_mod/lldb/__init__.py
+++ b/pwndbg/dbg_mod/lldb/__init__.py
@@ -2180,8 +2180,9 @@ class LLDB(pwndbg.dbg_mod.Debugger):
         Pick the first thread we can get our hands on, preferring the selected
         thread, if any is selected.
         """
-        inferior: LLDBProcess = cast(LLDBProcess, self.selected_inferior())
-        if inferior is None:
+        try:
+            inferior: LLDBProcess = cast(LLDBProcess, self.selected_inferior())
+        except pwndbg.dbg_mod.NoInferior:
             return None
 
         selected = inferior.process.GetSelectedThread()
@@ -2344,8 +2345,9 @@ class LLDB(pwndbg.dbg_mod.Debugger):
 
     @override
     def breakpoint_locations(self) -> List[pwndbg.dbg_mod.BreakpointLocation]:
-        inferior: LLDBProcess = self.selected_inferior()
-        if inferior is None:
+        try:
+            inferior: LLDBProcess = cast(LLDBProcess, self.selected_inferior())
+        except pwndbg.dbg_mod.NoInferior:
             return []
 
         bps: List[lldb.SBBreakpoint] = inferior.target.breakpoints

--- a/pwndbg/gdblib/vmmap.py
+++ b/pwndbg/gdblib/vmmap.py
@@ -41,8 +41,6 @@ def is_corefile() -> bool:
     As the two differ in output slighty.
     """
     inf = gdb.selected_inferior()
-    if inf is None:
-        return False
     conn = inf.connection
     if conn is None:
         return False

--- a/pwndbg/integration/__init__.py
+++ b/pwndbg/integration/__init__.py
@@ -190,38 +190,40 @@ class DecompilerConnection:
             self._binary_base_addr = manual_binary_address
             return
 
-        if inf := pwndbg.dbg.selected_inferior():
-            if not inf.alive():
-                return
+        try:
+            inf = pwndbg.dbg.selected_inferior()
+        except pwndbg.dbg_mod.NoInferior:
+            return
 
-            # Try to find the binary in the address space.
-            start_addr: Optional[int] = pwndbg.aglib.vmmap.named_region_start(
-                self.binary_path, exact_match=True
-            )
+        if not inf.alive():
+            return
+
+        # Try to find the binary in the address space.
+        start_addr: Optional[int] = pwndbg.aglib.vmmap.named_region_start(
+            self.binary_path, exact_match=True
+        )
+
+        if start_addr is None:
+            # Try harder! (likely we are remote debugging)
+            start_addr = pwndbg.aglib.vmmap.named_region_start(self.binary_path, exact_match=False)
 
             if start_addr is None:
-                # Try harder! (likely we are remote debugging)
-                start_addr = pwndbg.aglib.vmmap.named_region_start(
-                    self.binary_path, exact_match=False
-                )
-
-                if start_addr is None:
-                    if print_failure:
-                        basename: str = os.path.basename(self.binary_path)
-                        print(
-                            message.notice(
-                                f"The decompiled program {basename} doesn't seem to be loaded."
-                                " We will keep an eye out for it.\n"
-                            )
-                            + "If you know that it is actually loaded, check out "
-                            + message.hint("`di setbase --help`")
-                            + ".\n"
+                if print_failure:
+                    basename: str = os.path.basename(self.binary_path)
+                    print(
+                        message.notice(
+                            f"The decompiled program {basename} doesn't seem to be loaded."
+                            " We will keep an eye out for it.\n"
                         )
-                    return
-                else:
-                    self._binary_base_addr = start_addr
+                        + "If you know that it is actually loaded, check out "
+                        + message.hint("`di setbase --help`")
+                        + ".\n"
+                    )
+                return
             else:
                 self._binary_base_addr = start_addr
+        else:
+            self._binary_base_addr = start_addr
 
     def addr_to_mapped(self, rel_addr: int) -> int:
         """
@@ -793,8 +795,12 @@ class IntegrationManager:
         if raw_func_data is None:
             return None
 
-        inf = pwndbg.dbg.selected_inferior()
-        if not inf:
+        try:
+            inf = pwndbg.dbg.selected_inferior()
+        except pwndbg.dbg_mod.NoInferior:
+            return None
+
+        if not inf.alive():
             return None
 
         # Nothing to do for registers

--- a/pwndbg/integration/__init__.py
+++ b/pwndbg/integration/__init__.py
@@ -29,6 +29,7 @@ import pwndbg.aglib
 import pwndbg.aglib.elf
 import pwndbg.aglib.vmmap
 import pwndbg.color.syntax_highlight
+import pwndbg.dbg_mod
 import pwndbg.lib.cache
 import pwndbg.lib.pretty_print as pretty_print
 from pwndbg.color import message
@@ -512,10 +513,14 @@ class IntegrationManager:
         if not path:
             return False
 
-        if inf is not None or (inf := pwndbg.dbg.selected_inferior()) is not None:
+        try:
+            if inf is None:
+                inf = pwndbg.dbg.selected_inferior()
             # FIXME: Only implemented in GDB :(
             if pwndbg.dbg.name() == pwndbg.dbg_mod.DebuggerType.GDB:
                 return inf.remove_symbol_file(path)
+        except pwndbg.dbg_mod.NoInferior:
+            pass
 
         return False
 
@@ -552,8 +557,9 @@ class IntegrationManager:
         self._function_headers = None
         self._global_vars = None
 
-        inf: Optional[pwndbg.dbg_mod.Process] = pwndbg.dbg.selected_inferior()
-        if inf is None:
+        try:
+            inf: pwndbg.dbg_mod.Process = pwndbg.dbg.selected_inferior()
+        except pwndbg.dbg_mod.NoInferior:
             return 0
 
         # Remove old symbol file.

--- a/pwndbg/search.py
+++ b/pwndbg/search.py
@@ -39,7 +39,7 @@ def search(
     Yields:
         An iterator on the address matches
     """
-    i = pwndbg.dbg.selected_inferior()
+    inf = pwndbg.dbg.selected_inferior()
 
     maps = mappings or pwndbg.aglib.vmmap.get()
 
@@ -72,7 +72,7 @@ def search(
         if limit and count >= limit:
             break
 
-        for element in i.find_in_memory(
+        for element in inf.find_in_memory(
             bytearray(searchfor),
             start,
             end - start,


### PR DESCRIPTION
There are not a lot of places which actually need to check this, because most of our commands only run when the process is alive. There isn't a good way to embed this assumption into the type system that I know of, so lets move the burden to catching the exception.