### PR TITLE
Add count parameter to dps/dds/dqs/kd commands

### DIFF
--- a/pwndbg/commands/windbg.py
+++ b/pwndbg/commands/windbg.py
@@ -307,17 +307,24 @@ def eX(size, address, data, hex=True) -> None:
 
 parser = argparse.ArgumentParser(description="Dump pointers and symbols at the specified address.")
 parser.add_argument("addr", type=pwndbg.commands.HexOrAddressExpr, help="The address to dump from.")
+parser.add_argument(
+    "count",
+    type=int,
+    default=8,
+    nargs="?",
+    help="The number of pointers to dump (default 8).",
+)
 
 
 @pwndbg.commands.Command(
     parser, aliases=["kd", "dps", "dqs"], category=CommandCategory.WINDBG
 )  # TODO are these really all the same? They had identical implementation...
 @pwndbg.commands.OnlyWhenRunning
-def dds(addr):
+def dds(addr, count=8):
     """
     Dump pointers and symbols at the specified address.
     """
-    return pwndbg.commands.telescope.telescope(addr)
+    return pwndbg.commands.telescope.telescope(addr, count)
 
 
 da_parser = argparse.ArgumentParser(description="Dump a string at the specified address.")


### PR DESCRIPTION
## Summary

- Adds an optional `count` parameter to the `dps` command (and its aliases `dds`, `dqs`, `kd`) to specify the number of pointers to dump
- The parameter defaults to 8 (consistent with the default telescope lines)
- Follows the same pattern used by other WinDbg-style commands in the codebase

Fixes #2965

## Test plan

- [ ] Run `dps $sp` - should display 8 pointers (default)
- [ ] Run `dps $sp 16` - should display 16 pointers
- [ ] Run `dps -h` - should show the new count parameter in help text
- [ ] Verify the aliases (`dds`, `dqs`, `kd`) work the same way

🤖 Generated with [Claude Code](https://claude.com/code)