### PR TITLE
Add `di setpath` and improve syncing error messages

### DIFF
--- a/docs/commands/integrations/decompiler-integration.md
+++ b/docs/commands/integrations/decompiler-integration.md
@@ -3,7 +3,7 @@
 
 ```text
 usage: decompiler-integration [-h]
-                              {connect,c,disconnect,d,sync,s,jump,j,install,decomp,list,l,setbase}
+                              {connect,c,disconnect,d,sync,s,jump,j,install,decomp,list,l,setbase,setpath}
                               ...
 
 ```
@@ -240,11 +240,45 @@ needed when debugging a kernel module.
 
 If you wish to re-enable automatic base address detection, set this value to -1 (or
 restart Pwndbg).
+
+Setting this automatically unsets the `di setpath` value.
 #### Positional arguments
 
 |Positional Argument|Help|
 | :--- | :--- |
 |binary_addr|Memory address of the decompiled binary in the address space|
+
+#### Optional arguments
+
+|Short|Long|Help|
+| :--- | :--- | :--- |
+|-h|--help|show this help message and exit|
+
+### **decompiler-integration setpath**
+
+```text
+usage: decompiler-integration setpath [-h] path
+
+```
+
+Manually set the path of the binary as loaded in memory.
+
+Normally, Pwndbg will use the file path that the decompiler reports for the binary and
+check it against all files mapped into memory to find the correct base address.
+
+If for some reason the file names differ or your binary does not show up in the memory
+mappings, you can manually specify the actual path of the binary as loaded in memory (
+the one reported by /proc/<pid>/maps i.e. vmmap).
+
+If you wish to re-enable automatic base address detection, set this value to "" (or
+restart Pwndbg).
+
+Setting this automatically unsets the `di setbase` value.
+#### Positional arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|binary_path|File path of the decompiled binary as loaded in memory|
 
 #### Optional arguments
 

--- a/pwndbg/commands/integration.py
+++ b/pwndbg/commands/integration.py
@@ -509,7 +509,7 @@ def sync(fail_quietly: bool) -> None:
         case pwndbg.integration.Error.DEBUGGER_NOT_SUPPORTED:
             print("LLDB does not support syncing symbols. ", end="")
         case _:
-            print(message.error(f"Error: {sym_err.value}."))
+            print(message.error(f"Failed: {sym_err.value}."))
             if sym_err == pwndbg.integration.Error.BINARY_NOT_LOADED:
                 print(
                     "Try "
@@ -534,7 +534,7 @@ def sync(fail_quietly: bool) -> None:
             # It's fine to print this even if fail_quietly=True.
             print("No variables synced for the current function (no stack frame found).")
         case pwndbg.integration.Error.NO_CONNECTION:
-            print(message.error(f"Error: {sym_err.value}."))
+            print(message.error(f"Failed: {sym_err.value}."))
 
 
 def list_one_frame(frame: pwndbg.dbg_mod.Frame, idx: Optional[int] = None) -> None:

--- a/pwndbg/commands/integration.py
+++ b/pwndbg/commands/integration.py
@@ -503,7 +503,9 @@ def sync(fail_quietly: bool) -> None:
             if nsyms == 0:
                 print("No symbols synced? Something is off. ")
             else:
-                print(message.success(f"Synced {nsyms} symbols") + " (globals + functions). ", end="")
+                print(
+                    message.success(f"Synced {nsyms} symbols") + " (globals + functions). ", end=""
+                )
         case pwndbg.integration.Error.DEBUGGER_NOT_SUPPORTED:
             print("LLDB does not support syncing symbols. ", end="")
         case _:
@@ -529,8 +531,8 @@ def sync(fail_quietly: bool) -> None:
                 # It's fine to print this even if fail_quietly=True.
                 print("No variables synced for the current function.")
         case pwndbg.integration.Error.NO_FRAME:
-                # It's fine to print this even if fail_quietly=True.
-                print("No variables synced for the current function (no stack frame found).")
+            # It's fine to print this even if fail_quietly=True.
+            print("No variables synced for the current function (no stack frame found).")
         case pwndbg.integration.Error.NO_CONNECTION:
             print(message.error(f"Error: {sym_err.value}."))
 

--- a/pwndbg/commands/integration.py
+++ b/pwndbg/commands/integration.py
@@ -428,7 +428,6 @@ def soft_connection_check(also_sync: bool) -> bool:
     otherwise False.
     """
     if not pwndbg.integration.manager.is_connected():
-        print(message.error("Not connected to a decompiler."))
         print("Trying to connect.. ", end="")
 
         connect(also_sync=also_sync)

--- a/pwndbg/commands/integration.py
+++ b/pwndbg/commands/integration.py
@@ -497,13 +497,18 @@ def sync(fail_quietly: bool) -> None:
     print("Syncing symbols...")
 
     # Functions and globals
-    nsyms, upd_err = pwndbg.integration.manager.update_symbols()
-    match upd_err:
+    nsyms, sym_err = pwndbg.integration.manager.update_symbols()
+    match sym_err:
         case pwndbg.integration.Error.OK:
-            print(message.success(f"Synced {nsyms} symbols") + " (globals + functions). ", end="")
+            if nsyms == 0:
+                print("No symbols synced? Something is off. ")
+            else:
+                print(message.success(f"Synced {nsyms} symbols") + " (globals + functions). ", end="")
+        case pwndbg.integration.Error.DEBUGGER_NOT_SUPPORTED:
+            print("LLDB does not support syncing symbols. ", end="")
         case _:
-            print(message.error(f"Error: {upd_err.value}."))
-            if upd_err == pwndbg.integration.Error.BINARY_NOT_LOADED:
+            print(message.error(f"Error: {sym_err.value}."))
+            if sym_err == pwndbg.integration.Error.BINARY_NOT_LOADED:
                 print(
                     "Try "
                     + message.hint("`di setpath --help`")
@@ -511,15 +516,23 @@ def sync(fail_quietly: bool) -> None:
                     + message.hint("`di setbase --help`")
                     + "?"
                 )
+            # The error is fundamental to the setup, don't even try to sync function variables.
             return
 
     # Function-local variables
-    nvars = pwndbg.integration.manager.update_function_variables()
-    if nvars > 0:
-        print(message.success(f"Synced {nvars} variables") + " for the current function.")
-    else:
-        # It's fine to print this even if fail_quietly=True.
-        print("No variables synced for the current function.")
+    nvars, var_err = pwndbg.integration.manager.update_function_variables()
+    match var_err:
+        case pwndbg.integration.Error.OK:
+            if nvars > 0:
+                print(message.success(f"Synced {nvars} variables") + " for the current function.")
+            else:
+                # It's fine to print this even if fail_quietly=True.
+                print("No variables synced for the current function.")
+        case pwndbg.integration.Error.NO_FRAME:
+                # It's fine to print this even if fail_quietly=True.
+                print("No variables synced for the current function (no stack frame found).")
+        case pwndbg.integration.Error.NO_CONNECTION:
+            print(message.error(f"Error: {sym_err.value}."))
 
 
 def list_one_frame(frame: pwndbg.dbg_mod.Frame, idx: Optional[int] = None) -> None:

--- a/pwndbg/commands/integration.py
+++ b/pwndbg/commands/integration.py
@@ -436,6 +436,9 @@ def soft_connection_check(also_sync: bool) -> bool:
         if not pwndbg.integration.manager.is_connected():
             return False
 
+    # Give space to the actual command output.
+    print()
+
     return True
 
 

--- a/pwndbg/commands/integration.py
+++ b/pwndbg/commands/integration.py
@@ -514,13 +514,7 @@ def sync(fail_quietly: bool) -> None:
         case _:
             print(message.error(f"Failed: {sym_err.value}."))
             if sym_err == pwndbg.integration.Error.BINARY_NOT_LOADED:
-                print(
-                    "Try "
-                    + message.hint("`di setpath --help`")
-                    + " or "
-                    + message.hint("`di setbase --help`")
-                    + "?"
-                )
+                print(message.hint("Try `di setpath --help` or `di setbase --help`?"))
             # The error is fundamental to the setup, don't even try to sync function variables.
             return
 

--- a/pwndbg/commands/integration.py
+++ b/pwndbg/commands/integration.py
@@ -852,7 +852,7 @@ Setting this automatically unsets the `di setbase` value.
 parser_set_path.add_argument(
     "binary_path",
     metavar="path",
-    type=int,
+    type=str,
     help="File path of the decompiled binary as loaded in memory",
 )
 

--- a/pwndbg/commands/integration.py
+++ b/pwndbg/commands/integration.py
@@ -436,8 +436,8 @@ def soft_connection_check(also_sync: bool) -> bool:
         if not pwndbg.integration.manager.is_connected():
             return False
 
-    # Give space to the actual command output.
-    print()
+        # Give space to the actual command output.
+        print()
 
     return True
 

--- a/pwndbg/commands/integration.py
+++ b/pwndbg/commands/integration.py
@@ -497,8 +497,21 @@ def sync(fail_quietly: bool) -> None:
     print("Syncing symbols...")
 
     # Functions and globals
-    nsyms = pwndbg.integration.manager.update_symbols()
-    print(message.success(f"Synced {nsyms} symbols") + " (globals + functions). ", end="")
+    nsyms, upd_err = pwndbg.integration.manager.update_symbols()
+    match upd_err:
+        case pwndbg.integration.Error.OK:
+            print(message.success(f"Synced {nsyms} symbols") + " (globals + functions). ", end="")
+        case _:
+            print(message.error(f"Error: {upd_err.value}."))
+            if upd_err == pwndbg.integration.Error.BINARY_NOT_LOADED:
+                print(
+                    "Try "
+                    + message.hint("`di setpath --help`")
+                    + " or "
+                    + message.hint("`di setbase --help`")
+                    + "?"
+                )
+            return
 
     # Function-local variables
     nvars = pwndbg.integration.manager.update_function_variables()

--- a/pwndbg/commands/integration.py
+++ b/pwndbg/commands/integration.py
@@ -662,7 +662,7 @@ def setpath(path: str) -> None:
         pwndbg.integration.manual_binary_address = -1
 
     pwndbg.integration.manual_binary_path = path
-    print(f"Path of the decompiled binary in the address space set to {path}.")
+    print(f'Path of the decompiled binary in the address space set to "{path}".')
     if path == "":
         print("(back to automatic detection)")
 

--- a/pwndbg/commands/integration.py
+++ b/pwndbg/commands/integration.py
@@ -624,12 +624,39 @@ def list_(list_all: bool) -> None:
         list_one_frame(frame)
 
 
+def setpath(path: str) -> None:
+    # I make this a command instead of a config for consistency with setbase.
+
+    # Unset manual base first
+    if pwndbg.integration.manual_binary_address != -1:
+        print(
+            f"Unset the previously set `di setbase` value of {pwndbg.integration.manual_binary_address}."
+        )
+        pwndbg.integration.manual_binary_address = -1
+
+    pwndbg.integration.manual_binary_path = path
+    print(f"Path of the decompiled binary in the address space set to {path}.")
+    if path == "":
+        print("(back to automatic detection)")
+
+    if pwndbg.integration.manager.is_connected():
+        print("Reconnecting to apply changes..\n")
+        connect(also_sync=True)
+
+
 def setbase(base_addr: int) -> None:
     # I use a command like this instead of a config parameter because it seems
     # GDB doesn't allow values > 2^32.
     if base_addr < -1:
         print(message.error("Valid values are in [-1, 2^64)."))
         return
+
+    # Unset manual path first
+    if pwndbg.integration.manual_binary_path != "":
+        print(
+            f"Unset the previously set `di setpath` value of {pwndbg.integration.manual_binary_path}."
+        )
+        pwndbg.integration.manual_binary_path = ""
 
     pwndbg.integration.manual_binary_address = base_addr
     print(f"Base address of the decompiled binary set to {base_addr:#x}.")
@@ -780,6 +807,8 @@ needed when debugging a kernel module.
 
 If you wish to re-enable automatic base address detection, set this value to -1 (or
 restart Pwndbg).
+
+Setting this automatically unsets the `di setpath` value.
 """,
 )
 parser_set_base.add_argument(
@@ -787,6 +816,32 @@ parser_set_base.add_argument(
     metavar="addr",
     type=int,
     help="Memory address of the decompiled binary in the address space",
+)
+
+parser_set_path = subparsers.add_parser(
+    "setpath",
+    help="Manually set the path of the binary as loaded in memory",
+    description="""
+Manually set the path of the binary as loaded in memory.
+
+Normally, Pwndbg will use the file path that the decompiler reports for the binary and
+check it against all files mapped into memory to find the correct base address.
+
+If for some reason the file names differ or your binary does not show up in the memory
+mappings, you can manually specify the actual path of the binary as loaded in memory (
+the one reported by /proc/<pid>/maps i.e. vmmap).
+
+If you wish to re-enable automatic base address detection, set this value to "" (or
+restart Pwndbg).
+
+Setting this automatically unsets the `di setbase` value.
+""",
+)
+parser_set_path.add_argument(
+    "binary_path",
+    metavar="path",
+    type=int,
+    help="File path of the decompiled binary as loaded in memory",
 )
 
 
@@ -799,6 +854,7 @@ def decompiler_integration(
     install_sub: str = "",
     list_all: bool = False,
     binary_addr: int = -1,
+    binary_path: str = "",
 ):
     match command:
         case "connect" | "c":
@@ -817,6 +873,8 @@ def decompiler_integration(
             list_(list_all)
         case "setbase":
             setbase(binary_addr)
+        case "setpath":
+            setpath(binary_path)
 
 
 # ========= End of decompiler-integration command handling =========

--- a/pwndbg/commands/integration.py
+++ b/pwndbg/commands/integration.py
@@ -485,6 +485,9 @@ def sync(fail_quietly: bool) -> None:
         # Direct check, no retries.
         if not pwndbg.integration.manager.is_connected():
             return
+
+        # Something else is calling us, lets give the output some space.
+        print()
     else:
         # Noisy check with a connection attempt.
         # Don't try to sync because that sync would be quiet, and we want

--- a/pwndbg/commands/klookup.py
+++ b/pwndbg/commands/klookup.py
@@ -57,7 +57,7 @@ def klookup(symbol: str, apply: bool) -> None:
             print(message.success(f"{sym_addr:#x} {sym_type} {sym_name}"))
 
     if apply:
-        if pwndbg.dbg.name == pwndbg.dbg_mod.DebuggerType.LLDB:
+        if pwndbg.dbg.name() == pwndbg.dbg_mod.DebuggerType.LLDB:
             print(message.error("Symbolication is not yet supported on LLDB."))
             # Until we implement add_symbol_file for LLDB.
             return

--- a/pwndbg/dbg_mod/gdb/__init__.py
+++ b/pwndbg/dbg_mod/gdb/__init__.py
@@ -1109,7 +1109,7 @@ class GDBProcess(pwndbg.dbg_mod.Process):
         if base is None:
             gdb.execute(f"add-symbol-file {path}", to_string=True)
             return
-        gdb.execute(f"add-symbol-file {path} {base}")
+        gdb.execute(f"add-symbol-file {path} {base}", to_string=True)
 
     @override
     def remove_symbol_file(self, path: str) -> bool:

--- a/pwndbg/integration/__init__.py
+++ b/pwndbg/integration/__init__.py
@@ -231,7 +231,7 @@ class DecompilerConnection:
                     basename: str = os.path.basename(self.binary_path)
                     print(
                         message.notice(
-                            f"The decompiled program {basename} doesn't seem to be loaded."
+                            f'The decompiled program "{basename}" doesn\'t seem to be loaded.'
                             " We will keep an eye out for it.\n"
                         )
                         + "If you know that it is actually loaded, check out "

--- a/pwndbg/integration/__init__.py
+++ b/pwndbg/integration/__init__.py
@@ -149,6 +149,7 @@ class Error(Enum):
     BINARY_NOT_LOADED = "Couldn't find binary in address space"
     DEBUGGER_NOT_SUPPORTED = "The debugger does not support this operation"
     NOT_ALIVE = "The process is not alive"
+    NO_FRAME = "No stack frame found."
 
 
 # If the user wants to override our automatic detection
@@ -568,6 +569,12 @@ class IntegrationManager:
 
         Returns the amount of synced symbols and an error diagnostic.
 
+        Possible error values:
+            NO_CONNECTION
+            BINARY_NOT_LOADED
+            NOT_ALIVE
+            DEBUGGER_NOT_SUPPORTED
+
         FIXME: Currently they are all 8 bytes in size.
         """
         # We need to bail even if we are connected, but the binary is not loaded into
@@ -582,8 +589,7 @@ class IntegrationManager:
         self._function_headers = None
         self._global_vars = None
 
-        if pwndbg.dbg.name == pwndbg.dbg_mod.DebuggerType.LLDB:
-            print(message.error("Symbolication is not yet supported on LLDB."))
+        if pwndbg.dbg.name() == pwndbg.dbg_mod.DebuggerType.LLDB:
             # Until we implement add_symbol_file for LLDB.
             return 0, Error.DEBUGGER_NOT_SUPPORTED
 
@@ -676,7 +682,7 @@ class IntegrationManager:
 
         return False
 
-    def update_function_variables(self) -> int:
+    def update_function_variables(self) -> tuple[int, Error]:
         """
         Update debugger convnience varibles based on the function variables in the currently
         selected frame.
@@ -686,20 +692,21 @@ class IntegrationManager:
 
         Returns:
             The number of variables we successfully updated in the debugger.
+            An error diagnostic (NO_CONNECTION or NO_FRAME).
 
         FIXME: Currently this kinda doesn't work if it runs while we are in the function
         prologue. We should ideally run it only when we enter new functions and are past
         their prologues.
         """
         if self._connection is None:
-            return 0
+            return 0, Error.NO_CONNECTION
 
         # We could do some updates without having a valid selected frame by using pwndbg.aglib.regs.sp ,
         # but this probably complicates the code uneccessarily (see some previous commits in the PR).
         # I'm simply not sure when exactly can selected_frame() actually return None.
         frame: Optional[pwndbg.dbg_mod.Frame] = pwndbg.dbg.selected_frame()
         if frame is None:
-            return 0
+            return 0, Error.NO_FRAME
 
         # Invalidate this whole cache.
         # We could invalidate just for frame.pc() for the purposes of this function, but we want to invalidate
@@ -711,7 +718,7 @@ class IntegrationManager:
             frame
         )
         if rebased_vars is None:
-            return 0
+            return 0, Error.OK
 
         nupdated: int = 0
 
@@ -730,7 +737,7 @@ class IntegrationManager:
             )
             nupdated += 1 if ok else 0
 
-        return nupdated
+        return nupdated, Error.OK
 
     # ==== Getters ====
     # All getters are either cheap (no RPC) operations, or cached.

--- a/pwndbg/integration/__init__.py
+++ b/pwndbg/integration/__init__.py
@@ -142,6 +142,15 @@ _api_name_to_id = {
     "angr": DecompilerID.ANGR,
 }
 
+
+class Error(Enum):
+    OK = "Ok."
+    NO_CONNECTION = "Not connected to a decompiler"
+    BINARY_NOT_LOADED = "Couldn't find binary in address space"
+    DEBUGGER_NOT_SUPPORTED = "The debugger does not support this operation"
+    NOT_ALIVE = "The process is not alive"
+
+
 # If the user wants to override our automatic detection
 manual_binary_address: int = -1
 manual_binary_path: str = ""
@@ -544,21 +553,24 @@ class IntegrationManager:
 
     # ==== Setters ====
 
-    def update_symbols(self) -> int:
+    def update_symbols(self) -> tuple[int, Error]:
         """
         Update global variables and functions in the debugger.
 
         This always invalidates the cache for global variables and
         function headers, and requests them from the plugin.
 
-        Returns the amount of synced symbols.
+        Returns the amount of synced symbols and an error diagnostic.
 
         FIXME: Currently they are all 8 bytes in size.
         """
         # We need to bail even if we are connected, but the binary is not loaded into
         # the address space yet.
-        if self._connection is None or self._connection.binary_base_addr == -1:
-            return 0
+        if self._connection is None:
+            return 0, Error.NO_CONNECTION
+
+        if self._connection.binary_base_addr == -1:
+            return 0, Error.BINARY_NOT_LOADED
 
         # Invalidate the two caches.
         self._function_headers = None
@@ -567,12 +579,17 @@ class IntegrationManager:
         if pwndbg.dbg.name == pwndbg.dbg_mod.DebuggerType.LLDB:
             print(message.error("Symbolication is not yet supported on LLDB."))
             # Until we implement add_symbol_file for LLDB.
-            return 0
+            return 0, Error.DEBUGGER_NOT_SUPPORTED
 
         try:
             inf: pwndbg.dbg_mod.Process = pwndbg.dbg.selected_inferior()
         except pwndbg.dbg_mod.NoInferior:
-            return 0
+            # Should never happen because we already know that binary_base_address is set.
+            return 0, Error.NOT_ALIVE
+
+        if not inf.alive():
+            # Should never happen because we already know that binary_base_address is set.
+            return 0, Error.NOT_ALIVE
 
         # Remove old symbol file.
         # If we don't do this, the symbols will stack (run `info func` in GDB).
@@ -601,7 +618,7 @@ class IntegrationManager:
                 sym_name_set.add(clean_name)
 
         if not syms_to_add:
-            return 0
+            return 0, Error.OK
 
         _, elf_path = tempfile.mkstemp(prefix="symbols-", suffix=".elf")
         elf = niche_elf.ELFFile(self._connection.binary_base_addr)
@@ -614,7 +631,7 @@ class IntegrationManager:
         self._latest_symbol_file_path = elf_path
         # Delete the file after GDB closes the file descriptor.
         os.unlink(elf_path)
-        return len(syms_to_add)
+        return len(syms_to_add), Error.OK
 
     def _clean_type_str(self, type_str: str) -> str:
         # FIXME:

--- a/pwndbg/integration/__init__.py
+++ b/pwndbg/integration/__init__.py
@@ -144,6 +144,7 @@ _api_name_to_id = {
 
 # If the user wants to override our automatic detection
 manual_binary_address: int = -1
+manual_binary_path: str = ""
 
 
 class DecompilerConnection:
@@ -218,6 +219,8 @@ class DecompilerConnection:
                             " We will keep an eye out for it.\n"
                         )
                         + "If you know that it is actually loaded, check out "
+                        + message.hint("`di setpath --help`")
+                        + " or "
                         + message.hint("`di setbase --help`")
                         + ".\n"
                     )

--- a/pwndbg/integration/__init__.py
+++ b/pwndbg/integration/__init__.py
@@ -173,8 +173,9 @@ class DecompilerConnection:
     """The XML RPC server that is connected to the decompiler."""
     server: xmlrpc.client.ServerProxy
 
-    """The (host filesystem) path of the binary loaded in the decompiler.
-    It can be both an executable and a shared library."""
+    """The (host filesystem) path of the binary loaded as reported by the decompiler.
+    It can be both an executable and a shared library.
+    May not be relevant if manual_binary_address or manual_binary_path are set."""
     binary_path: str
 
     """Version information about the decompiler we are connected to. See
@@ -199,6 +200,7 @@ class DecompilerConnection:
 
     def _find_binary_addr(self, print_failure: bool = False) -> None:
         if manual_binary_address != -1:
+            # The user hardcoded the binary base address via `di setbase`.
             self._binary_base_addr = manual_binary_address
             return
 
@@ -210,14 +212,18 @@ class DecompilerConnection:
         if not inf.alive():
             return
 
+        if manual_binary_path != "":
+            # The user overrode what the decompiler says via `di setpath`.
+            path: str = manual_binary_path
+        else:
+            path = self.binary_path
+
         # Try to find the binary in the address space.
-        start_addr: Optional[int] = pwndbg.aglib.vmmap.named_region_start(
-            self.binary_path, exact_match=True
-        )
+        start_addr: Optional[int] = pwndbg.aglib.vmmap.named_region_start(path, exact_match=True)
 
         if start_addr is None:
             # Try harder! (likely we are remote debugging)
-            start_addr = pwndbg.aglib.vmmap.named_region_start(self.binary_path, exact_match=False)
+            start_addr = pwndbg.aglib.vmmap.named_region_start(path, exact_match=False)
 
             if start_addr is None:
                 if print_failure:


### PR DESCRIPTION
+ [x] I read the contributing documentation.
+ [x] I am providing a screenshot of the (new feature) / (fixed bug).

## Before
<img width="810" height="482" alt="image" src="https://github.com/user-attachments/assets/441e6f00-33df-40f5-8552-2e94ef5e5a91" />

## After
<img width="760" height="465" alt="image" src="https://github.com/user-attachments/assets/1f5c0760-b3ae-450e-a71e-cd156327c2f2" />


