### PR TITLE
Refactor lint.sh: Flag separation for skipping vermin/mpy, and improved error messaging

### DIFF
--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -22,6 +22,7 @@ The `lint.sh` script runs ruff, shfmt, and vermin. ruff is (mostly) able to auto
 ```
 !!! note
     You can find the configuration files for these tools in `pyproject.toml` or by checking the arguments passed inside `lint.sh`.
+    You can also run `./lint.sh -fo` to skip vermin and mypy, allowing for a quicker lint.
 
 When submitting a PR, the continuous integration (CI) job defined in `.github/workflows/lint.yml` will verify that running `./lint.sh` succeeds. Furthermore, you must not increase the number of `mypy --strict` errors as compared to the `dev` branch (see `.github/workflows/lint.sh`). Otherwise the job will fail and we won't be able to merge your PR. Make sure to have a type checker (mypy --strict, pyright, ty, pyrefly, ...) running in your python editor / IDE.
 

--- a/lint.sh
+++ b/lint.sh
@@ -91,7 +91,7 @@ else
         echo "========================================="
         echo "ERROR: Formatting issues detected by ruff."
         echo "       Exiting early. All checks were NOT run."
-        echo "       Use -f or --fix-and-check to fix issues automatically."
+        echo "       Use -f to fix issues automatically."
         echo "========================================="
         exit 1
     fi

--- a/lint.sh
+++ b/lint.sh
@@ -7,32 +7,41 @@ source "$(dirname "$0")/scripts/common.sh"
 cd $PWNDBG_ABS_PATH
 
 help_and_exit() {
-    echo "Usage: ./lint.sh [-f|--fix] [--format] [--all]"
-    echo "  -f,  --fix         fix issues if possible"
-    echo "  --format           run only ruff, shfmt, and vermin checks (skip mypy)"
-    echo "  --all              run all checks including mypy (default behavior)"
+    echo "Usage: ./lint.sh [--check | -fo|--fix-only | -f|--fix-and-check]"
+    echo "  --check                 run all checks without applying fixes (default behavior)"
+    echo "  -fo, --fix-only         fix formatting only, without running checks"
+    echo "  -f,  --fix-and-check    fix formatting first, then run checks"
     echo ""
-    echo "By default, all checks are run.  Use --format for a quick formatting-only check."
+    echo "By default, all checks are run. Fixes are not applied unless specified."
     exit 1
 }
 
-FIX=0
-FORMAT_ONLY=0
+if [[ $# -gt 1 ]]; then
+    help_and_exit
+fi
+
+CHECK_ONLY=1
+FIX_ONLY=0
+FIX_AND_CHECK=0
 
 while [[ $# -gt 0 ]]; do
     case $1 in
-        -f | --fix)
-            FIX=1
+        --check)
+            CHECK_ONLY=1
+            FIX_ONLY=0
+            FIX_AND_CHECK=0
             shift
             ;;
-        --format)
-            FORMAT_ONLY=1
+        -fo | --fix-only)
+            CHECK_ONLY=0
+            FIX_ONLY=1
+            FIX_AND_CHECK=0
             shift
             ;;
-        --all)
-            # Explicitly run all checks (default behavior)
-            # do we want to require --format or --all instead?
-            FORMAT_ONLY=0
+        -f | --fix-and-check)
+            CHECK_ONLY=0
+            FIX_ONLY=0
+            FIX_AND_CHECK=1
             shift
             ;;
         *)
@@ -58,13 +67,45 @@ call_shfmt() {
     fi
 }
 
-if [[ $FIX == 1 ]]; then
+if [[ $FIX_ONLY == 1 ]]; then
     $UV_RUN_LINT ruff format ${LINT_FILES}
     $UV_RUN_LINT ruff check --fix --output-format=full ${LINT_FILES}
     call_shfmt -w
+    set +o xtrace
+    echo ""
+    echo "========================================="
+    echo "NOTE: Only ruff, shfmt were run."
+    echo "      mypy and vermin were NOT run."
+    echo "      Use -f or no flags to run all checks."
+    echo "========================================="
+    exit 0
+elif [[ $FIX_AND_CHECK == 1 ]]; then
+    $UV_RUN_LINT ruff format ${LINT_FILES}
+    $UV_RUN_LINT ruff check --fix --output-format=full ${LINT_FILES}
+    call_shfmt -w
+    $UV_RUN_LINT vermin -vvv --no-tips -t=3.10- --eval-annotations --violations ${LINT_FILES}
 else
-    $UV_RUN_LINT ruff format --check --diff ${LINT_FILES}
-    call_shfmt
+    if ! $UV_RUN_LINT ruff format --check --diff ${LINT_FILES}; then
+        set +o xtrace
+        echo ""
+        echo "========================================="
+        echo "ERROR: Formatting issues detected by ruff."
+        echo "       Exiting early. All checks were NOT run."
+        echo "       Use -f or --fix-and-check to fix issues automatically."
+        echo "========================================="
+        exit 1
+    fi
+
+    if ! call_shfmt; then
+        set +o xtrace
+        echo ""
+        echo "========================================="
+        echo "ERROR: Formatting issues detected by shfmt."
+        echo "       Exiting early. All checks were NOT run."
+        echo "       Use -f or --fix-and-check to fix issues automatically."
+        echo "========================================="
+        exit 1
+    fi
 
     if [[ -z "$GITHUB_ACTIONS" ]]; then
         RUFF_OUTPUT_FORMAT=full
@@ -73,21 +114,7 @@ else
     fi
 
     $UV_RUN_LINT ruff check --output-format="${RUFF_OUTPUT_FORMAT}" ${LINT_FILES}
-fi
-
-# Checking minimum python version
-$UV_RUN_LINT vermin -vvv --no-tips -t=3.10- --eval-annotations --violations ${LINT_FILES}
-
-# Exit early if --format was specified
-if [[ $FORMAT_ONLY == 1 ]]; then
-    set +o xtrace
-    echo ""
-    echo "========================================="
-    echo "NOTE: Only ruff, shfmt, and vermin were run."
-    echo "      mypy was NOT run."
-    echo "      Use --all or no flags to run all checks."
-    echo "========================================="
-    exit 0
+    $UV_RUN_LINT vermin -vvv --no-tips -t=3.10- --eval-annotations --violations ${LINT_FILES}
 fi
 
 # mypy is run in a separate step on GitHub Actions

--- a/lint.sh
+++ b/lint.sh
@@ -102,7 +102,7 @@ else
         echo "========================================="
         echo "ERROR: Formatting issues detected by shfmt."
         echo "       Exiting early. All checks were NOT run."
-        echo "       Use -f or --fix-and-check to fix issues automatically."
+        echo "       Use -f to fix issues automatically."
         echo "========================================="
         exit 1
     fi

--- a/lint.sh
+++ b/lint.sh
@@ -114,6 +114,7 @@ else
     fi
 
     $UV_RUN_LINT ruff check --output-format="${RUFF_OUTPUT_FORMAT}" ${LINT_FILES}
+    # Checking minimum python version
     $UV_RUN_LINT vermin -vvv --no-tips -t=3.10- --eval-annotations --violations ${LINT_FILES}
 fi
 

--- a/lint.sh
+++ b/lint.sh
@@ -7,21 +7,32 @@ source "$(dirname "$0")/scripts/common.sh"
 cd $PWNDBG_ABS_PATH
 
 help_and_exit() {
-    echo "Usage: ./lint.sh [-f|--fix]"
+    echo "Usage: ./lint.sh [-f|--fix] [--format] [--all]"
     echo "  -f,  --fix         fix issues if possible"
+    echo "  --format           run only ruff, shfmt, and vermin checks (skip mypy)"
+    echo "  --all              run all checks including mypy (default behavior)"
+    echo ""
+    echo "By default, all checks are run.  Use --format for a quick formatting-only check."
     exit 1
 }
 
-if [[ $# -gt 1 ]]; then
-    help_and_exit
-fi
-
 FIX=0
+FORMAT_ONLY=0
 
 while [[ $# -gt 0 ]]; do
     case $1 in
         -f | --fix)
             FIX=1
+            shift
+            ;;
+        --format)
+            FORMAT_ONLY=1
+            shift
+            ;;
+        --all)
+            # Explicitly run all checks (default behavior)
+            # do we want to require --format or --all instead?
+            FORMAT_ONLY=0
             shift
             ;;
         *)
@@ -66,6 +77,18 @@ fi
 
 # Checking minimum python version
 $UV_RUN_LINT vermin -vvv --no-tips -t=3.10- --eval-annotations --violations ${LINT_FILES}
+
+# Exit early if --format was specified
+if [[ $FORMAT_ONLY == 1 ]]; then
+    set +o xtrace
+    echo ""
+    echo "========================================="
+    echo "NOTE: Only ruff, shfmt, and vermin were run."
+    echo "      mypy was NOT run."
+    echo "      Use --all or no flags to run all checks."
+    echo "========================================="
+    exit 0
+fi
 
 # mypy is run in a separate step on GitHub Actions
 if [[ -z "$GITHUB_ACTIONS" ]]; then


### PR DESCRIPTION
+ [x] I read the contributing documentation.
+ [x] I am providing a screenshot of the (new feature) / (fixed bug).
<img width="393" height="137" alt="vmware_GjSAWAkuES" src="https://github.com/user-attachments/assets/02b8c7b4-5837-470a-8f68-acc91edcc252" />

<img width="649" height="131" alt="vmware_YfbMS2LU6H" src="https://github.com/user-attachments/assets/0030e1a5-5e30-468a-9432-9b9560c37603" />

Issue https://github.com/pwndbg/pwndbg/issues/3591

Just a few questions I want to ask before I update the docs
1. Do we want a flag to be required? Like, should --format or --all be required? As of right now, the default without any flags is just all. Would need to update the lint.yml workflow if it required a flag 
2. Should mypy be the only difference between --format and --all as I have it now, or do we want them more accurate to the naming and have --format only run ruff format and shfmt? and then --all runs mypy, vermin, and ruff check?
currently I have it as shown in the image with the only difference being mypy, so if we want to keep it that way im going to update the help command to say "Use --format for skipping mypy (type checking)" or something instead of "quick formatting-only"
Because mypy is ofc the main time consumer, followed by vermin, and then ruff check is very fast, just wondering because naming wouldn't match up then because --format also runs ruff check, a linter, and vermin an analyzer for example
