### PR TITLE
lldb: implement add_symbol_file and remove_symbol_file

### DIFF
--- a/pwndbg/commands/klookup.py
+++ b/pwndbg/commands/klookup.py
@@ -57,11 +57,6 @@ def klookup(symbol: str, apply: bool) -> None:
             print(message.success(f"{sym_addr:#x} {sym_type} {sym_name}"))
 
     if apply:
-        if pwndbg.dbg.name == pwndbg.dbg_mod.DebuggerType.LLDB:
-            print(message.error("Symbolication is not yet supported on LLDB."))
-            # Until we implement add_symbol_file for LLDB.
-            return
-
         paging_info = pwndbg.aglib.kernel.arch_paginginfo()
         if paging_info is None:
             print(message.error(f"Unsupported architecture {pwndbg.aglib.arch.name}."))

--- a/pwndbg/dbg_mod/__init__.py
+++ b/pwndbg/dbg_mod/__init__.py
@@ -20,6 +20,7 @@ from typing import Tuple
 from typing import TypedDict
 from typing import TypeVar
 
+import lldb
 import pwndbg.lib.memory
 from pwndbg.lib.arch import ArchDefinition
 
@@ -693,7 +694,14 @@ class Process:
         """
         Adds a symbol file at base.
         """
-        raise NotImplementedError()
+        target = lldb.debugger.GetSelectedTarget()
+        # AddModule returns a SBModule object representing the file on disk
+        module = target.AddModule(path, None, None)
+
+        if module.IsValid and base is not None:
+            # Map the module to a specific address in the process memory
+            target.SetModuleLoadAddress(module, base)
+
 
     def remove_symbol_file(self, path: str) -> bool:
         """
@@ -703,7 +711,14 @@ class Process:
             True if we succeeded, False if not. If the file was never
             added or doesn't exist, that counts as failure.
         """
-        raise NotImplementedError()
+        target = lldb.debugger.GetSelectedTarget()
+        spec = lldb.SBFileSpec(path)
+        module = target.FindModule(spec)
+
+        if module.IsValid():
+            return target.RemoveModule(module)
+
+        return False
 
     def runcmd(self, cmd: str) -> str:
         """

--- a/pwndbg/integration/__init__.py
+++ b/pwndbg/integration/__init__.py
@@ -561,11 +561,6 @@ class IntegrationManager:
         self._function_headers = None
         self._global_vars = None
 
-        if pwndbg.dbg.name == pwndbg.dbg_mod.DebuggerType.LLDB:
-            print(message.error("Symbolication is not yet supported on LLDB."))
-            # Until we implement add_symbol_file for LLDB.
-            return 0
-
         try:
             inf: pwndbg.dbg_mod.Process = pwndbg.dbg.selected_inferior()
         except pwndbg.dbg_mod.NoInferior:


### PR DESCRIPTION
<!--
    Please make sure to read the linting and testing instructions at
    https://pwndbg.re/dev/contributing/ before creating a PR.
-->

+ [ ] I read the contributing documentation.
+ [ ] I am providing a screenshot of the (new feature) / (fixed bug).

### Description
This PR implements the  `add_symbol_file` and `remove_symbol_file` methods for the LLDB debugger backend. 

### Changes
- **`pwndbg/pwndbg/dbg_mod/__init__.py`**: 
    - Implemented `add_symbol_file` using `SBTarget.AddModule` and `SetModuleLoadAddress`.
    - Implemented `remove_symbol_file` using `SBFileSpec` and `SBTarget.RemoveModule`.
- **`pwndbg/pwndbg/integration/__init__.py`**: Removed the check blocking symbolication on LLDB.
- **`pwndbg/pwndbg/commands/klookup.py`**: Removed the check blocking `klookup` on LLDB.

### Implementation Details
- In LLDB, `AddModule` is used to introduce the symbol file to the target. 
- `SetModuleLoadAddress` is called when a `base` address is provided to ensure symbols are correctly shifted to match the memory layout of the debugged process.
- `remove_symbol_file` uses `SBFileSpec` to find the correct module handle before calling `RemoveModule`.



### Testing
- Logic verified against the [LLDB SBTarget API documentation](https://lldb.llvm.org/python_api/lldb.SBTarget.html).
- Static syntax checking performed on the modified files.
- Note: Full live integration testing in WSL was limited by a local LLDB-14 environment issue (`ModuleNotFoundError: No module named 'lldb.embedded_interpreter'`), but the code follows the established Pwndbg debugger abstraction.

Fixes #3595