### PR TITLE
draft: glibc 2.43 heap

### DIFF
--- a/pwndbg/aglib/heap/ptmalloc.py
+++ b/pwndbg/aglib/heap/ptmalloc.py
@@ -66,8 +66,12 @@ HEAP_MAX_SIZE: int = None
 
 NBINS = 128
 BINMAPSIZE = 4
-NFASTBINS = 10
 NSMALLBINS = 64
+
+
+def nfastbins():
+    glibc_version = pwndbg.glibc.get_version()
+    return 0 if glibc_version >= (2, 43) else 10
 
 
 # Note that we must inherit from `str` before `Enum`: https://stackoverflow.com/a/58608362/803801
@@ -680,7 +684,7 @@ class Arena:
         if self._fastbinsY is None:
             self._fastbinsY = []
             try:
-                for i in range(NFASTBINS):
+                for i in range(nfastbins()):
                     self._fastbinsY.append(int(self._gdbValue["fastbinsY"][i]))
             except pwndbg.dbg_mod.Error:
                 pass
@@ -777,7 +781,7 @@ class Arena:
         fd_offset = pwndbg.aglib.arch.ptrsize * 2
         safe_lnk = pwndbg.glibc.check_safe_linking()
         result = Bins(BinType.FAST)
-        for i in range(NFASTBINS):
+        for i in range(nfastbins()):
             size += pwndbg.aglib.arch.ptrsize * 2
             chain = pwndbg.chain.get(
                 int(self.fastbinsY[i]),
@@ -1565,11 +1569,8 @@ class GlibcMemoryAllocator(pwndbg.aglib.heap.heap.MemoryAllocator, Generic[TheTy
         The `struct malloc_chunk` comes from debugging symbols and it will not be there
         for statically linked binaries
         """
-        return (
-            pwndbg.aglib.typeinfo.load("struct malloc_chunk") is not None
-            and pwndbg.aglib.symbol.lookup_symbol_addr("global_max_fast", prefer_static=True)
-            is not None
-        )
+        return pwndbg.aglib.typeinfo.load("struct malloc_chunk") is not None
+        # pwndbg.aglib.symbol.lookup_symbol_addr("global_max_fast", prefer_static=True) is not None
 
 
 class DebugSymsHeap(GlibcMemoryAllocator[pwndbg.dbg_mod.Type, pwndbg.dbg_mod.Value]):

--- a/pwndbg/aglib/heap/ptmalloc.py
+++ b/pwndbg/aglib/heap/ptmalloc.py
@@ -2305,6 +2305,8 @@ class HeuristicHeap(
     def is_initialized(self) -> bool:
         # TODO/FIXME: If main_arena['top'] is been modified to 0, this will not work.
         # try to use vmmap or main_arena.top to find the heap
-        return any("[heap]" == x.objfile for x in pwndbg.aglib.vmmap.get()) or (
+        if not any("[heap]" == x.objfile for x in pwndbg.aglib.vmmap.get()) or (
             self.can_be_resolved() and self.main_arena.top != 0
-        )
+        ):
+            return int(self.mp["sbrk_base"]) != 0
+        return False

--- a/pwndbg/aglib/heap/ptmalloc.py
+++ b/pwndbg/aglib/heap/ptmalloc.py
@@ -769,6 +769,10 @@ class Arena:
         return self._heaps
 
     def fastbins(self) -> Bins:
+        if pwndbg.glibc.get_version() >= (2, 43):
+            print(message.info("fastbins were removed in 2.43"))
+            return None
+
         size = pwndbg.aglib.arch.ptrsize * 2
         fd_offset = pwndbg.aglib.arch.ptrsize * 2
         safe_lnk = pwndbg.glibc.check_safe_linking()

--- a/pwndbg/aglib/heap/ptmalloc.py
+++ b/pwndbg/aglib/heap/ptmalloc.py
@@ -2094,12 +2094,29 @@ class HeuristicHeap(
             # arena doesn't be allocated yet, so there's no tcache
             return None
 
+        tls_address = self.prompt_for_tls_address()
+        if pwndbg.glibc.get_version() >= (2, 43):
+            # NOTE: idk if this works for most/all cases
+            # a way that **should** work in most/all cases would be
+            # to scan throu tls variables, looking for either something on the heap
+            # or for `__tcache_dummy`, which is ~sizeof(tcache_perthread_struct)+ptrsize nullbytes
+            # in the ro (first) page of libc
+
+            _, main_arena_tls = self.brute_force_thread_local_variable_near_tls_base(
+                tls_address, lambda x: x == self.main_arena.address
+            )
+            self._thread_cache = tps(
+                pwndbg.aglib.memory.u64(main_arena_tls - 6 * pwndbg.aglib.arch.ptrsize)
+            )
+            self._thread_caches[pwndbg.dbg.selected_thread().index()] = self._thread_cache
+            return self._thread_cache
+
         if self.main_arena.next != self.main_arena.address or self.multithreaded:
             if self.prompt_for_brute_force_thread_cache_permission():
-                tls_address = self.prompt_for_tls_address()
                 if tls_address:
                     chunk_header_size = pwndbg.aglib.arch.ptrsize * 2
                     tcache_perthread_struct_size = self.tcache_perthread_struct.sizeof
+
                     lb, ub = arena.active_heap.start, arena.active_heap.end
 
                     def validator(guess: int) -> bool:

--- a/pwndbg/aglib/heap/structs.py
+++ b/pwndbg/aglib/heap/structs.py
@@ -56,6 +56,7 @@ else:
     PTR = ctypes.c_uint64  # type: ignore[misc]
     SIZE_T = ctypes.c_uint64  # type: ignore[misc]
 
+DEFAULT_THP_MODE = 0x3
 DEFAULT_TOP_PAD = 131072
 DEFAULT_MMAP_MAX = 65536
 DEFAULT_MMAP_THRESHOLD = 128 * 1024
@@ -1212,7 +1213,7 @@ DEFAULT_MP_.arena_test = 2 if pwndbg.aglib.arch.ptrsize == 4 else 8
 if (MallocPar._c_struct != c_malloc_par_2_23) and (MallocPar._c_struct != c_malloc_par_2_12):
     # the only difference between 2.23 and the rest is the lack of tcache
     DEFAULT_MP_.tcache_count = TCACHE_FILL_COUNT
-    if MallocPar._c_struct == c_malloc_par_2_42:
+    if MallocPar._c_struct == c_malloc_par_2_42 or MallocPar._c_struct == c_malloc_par_2_43:
         DEFAULT_MP_.tcache_small_bins = TCACHE_SMALL_BINS
         DEFAULT_MP_.tcache_max_bytes = (
             MAX_TCACHE_SMALL_SIZE + SIZE_SZ + MALLOC_ALIGN_MASK
@@ -1223,3 +1224,6 @@ if (MallocPar._c_struct != c_malloc_par_2_23) and (MallocPar._c_struct != c_mall
         DEFAULT_MP_.tcache_max_bytes = MAX_TCACHE_SMALL_SIZE
 if MallocPar._c_struct == c_malloc_par_2_12:
     DEFAULT_MP_.pagesize = DEFAULT_PAGE_SIZE
+
+if MallocPar._c_struct == c_malloc_par_2_43:
+    DEFAULT_MP_.thp_mode = DEFAULT_THP_MODE

--- a/pwndbg/aglib/heap/structs.py
+++ b/pwndbg/aglib/heap/structs.py
@@ -25,6 +25,8 @@ def fastbin_index(size: int) -> int:
         return (size >> 3) - 2
 
 
+# NOTE: these should be lazily evaluated
+
 GLIBC_VERSION = pwndbg.glibc.get_version()
 # TODO: Move these heap constants and macros to elsewhere, because pwndbg/aglib/heap/ptmalloc.py also uses them, we are duplicating them here.
 SIZE_SZ = pwndbg.aglib.arch.ptrsize
@@ -440,14 +442,78 @@ class c_malloc_state_2_27(Structure):
     ]
 
 
+class c_malloc_state_2_43(Structure):
+    """
+    This class represents malloc_state struct for GLIBC >= 2.43 as a ctypes struct.
+
+    https://github.com/bminor/glibc/blob/glibc-2.43/malloc/malloc.c#L1724 (doesn't exist yet)
+
+
+    struct malloc_state
+    {
+      /* Serialize access.  */
+      __libc_lock_define (, mutex);
+
+      /* Flags  */
+      int flags;
+
+      /* Base of the topmost chunk -- not otherwise kept in a bin */
+      mchunkptr top;
+
+      /* The remainder from the most recent split of a small request */
+      mchunkptr last_remainder;
+
+      /* Normal bins packed as described above */
+      mchunkptr bins[NBINS * 2 - 2];
+
+      /* Bitmap of bins */
+      unsigned int binmap[BINMAPSIZE];
+
+      /* Linked list */
+      struct malloc_state *next;
+
+      /* Linked list for free arenas.  Access to this field is serialized
+         by free_list_lock in arena.c.  */
+      struct malloc_state *next_free;
+
+      /* Number of threads attached to this arena.  0 if the arena is on
+         the free list.  Access to this field is serialized by
+         free_list_lock in arena.c.  */
+      INTERNAL_SIZE_T attached_threads;
+
+      /* Memory allocated from the system in this arena.  */
+      INTERNAL_SIZE_T system_mem;
+      INTERNAL_SIZE_T max_system_mem;
+    };
+    """
+
+    _fields_ = [
+        ("mutex", ctypes.c_int32),
+        ("flags", ctypes.c_int32),
+        ("top", c_pvoid),
+        ("last_remainder", c_pvoid),
+        ("bins", c_pvoid * (NBINS * 2 - 2)),
+        ("binmap", ctypes.c_int32 * BINMAPSIZE),
+        ("next", c_pvoid),
+        ("next_free", c_pvoid),
+        ("attached_threads", c_size_t),
+        ("system_mem", c_size_t),
+        ("max_system_mem", c_size_t),
+    ]
+
+
 class MallocState(CStruct2GDB):
     """
     This class represents malloc_state struct with interface compatible with `pwndbg.dbg_mod.Value`.
     """
 
-    if GLIBC_VERSION >= (2, 27):
+    glibc_version = pwndbg.glibc.get_version()
+
+    if glibc_version >= (2, 43):
+        _c_struct = c_malloc_state_2_43
+    if glibc_version >= (2, 27):
         _c_struct = c_malloc_state_2_27
-    elif GLIBC_VERSION >= (2, 23):
+    elif glibc_version >= (2, 23):
         _c_struct = c_malloc_state_2_26
     else:
         _c_struct = c_malloc_state_2_12
@@ -1021,12 +1087,91 @@ class c_malloc_par_2_42(Structure):
     ]
 
 
+class c_malloc_par_2_43(Structure):
+    """
+    This class represents the malloc_par struct for GLIBC >= 2.43 as a ctypes struct.
+
+    https://elixir.bootlin.com/glibc/glibc-2.43/source/malloc/malloc.c#L1864 (doesn't exist yet)
+
+    struct malloc_par
+    {
+      /* Tunable parameters */
+      unsigned long trim_threshold;
+      INTERNAL_SIZE_T top_pad;
+      INTERNAL_SIZE_T mmap_threshold;
+      INTERNAL_SIZE_T arena_test;
+      INTERNAL_SIZE_T arena_max;
+
+      /* Transparent Large Page support.  */
+      enum malloc_thp_mode_t thp_mode;
+      INTERNAL_SIZE_T thp_pagesize;
+      /* A value different than 0 means to align mmap allocation to hp_pagesize
+         add hp_flags on flags.  */
+      INTERNAL_SIZE_T hp_pagesize;
+      int hp_flags;
+
+      /* Memory map support */
+      int n_mmaps;
+      int n_mmaps_max;
+      int max_n_mmaps;
+      /* the mmap_threshold is dynamic, until the user sets
+         it manually, at which point we need to disable any
+         dynamic behavior. */
+      int no_dyn_threshold;
+
+      /* Statistics */
+      INTERNAL_SIZE_T mmapped_mem;
+      INTERNAL_SIZE_T max_mmapped_mem;
+
+      /* First address handed out by MORECORE/sbrk.  */
+      char *sbrk_base;
+
+    #if USE_TCACHE
+      /* Maximum number of small buckets to use.  */
+      size_t tcache_small_bins;
+      size_t tcache_max_bytes;
+      /* Maximum number of chunks in each bucket.  */
+      size_t tcache_count;
+      /* Maximum number of chunks to remove from the unsorted list, which
+         aren't used to prefill the cache.  */
+      size_t tcache_unsorted_limit;
+    #endif
+    };
+
+    """
+
+    _fields_ = [
+        ("trim_threshold", c_size_t),
+        ("top_pad", c_size_t),
+        ("mmap_threshold", c_size_t),
+        ("arena_test", c_size_t),
+        ("arena_max", c_size_t),
+        ("thp_mode", ctypes.c_int32),
+        ("thp_pagesize", c_size_t),
+        ("hp_pagesize", c_size_t),
+        ("hp_flags", ctypes.c_int32),
+        ("n_mmaps", ctypes.c_int32),
+        ("n_mmaps_max", ctypes.c_int32),
+        ("max_n_mmaps", ctypes.c_int32),
+        ("no_dyn_threshold", ctypes.c_int32),
+        ("mmapped_mem", c_size_t),
+        ("max_mmapped_mem", c_size_t),
+        ("sbrk_base", c_pvoid),
+        ("tcache_small_bins", c_size_t),
+        ("tcache_max_bytes", c_size_t),
+        ("tcache_count", c_size_t),
+        ("tcache_unsorted_limit", c_size_t),
+    ]
+
+
 class MallocPar(CStruct2GDB):
     """
     This class represents the malloc_par struct with interface compatible with `pwndbg.dbg_mod.Value`.
     """
 
-    if GLIBC_VERSION >= (2, 42):
+    if GLIBC_VERSION >= (2, 43):
+        _c_struct = c_malloc_par_2_43
+    elif GLIBC_VERSION >= (2, 42):
         _c_struct = c_malloc_par_2_42
     elif GLIBC_VERSION >= (2, 35):
         _c_struct = c_malloc_par_2_35

--- a/pwndbg/aglib/heap/structs.py
+++ b/pwndbg/aglib/heap/structs.py
@@ -47,7 +47,7 @@ BINMAPSIZE = 4
 TCACHE_SMALL_BINS = 64
 TCACHE_LARGE_BINS = 12
 TCACHE_MAX_BINS = TCACHE_SMALL_BINS + TCACHE_LARGE_BINS
-NFASTBINS = fastbin_index(request2size(MAX_FAST_SIZE)) + 1
+NFASTBINS = 0 if GLIBC_VERSION >= (2, 43) else fastbin_index(request2size(MAX_FAST_SIZE)) + 1
 
 if pwndbg.aglib.arch.ptrsize == 4:
     PTR = ctypes.c_uint32
@@ -61,7 +61,7 @@ DEFAULT_MMAP_MAX = 65536
 DEFAULT_MMAP_THRESHOLD = 128 * 1024
 DEFAULT_TRIM_THRESHOLD = 128 * 1024
 DEFAULT_PAGE_SIZE = 4096
-TCACHE_FILL_COUNT = 7
+TCACHE_FILL_COUNT = 16 if GLIBC_VERSION >= (2, 43) else 7
 MAX_TCACHE_SMALL_SIZE = (TCACHE_SMALL_BINS - 1) * MALLOC_ALIGN + MINSIZE - SIZE_SZ
 
 
@@ -511,7 +511,7 @@ class MallocState(CStruct2GDB):
 
     if glibc_version >= (2, 43):
         _c_struct = c_malloc_state_2_43
-    if glibc_version >= (2, 27):
+    elif glibc_version >= (2, 27):
         _c_struct = c_malloc_state_2_27
     elif glibc_version >= (2, 23):
         _c_struct = c_malloc_state_2_26


### PR DESCRIPTION
<!--
    Please make sure to read the linting and testing instructions at
    https://pwndbg.re/dev/contributing/ before creating a PR.
-->

+ [x] I read the contributing documentation.
+ [x] I am providing a screenshot of the (new feature) / (fixed bug).

<img width="875" height="904" alt="image" src="https://github.com/user-attachments/assets/78061104-6722-47ce-9399-6b878f203cbb" />
<img width="932" height="941" alt="image" src="https://github.com/user-attachments/assets/6ce8a0ea-9ac1-43bb-9639-f21d1f845636" />

**issues / questions:**
- debug syms heap is slow (compared to heuristics heap)
- the "fastbins were removed in 2.43" logging is probably done in the wrong place? (e.g it shouldn't be shown when you run `bins`)
- how to properly add tests? i doubt that copying over the glibc i compiled from master is really what we want here 
- ~~empty tcache (no entries at all) looks very ???~~ missing handling for `__tcache_dummy`
<img width="209" height="571" alt="image" src="https://github.com/user-attachments/assets/19ec3caa-c5a8-4279-b063-c5dd881c9a8b" />

**how to test (manually):**
- clone upstream glibc
- change version in `version.h` to `2.43` (otherwise debug syms heap is kinda broken)
- build/compile it, install it into `$DIR`
- `export LD_LIBRARY_PATH="$DIR/lib"`
- start testing
