### PR TITLE
Caching source file wrong assumptions? when replacing main objfile

### DIFF
--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -1402,7 +1402,7 @@ theme.add_param("code-prefix", "►", "prefix marker for 'context code' command"
 # All of these are also used for the decompilation context^^
 
 
-@pwndbg.lib.cache.cache_until("start")
+@pwndbg.lib.cache.cache_until("objfile")
 def get_highlight_source(filename: str) -> Tuple[str, ...]:
     # Notice that the code is cached
     with open(filename, encoding="utf-8", errors="ignore") as f:


### PR DESCRIPTION
Caching source file wrong assumptions? when replacing main objfile

This issue happens when developing microcontrollers / uploading new code. 

For example:
```
target remote ip:1234

file ./new.elf
load ./new.elf
monitor reset init

file ./new.elf
load ./new.elf
monitor reset init
```
^ new.elf can be different, and loaded into microcontroller, but it is same gdb session 
