### PR TITLE
LLDB: Add support for core files

### DIFF
--- a/pwndbg/dbg_mod/lldb/repl/__init__.py
+++ b/pwndbg/dbg_mod/lldb/repl/__init__.py
@@ -183,23 +183,26 @@ class EventRelay(EventHandler):
 
     @override
     def suspended(self, event: lldb.SBEvent) -> None:
-        # The event might have originated from a different source than the user
-        # currently has selected. Move focus to the where the event happened.
-        #
-        # state-changed events have no thread associated with them, and so
-        # SBThread::GetThreadFromEvent does not work. Interrogate each thread in
-        # the process and look for the most interesting one.
-        proc = lldb.SBProcess.GetProcessFromEvent(event)
-        for thread in proc.threads:
-            # Currently the one considered most interesting is simply the first
-            # that has any reason at all to be stopped.
-            if thread.stop_reason == lldb.eStopReasonNone:
-                continue
+        # Under some circumstances - like when debugging core files - the
+        # process driver may not actually know what the event is.
+        if event is not None:
+            # The event might have originated from a different source than the user
+            # currently has selected. Move focus to the where the event happened.
+            #
+            # state-changed events have no thread associated with them, and so
+            # SBThread::GetThreadFromEvent does not work. Interrogate each thread in
+            # the process and look for the most interesting one.
+            proc = lldb.SBProcess.GetProcessFromEvent(event)
+            for thread in proc.threads:
+                # Currently the one considered most interesting is simply the first
+                # that has any reason at all to be stopped.
+                if thread.stop_reason == lldb.eStopReasonNone:
+                    continue
 
-            if proc.GetSelectedThread().idx != thread.idx:
-                print(message.notice(f"[Switched to Thread {thread.id}]"))
-                assert proc.SetSelectedThread(thread)
-            break
+                if proc.GetSelectedThread().idx != thread.idx:
+                    print(message.notice(f"[Switched to Thread {thread.id}]"))
+                    assert proc.SetSelectedThread(thread)
+                break
 
         self.dbg._trigger_event(EventType.STOP)
 
@@ -591,7 +594,7 @@ def _exec_repl_command(
     if bits[0].startswith("ta") and "target".startswith(bits[0]):
         if len(bits) > 1 and bits[1].startswith("c") and "create".startswith(bits[1]):
             # This is `target create`
-            target_create(bits[2:], dbg)
+            target_create(driver, bits[2:], dbg)
             return True
         if len(bits) > 1 and bits[1].startswith("de") and "delete".startswith(bits[1]):
             # This is `target delete`
@@ -763,6 +766,10 @@ def _exec_repl_command(
         assert driver.has_process()
         assert driver.process.GetUniqueID() == process.process.GetUniqueID()
 
+        if driver.is_core_file():
+            print_warn("skipping coroutine: target is core file")
+            continue
+
         try:
             driver.run_coroutine(coroutine)
         except Exception:
@@ -924,7 +931,7 @@ target_create_ap = argparse.ArgumentParser(add_help=False, prog="target create")
 target_create_ap.add_argument("-S", "--sysroot")
 target_create_ap.add_argument("-a", "--arch")
 target_create_ap.add_argument("-b", "--build")
-target_create_ap.add_argument("-c", "--core")
+target_create_ap.add_argument("-c", "--core", action="store_true")
 target_create_ap.add_argument("-d", "--no-dependents")
 target_create_ap.add_argument("-p", "--platform")
 target_create_ap.add_argument("-r", "--remote-file")
@@ -933,7 +940,6 @@ target_create_ap.add_argument("-v", "--version")
 target_create_ap.add_argument("filename")
 target_create_unsupported = [
     "build",
-    "core",
     "no-dependents",
     "remote-file",
     "symfile",
@@ -957,7 +963,7 @@ def _get_target_triple(debugger: lldb.SBDebugger, filepath: str) -> str | None:
     return triple
 
 
-def target_create(args: List[str], dbg: LLDB) -> None:
+def target_create(driver: ProcessDriver, args: List[str], dbg: LLDB) -> None:
     """
     Creates a new target, registers it with the Pwndbg LLDB implementation, and
     sets up listeners for it.
@@ -966,6 +972,60 @@ def target_create(args: List[str], dbg: LLDB) -> None:
     if not args:
         return
 
+    if args.core:
+        target_create_core(driver, args, dbg)
+    else:
+        target_create_regular(args, dbg)
+
+
+def target_create_core(driver: ProcessDriver, args: Any, dbg: LLDB) -> None:
+    """
+    Starts core file debugging.
+
+    Despite the similar names and commands, this function is fundamentally
+    different from `target_create_regular`. This is so we can match the way the
+    regular LLDB CLI handles `target create --core`.
+
+    In the regular LLDB CLI, when one types in `target create --core <name>`,
+    a new special process is automatically launched, whose SBProcess object
+    behaves differently from those of regular processes.
+
+    In effect, in the LLDB CLI, creating a core file target both automatically
+    starts the process and puts the CLI into a special core file mode, in which
+    most lifetime-related user actions are forbidden.
+    """
+    if dbg.debugger.GetNumTargets() > 0:
+        print_error(
+            "Pwndbg does not support multiple targets. Please remove the current target with 'target delete' and try again."
+        )
+        return
+
+    # Create a no-target SBTarget that will hold our core file.
+    target = dbg.debugger.CreateTarget(None)
+    if target is None or not target.IsValid():
+        print_error("could not create target for core file debugging")
+        return
+    dbg.debugger.SetSelectedTarget(target)
+
+    result = driver.launch_core_file(target, args.filename)
+    match result:
+        case LaunchResultError(what):
+            print_error(f"could not launch core file: {what.description}")
+            return
+
+    split_triple = target.triple.split("-")
+    if len(split_triple) > 0:
+        arch = split_triple[0]
+    else:
+        arch = "unknown"
+
+    print(f"Core file '{args.filename}' ({arch}) was loaded.")
+
+
+def target_create_regular(args: Any, dbg: LLDB) -> None:
+    """
+    Creates a new regular target, and registers it with LLDB.
+    """
     if dbg.debugger.GetNumTargets() > 0:
         print_error(
             "Pwndbg does not support multiple targets. Please remove the current target with 'target delete' and try again."
@@ -1010,7 +1070,6 @@ def target_create(args: List[str], dbg: LLDB) -> None:
 
     dbg.debugger.SetSelectedTarget(target)
     print(f"Current executable set to '{args.filename}' ({target.triple.split('-')[0]})")
-    return
 
 
 process_launch_ap = argparse.ArgumentParser(add_help=False, prog="process launch")
@@ -1391,6 +1450,10 @@ def continue_process(driver: ProcessDriver, args: List[str], dbg: LLDB) -> None:
 
     if not driver.has_process():
         print_error("no process")
+        return
+
+    if driver.is_core_file():
+        print_error("cannot continue: target is core file")
         return
 
     driver.cont()

--- a/pwndbg/dbg_mod/lldb/repl/proc.py
+++ b/pwndbg/dbg_mod/lldb/repl/proc.py
@@ -216,6 +216,9 @@ class ProcessDriver:
     _io_driver_state: _IODriverState
     "Whether the I/O driver is currently running"
 
+    _is_core_file: bool
+    "Whether the current live process is actually a core file"
+
     def __init__(self, event_handler: EventHandler, debug=False):
         self.io = None
         self.process = None
@@ -227,6 +230,7 @@ class ProcessDriver:
         self._in_run_until_next_stop = 0
         self._in_run_coroutine = 0
         self._io_driver_state = _IODriverState.STOPPED
+        self._is_core_file = False
 
     def __enter__(self) -> ProcessDriver:
         return self
@@ -264,6 +268,14 @@ class ProcessDriver:
         active process also must necessarily be connected.
         """
         return self.process is not None
+
+    def is_core_file(self) -> bool:
+        """
+        Whether this driver's process is a core file.
+
+        Core file processes don't support changes to the lifetime of the process.
+        """
+        return self._is_core_file
 
     def interrupt(self, in_lldb_command_handler: bool = False) -> None:
         """
@@ -405,6 +417,8 @@ class ProcessDriver:
         will only start running after the start event is observed.
         """
 
+        assert not self._is_core_file, "_run_until_next_stop is not valid for core files"
+
         # If `only_if_started` is set, we defer the starting of the I/O driver
         # to the moment the start event is observed. Otherwise, we just start it
         # immediately.
@@ -536,6 +550,7 @@ class ProcessDriver:
         Continues execution of the process this object is driving, and returns
         whenever the process stops.
         """
+        assert not self._is_core_file, "cont is not valid for core files"
         assert self.has_process(), "called cont() on a driver with no process"
 
         self.eh.resumed()
@@ -588,7 +603,27 @@ class ProcessDriver:
                 #
                 # TODO/FIXME: Find a way to trigger the continued event before the process is resumed in LLDB
 
-                if not start_expected:
+                if self._is_core_file:
+                    # LLDB simply doesn't support continuing core file processes.
+                    # If we get here, either LLDB has completely lost it, or we
+                    # don't know how to handle this kind of command. Bail.
+                    assert not start_expected, "LLDB seemingly continued a core file process"
+
+                    # Because we don't have an event source, we can't directly
+                    # know if the process has been killed by the user. So, we
+                    # manually check against the state of the process after
+                    # every command.
+                    self.debug_print(
+                        f"Core File: Process state after command is {self.process.state:#x}"
+                    )
+                    if not self.process.IsValid() or self.process.state == lldb.eStateExited:
+                        self.process = None
+                        self._is_core_file = False
+                        self.debug_print("exited()")
+                        self.eh.exited()
+                        self.debug_print("Core File: Finished debugging core file")
+
+                elif not start_expected:
                     # Even if the current process has not been resumed, LLDB might
                     # have posted process events for us to handle. Do so now, but
                     # stop right away if there is nothing for us in the listener.
@@ -605,6 +640,7 @@ class ProcessDriver:
         process in this driver. Returns `True` if the coroutine ran to completion,
         and `False` if it was cancelled.
         """
+        assert not self._is_core_file, "run_coroutine is not valid for core files"
         try:
             return self._run_coroutine(coroutine)
         except CancelledError:
@@ -617,6 +653,7 @@ class ProcessDriver:
         This loop may be spuriously cancelled. We handle that in run_coroutine().
         """
 
+        assert not self._is_core_file, "_run_coroutine is not valid for core files"
         assert self.has_process(), "called run_coroutine() on a driver with no process"
 
         self.debug_print("Coroutine: Starting")
@@ -929,6 +966,53 @@ class ProcessDriver:
         else:
             self._prepare_listener_for(target)
             return self._enter(self._launch_local, target, io, env, args, working_dir, extra_flags)
+
+    def launch_core_file(self, target: lldb.SBTarget, core: str) -> LaunchResult:
+        """
+        Launches the given core file and puts the process driver into core file
+        mode.
+
+        In core file mode, using lifetime-related functionality - continuing,
+        running coroutines, etc. - is forbidden. Core file mode ends when the
+        process exits.
+
+        Fires the created() and suspended() events.
+        """
+
+        # The _enter machinery runs the event loop as part of initializing the
+        # new process. We don't want that here. Processes built by LoadCore
+        # don't broadcast lifetime events, and using _run_until_next_stop when
+        # there's nothing to listen to is iffy at best.
+
+        error = lldb.SBError()
+        self.process = target.LoadCore(core, error)
+
+        if not error.success:
+            self.process = None
+            return LaunchResultError(error, False)
+
+        assert self.process.IsValid()
+        self.debug_print("Core File: Loaded")
+        self.debug_print("Core File: All events will be simulated by ProcessDriver")
+
+        # Enter core file mode, disabling all lifetime controls in the process
+        # driver, as well as the event loop. This ensures that the driver won't
+        # get stuck trying to either control or handle events from a process
+        # that does not support it.
+        self._is_core_file = True
+
+        # Still fire the created event as normal. Process objects based on core
+        # files are created in the stopped state, and stay in it for the
+        # duration of their lifetimes.
+        #
+        # From the point of view of the rest of pwndbg, this is no different
+        # from firing the event after having run _wait_until_next_stop.
+        self.debug_print("Core File: created()")
+        self.eh.created()
+        self.debug_print("Core File: suspended(None)")
+        self.eh.suspended(None)
+
+        return LaunchResultSuccess()
 
     def attach(self, target: lldb.SBTarget, info: lldb.SBAttachInfo) -> LaunchResult:
         """


### PR DESCRIPTION
This PR adds support for debugging core files to `pwndbg-lldb`.

Prior art: #3301. Thanks @patryk4815!

The user interface tries to stick as close as it can to the regular LLDB CLI. Note that also means we're emulating its quirks, like `process kill` doing nothing in minidump mode, or `target create --core` immediately creating a pseudo-process. I feel it'd be surprising to users if we deviated from how the LLDB CLI does things, even if I'm persinally not a fan of this behavior.

I think I've tested this well enough to be confident it doesn't break anything, but I'd love to see if you guys can break this in some way I've overlooked.

<img width="1710" height="3210" alt="image" src="https://github.com/user-attachments/assets/9b5950af-215a-40d6-8c78-157fabac93ab" />

