### PR TITLE
 Fix typos in error messages

### DIFF
--- a/pwndbg/aglib/elf.py
+++ b/pwndbg/aglib/elf.py
@@ -529,5 +529,5 @@ def compile_with_flags(gcc_extra_flags):
         )
     except Exception as exception:
         print(message.error(exception))
-        print(message.error("An error occured while generating the debug symbols."))
+        print(message.error("An error occurred while generating the debug symbols."))
     return False

--- a/pwndbg/commands/cymbol.py
+++ b/pwndbg/commands/cymbol.py
@@ -191,7 +191,7 @@ def edit_custom_structure(custom_structure_name: str, custom_structure_path: str
             check=True,
         )
     except Exception:
-        print(message.error("An error occured during opening the source file."))
+        print(message.error("An error occurred during opening the source file."))
         print(message.error(f"Path to the custom structure: {custom_structure_path}"))
         print(message.error("Please try to manually edit the structure."))
         print(

--- a/pwndbg/gdblib/ptmalloc2_tracking.py
+++ b/pwndbg/gdblib/ptmalloc2_tracking.py
@@ -689,7 +689,7 @@ def install(disable_hardware_watchpoints=True) -> None:
             "This feature is experimental and is known to report false positives, take the"
         )
     )
-    print(message.warn("diagnostics it procudes with a grain of salt. Use at your own risk."))
+    print(message.warn("diagnostics it produces with a grain of salt. Use at your own risk."))
     print()
 
     # Disable hardware watchpoints.


### PR DESCRIPTION
Fixed the following typos:
- "procudes" → "produces" in ptmalloc2_tracking.py
- "occured" → "occurred" in elf.py and cymbol.py
