### PR TITLE
Pull out custom lint to seperate file

### DIFF
--- a/lint.sh
+++ b/lint.sh
@@ -50,6 +50,15 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+print_info() {
+    set +o xtrace
+    local MSG=$1
+    echo ""
+    echo "[info] ${MSG}"
+    echo ""
+    set -o xtrace
+}
+
 set -o xtrace
 
 LINT_FILES="pwndbg pwndbginit tests *.py scripts"
@@ -60,12 +69,15 @@ call_shfmt() {
         local SHFMT_FILES=$(find . -name "*.sh" -not -path "./.venv/*")
         # Indents are four spaces, binary ops can start a line, indent switch cases,
         # and allow spaces following a redirect
+        print_info "Running shfmt on .sh files..."
         $UV_RUN_LINT shfmt ${FLAGS} -i 4 -bn -ci -sr -d ${SHFMT_FILES}
     else
         echo "shfmt not installed, please install it"
         exit 2
     fi
 }
+
+print_info "Running ruff on python files..."
 
 if [[ $FIX_ONLY == 1 ]]; then
     $UV_RUN_LINT ruff format ${LINT_FILES}
@@ -95,16 +107,7 @@ else
         exit 1
     fi
 
-    if ! call_shfmt; then
-        set +o xtrace
-        echo ""
-        echo "========================================="
-        echo "ERROR: Formatting issues detected by shfmt."
-        echo "       Exiting early. All checks were NOT run."
-        echo "       Use -f to fix issues automatically."
-        echo "========================================="
-        exit 1
-    fi
+    call_shfmt
 
     if [[ -z "$GITHUB_ACTIONS" ]]; then
         RUFF_OUTPUT_FORMAT=full
@@ -116,12 +119,20 @@ else
 fi
 
 # Checking minimum python version
+print_info "Using vermin to check that the code is compatible with the lowest supported python version..."
 $UV_RUN_LINT vermin -vvv --no-tips -t=3.10- --eval-annotations --violations ${LINT_FILES}
 
 # Check our custom rules.
+print_info "Checking custom Pwndbg lint rules..."
 $UV_RUN_LINT scripts/custom-lint.py
 
 # mypy is run in a separate step on GitHub Actions
 if [[ -z "$GITHUB_ACTIONS" ]]; then
+    print_info "Running mypy to check for type errors in python files..."
     $UV_RUN_MYPY mypy $LINT_FILES
 fi
+
+set +o xtrace
+echo ""
+echo "[success] Lint passed!"
+set -o xtrace

--- a/lint.sh
+++ b/lint.sh
@@ -107,7 +107,16 @@ else
         exit 1
     fi
 
-    call_shfmt
+    if ! call_shfmt; then
+        set +o xtrace
+        echo ""
+        echo "========================================="
+        echo "ERROR: Formatting issues detected by shfmt."
+        echo "       Exiting early. All checks were NOT run."
+        echo "       Use -f to fix issues automatically."
+        echo "========================================="
+        exit 1
+    fi
 
     if [[ -z "$GITHUB_ACTIONS" ]]; then
         RUFF_OUTPUT_FORMAT=full

--- a/lint.sh
+++ b/lint.sh
@@ -83,7 +83,6 @@ elif [[ $FIX_AND_CHECK == 1 ]]; then
     $UV_RUN_LINT ruff format ${LINT_FILES}
     $UV_RUN_LINT ruff check --fix --output-format=full ${LINT_FILES}
     call_shfmt -w
-    $UV_RUN_LINT vermin -vvv --no-tips -t=3.10- --eval-annotations --violations ${LINT_FILES}
 else
     if ! $UV_RUN_LINT ruff format --check --diff ${LINT_FILES}; then
         set +o xtrace
@@ -114,17 +113,13 @@ else
     fi
 
     $UV_RUN_LINT ruff check --output-format="${RUFF_OUTPUT_FORMAT}" ${LINT_FILES}
-    # Checking minimum python version
-    $UV_RUN_LINT vermin -vvv --no-tips -t=3.10- --eval-annotations --violations ${LINT_FILES}
 fi
 
-# Check that pwndbg/lib does not import from pwndbg.aglib
-echo "Checking for aglib usage in pwndbg/lib..."
-if grep -rE "(import .*\.aglib|from .*\.aglib)" pwndbg/lib/; then
-    echo "Error: pwndbg/lib must not import from pwndbg.aglib"
-    echo "The 'lib' module is a low-level library and cannot depend on 'aglib'"
-    exit 1
-fi
+# Checking minimum python version
+$UV_RUN_LINT vermin -vvv --no-tips -t=3.10- --eval-annotations --violations ${LINT_FILES}
+
+# Check our custom rules.
+$UV_RUN_LINT scripts/custom-lint.py
 
 # mypy is run in a separate step on GitHub Actions
 if [[ -z "$GITHUB_ACTIONS" ]]; then

--- a/pwndbg/commands/tips.py
+++ b/pwndbg/commands/tips.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 
+import pwndbg
 import pwndbg.commands
 from pwndbg.commands import CommandCategory
 from pwndbg.lib.tips import color_tip
@@ -15,7 +16,7 @@ parser.add_argument("-a", "--all", action="store_true", help="Show all tips.")
 @pwndbg.commands.Command(parser, category=CommandCategory.MISC)
 def tips(all: bool) -> None:
     if all:
-        for tip in get_all_tips():
+        for tip in get_all_tips(pwndbg.dbg.name().value):
             print(color_tip(tip))
     else:
-        print(color_tip(get_tip_of_the_day()))
+        print(color_tip(get_tip_of_the_day(pwndbg.dbg.name().value)))

--- a/pwndbg/dbg_mod/lldb/repl/__init__.py
+++ b/pwndbg/dbg_mod/lldb/repl/__init__.py
@@ -59,6 +59,7 @@ import lldb
 from typing_extensions import override
 
 import pwndbg
+import pwndbg.dbg_mod
 from pwndbg.color import message
 from pwndbg.dbg_mod import EventType
 from pwndbg.dbg_mod.lldb import LLDB
@@ -236,7 +237,7 @@ def show_greeting() -> None:
         print(message.prompt("pwndbg: ") + message.system(line))
 
     if show_tip:
-        colored_tip = color_tip(get_tip_of_the_day())
+        colored_tip = color_tip(get_tip_of_the_day(pwndbg.dbg_mod.DebuggerType.LLDB.value))
         print(
             message.prompt("------- tip of the day (some of these don't work in LLDB yet!)")
             + message.system(" (disable with %s)" % message.notice("set show-tips off"))

--- a/pwndbg/gdblib/prompt.py
+++ b/pwndbg/gdblib/prompt.py
@@ -10,6 +10,7 @@ import pwndbg
 import pwndbg.aglib.proc
 import pwndbg.commands
 import pwndbg.commands.context
+import pwndbg.dbg_mod
 import pwndbg.decorators
 import pwndbg.gdblib.events
 import pwndbg.gdblib.functions
@@ -30,7 +31,7 @@ cur: Tuple[gdb.Inferior, gdb.InferiorThread] | None = None
 
 def initial_hook(*a: Any) -> None:
     if show_tip and not pwndbg.decorators.first_prompt:
-        colored_tip = color_tip(get_tip_of_the_day())
+        colored_tip = color_tip(get_tip_of_the_day(pwndbg.dbg_mod.DebuggerType.GDB.value))
         print(
             message.prompt("------- tip of the day")
             + message.system(" (disable with %s)" % message.notice("set show-tips off"))

--- a/pwndbg/lib/tips.py
+++ b/pwndbg/lib/tips.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+from enum import Enum
 from random import choice
 from typing import List
 
@@ -80,25 +81,37 @@ LLDB_TIPS: List[str] = [
 ]
 
 
-def get_tip_of_the_day() -> str:
+def get_tip_of_the_day(debugger_type: int) -> str:
     """
     Returns a random tip based on the current debugger type.
+
+    You should pass in pwndbg.dbg.name().value .
     """
-    return choice(get_all_tips())
+    return choice(get_all_tips(debugger_type))
 
 
-def get_all_tips() -> List[str]:
+def get_all_tips(debugger_type: int) -> List[str]:
     """
     Returns all tips applicable to the current debugger.
-    """
-    import pwndbg.dbg_mod
 
-    if pwndbg.dbg.name() == pwndbg.dbg_mod.DebuggerType.GDB:
-        return GDB_TIPS + PWNDBG_TIPS
-    elif pwndbg.dbg.name() == pwndbg.dbg_mod.DebuggerType.LLDB:
-        return LLDB_TIPS + PWNDBG_TIPS
-    else:
-        return PWNDBG_TIPS
+    You should pass in pwndbg.dbg.name().value .
+    """
+
+    # Needs to mirror pwndbg/dbg_mod/__init__.py:DebuggerType
+    class DebuggerType(Enum):
+        GDB = 1
+        LLDB = 2
+
+    valid_values = [e.value for e in DebuggerType]
+    assert debugger_type in valid_values
+
+    match debugger_type:
+        case DebuggerType.GDB.value:
+            return GDB_TIPS + PWNDBG_TIPS
+        case DebuggerType.LLDB.value:
+            return LLDB_TIPS + PWNDBG_TIPS
+        case _:
+            return PWNDBG_TIPS
 
 
 def color_tip(tip: str) -> str:

--- a/scripts/_docs/extract_function_docs.py
+++ b/scripts/_docs/extract_function_docs.py
@@ -62,12 +62,12 @@ def extract_functions() -> Sequence[ConvFunction]:
     Returns a dictionary that mapes function names to
     the corresponding _GdbFunction objects.
     """
+    # https://github.com/astral-sh/ruff/issues/22467
+    global pwndbg
     if pwndbg.dbg.is_gdblib_available():
-        # Since mypy and ruff both complain about this, maybe I just don't understand
-        # something?
-        # https://github.com/astral-sh/ruff/issues/22467
-        # import pwndbg.gdblib.functions
-        functions = pwndbg.gdblib.functions.functions  # type: ignore[attr-defined]
+        import pwndbg.gdblib.functions
+
+        functions = pwndbg.gdblib.functions.functions
     else:
         functions = []
 

--- a/scripts/custom-lint.py
+++ b/scripts/custom-lint.py
@@ -28,7 +28,7 @@ def check_forbiden_in_lines(
     """
     Check if any of the files specified in `files` match any of the regex's
     specified in `forbidden`. If so, print the offending line, the `err_msg`,
-    and exit 1.
+    and set LINT_FAILED=True.
 
     `exceptions` is a dictionary from file to a list of lines which are hardcoded
     to be fine. The line *content* is specified, and matched for exactly.

--- a/scripts/custom-lint.py
+++ b/scripts/custom-lint.py
@@ -83,8 +83,6 @@ def lib_is_pure() -> None:
 
 
 def main() -> None:
-    print("Checking Pwndbg custom lint rules...")
-
     lib_is_pure()
 
     if LINT_FAILED:

--- a/scripts/custom-lint.py
+++ b/scripts/custom-lint.py
@@ -47,10 +47,10 @@ def check_forbiden_in_lines(
             for bad in forbidden:
                 if re.search(bad, line) is not None:
                     # Lint failed.
-                    print("[!] Rule violation [!]")
+                    print("\n[!] Rule violation [!]")
                     print(f"Rule: {err_msg}")
                     print(f"But matched regex `{bad}` in {file}:{line_idx} :")
-                    print(f"=============\n{line}\n=============")
+                    print(f"=============\n{line}\n=============\n")
                     LINT_FAILED = True
 
 
@@ -83,7 +83,7 @@ def lib_is_pure() -> None:
     check_forbiden_in_lines(
         pwndbg_lib_py_files,
         forbidden,
-        "You may not reference debugger-related logic in pwndbg/lib/ files!\n"
+        "[lib_is_pure] You may not reference debugger-related logic in pwndbg/lib/ files!\n"
         "See: https://pwndbg.re/dev/contributing/common-pitfalls/#pwndbglib-files-should-only-access-pwndbglib .",
         exceptions,
     )
@@ -94,6 +94,10 @@ def main() -> None:
 
     if LINT_FAILED:
         print(red("Fatal: Custom lint check failed. See the violations above^."))
+        print(
+            "If you think the check is erroneous (e.g. we matched on a comment), feel free to fix"
+        )
+        print("it or add an exception (scripts/custom-lint.py).")
         sys.exit(1)
     else:
         print("Passed!")

--- a/scripts/custom-lint.py
+++ b/scripts/custom-lint.py
@@ -59,7 +59,14 @@ def lib_is_pure() -> None:
     Checks that pwndbg/lib/ does not contain any references
     to pwndbg.aglib, pwndbg.dbg and pwndbg.dbg_mod .
     """
-    forbidden: list[str] = ["pwndbg\\.aglib", "pwndbg\\.dbg", "pwndbg\\.dbg_mod"]
+    forbidden: list[str] = [
+        "pwndbg\\.aglib",
+        "pwndbg\\.dbg",
+        "pwndbg\\.dbg_mod",
+        "from pwndbg import aglib",
+        # import pwndbg.anything is bad, except import pwndbg.lib and pwndbg.color
+        r"import\s+pwndbg\.(?!lib)(?!color)",
+    ]
     exceptions: dict[Path, list[str]] = {
         (PWNDBG_ROOT / "pwndbg/lib/tips.py"): [
             # It's just a tip, not actual code, so it's fine.

--- a/scripts/custom-lint.py
+++ b/scripts/custom-lint.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+"""
+Check for custom Pwndbg lint rules on the codebase.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+PWNDBG_ROOT: Path = Path(__file__).parent.parent
+pwndbg_lib_py_files: list[Path] = list((PWNDBG_ROOT / "pwndbg/lib/").rglob("*.py"))
+
+RED = "\x1b[31m"
+NORMAL = "\x1b[0m"
+
+LINT_FAILED: bool = False
+
+
+def red(x: str) -> str:
+    return RED + x.replace(NORMAL, NORMAL + RED) + NORMAL
+
+
+def check_forbiden_in_lines(
+    files: list[Path], forbidden: list[str], err_msg: str, exceptions: dict[Path, list[str]]
+) -> None:
+    """
+    Check if any of the files specified in `files` match any of the regex's
+    specified in `forbidden`. If so, print the offending line, the `err_msg`,
+    and exit 1.
+
+    `exceptions` is a dictionary from file to a list of lines which are hardcoded
+    to be fine. The line *content* is specified, and matched for exactly.
+    """
+    global LINT_FAILED
+
+    for file in files:
+        lines = file.read_text().splitlines()
+        line_idx = 0
+        for line in lines:
+            line_idx += 1
+            if line in exceptions.get(file, []):
+                print(f"skipping {file}:{line_idx}..")
+                continue
+
+            for bad in forbidden:
+                if re.search(bad, line) is not None:
+                    # Lint failed.
+                    print("[!] Rule violation [!]")
+                    print(f"Rule: {err_msg}")
+                    print(f"But matched regex `{bad}` in {file}:{line_idx} :")
+                    print(f"=============\n{line}\n=============")
+                    LINT_FAILED = True
+
+
+def lib_is_pure() -> None:
+    """
+    Checks that pwndbg/lib/ does not contain any references
+    to pwndbg.aglib, pwndbg.dbg and pwndbg.dbg_mod .
+    """
+    forbidden: list[str] = ["pwndbg\\.aglib", "pwndbg\\.dbg", "pwndbg\\.dbg_mod"]
+    exceptions: dict[Path, list[str]] = {
+        (PWNDBG_ROOT / "pwndbg/lib/tips.py"): [
+            # It's just a tip, not actual code, so it's fine.
+            '    "Use GDB\'s `pi` command to run an interactive Python console where you can use Pwndbg APIs like `pwndbg.aglib.memory.read(addr, len)`, `pwndbg.aglib.memory.write(addr, data)`, `pwndbg.aglib.vmmap.get()` and so on!",',
+            # It's a comment.
+            "    You should pass in pwndbg.dbg.name().value .",
+        ],
+        (PWNDBG_ROOT / "pwndbg/lib/cache.py"): [
+            # It's a comment.
+            "    Not necessarily 1:1 with pwndbg.dbg_mod.EventTypes , but"
+        ],
+    }
+
+    check_forbiden_in_lines(
+        pwndbg_lib_py_files,
+        forbidden,
+        "You may not reference debugger-related logic in pwndbg/lib/ files!\n"
+        "See: https://pwndbg.re/dev/contributing/common-pitfalls/#pwndbglib-files-should-only-access-pwndbglib .",
+        exceptions,
+    )
+
+
+def main() -> None:
+    print("Checking Pwndbg custom lint rules...")
+
+    lib_is_pure()
+
+    if LINT_FAILED:
+        print(red("Fatal: Custom lint check failed. See the violations above^."))
+        sys.exit(1)
+    else:
+        print("Passed!")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
+ Also refactored tips.py so it doesn't touch pwndbg.dbg.
+ Also cleaned up the lint script to be a bit more user friendly.

Here is sample new output:
```
Minimum required versions: 3.10
Incompatible versions:     2.x
+ print_info 'Checking custom Pwndbg lint rules...'
+ set +o xtrace

[info] Checking custom Pwndbg lint rules...

+ /home/user/pwndbg/.venv/bin/uv run --group lint scripts/custom-lint.py
[!] Rule violation [!]
Rule: You may not reference debugger-related logic in pwndbg/lib/ files!
See: https://pwndbg.re/dev/contributing/common-pitfalls/#pwndbglib-files-should-only-access-pwndbglib .
But matched regex `pwndbg\.aglib` in /home/user/pwndbg/pwndbg/lib/abi.py:7 :
=============
pwndbg.aglib = "fake error for PR"
=============
skipping /home/user/pwndbg/pwndbg/lib/tips.py:15..
skipping /home/user/pwndbg/pwndbg/lib/tips.py:88..
skipping /home/user/pwndbg/pwndbg/lib/tips.py:97..
skipping /home/user/pwndbg/pwndbg/lib/cache.py:101..
Fatal: Custom lint check failed. See the violations above^.
```