### PR TITLE
Add concurrency control to build base pwndbg image tests

### DIFF
--- a/.github/workflows/base-image.yml
+++ b/.github/workflows/base-image.yml
@@ -12,6 +12,11 @@ on:
     paths:
       - 'uv.lock'
       - 'Dockerfile.base-apt'
+      - '.github/workflows/base-image.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'push' }}
 
 permissions:
   contents: read


### PR DESCRIPTION
+ [x] I read the contributing documentation.
+ [x] I am providing a screenshot of the (new feature) / (fixed bug).
<img width="727" height="495" alt="chrome_Y7JisDspfj" src="https://github.com/user-attachments/assets/ad0ae374-b46f-483a-a2f2-0bf30b130c98" />

In addition to PR #3608 
prevent possible race conditions that could cause cache corruptions in the case where build base pwndbg image tests were run simultaneously on dev branch

@patryk4815 I slightly edited what you put to not cancel concurrent runs on PRs and only on dev, because PRs won't --cache-to and I think that, like the other tests, they should finish anyway to spot in which commit issues were introduced

I also added .github/workflows/base-image.yml to the paths in which to run on in PRs because I think it should be run if the workflow is being changed 