### PR TITLE
Disable the flaky jemalloc tests

### DIFF
--- a/tests/library/dbg/tests/heap/test_heap.py
+++ b/tests/library/dbg/tests/heap/test_heap.py
@@ -656,6 +656,8 @@ re_match_valid_address = r"0x[0-9a-fA-F]{6,16}"
 async def test_jemalloc_find_extent(ctrl: Controller) -> None:
     import pwndbg.aglib
 
+    pytest.skip("Flaky test, needs fixing. See #3615")
+
     await launch_to(ctrl, HEAP_JEMALLOC_EXTENT_INFO, "break_here")
     if pwndbg.aglib.arch.name != "x86-64":
         pytest.skip("TODO multiarch")
@@ -688,6 +690,8 @@ async def test_jemalloc_find_extent(ctrl: Controller) -> None:
 @pwndbg_test
 async def test_jemalloc_extent_info(ctrl: Controller) -> None:
     import pwndbg.aglib
+
+    pytest.skip("Flaky test, needs fixing. See #3615")
 
     await launch_to(ctrl, HEAP_JEMALLOC_EXTENT_INFO, "break_here")
     if pwndbg.aglib.arch.name != "x86-64":
@@ -725,6 +729,8 @@ async def test_jemalloc_extent_info(ctrl: Controller) -> None:
 @pwndbg_test
 async def test_jemalloc_heap(ctrl: Controller) -> None:
     import pwndbg.aglib
+
+    pytest.skip("Flaky test, needs fixing. See #3615")
 
     await launch_to(ctrl, HEAP_JEMALLOC_HEAP, "break_here")
     if pwndbg.aglib.arch.name != "x86-64":


### PR DESCRIPTION
re: https://github.com/pwndbg/pwndbg/issues/3615

The fact that they are enabled is more annoying than the value they bring. It doesn't seem like anyone is taking up the effort to fix them so we should disable them for now.