### PR TITLE
install.sh should support installing pwndbg on armv8l

### DIFF
--- a/docs/install.sh
+++ b/docs/install.sh
@@ -194,7 +194,8 @@ case "$OS" in
             x86_64) FILE="${BINARY_NAME}_${VERSION}_x86_64-portable.tar.xz" ;;
             i686) FILE="${BINARY_NAME}_${VERSION}_x86_32-portable.tar.xz" ;;
             aarch64) FILE="${BINARY_NAME}_${VERSION}_arm64-portable.tar.xz" ;;
-            armv7*) FILE="${BINARY_NAME}_${VERSION}_armv7-portable.tar.xz" ;;
+            armv7l) FILE="${BINARY_NAME}_${VERSION}_armv7-portable.tar.xz" ;;
+            armv8l) FILE="${BINARY_NAME}_${VERSION}_armv7-portable.tar.xz" ;;
             riscv64) FILE="${BINARY_NAME}_${VERSION}_riscv64-portable.tar.xz" ;;
             ppc64) FILE="${BINARY_NAME}_${VERSION}_powerpc64-portable.tar.xz" ;;
             ppc64le) FILE="${BINARY_NAME}_${VERSION}_powerpc64le-portable.tar.xz" ;;


### PR DESCRIPTION
install.sh should support installing pwndbg on armv8l, it is 32bit mode on aarch64 cpu

eg:
```bash
$ setarch armv7l /bin/bash
$ uname -m
armv8l
$ curl install.pwndbg.re | sh
// should work fine now
```