### PR TITLE
Add caching to build base pwndbg image tests

### DIFF
--- a/.github/workflows/base-image.yml
+++ b/.github/workflows/base-image.yml
@@ -88,6 +88,7 @@ jobs:
             --progress=plain \
             --platform ${{ matrix.platform_base.platform }} \
             --build-arg image=${{ matrix.platform_base.base_image }} \
+            --cache-from type=registry,ref=ghcr.io/pwndbg/base-apt:cache-${{ matrix.platform_base.tag_name }} \
             -f ./Dockerfile.base-apt \
             -t ghcr.io/pwndbg/base-apt:latest-${{ matrix.platform_base.tag_name }} \
             .
@@ -98,6 +99,8 @@ jobs:
             --progress=plain \
             --platform ${{ matrix.platform_base.platform }} \
             --build-arg image=${{ matrix.platform_base.base_image }} \
+            --cache-from type=registry,ref=ghcr.io/pwndbg/base-apt:cache-${{ matrix.platform_base.tag_name }} \
+            --cache-to type=registry,ref=ghcr.io/pwndbg/base-apt:cache-${{ matrix.platform_base.tag_name }},mode=max \
             -f ./Dockerfile.base-apt \
             -t ghcr.io/pwndbg/base-apt:latest-${{ matrix.platform_base.tag_name }} \
             --push .

--- a/.github/workflows/base-image.yml
+++ b/.github/workflows/base-image.yml
@@ -123,7 +123,7 @@ jobs:
 
       - name: Create multi-arch manifest
         run: |
-          docker manifest create $IMAGE:latest \
+          docker buildx imagetools create $IMAGE:latest \
             $IMAGE:latest-amd64 \
             $IMAGE:latest-arm64 \
             $IMAGE:latest-armv7l \
@@ -132,8 +132,6 @@ jobs:
             $IMAGE:latest-riscv64 \
             $IMAGE:latest-386 \
             $IMAGE:latest-loong64
-  
-          docker manifest push $IMAGE:latest
 
       - name: Delete latest-* tags
         run: |

--- a/.github/workflows/base-image.yml
+++ b/.github/workflows/base-image.yml
@@ -123,7 +123,7 @@ jobs:
 
       - name: Create multi-arch manifest
         run: |
-          docker buildx imagetools create $IMAGE:latest \
+          docker buildx imagetools create -t $IMAGE:latest \
             $IMAGE:latest-amd64 \
             $IMAGE:latest-arm64 \
             $IMAGE:latest-armv7l \
@@ -135,7 +135,7 @@ jobs:
 
       - name: Delete latest-* tags
         run: |
-          apt install -y jq
+          sudo apt install -y jq
           for tag in latest-amd64 latest-arm64 latest-armv7l latest-ppc64le latest-s390x latest-riscv64 latest-386 latest-loong64; do
             echo "Deleting $IMAGE:$tag"
           


### PR DESCRIPTION
+ [x] I read the contributing documentation.
+ [x] I am providing a screenshot of the (new feature) / (fixed bug).

This is an addition to PR #3584 

This adds caching to the build base pwndbg image tests, reducing test times by multitudes

before
<img width="531" height="78" alt="chrome_u2XgAN3kgn" src="https://github.com/user-attachments/assets/4f46e2ec-4612-4292-8f7e-4485452ae558" />
after
<img width="518" height="66" alt="chrome_UAaek0D9hh" src="https://github.com/user-attachments/assets/b8d13d06-f2f0-488f-8635-db140b008578" />
1h 12m 19s > 35s
for one of them, for example, but this applies to all of them

This will take effect after the first time the tests are run, which will happen after this is merged

and bcuz patryk already set `if: github.ref == 'refs/heads/dev'` as a req for login to ghcr we don't have to worry about prs altering cache because docker push is the only part that runs --cache-to