### PR TITLE
Enable caching for docker tests, fix archlinux docker test from failing, and cleanup/optimize dockerfiles to follow best practices

### DIFF
--- a/.github/workflows/base-image.yml
+++ b/.github/workflows/base-image.yml
@@ -16,7 +16,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/base-image.yml
+++ b/.github/workflows/base-image.yml
@@ -15,8 +15,8 @@ on:
       - '.github/workflows/base-image.yml'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}${{ github.event_name == 'pull_request' && format('-{0}', github.run_id) || '' }}
-  cancel-in-progress: ${{ github.event_name == 'push' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/.github/workflows/base-image.yml
+++ b/.github/workflows/base-image.yml
@@ -15,6 +15,8 @@ on:
       - '.github/workflows/base-image.yml'
 
 concurrency:
+  # Pushes (dev): queue sequentially (prevent cache corruption)
+  # PRs: cancel old commits (only test latest)
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 

--- a/.github/workflows/base-image.yml
+++ b/.github/workflows/base-image.yml
@@ -15,7 +15,7 @@ on:
       - '.github/workflows/base-image.yml'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}${{ github.event_name == 'pull_request' && format('-{0}', github.run_id) || '' }}
   cancel-in-progress: ${{ github.event_name == 'push' }}
 
 permissions:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,7 +19,7 @@ on:
       - "!*.md"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}${{ github.event_name == 'pull_request' && format('-{0}', github.run_id) || '' }}
   cancel-in-progress: ${{ github.event_name == 'push' }}
 
 permissions:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,6 +19,8 @@ on:
       - "!*.md"
 
 concurrency:
+  # Pushes (dev): queue sequentially (prevent cache corruption)
+  # PRs: cancel old commits (only test latest)
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,11 +1,30 @@
 name: Test Docker
+
 on:
+  push:
+    branches:
+      - dev
+    paths:
+      - 'Dockerfile*'
+      - 'setup.sh'
+      - 'setup-dev.sh'
+      - 'uv.lock'
+      - 'pyproject.toml'
+      - '.github/workflows/docker.yml'
   pull_request:
     paths:
       - "**"
       - "!mkdocs.yml"
       - "!docs/**"
       - "!*.md"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'push' }}
+
+permissions:
+  contents: read
+  packages: write
 
 jobs:
   docker_x86-64:
@@ -18,21 +37,68 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
-
-      - name: Docker Build ${{ matrix.images }}
-        run: docker compose build ${{ matrix.images }}
-
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      
+      - name: Login to GHCR
+        if: github.event_name == 'push'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Docker Buildx ${{ matrix.images }} (cache-enabled)
+        run: |
+          case "${{ matrix.images }}" in
+            ubuntu22.04)
+              DOCKERFILE="Dockerfile"
+              BASE_IMAGE="ubuntu:22.04"
+              ;;
+            ubuntu24.04)
+              DOCKERFILE="Dockerfile"
+              BASE_IMAGE="ubuntu:24.04"
+              ;;
+            debian12)
+              DOCKERFILE="Dockerfile"
+              BASE_IMAGE="debian:12"
+              ;;
+            archlinux)
+              DOCKERFILE="Dockerfile.arch"
+              BASE_IMAGE="archlinux:latest"
+              ;;
+            fedora41)
+              DOCKERFILE="Dockerfile.dnf"
+              BASE_IMAGE="fedora:41"
+              ;;
+            fedora42)
+              DOCKERFILE="Dockerfile.dnf"
+              BASE_IMAGE="fedora:42"
+              ;;
+            fedora43)
+              DOCKERFILE="Dockerfile.dnf"
+              BASE_IMAGE="fedora:43"
+              ;;
+          esac
+          
+          docker buildx build \
+            --load \
+            --cache-from type=registry,ref=ghcr.io/pwndbg/cache:${{ matrix.images }} \
+            ${{ github.event_name == 'push' && format('--cache-to type=registry,ref=ghcr.io/pwndbg/cache:{0},mode=max', matrix.images) || '' }} \
+            -f $DOCKERFILE \
+            --build-arg image=$BASE_IMAGE \
+            -t ${{ matrix.images }}:latest \
+            .
+      
       - name: Run GDB Tests on ${{ matrix.images }}
-        run: |
-          docker compose run ${{ matrix.images }} ./tests.sh -d gdb -g gdb
-
+        run: docker compose run ${{ matrix.images }} ./tests.sh -d gdb -g gdb
+      
       - name: Run DBG Tests on GDB on ${{ matrix.images }}
-        run: |
-          docker compose run ${{ matrix.images }} ./tests.sh -d gdb -g dbg
-
+        run: docker compose run ${{ matrix.images }} ./tests.sh -d gdb -g dbg
+      
       - name: Run DBG Tests on LLDB on ${{ matrix.images }}
-        run: |
-          docker compose run ${{ matrix.images }} ./tests.sh -d lldb -g dbg
+        run: docker compose run ${{ matrix.images }} ./tests.sh -d lldb -g dbg
 
   docker_aarch64:
     strategy:
@@ -44,18 +110,53 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
-
-      - name: Docker Build ${{ matrix.images }}
-        run: docker compose build ${{ matrix.images }}
-
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      
+      - name: Login to GHCR
+        if: github.event_name == 'push'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Docker Buildx ${{ matrix.images }} (cache-enabled)
+        run: |
+          case "${{ matrix.images }}" in
+            ubuntu24.04)
+              DOCKERFILE="Dockerfile"
+              BASE_IMAGE="ubuntu:24.04"
+              ;;
+            fedora41)
+              DOCKERFILE="Dockerfile.dnf"
+              BASE_IMAGE="fedora:41"
+              ;;
+            fedora42)
+              DOCKERFILE="Dockerfile.dnf"
+              BASE_IMAGE="fedora:42"
+              ;;
+            fedora43)
+              DOCKERFILE="Dockerfile.dnf"
+              BASE_IMAGE="fedora:43"
+              ;;
+          esac
+          
+          docker buildx build \
+            --load \
+            --cache-from type=registry,ref=ghcr.io/pwndbg/cache:${{ matrix.images }}-arm64 \
+            ${{ github.event_name == 'push' && format('--cache-to type=registry,ref=ghcr.io/pwndbg/cache:{0}-arm64,mode=max', matrix.images) || '' }} \
+            -f $DOCKERFILE \
+            --build-arg image=$BASE_IMAGE \
+            -t ${{ matrix.images }}:latest \
+            .
+      
       - name: Run Cross Tests on GDB on ${{ matrix.images }}
-        run: |
-          docker compose run ${{ matrix.images }} ./tests.sh -d gdb -g cross-arch-user
-
+        run: docker compose run ${{ matrix.images }} ./tests.sh -d gdb -g cross-arch-user
+      
       - name: Run DBG Tests on GDB on ${{ matrix.images }}
-        run: |
-          docker compose run ${{ matrix.images }} ./tests.sh -d gdb -g dbg
-
+        run: docker compose run ${{ matrix.images }} ./tests.sh -d gdb -g dbg
+      
       - name: Run DBG Tests on LLDB on ${{ matrix.images }}
-        run: |
-          docker compose run ${{ matrix.images }} ./tests.sh -d lldb -g dbg
+        run: docker compose run ${{ matrix.images }} ./tests.sh -d lldb -g dbg

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,8 +19,8 @@ on:
       - "!*.md"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}${{ github.event_name == 'pull_request' && format('-{0}', github.run_id) || '' }}
-  cancel-in-progress: ${{ github.event_name == 'push' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,7 +20,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,13 +27,13 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && \
 # setup.sh needs scripts/common.sh
 COPY ./scripts/common.sh /pwndbg/scripts/
 
-COPY ./setup.sh /pwndbg/
 COPY ./uv.lock /pwndbg/
 COPY ./pyproject.toml /pwndbg/
 
 # pyproject.toml requires these files, pip install would fail
 RUN touch README.md && mkdir pwndbg && touch pwndbg/empty.py
 
+COPY ./setup.sh /pwndbg/
 RUN DEBIAN_FRONTEND=noninteractive ./setup.sh
 
 # Comment these lines if you won't run the tests.

--- a/Dockerfile.arch
+++ b/Dockerfile.arch
@@ -19,17 +19,16 @@ ENV UV_PROJECT_ENVIRONMENT=/venv
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && \
     echo $TZ > /etc/timezone && \
     pacman -Syu --noconfirm && \
-    localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8 && \
-    pacman -S --noconfirm vim && \
+    localedef -i en_US -c -f UTF-8 en_US.UTF-8 && \
+    pacman -S --noconfirm vim base-devel && \
     pacman -Scc --noconfirm
 
 # setup.sh needs scripts/common.sh
-RUN mkdir scripts
-ADD ./scripts/common.sh /pwndbg/scripts/
+COPY ./scripts/common.sh /pwndbg/scripts/
 
-ADD ./setup.sh /pwndbg/
-ADD ./uv.lock /pwndbg/
-ADD ./pyproject.toml /pwndbg/
+COPY ./setup.sh /pwndbg/
+COPY ./uv.lock /pwndbg/
+COPY ./pyproject.toml /pwndbg/
 
 # pyproject.toml requires these files, pip install would fail
 RUN touch README.md && mkdir pwndbg && touch pwndbg/empty.py
@@ -38,12 +37,12 @@ RUN sed -i 's/read -p "Do you want to do a full system update?/#read/' ./setup.s
     ./setup.sh
 
 # Comment these lines if you won't run the tests.
-ADD ./setup-dev.sh /pwndbg/
+COPY ./setup-dev.sh /pwndbg/
 RUN ./setup-dev.sh
 
 # Cleanup dummy files
 RUN rm README.md && rm -rf pwndbg
 
-ADD . /pwndbg/
+COPY . /pwndbg/
 
 ENV PATH="${PWNDBG_VENV_PATH}/bin:${PATH}"

--- a/Dockerfile.arch
+++ b/Dockerfile.arch
@@ -20,7 +20,7 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && \
     echo $TZ > /etc/timezone && \
     pacman -Syu --noconfirm && \
     localedef -i en_US -c -f UTF-8 en_US.UTF-8 && \
-    pacman -S --noconfirm vim base-devel && \
+    pacman -S --noconfirm vim && \
     pacman -Scc --noconfirm
 
 # setup.sh needs scripts/common.sh

--- a/Dockerfile.base-apt
+++ b/Dockerfile.base-apt
@@ -15,16 +15,21 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && \
     echo $TZ > /etc/timezone && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
-        locales vim && \
-    localedef -i en_US -c -f UTF-8 en_US.UTF-8
+        locales vim \
+        # pip/python dependencies
+        git python3 python3-dev python3-venv patch libncurses-dev libssl-dev libffi-dev pkg-config cmake build-essential curl \
+        # Pwndbg tests dependencies
+        make pkg-config gcc musl-tools golang libc6-dev libc6-dbg && \
+    localedef -i en_US -c -f UTF-8 en_US.UTF-8 && \
+    rm -rf /var/lib/apt/lists/*
 
-# pip/python dependencies
-RUN apt install -y git python3 python3-dev python3-venv patch libncurses-dev libssl-dev libffi-dev pkg-config cmake build-essential curl
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --profile=minimal -y && \
-    for bin in $HOME/.cargo/bin/*; do [ -x "$bin" ] && ln -sf "$bin" /usr/local/bin/$(basename "$bin"); done
+    for bin in "$HOME"/.cargo/bin/*; do \
+      [ -x "$bin" ] && ln -sf "$bin" "/usr/local/bin/$(basename "$bin")"; \
+    done
 
-# Pwndbg tests dependencies
-RUN apt install -y make pkg-config gcc musl-tools golang libc6-dev libc6-dbg
 # TODO: jemalloc build
 
 # Pwndbg runtime dependencies
@@ -36,7 +41,7 @@ RUN ARCH=$(uname -m) && \
         i686) ZIG_ARCH="x86";; \
         *) ZIG_ARCH="$ARCH";; \
     esac && \
-    curl -L https://ziglang.org/download/${ZIG_VERSION}/zig-${ZIG_ARCH}-linux-${ZIG_VERSION}.tar.xz -o /tmp/zig.tar.xz && \
+    curl -L "https://ziglang.org/download/${ZIG_VERSION}/zig-${ZIG_ARCH}-linux-${ZIG_VERSION}.tar.xz" -o /tmp/zig.tar.xz && \
     tar -xf /tmp/zig.tar.xz -C /tmp && \
     rm /tmp/zig.tar.xz && \
     mkdir -p /opt/zig && \

--- a/Dockerfile.dnf
+++ b/Dockerfile.dnf
@@ -38,9 +38,7 @@ COPY ./pyproject.toml /pwndbg/
 # pyproject.toml requires these files, pip install would fail
 RUN touch README.md && mkdir pwndbg && touch pwndbg/empty.py
 
-# fix for py3.14 because wheels aren't available so packages need to be built
 # RUN uv sync --all-groups --all-extras
-RUN dnf install -y uv patch ncurses-devel gcc g++
 COPY ./setup.sh /pwndbg/
 RUN ./setup.sh
 

--- a/Dockerfile.dnf
+++ b/Dockerfile.dnf
@@ -25,6 +25,10 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && \
     dnf clean all && \
     rm -rf /var/cache/dnf
 
+# Fix for BuildKit PAM error: https://github.com/docker/build-push-action/issues/1302
+RUN printf '#!/bin/sh\nexec "$@"' > /usr/local/bin/sudo && \
+    chmod +x /usr/local/bin/sudo
+
 # setup.sh needs scripts/common.sh
 COPY ./scripts/common.sh /pwndbg/scripts/
 

--- a/Dockerfile.dnf
+++ b/Dockerfile.dnf
@@ -28,7 +28,6 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && \
 # setup.sh needs scripts/common.sh
 COPY ./scripts/common.sh /pwndbg/scripts/
 
-COPY ./setup.sh /pwndbg/
 COPY ./uv.lock /pwndbg/
 COPY ./pyproject.toml /pwndbg/
 
@@ -36,9 +35,9 @@ COPY ./pyproject.toml /pwndbg/
 RUN touch README.md && mkdir pwndbg && touch pwndbg/empty.py
 
 # fix for py3.14 because wheels aren't available so packages need to be built
-# RUN dnf install -y uv git python3-devel patch ncurses-devel gcc
 # RUN uv sync --all-groups --all-extras
 RUN dnf install -y uv git python3-devel patch ncurses-devel gcc g++
+COPY ./setup.sh /pwndbg/
 RUN ./setup.sh
 
 # Comment these lines if you won't run the tests.

--- a/Dockerfile.dnf
+++ b/Dockerfile.dnf
@@ -40,7 +40,7 @@ RUN touch README.md && mkdir pwndbg && touch pwndbg/empty.py
 
 # fix for py3.14 because wheels aren't available so packages need to be built
 # RUN uv sync --all-groups --all-extras
-RUN dnf install -y uv git python3-devel patch ncurses-devel gcc g++
+RUN dnf install -y uv patch ncurses-devel gcc g++
 COPY ./setup.sh /pwndbg/
 RUN ./setup.sh
 

--- a/Dockerfile.dnf
+++ b/Dockerfile.dnf
@@ -25,7 +25,7 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && \
     dnf clean all && \
     rm -rf /var/cache/dnf
 
-# Fix for BuildKit PAM error: https://github.com/docker/build-push-action/issues/1302
+# Fix for BuildKit PAM error for fedora41 tests: https://github.com/docker/build-push-action/issues/1302
 RUN printf '#!/bin/sh\nexec "$@"' > /usr/local/bin/sudo && \
     chmod +x /usr/local/bin/sudo
 

--- a/setup-dev.sh
+++ b/setup-dev.sh
@@ -145,7 +145,6 @@ EOF
         lib32-glibc \
         curl \
         wget \
-        base-devel \
         gdb \
         parallel \
         musl

--- a/setup-dev.sh
+++ b/setup-dev.sh
@@ -91,7 +91,6 @@ install_apt() {
         curl \
         wget \
         build-essential \
-        gdb \
         gdb-multiarch \
         parallel \
         qemu-system-x86 \
@@ -140,12 +139,10 @@ EOF
     sudo pacman -Syu --noconfirm || true
     sudo pacman -S --needed --noconfirm \
         nasm \
-        gcc \
         glibc-debug \
         lib32-glibc \
-        curl \
+        base-devel \
         wget \
-        gdb \
         parallel \
         musl
 
@@ -157,13 +154,10 @@ EOF
 install_dnf() {
     sudo dnf upgrade || true
     sudo dnf install -y \
-        make \
         nasm \
-        gcc \
         curl \
         wget \
         musl-gcc \
-        g++ \
         parallel \
         qemu-system-x86 \
         qemu-system-arm \

--- a/setup.sh
+++ b/setup.sh
@@ -74,7 +74,7 @@ install_pacman() {
     if [[ "$answer" == "y" ]]; then
         sudo pacman -Syu || true
     fi
-    sudo pacman -S --noconfirm --needed git gdb python which debuginfod curl base-devel
+    sudo pacman -S --noconfirm --needed git gdb python which debuginfod curl gcc make patch
     if [ -z "$UPDATE_MODE" ]; then
         if ! grep -qs "^set debuginfod enabled on" ~/.gdbinit; then
             echo "set debuginfod enabled on" >> ~/.gdbinit

--- a/setup.sh
+++ b/setup.sh
@@ -28,7 +28,7 @@ install_apt() {
 
 install_dnf() {
     sudo dnf update || true
-    sudo dnf -y install git gdb gdb-gdbserver python3-devel
+    sudo dnf -y install git gdb gdb-gdbserver python3-devel gcc g++ make patch ncurses-devel
     sudo dnf -y debuginfo-install glibc
 }
 

--- a/setup.sh
+++ b/setup.sh
@@ -74,7 +74,7 @@ install_pacman() {
     if [[ "$answer" == "y" ]]; then
         sudo pacman -Syu || true
     fi
-    sudo pacman -S --noconfirm --needed git gdb python which debuginfod curl
+    sudo pacman -S --noconfirm --needed git gdb python which debuginfod curl base-devel
     if [ -z "$UPDATE_MODE" ]; then
         if ! grep -qs "^set debuginfod enabled on" ~/.gdbinit; then
             echo "set debuginfod enabled on" >> ~/.gdbinit


### PR DESCRIPTION
+ [x] I read the contributing documentation.
+ [x] I am providing a screenshot of the (new feature) / (fixed bug).

before
<img width="1506" height="36" alt="chrome_tOoujk4asX" src="https://github.com/user-attachments/assets/f7880832-1930-4c9b-9e54-2aca510089d4" />
after
<img width="1494" height="33" alt="chrome_n8iEbtq9va" src="https://github.com/user-attachments/assets/e05cc5e5-8dba-406d-b834-52b60af32573" />
5m 21s > 1m 56s

would ofc take effect only after this is merged 

only reason it takes 1m 30s - 2m ish instead of 30s is because of the --load flag so that it can be ran with docker compose run

ArchLinux Docker test
before
<img width="1492" height="34" alt="chrome_tIEMQhQx3a" src="https://github.com/user-attachments/assets/3d379e39-afd8-4c14-a1d1-f8710e66e7fa" />
after
<img width="1490" height="34" alt="chrome_X2xGQsKBJ9" src="https://github.com/user-attachments/assets/3f885e55-e29c-4233-ad12-76e391a47ba9" />
fail > pass
was broken because of Arch Linux updating to Python 3.14

This also makes it run on dev, in which it didn't before, just to update the cache if any changes are made to any files that would affect the image.


This PR also adds build tools to setup-sh for pacman and dnf install portions so that wheels for Python 3.14 aren't required for all packages. Without this, currently fedora:43 and archlinux:latest will fail when running setup.sh.
Also, then with that removes the Dockerfile.dnf patch that was put in there to support gnureadline 
https://github.com/ludwigschwardt/python-gnureadline/issues/80#issuecomment-3640302277
well and jpype1

lmk thoughts