### PR TITLE
Fix lockfile issues caused by pytest-cov update

### DIFF
--- a/nix/pyenv.nix
+++ b/nix/pyenv.nix
@@ -77,7 +77,6 @@ let
     "coverage"
     "mypy-extensions"
     "pytest"
-    "pytest-cov"
     "mypy"
     "vermin"
     # decomp2dbg deps
@@ -110,6 +109,8 @@ let
     "plumbum"
     "rpyc"
     "iniconfig"
+    "pytest-cov"
+    "hatch-fancy-pypi-readme"
     # decomp2dbg deps
     "decomp2dbg"
     "filelock"
@@ -140,7 +141,7 @@ let
     final: prev:
     (genPkgsNeeded pkgsNeedSetuptools [ "setuptools" ] final prev)
     // (genPkgsNeeded pkgsNeedFlitcore [ "flit-core" ] final prev)
-    // (genPkgsNeeded pkgsNeedHatchling [ "hatchling" "hatch-vcs" ] final prev)
+    // (genPkgsNeeded pkgsNeedHatchling [ "hatchling" "hatch-vcs" "hatch-fancy-pypi-readme" ] final prev)
     // (genPkgsNeeded pkgsNeedPoetry [ "poetry-core" ] final prev);
 
   dummy = pkgs.runCommand "dummy" { } "mkdir $out";
@@ -153,11 +154,6 @@ let
 
     # ziglang is only supported on few platforms
     ziglang = prev.ziglang.override {
-      sourcePreference = "wheel";
-    };
-
-    # use wheel to avoid build system issues with pytest-cov 7.0.0
-    pytest-cov = prev.pytest-cov.override {
       sourcePreference = "wheel";
     };
 

--- a/nix/pyenv.nix
+++ b/nix/pyenv.nix
@@ -156,6 +156,11 @@ let
       sourcePreference = "wheel";
     };
 
+    # use wheel to avoid build system issues with pytest-cov 7.0.0
+    pytest-cov = prev.pytest-cov.override {
+      sourcePreference = "wheel";
+    };
+
     psutil = pkgs.callPackage (
       {
         darwin,

--- a/nix/pyenv.nix
+++ b/nix/pyenv.nix
@@ -110,7 +110,6 @@ let
     "rpyc"
     "iniconfig"
     "pytest-cov"
-    "hatch-fancy-pypi-readme"
     # decomp2dbg deps
     "decomp2dbg"
     "filelock"


### PR DESCRIPTION
+ [x] I read the contributing documentation.
+ [ ] I am providing a screenshot of the (new feature) / (fixed bug).

Dependabot updating pytest-cov from 4.1.0 to 7.0.0 caused issues because pytest-cov no longer uses setuptools, they use hatchling. https://github.com/pytest-dev/pytest-cov/commit/fa72cf3b21c30599eb1793d3f769e1b7090e76da#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711

This fixes the issue by updating what packages need hatchling to include pytest-cov and hatch-fancy-pypi-readme. Also removes pytest-cov from requiring setuptools.