### PR TITLE
Follow branches for Sparc

### DIFF
--- a/pwndbg/aglib/disasm/disassembly.py
+++ b/pwndbg/aglib/disasm/disassembly.py
@@ -20,6 +20,7 @@ import pwndbg.aglib.disasm.loongarch64
 import pwndbg.aglib.disasm.mips
 import pwndbg.aglib.disasm.ppc
 import pwndbg.aglib.disasm.riscv
+import pwndbg.aglib.disasm.sparc
 import pwndbg.aglib.disasm.x86
 import pwndbg.aglib.memory
 import pwndbg.emu.emulator
@@ -61,6 +62,13 @@ Enabling this may make disassembly slower.
 # Any larger changes of the program counter will cause the cache to reset.
 
 next_addresses_cache: set[int] = set()
+
+# The disassembly system isn't able to remember that an instruction is a delay slot instruction when it is disassembled in isolation
+# from the branch is belongs to.
+# This cache is used to handle this. Each address points to the branch that created the delay slot.
+delay_slot_cache: collections.defaultdict[int, PwndbgInstruction | None] = collections.defaultdict(
+    lambda: None
+)
 
 
 # Register GDB event listeners for all stop events
@@ -344,6 +352,26 @@ def one_with_config():
     return None
 
 
+def set_visual_split(set_ins: PwndbgInstruction, check_ins: PwndbgInstruction, linear: bool):
+    """
+    Internal helper function to set the .split property for display purposes.
+
+    This should only be called when the callee knows that a split should be created.
+
+    set_ins is the instruction that we are modifying
+
+    checks_ins is the one used to check if a split is necessary.
+    The same as set_ins unless it's a delay slot.
+    """
+    if not linear and (
+        check_ins.next != check_ins.address + check_ins.size
+        or check_ins.force_unconditional_jump_target
+    ):
+        set_ins.split = SplitType.BRANCH_TAKEN
+    else:
+        set_ins.split = SplitType.BRANCH_NOT_TAKEN
+
+
 # Return (list of PwndbgInstructions, index in list where instruction.address = passed in address)
 def near(
     address,
@@ -476,11 +504,11 @@ def near(
         # 1. We know the instruction is "jump_like" - it mutates the PC. We don't necessarily know the target, but know it can have one.
         # 2. The instruction has an explicitly resolved target which is not the next instruction in memory
         # 3. The instruction repeats (like x86 `REP`)
+        split_insn = insn
         if insn.jump_like or insn.has_jump_target or insn.next == insn.address:
-            split_insn = insn
-
-            # If this instruction has a delay slot, disassemble the delay slot instruction
-            # And append it to the list
+            # This branch handles delay slots. Delay slots have an interesting quirk in debuggers:
+            # sometimes the debugger can pause in the delay slot, and sometimes the debugger will
+            # automatically step over it.
             if insn.causes_branch_delay:
                 # Delay slots are instructions after branches that always execute.
                 # Unicorn cannot be paused in a delay slot instruction.
@@ -493,6 +521,10 @@ def near(
                 # There might not be a valid instruction at the branch delay slot
                 if split_insn is None:
                     break
+
+                next_addresses_cache.add(split_insn.address)
+
+                delay_slot_cache[split_insn.address] = insn
 
                 insns.append(split_insn)
 
@@ -510,14 +542,21 @@ def near(
                 ):
                     target = insn.target
 
-            if not linear and (
-                insn.next != insn.address + insn.size or insn.force_unconditional_jump_target
-            ):
-                split_insn.split = SplitType.BRANCH_TAKEN
-            else:
-                split_insn.split = SplitType.BRANCH_NOT_TAKEN
+            set_visual_split(split_insn, insn, linear)
 
-        # Address to disassemble & emulate
+        # Handle edge case where debugger is paused on the delay slot instruction
+        # Force the disassembly flow to follow the direction of the branch
+        if (cached_ins := delay_slot_cache[insn.address]) is not None:
+            if not cached_ins.call_like and (
+                cached_ins.is_unconditional_jump or cached_ins.is_conditional_jump_taken
+            ):
+                insn.next = cached_ins.next
+
+                # if not cached_ins.call_like:
+                target = insn.next
+
+            set_visual_split(insn, cached_ins, linear)
+
         next_addresses_cache.add(target)
 
         # The emulator is stepped within this call
@@ -553,6 +592,7 @@ ALL_DISASSEMBLY_ASSISTANTS: dict[
         "loongarch64"
     ),
     "powerpc": lambda: pwndbg.aglib.disasm.ppc.PowerPCDisassemblyAssistant("powerpc"),
+    "sparc": lambda: pwndbg.aglib.disasm.sparc.SparcDisassemblyAssistant("sparc"),
 }
 
 

--- a/pwndbg/aglib/disasm/disassembly.py
+++ b/pwndbg/aglib/disasm/disassembly.py
@@ -360,7 +360,7 @@ def set_visual_split(set_ins: PwndbgInstruction, check_ins: PwndbgInstruction, l
 
     set_ins is the instruction that we are modifying
 
-    checks_ins is the one used to check if a split is necessary.
+    checks_ins is the one used to check what type of split is necessary.
     The same as set_ins unless it's a delay slot.
     """
     if not linear and (
@@ -550,10 +550,7 @@ def near(
             if not cached_ins.call_like and (
                 cached_ins.is_unconditional_jump or cached_ins.is_conditional_jump_taken
             ):
-                insn.next = cached_ins.next
-
-                # if not cached_ins.call_like:
-                target = insn.next
+                target = insn.next = cached_ins.next
 
             set_visual_split(insn, cached_ins, linear)
 

--- a/pwndbg/aglib/disasm/instruction.py
+++ b/pwndbg/aglib/disasm/instruction.py
@@ -42,6 +42,7 @@ from capstone.riscv import RISCV_INS_C_JALR
 from capstone.riscv import RISCV_INS_C_JR
 from capstone.riscv import RISCV_INS_JAL
 from capstone.riscv import RISCV_INS_JALR
+from capstone.sparc import SPARC_INS_ALIAS_BA
 from capstone.sparc import SPARC_INS_ALIAS_CALL
 from capstone.sparc import SPARC_INS_CALL
 from capstone.sparc import SPARC_INS_JMPL
@@ -75,7 +76,12 @@ UNCONDITIONAL_JUMP_INSTRUCTIONS: dict[int, set[int]] = {
         MIPS_INS_B,
         MIPS_INS_ALIAS_B,
     },
-    CS_ARCH_SPARC: {SPARC_INS_CALL, SPARC_INS_ALIAS_CALL, SPARC_INS_JMPL},
+    CS_ARCH_SPARC: {
+        SPARC_INS_CALL,
+        SPARC_INS_ALIAS_CALL,
+        SPARC_INS_JMPL,
+        SPARC_INS_ALIAS_BA,
+    },
     CS_ARCH_ARM: {
         ARM_INS_TBB,
         ARM_INS_TBH,
@@ -570,6 +576,9 @@ class PwndbgInstructionImpl(PwndbgInstruction):
         if hasattr(self.cs_insn, "cc"):
             info += f"\n\tARM condition code: {self.cs_insn.cc}"
             info += f"\n\tThumb mode: {1 if self.cs_insn._cs._mode & CS_MODE_THUMB else 0}"
+
+        if hasattr(self.cs_insn, "cc_field"):
+            info += f"\n\tSPARC cc_field: {self.cs_insn.cc_field}"
 
         return info
 

--- a/pwndbg/aglib/disasm/sparc.py
+++ b/pwndbg/aglib/disasm/sparc.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import override
 
 from capstone.sparc import *  # noqa: F403
+from typing_extensions import override
 
 import pwndbg.aglib.disasm.arch
 from pwndbg.aglib.disasm.instruction import ALL_JUMP_GROUPS

--- a/pwndbg/aglib/disasm/sparc.py
+++ b/pwndbg/aglib/disasm/sparc.py
@@ -1,6 +1,15 @@
 from __future__ import annotations
 
+from collections.abc import Callable
+from typing import override
+
 from capstone.sparc import *  # noqa: F403
+
+import pwndbg.aglib.disasm.arch
+from pwndbg.aglib.disasm.instruction import ALL_JUMP_GROUPS
+from pwndbg.aglib.disasm.instruction import InstructionCondition
+from pwndbg.aglib.disasm.instruction import PwndbgInstruction
+from pwndbg.emu.emulator import Emulator
 
 # Instruction groups for future use
 SPARC_LOAD_INSTRUCTIONS = {
@@ -18,3 +27,89 @@ SPARC_STORE_INSTRUCTIONS = {
     SPARC_INS_ST: 4,
     SPARC_INS_STD: 8,
 }
+
+SPARC_CONDITIONAL_BRANCHES = {
+    SPARC_INS_B,  # This is only conditional if .cc != SPARC_CC_ICC_A
+    SPARC_INS_ALIAS_BE,
+    SPARC_INS_ALIAS_BNE,
+    SPARC_INS_ALIAS_BNEG,
+    SPARC_INS_ALIAS_BPOS,
+    SPARC_INS_ALIAS_BVS,
+    SPARC_INS_ALIAS_BVC,
+    SPARC_INS_ALIAS_BCS,
+    SPARC_INS_ALIAS_BCC,
+    SPARC_INS_ALIAS_BL,
+    SPARC_INS_ALIAS_BLE,
+    SPARC_INS_ALIAS_BG,
+    SPARC_INS_ALIAS_BGE,
+    SPARC_INS_ALIAS_BLEU,
+    SPARC_INS_ALIAS_BGU,
+}
+
+# CCR BITS:
+# 0 = C (Carry)
+# 1 = V (Overflow)
+# 2 = Z (Zero)
+# 3 = N (Negative)
+CCR_C_MASK = 1 << 0
+CCR_V_MASK = 1 << 1
+CCR_Z_MASK = 1 << 2
+CCR_N_MASK = 1 << 3
+
+# Key is ICC code
+# lambda parameters: (current ccr value)
+# Source of conditions: https://arcb.csc.ncsu.edu/~mueller/codeopt/codeopt00/notes/condbranch.html
+ICC_CONDITION_RESOLVERS: dict[int, Callable[[int], bool]] = {
+    SPARC_CC_ICC_NE: lambda ccr: not (ccr & CCR_Z_MASK),
+    SPARC_CC_ICC_E: lambda ccr: bool(ccr & CCR_Z_MASK),
+    SPARC_CC_ICC_G: lambda ccr: not ((ccr & CCR_N_MASK) ^ (ccr & CCR_V_MASK))
+    and not (ccr & CCR_Z_MASK),
+    SPARC_CC_ICC_LE: lambda ccr: bool((ccr & CCR_N_MASK) ^ (ccr & CCR_V_MASK))
+    or bool(ccr & CCR_Z_MASK),
+    SPARC_CC_ICC_GE: lambda ccr: not ((ccr & CCR_N_MASK) ^ (ccr & CCR_V_MASK)),
+    SPARC_CC_ICC_L: lambda ccr: bool((ccr & CCR_N_MASK) ^ (ccr & CCR_V_MASK)),
+    SPARC_CC_ICC_GU: lambda ccr: not (ccr & CCR_Z_MASK) and not (ccr & CCR_C_MASK),
+    SPARC_CC_ICC_LEU: lambda ccr: bool(ccr & CCR_Z_MASK) or bool(ccr & CCR_C_MASK),
+    SPARC_CC_ICC_CC: lambda ccr: not (ccr & CCR_C_MASK),
+    SPARC_CC_ICC_CS: lambda ccr: bool(ccr & CCR_C_MASK),
+    SPARC_CC_ICC_POS: lambda ccr: not (ccr & CCR_N_MASK),
+    SPARC_CC_ICC_NEG: lambda ccr: bool(ccr & CCR_N_MASK),
+    SPARC_CC_ICC_VC: lambda ccr: not (ccr & CCR_V_MASK),
+    SPARC_CC_ICC_VS: lambda ccr: bool(ccr & CCR_V_MASK),
+}
+
+
+class SparcDisassemblyAssistant(pwndbg.aglib.disasm.arch.DisassemblyAssistant):
+    @override
+    def _condition(self, instruction: PwndbgInstruction, emu: Emulator) -> InstructionCondition:
+        if instruction.id in SPARC_CONDITIONAL_BRANCHES:
+            cc_field = instruction.cs_insn.cc_field
+
+            if cc_field == SPARC_CC_FIELD_ICC:
+                cc = instruction.cs_insn.cc
+
+                # This indicates it is an unconditional branch
+                if cc == SPARC_CC_ICC_A:
+                    instruction.declare_is_unconditional_jump = True
+                    return InstructionCondition.UNDETERMINED
+
+                ccr = self._read_register_name(instruction, "ccr", emu)
+
+                if ccr is None:
+                    return InstructionCondition.UNDETERMINED
+
+                conditional = ICC_CONDITION_RESOLVERS.get(cc, lambda *a: None)(ccr)
+
+                if conditional is None:
+                    return InstructionCondition.UNDETERMINED
+
+                return InstructionCondition.TRUE if conditional else InstructionCondition.FALSE
+
+        return InstructionCondition.UNDETERMINED
+
+    @override
+    def _resolve_target(self, instruction: PwndbgInstruction, emu: Emulator | None):
+        if bool(instruction.groups & ALL_JUMP_GROUPS):
+            instruction.causes_branch_delay = True
+
+        return super()._resolve_target(instruction, emu)

--- a/pwndbg/emu/emulator.py
+++ b/pwndbg/emu/emulator.py
@@ -82,7 +82,7 @@ arch_to_UC: dict[PWNDBG_SUPPORTED_ARCHITECTURES_TYPE, int] = {
     "i386": U.UC_ARCH_X86,
     "x86-64": U.UC_ARCH_X86,
     "mips": U.UC_ARCH_MIPS,
-    "sparc": U.UC_ARCH_SPARC,
+    # "sparc": U.UC_ARCH_SPARC,
     "arm": U.UC_ARCH_ARM,
     "armcm": U.UC_ARCH_ARM,
     "aarch64": U.UC_ARCH_ARM64,
@@ -164,7 +164,11 @@ arch_to_reg_const_map: dict[PWNDBG_SUPPORTED_ARCHITECTURES_TYPE, dict[str, int]]
 }
 
 # Architectures for which we want to enable virtual TLB mode
-enable_virtual_tlb = {"s390x": True, "powerpc": True}
+enable_virtual_tlb: dict[PWNDBG_SUPPORTED_ARCHITECTURES_TYPE, bool] = {
+    "s390x": True,
+    "powerpc": True,
+    "sparc": True,
+}
 
 # combine the flags with | operator. -1 for all
 (
@@ -633,6 +637,8 @@ class Emulator:
             and "isa32r6" in gdb.newest_frame().architecture().name()
         ):
             mode |= U.UC_MODE_MIPS32R6
+        elif arch == "sparc":
+            mode |= {4: U.UC_MODE_SPARC32, 8: U.UC_MODE_SPARC64}[pwndbg.aglib.arch.ptrsize]
         elif arch == "s390x":
             pass  # fails with invalid mode error otherwise
         else:
@@ -648,6 +654,8 @@ class Emulator:
     def map_page(self, page) -> bool:
         page = pwndbg.lib.memory.page_align(page)
         size = pwndbg.lib.memory.PAGE_SIZE
+
+        # TODO: for Sparc, page size must be 0x2000
 
         debug(DEBUG_MEM_MAP, "# Mapping %#x-%#x", (page, page + size))
 


### PR DESCRIPTION
Enhances disassembly while debugging Sparc programs. There are now handlers that determine whether branches are taken or not, and the disassembly flow follows them accordingly. Previously, because we didn't determine branch outcomes, the disassembly jumped all over the place.

See this in action: https://asciinema.org/a/AaGBYGuQMIYzRK3f

An interesting quirk of delay slots that came up while debugging Sparc: GDB allows you to be paused within a delay slot instruction in Sparc. This is not the case for MIPS, where you cannot put a breakpoint and cannot be paused within a delay slot - single-stepping a branch with a delay slot will skip over it. With Sparc, you can be paused within the delay slot. The disassembly code had an implicit assumption that this was not possible, which had to be fixed.