### PR TITLE
Implementing `typeinfo_recovery` decorator and general refactoring

### DIFF
--- a/pwndbg/aglib/disasm/arch.py
+++ b/pwndbg/aglib/disasm/arch.py
@@ -594,11 +594,13 @@ class DisassemblyAssistant:
             )
 
     @staticmethod
-    def _syscall_name(number: int, arch: str) -> str | None:
+    def _syscall_name(number: int, arch: str | None = None) -> str | None:
         """
         Given a syscall number and architecture, returns the name of the syscall.
         E.g. execve == 59 on x86-64
         """
+        if arch is None:
+            arch = pwndbg.aglib.arch.name
         arch_module = {
             "arm": linux.arm,
             "armcm": linux.arm,

--- a/pwndbg/aglib/disasm/arch.py
+++ b/pwndbg/aglib/disasm/arch.py
@@ -588,13 +588,11 @@ class DisassemblyAssistant:
         )
 
     @staticmethod
-    def _syscall_name(number: int, arch: str | None = None) -> str | None:
+    def _syscall_name(number: int, arch: str) -> str | None:
         """
         Given a syscall number and architecture, returns the name of the syscall.
         E.g. execve == 59 on x86-64
         """
-        if arch is None:
-            arch = pwndbg.aglib.arch.name
         arch_module = {
             "arm": linux.arm,
             "armcm": linux.arm,

--- a/pwndbg/aglib/disasm/loongarch64.py
+++ b/pwndbg/aglib/disasm/loongarch64.py
@@ -21,10 +21,10 @@ CONDITION_RESOLVERS: dict[int, Callable[[list[int]], bool]] = {
     LOONGARCH_INS_BNEZ: lambda ops: ops[0] != 0,
     LOONGARCH_INS_BEQ: lambda ops: ops[0] == ops[1],
     LOONGARCH_INS_BNE: lambda ops: ops[0] != ops[1],
-    LOONGARCH_INS_BGE: lambda ops: bit_math.to_signed(ops[0], pwndbg.aglib.arch.ptrsize * 8)
-    >= bit_math.to_signed(ops[1], pwndbg.aglib.arch.ptrsize * 8),
-    LOONGARCH_INS_BLT: lambda ops: bit_math.to_signed(ops[0], pwndbg.aglib.arch.ptrsize * 8)
-    < bit_math.to_signed(ops[1], pwndbg.aglib.arch.ptrsize * 8),
+    LOONGARCH_INS_BGE: lambda ops: bit_math.to_signed(ops[0], pwndbg.aglib.arch.ptrbits)
+    >= bit_math.to_signed(ops[1], pwndbg.aglib.arch.ptrbits),
+    LOONGARCH_INS_BLT: lambda ops: bit_math.to_signed(ops[0], pwndbg.aglib.arch.ptrbits)
+    < bit_math.to_signed(ops[1], pwndbg.aglib.arch.ptrbits),
     LOONGARCH_INS_BLTU: lambda ops: ops[0] < ops[1],
     LOONGARCH_INS_BGEU: lambda ops: ops[0] >= ops[1],
 }

--- a/pwndbg/aglib/disasm/mips.py
+++ b/pwndbg/aglib/disasm/mips.py
@@ -88,12 +88,12 @@ CONDITION_RESOLVERS: dict[int, Callable[[list[int]], bool]] = {
     MIPS_INS_BNEZ: lambda ops: ops[0] != 0,
     MIPS_INS_BEQ: lambda ops: ops[0] == ops[1],
     MIPS_INS_BNE: lambda ops: ops[0] != ops[1],
-    MIPS_INS_BGEZ: lambda ops: bit_math.to_signed(ops[0], pwndbg.aglib.arch.ptrsize * 8) >= 0,
-    MIPS_INS_BGEZAL: lambda ops: bit_math.to_signed(ops[0], pwndbg.aglib.arch.ptrsize * 8) >= 0,
-    MIPS_INS_BGTZ: lambda ops: bit_math.to_signed(ops[0], pwndbg.aglib.arch.ptrsize * 8) > 0,
-    MIPS_INS_BLEZ: lambda ops: bit_math.to_signed(ops[0], pwndbg.aglib.arch.ptrsize * 8) <= 0,
-    MIPS_INS_BLTZAL: lambda ops: bit_math.to_signed(ops[0], pwndbg.aglib.arch.ptrsize * 8) < 0,
-    MIPS_INS_BLTZ: lambda ops: bit_math.to_signed(ops[0], pwndbg.aglib.arch.ptrsize * 8) < 0,
+    MIPS_INS_BGEZ: lambda ops: bit_math.to_signed(ops[0], pwndbg.aglib.arch.ptrbits) >= 0,
+    MIPS_INS_BGEZAL: lambda ops: bit_math.to_signed(ops[0], pwndbg.aglib.arch.ptrbits) >= 0,
+    MIPS_INS_BGTZ: lambda ops: bit_math.to_signed(ops[0], pwndbg.aglib.arch.ptrbits) > 0,
+    MIPS_INS_BLEZ: lambda ops: bit_math.to_signed(ops[0], pwndbg.aglib.arch.ptrbits) <= 0,
+    MIPS_INS_BLTZAL: lambda ops: bit_math.to_signed(ops[0], pwndbg.aglib.arch.ptrbits) < 0,
+    MIPS_INS_BLTZ: lambda ops: bit_math.to_signed(ops[0], pwndbg.aglib.arch.ptrbits) < 0,
 }
 
 CONDITION_RESOLVERS[MIPS_INS_ALIAS_BEQZ] = CONDITION_RESOLVERS[MIPS_INS_BEQZ]

--- a/pwndbg/aglib/disasm/riscv.py
+++ b/pwndbg/aglib/disasm/riscv.py
@@ -212,8 +212,8 @@ class RISCVDisassemblyAssistant(pwndbg.aglib.disasm.arch.DisassemblyAssistant):
         if src1_unsigned is None or src2_unsigned is None:
             return InstructionCondition.UNDETERMINED
 
-        src1_signed = bit_math.to_signed(src1_unsigned, pwndbg.aglib.arch.ptrsize * 8)
-        src2_signed = bit_math.to_signed(src2_unsigned, pwndbg.aglib.arch.ptrsize * 8)
+        src1_signed = bit_math.to_signed(src1_unsigned, pwndbg.aglib.arch.ptrbits)
+        src2_signed = bit_math.to_signed(src2_unsigned, pwndbg.aglib.arch.ptrbits)
 
         condition = {
             RISCV_INS_BEQ: src1_signed == src2_signed,

--- a/pwndbg/aglib/kernel/__init__.py
+++ b/pwndbg/aglib/kernel/__init__.py
@@ -305,11 +305,7 @@ def get_double_linked_list(head: int, minlen: int = 0x1, maxlen: int = 0x1000) -
 
 def in_kmem_cache(val: int, name: str, strict: bool = True) -> bool:
     # name is a substr of any of the target caches' names
-    cache = None
-    try:
-        cache = pwndbg.aglib.kernel.slab.find_containing_slab_cache(val)
-    except Exception:
-        pass
+    cache = pwndbg.aglib.kernel.slab.find_containing_slab_cache(val)
     if not cache:
         return False
     if strict:

--- a/pwndbg/aglib/kernel/__init__.py
+++ b/pwndbg/aglib/kernel/__init__.py
@@ -131,7 +131,7 @@ def typeinfo_recovery(
                 if "CONFIG_RANDSTRUCT" in pwndbg.aglib.kernel.kconfig():
                     print(
                         message.warn(
-                            "please note that some structs may not be recoverable when CONFIG_RANSTRUCT=y"
+                            "please note that some structs may not be recoverable when CONFIG_RANDSTRUCT=y"
                         )
                     )
                 return False

--- a/pwndbg/aglib/kernel/__init__.py
+++ b/pwndbg/aglib/kernel/__init__.py
@@ -19,6 +19,7 @@ import pwndbg.aglib.kernel.vmmap
 import pwndbg.aglib.memory
 import pwndbg.aglib.proc
 import pwndbg.aglib.symbol
+import pwndbg.aglib.typeinfo
 import pwndbg.color.message as message
 import pwndbg.dbg_mod
 import pwndbg.lib.cache
@@ -27,12 +28,19 @@ import pwndbg.lib.memory
 import pwndbg.search
 from pwndbg.aglib.kernel.paging import ArchPagingInfo
 from pwndbg.aglib.kernel.paging import PagewalkResult
+from pwndbg.lib.regs import BitFlags
 
 _kconfig: pwndbg.aglib.kernel.kconfig_mod.Kconfig | None = None
 
 P = ParamSpec("P")
 D = TypeVar("D")
 T = TypeVar("T")
+
+
+class TypeNotRecovered(Exception):
+    def __init__(self, name: str, msg: str) -> None:
+        self.name = name
+        super().__init__(msg)
 
 
 def BIT(shift: int):
@@ -101,24 +109,26 @@ def requires_debug_info(default: D = None) -> Callable[[Callable[P, T]], Callabl
 
 def typeinfo_recovery(
     name: str, requires_kversion: bool = False, requires_kbase: bool = False
-) -> Callable[[Callable[P, str]], Callable[P, bool]]:
-    def decorator(f: Callable[P, str]) -> Callable[P, bool]:
+) -> Callable[[Callable[P, str]], Callable[P, None]]:
+    def decorator(f: Callable[P, str]) -> Callable[P, None]:
         # returns true if the type exists or has been successfully recovered
         @functools.wraps(f)
-        def func(*args: P.args, **kwargs: P.kwargs) -> bool:
-            if has_debug_info():
-                return True
-            if not has_debug_symbols():
+        def func(*args: P.args, **kwargs: P.kwargs) -> None:
+            if not pwndbg.dbg.selected_inferior().is_linux():
                 # make sure the target is linux, should we specify symbols instead?
-                return False
+                raise TypeNotRecovered(name, "target is not linux")
+            if has_debug_info():
+                return
             if pwndbg.aglib.typeinfo.lookup_types(name) is not None:
-                return True
+                return
             if requires_kversion and kversion() is None:
-                print(message.warn(f"recovering {name} failed because kversion is unavailable"))
-                return False
+                raise TypeNotRecovered(
+                    name, message.warn(f"recovering {name} failed because kversion is unavailable")
+                )
             if requires_kbase and kbase() is None:
-                print(message.warn(f"recovering {name} failed because kbase is unavailable"))
-                return False
+                raise TypeNotRecovered(
+                    name, message.warn(f"recovering {name} failed because kbase is unavailable")
+                )
             # f(*args, **kwargs)
             try:
                 result = f(*args, **kwargs)
@@ -127,15 +137,8 @@ def typeinfo_recovery(
                 pwndbg.commands.cymbol.add_structure_from_header(header_file_path, fname, True)
                 os.unlink(header_file_path)
             except Exception as e:
-                print(message.warn(f"recovering {name} failed with error:\n{e}"))
-                if "CONFIG_RANDSTRUCT" in pwndbg.aglib.kernel.kconfig():
-                    print(
-                        message.warn(
-                            "please note that some structs may not be recoverable when CONFIG_RANDSTRUCT=y"
-                        )
-                    )
-                return False
-            return True
+                raise TypeNotRecovered(name, str(e))
+            return
 
         return func
 
@@ -201,7 +204,9 @@ def kconfig() -> pwndbg.aglib.kernel.kconfig_mod.Kconfig | None:
             config_start = result + len("IKCFG_ST")
             config_end = next(pwndbg.search.search(b"IKCFG_ED", start=config_start), None)
     if (
-        not pwndbg.aglib.memory.is_kernel(config_start)
+        not config_start
+        or not config_end
+        or not pwndbg.aglib.memory.is_kernel(config_start)
         or not pwndbg.aglib.memory.is_kernel(config_end)
         or config_start >= config_end
     ):
@@ -237,6 +242,8 @@ def kversion() -> str | None:
     if mapping is None:
         return None
     version_addr = next(pwndbg.search.search(b"Linux version", mappings=[mapping]), None)
+    if version_addr is None:
+        return None
     return pwndbg.aglib.memory.string(version_addr).decode("ascii").strip()
 
 
@@ -324,7 +331,9 @@ class ArchOps(ABC):
     # in the page_to_pfn() and pfn_to_page() methods in the future.
 
     @abstractmethod
-    def per_cpu(self, addr: int | pwndbg.dbg_mod.Value, cpu=None) -> pwndbg.dbg_mod.Value:
+    def per_cpu(
+        self, addr: int | pwndbg.dbg_mod.Value, cpu: int | None = None
+    ) -> pwndbg.dbg_mod.Value | None:
         raise NotImplementedError()
 
     @abstractmethod
@@ -658,9 +667,19 @@ def kbase() -> int | None:
 
 
 @pwndbg.lib.cache.cache_until("stop")
-def pagewalk(addr, entry: int = None, virt: bool = True) -> PagewalkResult:
-    # assumes entry is a valid physaddr (+ flags)
-    # the strategy is to walk any virtual pgd first
+def page_shift() -> int:
+    ops = arch_ops()
+    if ops:
+        return ops.page_shift
+    raise NotImplementedError()
+
+
+@pwndbg.lib.cache.cache_until("stop")
+def pagewalk(addr, entry: int | None = None, virt: bool = True) -> PagewalkResult:
+    """
+    assumes entry is a valid physaddr (+ flags)
+    the strategy is to walk any virtual pgd first
+    """
     pi = arch_paginginfo()
     if pi:
         return pi.pagewalk(addr, entry, virt)
@@ -672,6 +691,14 @@ def pagescan(entry=None) -> tuple[pwndbg.lib.memory.Page, ...]:
     pi = arch_paginginfo()
     if pi:
         return tuple(pi.pagescan(entry))
+    raise NotImplementedError()
+
+
+@pwndbg.lib.cache.cache_until("stop")
+def bitflags(level: pwndbg.aglib.kernel.paging.PageTableLevel) -> BitFlags:
+    pi = arch_paginginfo()
+    if pi:
+        return pi.bitflags(level)
     raise NotImplementedError()
 
 
@@ -698,7 +725,7 @@ def num_numa_nodes() -> int:
     """Returns the number of NUMA nodes that are online on the system"""
     kc = kconfig()
 
-    if "CONFIG_NUMA" not in kc:
+    if not kc or "CONFIG_NUMA" not in kc:
         return 1
 
     if "CONFIG_NODES_SHIFT" not in kc:

--- a/pwndbg/aglib/kernel/__init__.py
+++ b/pwndbg/aglib/kernel/__init__.py
@@ -100,7 +100,7 @@ def requires_debug_info(default: D = None) -> Callable[[Callable[P, T]], Callabl
 
 
 def typeinfo_recovery(
-    name: str, kversion: bool = False, kbase: bool = False
+    name: str, requires_kversion: bool = False, requires_kbase: bool = False
 ) -> Callable[[Callable[P, str]], Callable[P, bool]]:
     def decorator(f: Callable[P, str]) -> Callable[P, bool]:
         # returns true if the type exists or has been successfully recovered
@@ -113,10 +113,10 @@ def typeinfo_recovery(
                 return False
             if pwndbg.aglib.typeinfo.lookup_types(name) is not None:
                 return True
-            if kversion and pwndbg.aglib.kernel.kversion() is None:
+            if requires_kversion and kversion() is None:
                 print(message.warn(f"recovering {name} failed because kversion is unavailable"))
                 return False
-            if kbase and pwndbg.aglib.kernel.kbase() is None:
+            if requires_kbase and kbase() is None:
                 print(message.warn(f"recovering {name} failed because kbase is unavailable"))
                 return False
             # f(*args, **kwargs)
@@ -128,7 +128,7 @@ def typeinfo_recovery(
                 os.unlink(header_file_path)
             except Exception as e:
                 print(message.warn(f"recovering {name} failed with error:\n{e}"))
-                if "CONFIG_RANSTRUCT" in pwndbg.aglib.kernel.kconfig():
+                if "CONFIG_RANDSTRUCT" in pwndbg.aglib.kernel.kconfig():
                     print(
                         message.warn(
                             "please note that some structs may not be recoverable when CONFIG_RANSTRUCT=y"
@@ -303,14 +303,16 @@ def get_double_linked_list(head: int, minlen: int = 0x1, maxlen: int = 0x1000) -
 
 def in_kmem_cache(val: int, name: str, strict: bool = True) -> bool:
     # name is a substr of any of the target caches' names
+    cache = None
     try:
         cache = pwndbg.aglib.kernel.slab.find_containing_slab_cache(val)
-        if strict:
-            return name == cache.name
-        return name in cache.name
     except Exception:
         pass
-    return False
+    if not cache:
+        return False
+    if strict:
+        return name == cache.name
+    return name in cache.name
 
 
 class ArchOps(ABC):

--- a/pwndbg/aglib/kernel/__init__.py
+++ b/pwndbg/aglib/kernel/__init__.py
@@ -780,9 +780,3 @@ def current_task(cpu: int | None = None) -> int:
     if (syms := arch_symbols()) is not None:
         return syms.current_task(cpu)
     return None
-
-
-def init_task() -> pwndbg.dbg_mod.Value:
-    if (syms := arch_symbols()) is not None:
-        return syms.init_task()
-    return None

--- a/pwndbg/aglib/kernel/__init__.py
+++ b/pwndbg/aglib/kernel/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import functools
+import os
 import re
 from abc import ABC
 from abc import abstractmethod
@@ -124,6 +125,7 @@ def typeinfo_recovery(
                 header_file_path = pwndbg.commands.cymbol.create_temp_header_file(result)
                 fname = name.split()[-1] + "_structs"
                 pwndbg.commands.cymbol.add_structure_from_header(header_file_path, fname, True)
+                os.unlink(header_file_path)
             except Exception as e:
                 print(message.warn(f"recovering {name} failed with error:\n{e}"))
                 if "CONFIG_RANSTRUCT" in pwndbg.aglib.kernel.kconfig():
@@ -140,7 +142,7 @@ def typeinfo_recovery(
     return decorator
 
 
-@pwndbg.lib.cache.cache_until("stop")
+@pwndbg.lib.cache.cache_until("start")
 def nproc() -> int:
     """Returns the number of processing units available, similar to nproc(1)"""
     return len(pwndbg.dbg.selected_inferior().send_monitor("info cpus").splitlines())
@@ -289,6 +291,8 @@ def get_double_linked_list(head: int, minlen: int = 0x1, maxlen: int = 0x1000) -
         if nxt == result[0]:
             break
     if nxt != result[0]:
+        return None
+    if len(result) < minlen:
         return None
     for i, nxt in enumerate(result):
         p = pwndbg.aglib.memory.read_pointer_width(nxt + pwndbg.aglib.arch.ptrsize)

--- a/pwndbg/aglib/kernel/__init__.py
+++ b/pwndbg/aglib/kernel/__init__.py
@@ -20,7 +20,6 @@ import pwndbg.aglib.memory
 import pwndbg.aglib.proc
 import pwndbg.aglib.symbol
 import pwndbg.aglib.typeinfo
-import pwndbg.color.message as message
 import pwndbg.dbg_mod
 import pwndbg.lib.cache
 import pwndbg.lib.kernel.structs
@@ -122,13 +121,9 @@ def typeinfo_recovery(
             if pwndbg.aglib.typeinfo.lookup_types(name) is not None:
                 return
             if requires_kversion and kversion() is None:
-                raise TypeNotRecovered(
-                    name, message.warn(f"recovering {name} failed because kversion is unavailable")
-                )
+                raise TypeNotRecovered(name, "kernel version is unavailable")
             if requires_kbase and kbase() is None:
-                raise TypeNotRecovered(
-                    name, message.warn(f"recovering {name} failed because kbase is unavailable")
-                )
+                raise TypeNotRecovered(name, "kernel base not found")
             # f(*args, **kwargs)
             try:
                 result = f(*args, **kwargs)

--- a/pwndbg/aglib/kernel/__init__.py
+++ b/pwndbg/aglib/kernel/__init__.py
@@ -18,13 +18,14 @@ import pwndbg.aglib.kernel.vmmap
 import pwndbg.aglib.memory
 import pwndbg.aglib.proc
 import pwndbg.aglib.symbol
+import pwndbg.color.message as message
 import pwndbg.dbg_mod
 import pwndbg.lib.cache
 import pwndbg.lib.kernel.structs
 import pwndbg.lib.memory
 import pwndbg.search
 from pwndbg.aglib.kernel.paging import ArchPagingInfo
-from pwndbg.aglib.kernel.paging import PageTableLevel
+from pwndbg.aglib.kernel.paging import PagewalkResult
 
 _kconfig: pwndbg.aglib.kernel.kconfig_mod.Kconfig | None = None
 
@@ -97,11 +98,52 @@ def requires_debug_info(default: D = None) -> Callable[[Callable[P, T]], Callabl
     return decorator
 
 
-@requires_debug_symbols("nr_cpu_ids", default=1)
+def typeinfo_recovery(
+    name: str, kversion: bool = False, kbase: bool = False
+) -> Callable[[Callable[P, str]], Callable[P, bool]]:
+    def decorator(f: Callable[P, str]) -> Callable[P, bool]:
+        # returns true if the type exists or has been successfully recovered
+        @functools.wraps(f)
+        def func(*args: P.args, **kwargs: P.kwargs) -> bool:
+            if has_debug_info():
+                return True
+            if not has_debug_symbols():
+                # make sure the target is linux, should we specify symbols instead?
+                return False
+            if pwndbg.aglib.typeinfo.lookup_types(name) is not None:
+                return True
+            if kversion and pwndbg.aglib.kernel.kversion() is None:
+                print(message.warn(f"recovering {name} failed because kversion is unavailable"))
+                return False
+            if kbase and pwndbg.aglib.kernel.kbase() is None:
+                print(message.warn(f"recovering {name} failed because kbase is unavailable"))
+                return False
+            # f(*args, **kwargs)
+            try:
+                result = f(*args, **kwargs)
+                header_file_path = pwndbg.commands.cymbol.create_temp_header_file(result)
+                fname = name.split()[-1] + "_structs"
+                pwndbg.commands.cymbol.add_structure_from_header(header_file_path, fname, True)
+            except Exception as e:
+                print(message.warn(f"recovering {name} failed with error:\n{e}"))
+                if "CONFIG_RANSTRUCT" in pwndbg.aglib.kernel.kconfig():
+                    print(
+                        message.warn(
+                            "please note that some structs may not be recoverable when CONFIG_RANSTRUCT=y"
+                        )
+                    )
+                return False
+            return True
+
+        return func
+
+    return decorator
+
+
+@pwndbg.lib.cache.cache_until("stop")
 def nproc() -> int:
     """Returns the number of processing units available, similar to nproc(1)"""
-    val = pwndbg.aglib.kernel.symbol.try_usymbol("nr_cpu_ids", 32)
-    return val
+    return len(pwndbg.dbg.selected_inferior().send_monitor("info cpus").splitlines())
 
 
 @pwndbg.lib.cache.cache_until("stop")
@@ -228,6 +270,45 @@ def get_idt_entries() -> list[pwndbg.lib.kernel.structs.IDTEntry]:
     return entries
 
 
+def current_cpu() -> int:
+    return pwndbg.dbg.selected_thread().index() - 1
+
+
+def get_double_linked_list(head: int, minlen: int = 0x1, maxlen: int = 0x1000) -> list[int] | None:
+    # head is a pointer to the double linked list
+    # None if not a doubly linked list
+    if not pwndbg.aglib.memory.is_kernel(head):
+        return None
+    nxt = head
+    result = []
+    for _ in range(maxlen):
+        if not pwndbg.aglib.memory.is_kernel(nxt):
+            return None
+        result.append(nxt)
+        nxt = pwndbg.aglib.memory.read_pointer_width(nxt)
+        if nxt == result[0]:
+            break
+    if nxt != result[0]:
+        return None
+    for i, nxt in enumerate(result):
+        p = pwndbg.aglib.memory.read_pointer_width(nxt + pwndbg.aglib.arch.ptrsize)
+        if p != result[i - 1]:
+            return None
+    return result
+
+
+def in_kmem_cache(val: int, name: str, strict: bool = True) -> bool:
+    # name is a substr of any of the target caches' names
+    try:
+        cache = pwndbg.aglib.kernel.slab.find_containing_slab_cache(val)
+        if strict:
+            return name == cache.name
+        return name in cache.name
+    except Exception:
+        pass
+    return False
+
+
 class ArchOps(ABC):
     # More information on the physical memory model of the Linux kernel and
     # especially the mapping between pages and page frame numbers (pfn) can
@@ -295,10 +376,6 @@ class ArchOps(ABC):
         return arch_paginginfo().kbase
 
     @property
-    def ptr_size(self) -> int:
-        raise NotImplementedError()
-
-    @property
     def page_size(self) -> int:
         return 1 << self.page_shift
 
@@ -323,7 +400,7 @@ class ArchOps(ABC):
 
 class x86Ops(ArchOps):
     def phys_to_virt(self, phys: int) -> int:
-        return (phys + self.page_offset) % (1 << self.ptr_size)
+        return (phys + self.page_offset) % (1 << pwndbg.aglib.arch.ptrbits)
 
     def phys_to_pfn(self, phys: int) -> int:
         return phys >> self.page_shift
@@ -331,21 +408,12 @@ class x86Ops(ArchOps):
     def pfn_to_phys(self, pfn: int) -> int:
         return pfn << self.page_shift
 
-    @property
-    @abstractmethod
-    def ptr_size(self) -> int:
-        raise NotImplementedError()
-
     @staticmethod
     def paging_enabled() -> bool:
         return int(pwndbg.aglib.regs.read_reg("cr0")) & BIT(31) != 0
 
 
 class i386Ops(x86Ops):
-    @property
-    def ptr_size(self) -> int:
-        return 32
-
     def virt_to_phys(self, virt: int) -> int:
         return (virt - self.page_offset) % (1 << 32)
 
@@ -365,20 +433,16 @@ class x86_64Ops(x86Ops):
     def __init__(self) -> None:
         self.phys_base = 0x1000000
 
-    @property
-    def ptr_size(self) -> int:
-        return 64
-
     @requires_debug_symbols("__per_cpu_offset", "nr_iowait_cpu", checkall=False)
     def per_cpu(
         self, addr: int | pwndbg.dbg_mod.Value, cpu: int | None = None
     ) -> pwndbg.dbg_mod.Value:
         if cpu is None:
-            cpu = pwndbg.dbg.selected_thread().index() - 1
+            cpu = current_cpu()
 
         per_cpu_offset = int(pwndbg.aglib.kernel.per_cpu_offset())
 
-        offset = pwndbg.aglib.memory.u(per_cpu_offset + (cpu * 8))
+        offset = pwndbg.aglib.memory.read_pointer_width(per_cpu_offset + (cpu * 8))
         per_cpu_addr = (int(addr) + offset) % 2**64
         if isinstance(addr, pwndbg.dbg_mod.Value):
             return pwndbg.dbg.selected_inferior().create_value(per_cpu_addr, addr.type)
@@ -387,7 +451,7 @@ class x86_64Ops(x86Ops):
     def virt_to_phys(self, virt: int) -> int:
         if not (pwndbg.aglib.memory.is_kernel(virt) and virt < arch_paginginfo().vmalloc):
             # if not within physmap range, first find the physmap address
-            virt = pagewalk(virt)[0].virt
+            virt = pagewalk(virt).virt
         if virt is None:
             return None
         return virt - self.page_offset
@@ -404,16 +468,12 @@ class x86_64Ops(x86Ops):
 
 
 class Aarch64Ops(ArchOps):
-    @property
-    def ptr_size(self):
-        return 64
-
     @requires_debug_symbols("__per_cpu_offset", "nr_iowait_cpu", checkall=False)
     def per_cpu(
         self, addr: int | pwndbg.dbg_mod.Value, cpu: int | None = None
     ) -> pwndbg.dbg_mod.Value:
         if cpu is None:
-            cpu = pwndbg.dbg.selected_thread().index() - 1
+            cpu = current_cpu()
 
         per_cpu_offset = int(pwndbg.aglib.kernel.per_cpu_offset())
 
@@ -426,7 +486,7 @@ class Aarch64Ops(ArchOps):
     def virt_to_phys(self, virt: int) -> int:
         if not (pwndbg.aglib.memory.is_kernel(virt) and virt < arch_paginginfo().vmalloc):
             # if not within physmap range, first find the physmap address
-            virt = pagewalk(virt)[0].virt
+            virt = pagewalk(virt).virt
         if virt is None:
             return None
         return virt - self.page_offset + self.phys_offset
@@ -483,14 +543,6 @@ def arch_symbols() -> pwndbg.aglib.kernel.symbol.ArchSymbols | None:
     elif pwndbg.aglib.arch.name == "x86-64":
         return pwndbg.aglib.kernel.symbol.x86_64Symbols()
     return None
-
-
-def ptr_size() -> int:
-    ops = arch_ops()
-    if ops:
-        return ops.ptr_size
-    else:
-        raise NotImplementedError()
 
 
 def page_size() -> int:
@@ -615,19 +667,21 @@ def kbase() -> int | None:
 
 
 @pwndbg.lib.cache.cache_until("stop")
-def pagewalk(addr, entry=None) -> tuple[PageTableLevel, ...]:
+def pagewalk(addr, entry: int = None, virt: bool = True) -> PagewalkResult:
+    # assumes entry is a valid physaddr (+ flags)
+    # the strategy is to walk any virtual pgd first
     pi = arch_paginginfo()
     if pi:
-        return pi.pagewalk(addr, entry)
+        return pi.pagewalk(addr, entry, virt)
     else:
         raise NotImplementedError()
 
 
 @pwndbg.lib.cache.cache_until("stop")
-def pagetable_scan(entry=None) -> tuple[pwndbg.lib.memory.Page, ...]:
+def pagescan(entry=None) -> tuple[pwndbg.lib.memory.Page, ...]:
     pi = arch_paginginfo()
     if pi:
-        return tuple(pi.pagetable_scan(entry))
+        return tuple(pi.pagescan(entry))
     else:
         raise NotImplementedError()
 
@@ -722,7 +776,13 @@ def map_idr() -> pwndbg.dbg_mod.Value:
     return None
 
 
-def current_task() -> pwndbg.dbg_mod.Value:
+def current_task(cpu: int | None = None) -> int:
     if (syms := arch_symbols()) is not None:
-        return syms.current_task()
+        return syms.current_task(cpu)
+    return None
+
+
+def init_task() -> pwndbg.dbg_mod.Value:
+    if (syms := arch_symbols()) is not None:
+        return syms.init_task()
     return None

--- a/pwndbg/aglib/kernel/bpf.py
+++ b/pwndbg/aglib/kernel/bpf.py
@@ -4,7 +4,6 @@ import pwndbg
 import pwndbg.aglib.kernel.symbol
 import pwndbg.aglib.memory
 import pwndbg.aglib.typeinfo
-import pwndbg.color.message as message
 
 
 def get_struct_bpf_prog():
@@ -217,24 +216,17 @@ def get_bpf_struct_offsets(prog_idr, map_idr) -> int:
     return xarray_pad_sz
 
 
-def load_bpf_typeinfo():
-    if pwndbg.aglib.typeinfo.lookup_types("struct bpf_map") is not None:
-        return
-    if pwndbg.aglib.kernel.symbol.kversion_cint() is None:
-        return
+@pwndbg.aglib.kernel.typeinfo_recovery("struct bpf_map", kversion=True)
+def load_bpf_typeinfo() -> str:
     prog_idr = pwndbg.aglib.kernel.prog_idr()
     map_idr = pwndbg.aglib.kernel.map_idr()
     if not prog_idr or not map_idr:
-        print(message.warn("cannot find either prog_idr or map_idr"))
-        return
+        raise AssertionError("cannot find either prog_idr or map_idr")
     xarray_pad_sz = get_bpf_struct_offsets(prog_idr, map_idr)
     if not xarray_pad_sz:
-        print(
-            message.warn(
-                "cannot find xa_head -- might be uninitialized (add a bpf prog/map first!)"
-            )
+        raise AssertionError(
+            "cannot find xa_head -- might be uninitialized (add a bpf prog/map first!)"
         )
-        return
     result = pwndbg.aglib.kernel.symbol.COMMON_TYPES
     result += f"""
     struct xarray {{
@@ -265,5 +257,4 @@ def load_bpf_typeinfo():
     """
     result += get_struct_bpf_prog()
     result += get_struct_bpf_map()
-    header_file_path = pwndbg.commands.cymbol.create_temp_header_file(result)
-    pwndbg.commands.cymbol.add_structure_from_header(header_file_path, "bpf_structs", True)
+    return result

--- a/pwndbg/aglib/kernel/bpf.py
+++ b/pwndbg/aglib/kernel/bpf.py
@@ -216,17 +216,16 @@ def get_bpf_struct_offsets(prog_idr, map_idr) -> int:
     return xarray_pad_sz
 
 
-@pwndbg.aglib.kernel.typeinfo_recovery("struct bpf_map", kversion=True)
+@pwndbg.aglib.kernel.typeinfo_recovery("struct bpf_map", requires_kversion=True)
 def load_bpf_typeinfo() -> str:
     prog_idr = pwndbg.aglib.kernel.prog_idr()
     map_idr = pwndbg.aglib.kernel.map_idr()
     if not prog_idr or not map_idr:
         raise AssertionError("cannot find either prog_idr or map_idr")
     xarray_pad_sz = get_bpf_struct_offsets(prog_idr, map_idr)
-    if not xarray_pad_sz:
-        raise AssertionError(
-            "cannot find xa_head -- might be uninitialized (add a bpf prog/map first!)"
-        )
+    assert xarray_pad_sz, (
+        "cannot find xa_head -- might be uninitialized (add a bpf prog/map first!)"
+    )
     result = pwndbg.aglib.kernel.symbol.COMMON_TYPES
     result += f"""
     struct xarray {{

--- a/pwndbg/aglib/kernel/bpf.py
+++ b/pwndbg/aglib/kernel/bpf.py
@@ -217,7 +217,7 @@ def get_bpf_struct_offsets(prog_idr, map_idr) -> int:
 
 
 @pwndbg.aglib.kernel.typeinfo_recovery("struct bpf_map", requires_kversion=True)
-def load_bpf_typeinfo() -> str:
+def recover_bpf_typeinfo() -> str:
     prog_idr = pwndbg.aglib.kernel.prog_idr()
     map_idr = pwndbg.aglib.kernel.map_idr()
     if not prog_idr or not map_idr:

--- a/pwndbg/aglib/kernel/buddydump.py
+++ b/pwndbg/aglib/kernel/buddydump.py
@@ -74,16 +74,12 @@ def find_zone_offsets() -> tuple[int, int, int, int, int]:
     return pcp_off, name_off, freelist_off, pcp_pad, zone_sz
 
 
-def load_buddydump_typeinfo():
-    if pwndbg.aglib.typeinfo.lookup_types("struct pglist_data") is not None:
-        return
-    if pwndbg.aglib.kernel.symbol.kversion_cint() is None:
-        return
+@pwndbg.aglib.kernel.typeinfo_recovery("struct pglist_data", kversion=True)
+def load_buddydump_typeinfo() -> str:
     nmtypes = pwndbg.aglib.kernel.symbol.nmtypes()
     nzones = pwndbg.aglib.kernel.symbol.nzones()
     nnodes = pwndbg.aglib.kernel.num_numa_nodes()
     npcplist = pwndbg.aglib.kernel.symbol.npcplist()
-    pwndbg.aglib.kernel.symbol.load_common_structs()
 
     result = f"#define KVERSION {pwndbg.aglib.kernel.symbol.kversion_cint()}\n"
     result += pwndbg.aglib.kernel.symbol.COMMON_TYPES
@@ -133,5 +129,4 @@ def load_buddydump_typeinfo():
         // ... the rest of the fields are not important
     }} pg_data_t;
     """
-    header_file_path = pwndbg.commands.cymbol.create_temp_header_file(result)
-    pwndbg.commands.cymbol.add_structure_from_header(header_file_path, "buddydump_structs", True)
+    return result

--- a/pwndbg/aglib/kernel/buddydump.py
+++ b/pwndbg/aglib/kernel/buddydump.py
@@ -74,7 +74,7 @@ def find_zone_offsets() -> tuple[int, int, int, int, int]:
     return pcp_off, name_off, freelist_off, pcp_pad, zone_sz
 
 
-@pwndbg.aglib.kernel.typeinfo_recovery("struct pglist_data", kversion=True)
+@pwndbg.aglib.kernel.typeinfo_recovery("struct pglist_data", requires_kversion=True)
 def load_buddydump_typeinfo() -> str:
     nmtypes = pwndbg.aglib.kernel.symbol.nmtypes()
     nzones = pwndbg.aglib.kernel.symbol.nzones()

--- a/pwndbg/aglib/kernel/buddydump.py
+++ b/pwndbg/aglib/kernel/buddydump.py
@@ -75,7 +75,7 @@ def find_zone_offsets() -> tuple[int, int, int, int, int]:
 
 
 @pwndbg.aglib.kernel.typeinfo_recovery("struct pglist_data", requires_kversion=True)
-def load_buddydump_typeinfo() -> str:
+def recover_buddydump_typeinfo() -> str:
     nmtypes = pwndbg.aglib.kernel.symbol.nmtypes()
     nzones = pwndbg.aglib.kernel.symbol.nzones()
     nnodes = pwndbg.aglib.kernel.num_numa_nodes()

--- a/pwndbg/aglib/kernel/dmabuf.py
+++ b/pwndbg/aglib/kernel/dmabuf.py
@@ -9,7 +9,7 @@ def find_dmabuf_offsets(dmabuf) -> tuple[int, int, int]:
     ptrsize = pwndbg.aglib.arch.ptrsize
     heap_buffer = pwndbg.aglib.memory.read_pointer_width(dmabuf + 2 * ptrsize)
     for i in range(1, MAX):
-        # see load_dmabuf_typeinfo (struct dma_buf) for an explanation
+        # see recover_dmabuf_typeinfo (struct dma_buf) for an explanation
         # this loop is searching the `size` field from `list_node`
         size = pwndbg.aglib.memory.read_pointer_width(dmabuf - (i + 5) * ptrsize)
         file = pwndbg.aglib.memory.read_pointer_width(dmabuf - (i + 4) * ptrsize)
@@ -55,7 +55,7 @@ def find_dmabuf_offsets(dmabuf) -> tuple[int, int, int]:
 
 
 @pwndbg.aglib.kernel.typeinfo_recovery("struct dma_buf")
-def load_dmabuf_typeinfo(first_dmabuf: int) -> str:
+def recover_dmabuf_typeinfo(first_dmabuf: int) -> str:
     # reaching here means priv exists
     sg_table_off, exp_name_off, list_node_off = find_dmabuf_offsets(first_dmabuf)
     result = pwndbg.aglib.kernel.symbol.COMMON_TYPES

--- a/pwndbg/aglib/kernel/dmabuf.py
+++ b/pwndbg/aglib/kernel/dmabuf.py
@@ -54,10 +54,9 @@ def find_dmabuf_offsets(dmabuf) -> tuple[int, int, int]:
     return sg_table_off, exp_name_off, list_node_off
 
 
-def load_dmabuf_typeinfo(first_dmabuf: int):
+@pwndbg.aglib.kernel.typeinfo_recovery("struct dma_buf")
+def load_dmabuf_typeinfo(first_dmabuf: int) -> str:
     # reaching here means priv exists
-    if pwndbg.aglib.typeinfo.lookup_types("struct dma_buf") is not None:
-        return
     sg_table_off, exp_name_off, list_node_off = find_dmabuf_offsets(first_dmabuf)
     result = pwndbg.aglib.kernel.symbol.COMMON_TYPES
     result += f"""
@@ -101,5 +100,4 @@ def load_dmabuf_typeinfo(first_dmabuf: int):
         /* rest of the fields are irrelevant */
     }};
     """
-    header_file_path = pwndbg.commands.cymbol.create_temp_header_file(result)
-    pwndbg.commands.cymbol.add_structure_from_header(header_file_path, "dmabuf_structs", True)
+    return result

--- a/pwndbg/aglib/kernel/paging.py
+++ b/pwndbg/aglib/kernel/paging.py
@@ -65,7 +65,7 @@ class PageTableScan:
         self.inf = pwndbg.dbg.selected_inferior()
         self.fmt = "<" + ("Q" if self.ptrsize == 8 else "I") * (self.pagesz // self.ptrsize)
         self.cache: dict[tuple[int, int], list[tuple[int, int, int]]] = {}
-        self.entry_cache: dict[int, list[int]] = {}
+        self.entry_cache: dict[int, tuple[int]] = {}
         self.arch = pwndbg.aglib.arch.name
 
     def scan(self, entry: int, is_kernel: bool = False) -> list[Page]:
@@ -112,8 +112,8 @@ class PageTableScan:
         ranges: list[tuple[int, int, int]] = []
         append = ranges.append
         # the range currently being merged, curr_off == None means there is no current range being merged
-        curr_off = curr_sz = curr_flags = 0
         curr_off = None
+        curr_sz = curr_flags = 0
         # len(entries) == self.pagesz // self.ptrsize, try not to do division here
         size = pagesz * (len(entries) ** (level - 1))
         # per entry offset relative to the start of the current pagetable,
@@ -123,7 +123,7 @@ class PageTableScan:
         # consecutive identical pt entries will be clapsed into one. None means not x86-64
         # I believe this is what gdb-pt-dump does as this gives identical output
         prev = 0 if self.arch == "x86-64" else None
-        for i, entry in enumerate(entries):
+        for entry in entries:
             if prev and prev == entry:
                 pass
             elif entry == 0:
@@ -278,7 +278,8 @@ class ArchPagingInfo:
     def adjust(self, name: str) -> str:
         raise NotImplementedError()
 
-    def markers(self) -> tuple[tuple[str, int], ...]:
+    @pwndbg.lib.cache.cache_until("stop")
+    def markers(self) -> tuple[tuple[str | None, int | None], ...]:
         raise NotImplementedError()
 
     def handle_kernel_pages(self, pages: tuple[Page, ...]) -> None:
@@ -405,6 +406,8 @@ class x86_64PagingInfo(ArchPagingInfo):
         try:
             target = self.physmap.to_bytes(8, byteorder="little")
             mapping = pwndbg.aglib.kernel.first_kernel_ro_page()
+            if not mapping:
+                return None, None
             result = next(
                 pwndbg.search.search(target, mappings=[mapping], aligned=pwndbg.aglib.arch.ptrsize),
                 None,
@@ -465,10 +468,11 @@ class x86_64PagingInfo(ArchPagingInfo):
     @property
     @pwndbg.lib.cache.cache_until("stop")
     def paging_level(self) -> int:
-        return 4 if (pwndbg.aglib.regs.read_reg("cr4") & (1 << 12)) == 0 else 5
+        cr4 = pwndbg.aglib.regs.read_reg("cr4")
+        return 4 if cr4 is None or (cr4 & (1 << 12)) == 0 else 5
 
     @pwndbg.lib.cache.cache_until("stop")
-    def markers(self) -> tuple[tuple[str | None, int], ...]:
+    def markers(self) -> tuple[tuple[str | None, int | None], ...]:
         # https://www.kernel.org/doc/Documentation/x86/x86_64/mm.txt
         return (
             (self.USERLAND, 0),
@@ -527,8 +531,10 @@ class x86_64PagingInfo(ArchPagingInfo):
                     page.objfile = self.KERNELBSS
                 else:
                     page.objfile = self.KERNELRO
+        if not stack:
+            return
         for i, page in enumerate(pages):
-            if stack and stack in page:
+            if stack in page:
                 page.objfile += " [stack]"
 
     def pagewalk(self, target: int, entry: int | None, virt: bool = True) -> PagewalkResult:
@@ -541,6 +547,8 @@ class x86_64PagingInfo(ArchPagingInfo):
     def pagescan(self, entry: int | None = None) -> list[Page]:
         if entry is None:
             entry = pwndbg.aglib.regs.read_reg("cr3")
+        if entry is None:
+            return []
         return self._pagescan(entry)
 
     def bitflags(self, level: PageTableLevel) -> BitFlags:
@@ -570,14 +578,14 @@ class Aarch64PagingInfo(ArchPagingInfo):
     @pwndbg.lib.cache.cache_until("stop")
     def tcr_el1(self) -> BitFlags:
         tcr = pwndbg.lib.regs.aarch64_tcr_flags
-        tcr.value = pwndbg.aglib.regs.read_reg("TCR_EL1")
+        tcr.value = pwndbg.aglib.regs.read_reg("TCR_EL1") or 0
         return tcr
 
     @property
     @pwndbg.lib.cache.cache_until("stop")
     def va_bits(self) -> int:
         id_aa64mmfr2_el1 = pwndbg.lib.regs.aarch64_mmfr_flags
-        id_aa64mmfr2_el1.value = pwndbg.aglib.regs.read_reg("ID_AA64MMFR2_EL1")
+        id_aa64mmfr2_el1.value = pwndbg.aglib.regs.read_reg("ID_AA64MMFR2_EL1") or 0
         feat_lva = id_aa64mmfr2_el1.value is not None and id_aa64mmfr2_el1["VARange"] == 0b0001
         va_bits: int = 64 - self.tcr_el1["T1SZ"]  # this is prob only `vabits_actual`
         self.PAGE_OFFSET = self._PAGE_OFFSET(va_bits)  # physmap base address without KASLR
@@ -665,7 +673,7 @@ class Aarch64PagingInfo(ArchPagingInfo):
 
     @property
     @pwndbg.lib.cache.cache_until("stop")
-    def pci(self) -> int:
+    def pci(self) -> int | None:
         if self.kversion is None or self.VMEMMAP_START is None or self.VMEMMAP_SIZE is None:
             return None
         self.pci_end = INVALID_ADDR
@@ -684,9 +692,9 @@ class Aarch64PagingInfo(ArchPagingInfo):
     def fixmap(self) -> int:
         if self.kversion is None:
             return INVALID_ADDR
-        if self.kversion < (5, 11):
+        if self.pci and self.kversion < (5, 11):
             FIXADDR_TOP = self.pci - 0x00200000  # 2M
-        elif self.kversion < (6, 9):
+        elif self.VMEMMAP_START and self.kversion < (6, 9):
             FIXADDR_TOP = self.VMEMMAP_START - 0x02000000  # 32M
         else:
             FIXADDR_TOP = (-0x00800000) & 0xFFFFFFFFFFFFFFFF
@@ -768,10 +776,10 @@ class Aarch64PagingInfo(ArchPagingInfo):
         return (self.va_bits - self.page_shift + (self.page_shift - 4)) // (self.page_shift - 3)
 
     @pwndbg.lib.cache.cache_until("stop")
-    def markers(self) -> tuple[tuple[str | None, int], ...]:
+    def markers(self) -> tuple[tuple[str | None, int | None], ...]:
         address_markers = pwndbg.aglib.symbol.lookup_symbol_addr("address_markers")
         if address_markers is not None:
-            sections = [(self.USERLAND, 0)]
+            sections: list[tuple[str | None, int | None]] = [(self.USERLAND, 0)]
             value = 0
             name = None
             for i in range(20):
@@ -823,6 +831,7 @@ class Aarch64PagingInfo(ArchPagingInfo):
     def handle_kernel_pages(self, pages: tuple[Page, ...]) -> None:
         if self.kbase is None:
             return
+        stack = pwndbg.aglib.regs.read_reg(pwndbg.aglib.regs.stack)
         for i in range(len(pages)):
             page = pages[i]
             if self.module_start and self.module_start <= page.start < self.kbase:
@@ -834,7 +843,7 @@ class Aarch64PagingInfo(ArchPagingInfo):
                         page.objfile = self.KERNELBSS
                     else:
                         page.objfile = self.KERNELRO
-            if pwndbg.aglib.regs.read_reg(pwndbg.aglib.regs.stack) in page:
+            if stack and stack in page:
                 page.objfile += " [stack]"
 
     @property
@@ -869,13 +878,18 @@ class Aarch64PagingInfo(ArchPagingInfo):
         # assumes entry should be from `kcurrent --set` and should be TTBR0_EL1 for a task
         if entry is None:
             entry = pwndbg.aglib.regs.read_reg("TTBR0_EL1")
+        if entry is None:
+            return []
         result = self._pagescan(entry | 3, is_kernel=False)
         if pwndbg.aglib.memory.is_kernel(pwndbg.aglib.regs.pc):
-            result += self._pagescan(pwndbg.aglib.regs.read_reg("TTBR1_EL1") | 3, is_kernel=True)
+            entry = pwndbg.aglib.regs.read_reg("TTBR1_EL1")
+            if entry is None:
+                return []
+            result += self._pagescan(entry | 3, is_kernel=True)
         return result
 
     def bitflags(self, level: PageTableLevel) -> BitFlags:
-        if level.level == 1 or self.should_stop_pagewalk(level.entry):
+        if level.level == 1 or not level.entry or self.should_stop_pagewalk(level.entry):
             # block or page
             return BitFlags([("UNX", 54), ("PNX", 53), ("AP", (6, 7))])
         return BitFlags([("UNX", 60), ("PNX", 59), ("AP", (61, 62))])

--- a/pwndbg/aglib/kernel/paging.py
+++ b/pwndbg/aglib/kernel/paging.py
@@ -169,7 +169,7 @@ class PageTableScan:
                         if rflags == curr_flags and roff == 0:
                             curr_sz += rsz
                             left += 1
-                if n > 1:  # (prepare to) merge the first page chunk range if needed
+                if n > 1:  # (prepare to) merge the last page chunk range if needed
                     # if n == 1, last == first which is handled by the previous if-block
                     if curr_off is not None:
                         # don't do this if n == 1 because we may want to coalesce further

--- a/pwndbg/aglib/kernel/paging.py
+++ b/pwndbg/aglib/kernel/paging.py
@@ -33,10 +33,20 @@ def first_kernel_page_start() -> int:
 
 @dataclass
 class PageTableLevel:
-    name: str
-    entry: int
-    virt: int  # within physmap
-    idx: int
+    name: str | None = None
+    entry: int | None = None
+    virt: int | None = None  # within physmap
+    phys: int | None = None  # physcal address
+    idx: int | None = None
+    level: int | None = None
+
+
+@dataclass
+class PagewalkResult:
+    virt: int | None = None  # within physmap
+    phys: int | None = None  # physcal address
+    entry: int | None = None
+    levels: tuple[PageTableLevel, ...] = ()
 
 
 class PageTableScan:
@@ -68,8 +78,6 @@ class PageTableScan:
         --> around 45-65% of the time is used to read qemu system memory depending on arch and kernel
             (the theoratical limit would be that all time consumed is used for reading memory)
         --> 2.35x speed up for x64 and more than 10x speed up for aarch64
-        one caveat is that it occasionally show unmapped (checked with pagewalk) vmalloc regions
-        but that happens for gdb-pt-dump as well
         """
         entry &= self.PAGE_ENTRY_MASK
         if (entry, self.paging_level) not in self.cache:
@@ -84,7 +92,8 @@ class PageTableScan:
             if is_kernel:
                 nbits = self.ptrsize * 8 - kernel_prefix_shift
                 offset += ((1 << nbits) - 1) << kernel_prefix_shift
-            if curr and offset in curr and flags == curr.flags:
+            if curr and offset == curr.end and flags == curr.flags:
+                # merge contiguous chunks
                 curr.memsz = max(curr.memsz, offset + size - curr.start)
             else:
                 if curr:
@@ -110,13 +119,12 @@ class PageTableScan:
         offset = 0
         # TODO: prev is used to avoid clustering the vmmap output with espfix ranges (happens for x86-64)
         # consecutive identical pt entries will be clapsed into one. None means not x86-64
-        # I believe this is what gdb-pt-dump does as this gives identical output for espfix
+        # I believe this is what gdb-pt-dump does as this gives identical output
         prev = 0 if self.arch == "x86-64" else None
         for i, entry in enumerate(entries):
             if prev and prev == entry:
-                offset += size
-                continue
-            if entry == 0:
+                pass
+            elif entry == 0:
                 if curr_off is not None:
                     append((curr_off, curr_sz, curr_flags))
                     curr_off = None
@@ -150,17 +158,29 @@ class PageTableScan:
                     # each time the level is decremented, garanteed to terminate
                     self._scan(addr, level - 1)
                 arr = self.cache[key]
+                # The following if-blocks are purely for optimization purposes
+                # coalesce as much as we can
                 left, n = 0, len(arr)
-                if n > 0:
-                    r = arr[0]
+                right = n - 1
+                if n > 0:  # merge the first page chunk range if needed
                     if curr_off is not None:
-                        if r[2] == curr_flags:
-                            curr_sz += r[1]
+                        roff, rsz, rflags = arr[0]
+                        # is the first non-zero entry actually the first (0 th) entry?
+                        if rflags == curr_flags and roff == 0:
+                            curr_sz += rsz
                             left += 1
+                if n > 1:  # (prepare to) merge the first page chunk range if needed
+                    # if n == 1, last == first which is handled by the previous if-block
+                    if curr_off is not None:
+                        # don't do this if n == 1 because we may want to coalesce further
                         append((curr_off, curr_sz, curr_flags))
-                    r = arr[n - 1]
-                    curr_off, curr_sz, curr_flags = offset + r[0], r[1], r[2]
-                for roff, rsz, rflags in arr[left : n - 1]:
+                        curr_off = None
+                    roff, rsz, rflags = arr[n - 1]
+                    # is the last non-zero entry actually the last (e.g. 511 th) entry?
+                    if roff + rsz == size:
+                        curr_off, curr_sz, curr_flags = offset + roff, rsz, rflags
+                        right -= 1
+                for roff, rsz, rflags in arr[left : right + 1]:
                     append((offset + roff, rsz, rflags))
             offset += size
             if prev is not None:
@@ -169,13 +189,13 @@ class PageTableScan:
             append((curr_off, curr_sz, curr_flags))
         self.cache[(orig, level)] = ranges
 
-    def walk(self, target: int, entry: int) -> list[PageTableLevel]:
+    def walk(self, target: int, entry: int) -> PagewalkResult:
         page_shift = self.page_shift
-        result = [PageTableLevel(None, None, None, None) for _ in range(self.paging_level + 1)]
+        levels = [PageTableLevel() for _ in range(self.paging_level)]
         resolved = offset_mask = None
-        for i in range(self.paging_level, 0, -1):
+        for i in range(self.paging_level - 1, -1, -1):
             resolved = None
-            shift = page_shift + self.PAGE_INDEX_LEN * (i - 1)
+            shift = page_shift + self.PAGE_INDEX_LEN * i
             idx = (target >> shift) & self.PAGE_INDEX_MASK
             addr = entry & self.PAGE_ENTRY_MASK
             if addr not in self.entry_cache:
@@ -185,17 +205,20 @@ class PageTableScan:
             entry = self.entry_cache[addr][idx]
             if not entry:
                 break
-            result[i].virt = addr  # phys addr at this point
-            result[i].idx = idx
-            result[i].entry = entry
+            levels[i].phys = addr
+            levels[i].idx = idx
+            levels[i].entry = entry
+            levels[i].level = i + 1
             offset_mask = (1 << shift) - 1
             resolved = (entry & self.PAGE_ENTRY_MASK, offset_mask)
             if self.should_stop_pagewalk(entry):
                 break
+        result = PagewalkResult()
         if resolved and offset_mask is not None:
             addr, offset_mask = resolved
-            result[0].virt = addr + (target & offset_mask)
-            result[0].entry = entry
+            result.phys = addr + (target & offset_mask)
+            result.entry = entry
+        result.levels = tuple(levels)
         return result
 
 
@@ -260,7 +283,7 @@ class ArchPagingInfo:
         # this is arch dependent
         raise NotImplementedError()
 
-    def kbase_helper(self, address: int) -> int | None:
+    def _kbase(self, address: int) -> int | None:
         if address is None:
             return None
         for mapping in kernel_vmmap_pages():
@@ -276,10 +299,10 @@ class ArchPagingInfo:
 
         return None
 
-    def pagewalk(self, target: int, entry: int | None) -> tuple[PageTableLevel, ...]:
+    def pagewalk(self, target: int, entry: int | None, virt: bool = True) -> PagewalkResult:
         raise NotImplementedError()
 
-    def pagetable_scan(self, entry: int | None = None) -> list[Page]:
+    def pagescan(self, entry: int | None = None) -> list[Page]:
         raise NotImplementedError()
 
     @property
@@ -305,28 +328,28 @@ class ArchPagingInfo:
         success = pwndbg.dbg.selected_inferior().send_remote("qqemu.PhyMemMode") == b"1"
         return oldval, success
 
-    def pagewalk_helper(self, target: int, entry: int) -> tuple[PageTableLevel, ...]:
-        base = self.physmap
-        if entry > base:
-            # user inputted a physmap address as pointer to pgd
-            entry -= base
+    def _pagewalk(self, target: int, entry: int, virt: bool) -> PagewalkResult:
         scan = self.pagetablescan(entry)
         oldval, success = self.switch_to_phymem_mode()
         if not success:
-            return ()
+            return PagewalkResult()
         try:
             result = scan.walk(target, entry)
-            for i, level in enumerate(result):
-                if level.virt is None:
+            if not virt:
+                return result
+            levels = result.levels
+            for i, level in enumerate(levels):
+                if level.phys is None:
                     continue
-                level.virt = level.virt + base - self.phys_offset
-                level.name = self.pagetable_level_names[i]
-            return tuple(result)
+                level.virt = level.phys + self.physmap - self.phys_offset
+                level.name = self.pagetable_level_names[level.level]
+            result.virt = result.phys + self.physmap - self.phys_offset
+            return result
         finally:  # so that the PhyMemMode value is always restored
             pwndbg.dbg.selected_inferior().send_remote(f"Qqemu.PhyMemMode:{oldval}")
-        return ()
+        return PagewalkResult()
 
-    def pagetable_scan_helper(self, entry: int, is_kernel: bool = False) -> list[Page]:
+    def _pagescan(self, entry: int, is_kernel: bool = False) -> list[Page]:
         scan = self.pagetablescan(entry)
         oldval, success = self.switch_to_phymem_mode()
         if not success:
@@ -337,7 +360,7 @@ class ArchPagingInfo:
             pwndbg.dbg.selected_inferior().send_remote(f"Qqemu.PhyMemMode:{oldval}")
         return []
 
-    def pageentry_bitflags(self, level: int) -> BitFlags:
+    def bitflags(self, level: PageTableLevel) -> BitFlags:
         raise NotImplementedError()
 
     def should_stop_pagewalk(self, level: int) -> bool:
@@ -406,7 +429,7 @@ class x86_64PagingInfo(ArchPagingInfo):
         idt_entries = pwndbg.aglib.kernel.get_idt_entries()
         if len(idt_entries) == 0:
             return None
-        return self.kbase_helper(idt_entries[0].offset)
+        return self._kbase(idt_entries[0].offset)
 
     @property
     def page_shift(self) -> int:
@@ -477,9 +500,11 @@ class x86_64PagingInfo(ArchPagingInfo):
     def handle_kernel_pages(self, pages: tuple[Page, ...]) -> None:
         kernel_idx = None
         kbase = self.kbase
+        stack = pwndbg.aglib.regs.read_reg(pwndbg.aglib.regs.stack)
         for i, page in enumerate(pages):
             if kernel_idx is None and kbase is not None and kbase in page:
                 kernel_idx = i
+                break
         if kernel_idx is None:
             return
         has_loadable_driver = False
@@ -499,20 +524,21 @@ class x86_64PagingInfo(ArchPagingInfo):
                     page.objfile = self.KERNELBSS
                 else:
                     page.objfile = self.KERNELRO
-            if pwndbg.aglib.regs.read_reg(pwndbg.aglib.regs.stack) in page:
-                page.objfile = "kernel [stack]"
+        for i, page in enumerate(pages):
+            if stack and stack in page:
+                page.objfile += " [stack]"
 
-    def pagewalk(self, target: int, entry: int | None) -> tuple[PageTableLevel, ...]:
+    def pagewalk(self, target: int, entry: int | None, virt: bool = True) -> PagewalkResult:
         if entry is None:
             entry = pwndbg.aglib.regs.read_reg("cr3")
-        return self.pagewalk_helper(target, entry)
+        return self._pagewalk(target, entry, virt)
 
-    def pagetable_scan(self, entry: int | None = None) -> list[Page]:
+    def pagescan(self, entry: int | None = None) -> list[Page]:
         if entry is None:
             entry = pwndbg.aglib.regs.read_reg("cr3")
-        return self.pagetable_scan_helper(entry)
+        return self._pagescan(entry)
 
-    def pageentry_bitflags(self, _: int) -> BitFlags:
+    def bitflags(self, _: PageTableLevel) -> BitFlags:
         return BitFlags([("NX", 63), ("PS", 7), ("A", 5), ("U", 2), ("W", 1), ("P", 0)])
 
     def should_stop_pagewalk(self, entry: int) -> bool:
@@ -573,7 +599,7 @@ class Aarch64PagingInfo(ArchPagingInfo):
     @property
     @pwndbg.lib.cache.cache_until("stop")
     def kbase(self) -> int | None:
-        return self.kbase_helper(pwndbg.aglib.regs.read_reg("vbar"))
+        return self._kbase(pwndbg.aglib.regs.read_reg("vbar"))
 
     @property
     @pwndbg.lib.cache.cache_until("stop")
@@ -668,6 +694,8 @@ class Aarch64PagingInfo(ArchPagingInfo):
     @pwndbg.lib.cache.cache_until("stop")
     def ksize(self) -> int:
         start = pwndbg.aglib.symbol.lookup_symbol_addr("_text")
+        if start is None:
+            start = self.kbase
         end = pwndbg.aglib.symbol.lookup_symbol_addr("_end")
         if start is not None and end is not None:
             return end - start
@@ -792,21 +820,17 @@ class Aarch64PagingInfo(ArchPagingInfo):
             return
         for i in range(len(pages)):
             page = pages[i]
-            if page.start > self.kbase + self.ksize:
-                continue
             if self.module_start and self.module_start <= page.start < self.kbase:
                 page.objfile = self.KERNELDRIVER
-                continue
-            if page.start < self.kbase:
-                continue
-            page.objfile = self.KERNELLAND
-            if not page.execute:
-                if page.write:
-                    page.objfile = self.KERNELBSS
-                else:
-                    page.objfile = self.KERNELRO
+            elif self.kbase <= page.start < self.kbase + self.ksize:
+                page.objfile = self.KERNELLAND
+                if not page.execute:
+                    if page.write:
+                        page.objfile = self.KERNELBSS
+                    else:
+                        page.objfile = self.KERNELRO
             if pwndbg.aglib.regs.read_reg(pwndbg.aglib.regs.stack) in page:
-                page.objfile = "kernel [stack]"
+                page.objfile += " [stack]"
 
     @property
     @pwndbg.lib.cache.cache_until("start")
@@ -825,28 +849,26 @@ class Aarch64PagingInfo(ArchPagingInfo):
             pass
         return 0x40000000  # default
 
-    def pagewalk(self, target: int, entry: int | None) -> tuple[PageTableLevel, ...]:
+    def pagewalk(self, target: int, entry: int | None, virt: bool = True) -> PagewalkResult:
         if entry is None:
             if pwndbg.aglib.memory.is_kernel(target):
                 entry = pwndbg.aglib.regs.read_reg("TTBR1_EL1")
             else:
                 entry = pwndbg.aglib.regs.read_reg("TTBR0_EL1")
         entry |= 3  # marks the entry as a table
-        return self.pagewalk_helper(target, entry)
+        return self._pagewalk(target, entry, virt)
 
-    def pagetable_scan(self, entry: int | None = None) -> list[Page]:
+    def pagescan(self, entry: int | None = None) -> list[Page]:
         # assumes entry should be from `kcurrent --set` and should be TTBR0_EL1 for a task
         if entry is None:
             entry = pwndbg.aglib.regs.read_reg("TTBR0_EL1")
-        result = self.pagetable_scan_helper(entry | 3, is_kernel=False)
+        result = self._pagescan(entry | 3, is_kernel=False)
         if pwndbg.aglib.memory.is_kernel(pwndbg.aglib.regs.pc):
-            result += self.pagetable_scan_helper(
-                pwndbg.aglib.regs.read_reg("TTBR1_EL1") | 3, is_kernel=True
-            )
+            result += self._pagescan(pwndbg.aglib.regs.read_reg("TTBR1_EL1") | 3, is_kernel=True)
         return result
 
-    def pageentry_bitflags(self, level: int) -> BitFlags:
-        if level != 0:
+    def bitflags(self, level: PageTableLevel) -> BitFlags:
+        if level.level == 1 or self.should_stop_pagewalk(level.entry):
             # block or page
             return BitFlags([("UNX", 54), ("PNX", 53), ("AP", (6, 7))])
         return BitFlags([("UNX", 60), ("PNX", 59), ("AP", (61, 62))])

--- a/pwndbg/aglib/kernel/paging.py
+++ b/pwndbg/aglib/kernel/paging.py
@@ -13,6 +13,7 @@ import pwndbg.aglib.symbol
 import pwndbg.aglib.typeinfo
 import pwndbg.lib.cache
 import pwndbg.lib.regs
+import pwndbg.search
 from pwndbg.aglib.disasm.instruction import PwndbgInstruction
 from pwndbg.aglib.kernel.vmmap import kernel_vmmap_pages
 from pwndbg.lib.memory import Page
@@ -111,7 +112,8 @@ class PageTableScan:
         ranges: list[tuple[int, int, int]] = []
         append = ranges.append
         # the range currently being merged, curr_off == None means there is no current range being merged
-        curr_off = curr_sz = curr_flags = None
+        curr_off = curr_sz = curr_flags = 0
+        curr_off = None
         # len(entries) == self.pagesz // self.ptrsize, try not to do division here
         size = pagesz * (len(entries) ** (level - 1))
         # per entry offset relative to the start of the current pagetable,
@@ -283,7 +285,7 @@ class ArchPagingInfo:
         # this is arch dependent
         raise NotImplementedError()
 
-    def _kbase(self, address: int) -> int | None:
+    def _kbase(self, address: int | None) -> int | None:
         if address is None:
             return None
         for mapping in kernel_vmmap_pages():
@@ -331,28 +333,29 @@ class ArchPagingInfo:
     def _pagewalk(self, target: int, entry: int, virt: bool) -> PagewalkResult:
         scan = self.pagetablescan(entry)
         oldval, success = self.switch_to_phymem_mode()
-        if not success:
+        if not success or not scan:
             return PagewalkResult()
         try:
             result = scan.walk(target, entry)
             if not virt:
                 return result
             levels = result.levels
-            for i, level in enumerate(levels):
-                if level.phys is None:
+            for level in levels:
+                if level.phys is None or level.level is None:
                     continue
                 level.virt = level.phys + self.physmap - self.phys_offset
                 level.name = self.pagetable_level_names[level.level]
-            result.virt = result.phys + self.physmap - self.phys_offset
+            if result.phys is not None:
+                result.virt = result.phys + self.physmap - self.phys_offset
             return result
         finally:  # so that the PhyMemMode value is always restored
             pwndbg.dbg.selected_inferior().send_remote(f"Qqemu.PhyMemMode:{oldval}")
-        return PagewalkResult()
+            return PagewalkResult()
 
     def _pagescan(self, entry: int, is_kernel: bool = False) -> list[Page]:
         scan = self.pagetablescan(entry)
         oldval, success = self.switch_to_phymem_mode()
-        if not success:
+        if not success or not scan:
             return []
         try:
             return scan.scan(entry, is_kernel)
@@ -363,7 +366,7 @@ class ArchPagingInfo:
     def bitflags(self, level: PageTableLevel) -> BitFlags:
         raise NotImplementedError()
 
-    def should_stop_pagewalk(self, level: int) -> bool:
+    def should_stop_pagewalk(self, entry: int) -> bool:
         raise NotImplementedError()
 
     @property
@@ -397,7 +400,7 @@ class x86_64PagingInfo(ArchPagingInfo):
         return 48 if self.paging_level == 4 else 51
 
     @pwndbg.lib.cache.cache_until("stop")
-    def get_vmalloc_vmemmap_bases(self) -> tuple[int, int]:
+    def get_vmalloc_vmemmap_bases(self) -> tuple[int | None, int | None]:
         result = None
         try:
             target = self.physmap.to_bytes(8, byteorder="little")
@@ -465,7 +468,7 @@ class x86_64PagingInfo(ArchPagingInfo):
         return 4 if (pwndbg.aglib.regs.read_reg("cr4") & (1 << 12)) == 0 else 5
 
     @pwndbg.lib.cache.cache_until("stop")
-    def markers(self) -> tuple[tuple[str, int], ...]:
+    def markers(self) -> tuple[tuple[str | None, int], ...]:
         # https://www.kernel.org/doc/Documentation/x86/x86_64/mm.txt
         return (
             (self.USERLAND, 0),
@@ -531,6 +534,8 @@ class x86_64PagingInfo(ArchPagingInfo):
     def pagewalk(self, target: int, entry: int | None, virt: bool = True) -> PagewalkResult:
         if entry is None:
             entry = pwndbg.aglib.regs.read_reg("cr3")
+        if entry is None:
+            return PagewalkResult()
         return self._pagewalk(target, entry, virt)
 
     def pagescan(self, entry: int | None = None) -> list[Page]:
@@ -538,7 +543,7 @@ class x86_64PagingInfo(ArchPagingInfo):
             entry = pwndbg.aglib.regs.read_reg("cr3")
         return self._pagescan(entry)
 
-    def bitflags(self, _: PageTableLevel) -> BitFlags:
+    def bitflags(self, level: PageTableLevel) -> BitFlags:
         return BitFlags([("NX", 63), ("PS", 7), ("A", 5), ("U", 2), ("W", 1), ("P", 0)])
 
     def should_stop_pagewalk(self, entry: int) -> bool:
@@ -763,7 +768,7 @@ class Aarch64PagingInfo(ArchPagingInfo):
         return (self.va_bits - self.page_shift + (self.page_shift - 4)) // (self.page_shift - 3)
 
     @pwndbg.lib.cache.cache_until("stop")
-    def markers(self) -> tuple[tuple[str, int], ...]:
+    def markers(self) -> tuple[tuple[str | None, int], ...]:
         address_markers = pwndbg.aglib.symbol.lookup_symbol_addr("address_markers")
         if address_markers is not None:
             sections = [(self.USERLAND, 0)]
@@ -804,7 +809,7 @@ class Aarch64PagingInfo(ArchPagingInfo):
     def adjust(self, name: str) -> str:
         name = name.lower()
         if "end" in name:
-            return None
+            return ""
         if "linear" in name:
             return self.PHYSMAP
         if "modules" in name:
@@ -855,6 +860,8 @@ class Aarch64PagingInfo(ArchPagingInfo):
                 entry = pwndbg.aglib.regs.read_reg("TTBR1_EL1")
             else:
                 entry = pwndbg.aglib.regs.read_reg("TTBR0_EL1")
+        if entry is None:
+            return PagewalkResult()
         entry |= 3  # marks the entry as a table
         return self._pagewalk(target, entry, virt)
 

--- a/pwndbg/aglib/kernel/paging.py
+++ b/pwndbg/aglib/kernel/paging.py
@@ -85,7 +85,7 @@ class PageTableScan:
         result = []
         curr = None
         kernel_prefix_shift = self.paging_level * self.PAGE_INDEX_LEN + self.page_shift
-        # assumes self.cache[*] is sorted
+        # assumes the elements in self.cache[*] are sorted and non-overlapping
         for offset, size, flags in self.cache[(entry, self.paging_level)]:
             if self.arch == "x86-64":
                 is_kernel = offset >= (1 << 47)

--- a/pwndbg/aglib/kernel/slab.py
+++ b/pwndbg/aglib/kernel/slab.py
@@ -621,7 +621,7 @@ def kmem_cache_structs(node_cache_pad):
     return result
 
 
-@pwndbg.aglib.kernel.typeinfo_recovery("struct kmem_cache", kversion=True)
+@pwndbg.aglib.kernel.typeinfo_recovery("struct kmem_cache", requires_kversion=True)
 def load_slab_typeinfo() -> str:
     kconfig = pwndbg.aglib.kernel.kconfig()
     defs = []

--- a/pwndbg/aglib/kernel/slab.py
+++ b/pwndbg/aglib/kernel/slab.py
@@ -421,6 +421,8 @@ class Slab:
 
 
 def find_containing_slab_cache(addr: int) -> SlabCache | None:
+    if not load_slab_typeinfo():
+        return None
     page = pwndbg.aglib.memory.get_typed_pointer_value("struct page", kernel.virt_to_page(addr))
     head_page = compound_head(page)
 
@@ -619,12 +621,8 @@ def kmem_cache_structs(node_cache_pad):
     return result
 
 
-def load_slab_typeinfo():
-    if pwndbg.aglib.typeinfo.lookup_types("struct kmem_cache") is not None:
-        return
-    if pwndbg.aglib.kernel.symbol.kversion_cint() is None:
-        return
-    pwndbg.aglib.kernel.symbol.load_common_structs()
+@pwndbg.aglib.kernel.typeinfo_recovery("struct kmem_cache", kversion=True)
+def load_slab_typeinfo() -> str:
     kconfig = pwndbg.aglib.kernel.kconfig()
     defs = []
     configs = (
@@ -704,5 +702,4 @@ def load_slab_typeinfo():
         struct kmem_cache_node *node[{pwndbg.aglib.kernel.num_numa_nodes()}];
     }};
     """
-    header_file_path = pwndbg.commands.cymbol.create_temp_header_file(result)
-    pwndbg.commands.cymbol.add_structure_from_header(header_file_path, "slab_structs", True)
+    return result

--- a/pwndbg/aglib/kernel/slab.py
+++ b/pwndbg/aglib/kernel/slab.py
@@ -420,8 +420,7 @@ class Slab:
 
 
 def find_containing_slab_cache(addr: int) -> SlabCache | None:
-    if not load_slab_typeinfo():
-        return None
+    recover_slab_typeinfo()
     page = pwndbg.aglib.memory.get_typed_pointer_value("struct page", kernel.virt_to_page(addr))
     head_page = compound_head(page)
 
@@ -621,7 +620,7 @@ def kmem_cache_structs(node_cache_pad):
 
 
 @pwndbg.aglib.kernel.typeinfo_recovery("struct kmem_cache", requires_kversion=True)
-def load_slab_typeinfo() -> str:
+def recover_slab_typeinfo() -> str:
     kconfig = pwndbg.aglib.kernel.kconfig()
     defs = []
     configs = (

--- a/pwndbg/aglib/kernel/slab.py
+++ b/pwndbg/aglib/kernel/slab.py
@@ -14,6 +14,7 @@ from pwndbg.aglib.kernel.macros import swab
 
 
 def caches() -> Generator[SlabCache, None, None]:
+    recover_slab_typeinfo()
     slab_caches = pwndbg.aglib.kernel.slab_caches()
     if slab_caches is None:
         # Symbol not found

--- a/pwndbg/aglib/kernel/slab.py
+++ b/pwndbg/aglib/kernel/slab.py
@@ -421,15 +421,17 @@ class Slab:
 
 
 def find_containing_slab_cache(addr: int) -> SlabCache | None:
-    recover_slab_typeinfo()
-    page = pwndbg.aglib.memory.get_typed_pointer_value("struct page", kernel.virt_to_page(addr))
-    head_page = compound_head(page)
+    recover_slab_typeinfo()  # throws a separate exception
+    try:
+        page = pwndbg.aglib.memory.get_typed_pointer_value("struct page", kernel.virt_to_page(addr))
+        head_page = compound_head(page)
 
-    slab_type = pwndbg.aglib.typeinfo.load(f"struct {slab_struct_type()}")
-    assert slab_type is not None, "Symbol slab not found"
-
-    slab = head_page.cast(slab_type)
-    return SlabCache(slab["slab_cache"])
+        slab_type = pwndbg.aglib.typeinfo.load(f"struct {slab_struct_type()}")
+        slab = head_page.cast(slab_type)
+        return SlabCache(slab["slab_cache"])
+    except Exception:
+        pass
+    return None
 
 
 #########################################

--- a/pwndbg/aglib/kernel/symbol.py
+++ b/pwndbg/aglib/kernel/symbol.py
@@ -3,11 +3,14 @@ from __future__ import annotations
 import re
 from typing import Any
 
+import pwndbg.aglib.disasm.disassembly
 import pwndbg.aglib.kernel
 import pwndbg.aglib.memory
+import pwndbg.aglib.qemu
 import pwndbg.aglib.symbol
 import pwndbg.aglib.typeinfo
 import pwndbg.commands
+import pwndbg.dbg_mod
 import pwndbg.lib.cache
 from pwndbg.aglib.disasm.instruction import PwndbgInstruction
 from pwndbg.dbg_mod import EventType
@@ -35,9 +38,9 @@ def migratetype_names() -> tuple[str, ...]:
         "HighAtomic",
     ]
     kconfig = pwndbg.aglib.kernel.kconfig()
-    if "CONFIG_CMA" in kconfig:
+    if kconfig and "CONFIG_CMA" in kconfig:
         names.append("CMA")
-    if "CONFIG_MEMORY_ISOLATION" in kconfig:
+    if kconfig and "CONFIG_MEMORY_ISOLATION" in kconfig:
         names.append("Isolate")
     return tuple(names)
 
@@ -94,7 +97,8 @@ def npcplist() -> int:
             return 3
         return 12
     node_data0 = pwndbg.aglib.kernel.node_data()
-    if "CONFIG_NUMA" in pwndbg.aglib.kernel.kconfig():
+    kconfig = pwndbg.aglib.kernel.kconfig()
+    if kconfig and "CONFIG_NUMA" in kconfig:
         node_data0 = node_data0.dereference()
     zone = node_data0[0]["node_zones"][0]
     # index 0 should always exist
@@ -107,7 +111,7 @@ def npcplist() -> int:
     return 0
 
 
-def kversion_cint(kversion: tuple[int, int, int] | None = None) -> int | None:
+def kversion_cint(kversion: tuple[int, ...] | None = None) -> int | None:
     if kversion is None:
         kversion = pwndbg.aglib.kernel.krelease()
     if kversion is None or len(kversion) != 3:
@@ -183,13 +187,14 @@ enum pageflags {
 
 
 @pwndbg.aglib.kernel.typeinfo_recovery("struct page", requires_kversion=True)
-def load_page_typeinfo() -> str:
+def recover_page_typeinfo() -> str:
     defs = []
     for config in (
         "CONFIG_MEMCG",
         "CONFIG_KASAN",
     ):
-        if config in pwndbg.aglib.kernel.kconfig():
+        kconfig = pwndbg.aglib.kernel.kconfig()
+        if kconfig and config in kconfig:
             defs.append(config)
     result = f"#define KVERSION {kversion_cint()}\n"
     result += "\n".join(f"#define {s}" for s in defs)
@@ -272,11 +277,11 @@ def load_page_typeinfo() -> str:
 
 @pwndbg.dbg.event_handler(EventType.NEW_MODULE)
 def load_common_structs_on_load_linux() -> None:
-    # basically want to be sure that the symbol file is a vmlinux with symbols
-    # has_debug_symbols without args checks for `commit_creds`
-    # load_common_structs would check if typeinfo has already been added (so doesnt readd)
-    if pwndbg.aglib.qemu.is_qemu_kernel():
-        load_page_typeinfo()
+    if pwndbg.aglib.qemu.is_qemu_kernel() and pwndbg.dbg.selected_inferior().is_linux():
+        try:
+            recover_page_typeinfo()
+        except Exception as _:
+            pass
 
 
 class ArchSymbols:
@@ -309,10 +314,10 @@ class ArchSymbols:
         return "\n".join(disass)
 
     def regex(self, s: str, pattern: str, nth: int) -> re.Match[Any] | None:
-        pattern = re.compile(pattern)
+        p = re.compile(pattern)
         if nth == 0:
-            return pattern.search(s)
-        matches = list(pattern.finditer(s))
+            return p.search(s)
+        matches = list(p.finditer(s))
         if nth < len(matches):
             return matches[nth]
         return None
@@ -388,8 +393,9 @@ class ArchSymbols:
         return pwndbg.aglib.memory.get_typed_pointer("unsigned long", prog_idr)
 
     @pwndbg.lib.cache.cache_until("stop")
-    def current_task(self, cpu: int | None) -> int:
+    def current_task(self, cpu: int | None) -> int | None:
         # using symbols usually yield incorrect results
+        current_task = None
         if pwndbg.aglib.arch.name == "aarch64":
             current_task = self._current_task()
         elif pwndbg.aglib.kernel.has_debug_symbols(self.current_task_heuristic_func):
@@ -464,6 +470,8 @@ class x86_64Symbols(ArchSymbols):
 
     def _node_data(self) -> int | None:
         disass = self.disass(self.node_data_heuristic_func)
+        if not disass:
+            return None
         result = self.qword_op_reg_memoff(disass, op="mov", sign="-")
         if result is not None:
             return result
@@ -471,10 +479,14 @@ class x86_64Symbols(ArchSymbols):
 
     def _slab_caches(self) -> int | None:
         disass = self.disass(self.slab_caches_heuristic_func)
+        if not disass:
+            return None
         return self.qword_mov_reg_const(disass)
 
     def _per_cpu_offset(self) -> int | None:
         disass = self.disass(self.per_cpu_offset_heuristic_func)
+        if not disass:
+            return None
         result = self.qword_op_reg_memoff(disass, op="add", sign="-")
         if result is not None:
             return result
@@ -485,11 +497,15 @@ class x86_64Symbols(ArchSymbols):
 
     def _modules(self) -> int | None:
         disass = self.disass(self.modules_heuristic_func)
+        if not disass:
+            return None
         return self.qword_mov_reg_ripoff(disass)
 
     def _db_list(self) -> int | None:
         offset = 0x10  # offset of the lock
         disass = self.disass(self.db_list_heuristic_func)
+        if not disass:
+            return None
         result = self.qword_mov_reg_const(disass)
         if result is not None:
             return result - offset
@@ -497,6 +513,8 @@ class x86_64Symbols(ArchSymbols):
 
     def _map_idr(self) -> int | None:
         disass = self.disass(self.bpf_map_heuristic_func, lines=50)
+        if not disass:
+            return None
         result = self.qword_mov_reg_const(disass, nth=1)
         if result is not None:
             return result
@@ -504,6 +522,8 @@ class x86_64Symbols(ArchSymbols):
 
     def _prog_idr(self) -> int | None:
         disass = self.disass(self.bpf_prog_heuristic_func, lines=50)
+        if not disass:
+            return None
         result = self.qword_mov_reg_const(disass, nth=1)
         if result is not None:
             return result
@@ -511,6 +531,8 @@ class x86_64Symbols(ArchSymbols):
 
     def _current_task(self) -> int | None:
         disass = self.disass(self.current_task_heuristic_func)
+        if not disass:
+            return None
         result = self.dword_mov_reg_const(disass)
         if result is not None:
             return result
@@ -539,10 +561,14 @@ class Aarch64Symbols(ArchSymbols):
 
     def _node_data(self) -> int | None:
         disass = self.disass(self.node_data_heuristic_func)
+        if not disass:
+            return None
         return self.qword_adrp_add_const(disass)
 
     def _slab_caches(self) -> int | None:
         disass = self.disass(self.slab_caches_heuristic_func)
+        if not disass:
+            return None
         result = self.qword_adrp_add_const(disass)
         if result:
             return result
@@ -564,10 +590,14 @@ class Aarch64Symbols(ArchSymbols):
 
     def _per_cpu_offset(self) -> int | None:
         disass = self.disass(self.per_cpu_offset_heuristic_func)
+        if not disass:
+            return None
         return self.qword_adrp_add_const(disass)
 
     def _modules(self) -> int | None:
         disass = self.disass(self.modules_heuristic_func)
+        if not disass:
+            return None
         # adrp x<num>, 0x....
         # ...
         # add x<num>, x<num>, #0x...
@@ -587,6 +617,8 @@ class Aarch64Symbols(ArchSymbols):
     def _db_list(self) -> int | None:
         offset = 0x10  # offset of the lock
         disass = self.disass(self.db_list_heuristic_func)
+        if not disass:
+            return None
         result = self.qword_adrp_add_const(disass)
         if result is not None:
             return result - offset
@@ -594,6 +626,8 @@ class Aarch64Symbols(ArchSymbols):
 
     def _map_idr(self) -> int | None:
         disass = self.disass(self.bpf_map_heuristic_func, lines=50)
+        if not disass:
+            return None
         result = self.qword_adrp_add_const(disass, nth=1)
         if result is not None:
             return result
@@ -601,10 +635,12 @@ class Aarch64Symbols(ArchSymbols):
 
     def _prog_idr(self) -> int | None:
         disass = self.disass(self.bpf_prog_heuristic_func, lines=50)
+        if not disass:
+            return None
         result = self.qword_adrp_add_const(disass, nth=1)
         if result is not None:
             return result
         return self.qword_adrp_add_const(disass)
 
-    def _current_task(self) -> int:
+    def _current_task(self) -> int | None:
         return pwndbg.aglib.regs.read_reg("sp_el0")

--- a/pwndbg/aglib/kernel/symbol.py
+++ b/pwndbg/aglib/kernel/symbol.py
@@ -401,13 +401,6 @@ class ArchSymbols:
                 current_task = pwndbg.aglib.memory.read_pointer_width(int(current_task))
         return current_task
 
-    @pwndbg.lib.cache.cache_until("stop")
-    def init_task(self) -> pwndbg.dbg_mod.Value:
-        init_task = pwndbg.aglib.symbol.lookup_symbol("init_task")
-        if not init_task:
-            init_task = pwndbg.aglib.kernel.ktask.INIT_TASK
-        return pwndbg.aglib.memory.get_typed_pointer("unsigned long", init_task)
-
     def _node_data(self) -> int | None:
         raise NotImplementedError()
 

--- a/pwndbg/aglib/kernel/symbol.py
+++ b/pwndbg/aglib/kernel/symbol.py
@@ -9,6 +9,7 @@ import pwndbg.aglib.symbol
 import pwndbg.aglib.typeinfo
 import pwndbg.commands
 import pwndbg.lib.cache
+from pwndbg.aglib.disasm.instruction import PwndbgInstruction
 from pwndbg.dbg_mod import EventType
 
 #########################################
@@ -54,7 +55,7 @@ def try_usymbol(name: str, size: int | None = None) -> int | None:
             return None
 
         if size is None:
-            size = pwndbg.aglib.kernel.ptr_size()
+            size = pwndbg.aglib.arch.ptrbits
 
         if size == 8:
             return pwndbg.aglib.memory.u(symbol)
@@ -129,6 +130,7 @@ typedef char s8;
 typedef unsigned short u16;
 typedef unsigned int u32;
 typedef long long s64;
+typedef unsigned long u64;
 #define bool int
 #if UINTPTR_MAX == 0xffffffff
     typedef int16_t arch_word_t;
@@ -136,11 +138,24 @@ typedef long long s64;
     typedef int32_t arch_word_t;
 #endif
 typedef struct {
+    unsigned int val;
+} kuid_t;
+typedef struct {
+    unsigned int val;
+} kgid_t;
+typedef int pid_t;
+typedef struct {
     int counter;
 } atomic_t;
+typedef struct refcount_struct {
+	atomic_t refs;
+} refcount_t;
 
 struct list_head {
     struct list_head *next, *prev;
+};
+struct hlist_node {
+	struct hlist_node *next, **pprev;
 };
 struct kmem_cache;
 enum pageflags {
@@ -168,11 +183,8 @@ enum pageflags {
 """
 
 
-def load_common_structs() -> None:
-    if pwndbg.aglib.kernel.has_debug_info() or not kversion_cint():
-        return
-    if pwndbg.aglib.typeinfo.lookup_types("struct page") is not None:
-        return
+@pwndbg.aglib.kernel.typeinfo_recovery("struct page", kversion=True)
+def load_page_typeinfo() -> str:
     defs = []
     for config in (
         "CONFIG_MEMCG",
@@ -256,10 +268,7 @@ def load_common_structs() -> None:
 #endif
     };
     """
-    header_file_path = pwndbg.commands.cymbol.create_temp_header_file(result)
-    pwndbg.commands.cymbol.add_structure_from_header(
-        header_file_path, "common_kernel_structs", True
-    )
+    return result
 
 
 @pwndbg.dbg.event_handler(EventType.NEW_MODULE)
@@ -267,11 +276,8 @@ def load_common_structs_on_load_linux() -> None:
     # basically want to be sure that the symbol file is a vmlinux with symbols
     # has_debug_symbols without args checks for `commit_creds`
     # load_common_structs would check if typeinfo has already been added (so doesnt readd)
-    if pwndbg.aglib.qemu.is_qemu_kernel() and pwndbg.aglib.kernel.has_debug_symbols():
-        try:
-            load_common_structs()
-        except Exception:
-            pass
+    if pwndbg.aglib.qemu.is_qemu_kernel():
+        load_page_typeinfo()
 
 
 class ArchSymbols:
@@ -293,8 +299,15 @@ class ArchSymbols:
         sym = pwndbg.aglib.symbol.lookup_symbol(name)
         if sym is None:
             return None
-        disass = "\n".join(pwndbg.aglib.nearpc.nearpc(int(sym), lines=lines))
-        return pwndbg.color.strip(disass)
+        addr = int(sym)
+        disass = []
+        for _ in range(lines):
+            instr: PwndbgInstruction = pwndbg.aglib.disasm.disassembly.get_one_instruction(
+                addr, enhance=False
+            )
+            disass.append(instr.asm_string)
+            addr = instr.next
+        return "\n".join(disass)
 
     def regex(self, s: str, pattern: str, nth: int) -> re.Match[Any] | None:
         pattern = re.compile(pattern)
@@ -305,6 +318,7 @@ class ArchSymbols:
             return matches[nth]
         return None
 
+    @pwndbg.lib.cache.cache_until("stop")
     def node_data(self) -> pwndbg.dbg_mod.Value:
         node_data = pwndbg.aglib.symbol.lookup_symbol("node_data")
         if pwndbg.aglib.kernel.has_debug_info():
@@ -315,6 +329,7 @@ class ArchSymbols:
             node_data = self._node_data()
         return pwndbg.aglib.memory.get_typed_pointer("unsigned long", node_data)
 
+    @pwndbg.lib.cache.cache_until("stop")
     def slab_caches(self) -> pwndbg.dbg_mod.Value:
         slab_caches = pwndbg.aglib.symbol.lookup_symbol("slab_caches")
         if slab_caches is None and pwndbg.aglib.kernel.has_debug_symbols(
@@ -323,6 +338,7 @@ class ArchSymbols:
             slab_caches = self._slab_caches()
         return pwndbg.aglib.memory.get_typed_pointer_value("struct list_head", slab_caches)
 
+    @pwndbg.lib.cache.cache_until("stop")
     def per_cpu_offset(self) -> pwndbg.dbg_mod.Value:
         per_cpu_offset = pwndbg.aglib.symbol.lookup_symbol("__per_cpu_offset")
         if per_cpu_offset is not None:
@@ -331,6 +347,7 @@ class ArchSymbols:
             per_cpu_offset = self._per_cpu_offset()
         return pwndbg.aglib.memory.get_typed_pointer("unsigned long", per_cpu_offset)
 
+    @pwndbg.lib.cache.cache_until("stop")
     def modules(self) -> pwndbg.dbg_mod.Value:
         modules = pwndbg.aglib.symbol.lookup_symbol("modules")
         if modules:
@@ -339,6 +356,7 @@ class ArchSymbols:
             modules = self._modules()
         return pwndbg.aglib.memory.get_typed_pointer("unsigned long", modules)
 
+    @pwndbg.lib.cache.cache_until("stop")
     def db_list(self) -> pwndbg.dbg_mod.Value:
         if pwndbg.aglib.kernel.krelease() >= (6, 10):
             debugfs_list = pwndbg.aglib.symbol.lookup_symbol("debugfs_list")
@@ -352,6 +370,7 @@ class ArchSymbols:
             db_list = self._db_list()
         return pwndbg.aglib.memory.get_typed_pointer("struct list_head", db_list)
 
+    @pwndbg.lib.cache.cache_until("stop")
     def map_idr(self) -> pwndbg.dbg_mod.Value:
         map_idr = pwndbg.aglib.symbol.lookup_symbol("map_idr")
         if map_idr:
@@ -360,6 +379,7 @@ class ArchSymbols:
             map_idr = self._map_idr()
         return pwndbg.aglib.memory.get_typed_pointer("unsigned long", map_idr)
 
+    @pwndbg.lib.cache.cache_until("stop")
     def prog_idr(self) -> pwndbg.dbg_mod.Value:
         prog_idr = pwndbg.aglib.symbol.lookup_symbol("prog_idr")
         if prog_idr:
@@ -368,20 +388,25 @@ class ArchSymbols:
             prog_idr = self._prog_idr()
         return pwndbg.aglib.memory.get_typed_pointer("unsigned long", prog_idr)
 
-    def current_task(self) -> pwndbg.dbg_mod.Value:
-        current_task = pwndbg.aglib.symbol.lookup_symbol("current_task")
-        if current_task:
-            current_task = pwndbg.aglib.kernel.per_cpu(current_task)
-            return current_task.dereference()
+    @pwndbg.lib.cache.cache_until("stop")
+    def current_task(self, cpu: int | None) -> int:
+        # using symbols usually yield incorrect results
         if pwndbg.aglib.arch.name == "aarch64":
             current_task = self._current_task()
         elif pwndbg.aglib.kernel.has_debug_symbols(self.current_task_heuristic_func):
             current_task = self._current_task()
             if current_task is not None:
-                current_task = pwndbg.aglib.kernel.per_cpu(current_task)
-            # current_task is int but needed here to make the linter happy
-            current_task = pwndbg.aglib.memory.read_pointer_width(int(current_task))
-        return pwndbg.aglib.memory.get_typed_pointer("unsigned long", current_task)
+                current_task = pwndbg.aglib.kernel.per_cpu(current_task, cpu=cpu)
+                # current_task is int but needed here to make the linter happy
+                current_task = pwndbg.aglib.memory.read_pointer_width(int(current_task))
+        return current_task
+
+    @pwndbg.lib.cache.cache_until("stop")
+    def init_task(self) -> pwndbg.dbg_mod.Value:
+        init_task = pwndbg.aglib.symbol.lookup_symbol("init_task")
+        if not init_task:
+            init_task = pwndbg.aglib.kernel.ktask.INIT_TASK
+        return pwndbg.aglib.memory.get_typed_pointer("unsigned long", init_task)
 
     def _node_data(self) -> int | None:
         raise NotImplementedError()
@@ -498,8 +523,8 @@ class x86_64Symbols(ArchSymbols):
         result = self.dword_mov_reg_const(disass)
         if result is not None:
             return result
-        disass = self.disass(self.current_task_heuristic_func, lines=20)
-        return self.qword_op_reg_memoff(disass, op="mov", sign="+")
+        result = self.qword_mov_reg_const(disass)
+        return result
 
 
 class Aarch64Symbols(ArchSymbols):

--- a/pwndbg/aglib/kernel/symbol.py
+++ b/pwndbg/aglib/kernel/symbol.py
@@ -183,7 +183,7 @@ enum pageflags {
 """
 
 
-@pwndbg.aglib.kernel.typeinfo_recovery("struct page", kversion=True)
+@pwndbg.aglib.kernel.typeinfo_recovery("struct page", requires_kversion=True)
 def load_page_typeinfo() -> str:
     defs = []
     for config in (

--- a/pwndbg/aglib/kernel/vmmap.py
+++ b/pwndbg/aglib/kernel/vmmap.py
@@ -440,7 +440,7 @@ def kernel_vmmap() -> tuple[pwndbg.lib.memory.Page, ...]:
         for page in pages:
             if page.objfile == kv.pi.ESPSTACK:
                 continue
-            entry = pwndbg.aglib.kernel.pagewalk(page.start)[0].entry
+            entry = pwndbg.aglib.kernel.pagewalk(page.start).entry
             if entry and entry >> 63 == 0:
                 page.flags |= 1
 

--- a/pwndbg/aglib/kernel/vmmap.py
+++ b/pwndbg/aglib/kernel/vmmap.py
@@ -411,7 +411,7 @@ def kernel_vmmap_pages() -> tuple[Page, ...]:
             entry = pwndbg.commands.kcurrent.KCURRENT_PGD
             if entry and pwndbg.aglib.memory.is_kernel(entry):
                 entry = pwndbg.aglib.kernel.virt_to_phys(entry)
-            return pwndbg.aglib.kernel.pagetable_scan(entry)
+            return pwndbg.aglib.kernel.pagescan(entry)
         case "pt-dump":
             return kernel_vmmap_via_page_tables()
         case "monitor":

--- a/pwndbg/aglib/memory.py
+++ b/pwndbg/aglib/memory.py
@@ -232,7 +232,7 @@ def u(addr: int, size: int | None = None) -> int:
     to the pointer width.
     """
     if size is None:
-        size = pwndbg.aglib.arch.ptrsize * 8
+        size = pwndbg.aglib.arch.ptrbits
     return {8: u8, 16: u16, 32: u32, 64: u64}[size](addr)
 
 

--- a/pwndbg/aglib/onegadget.py
+++ b/pwndbg/aglib/onegadget.py
@@ -141,7 +141,7 @@ class Lambda:
                 #       |                       ^~~~~~~~~
                 #  while parsing (u64)xmm0 >> 64 for argv[1]
 
-                bits = pwndbg.aglib.arch.ptrsize * 8
+                bits = pwndbg.aglib.arch.ptrbits
                 if XMM_SHIFT in obj:
                     obj = obj.replace(XMM_SHIFT + str(bits), f".v{128 // bits}_int{bits}[1]")
                 else:

--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -817,6 +817,19 @@ def OnlyWhenPagingEnabled(function: Callable[P, T]) -> Callable[P, T | None]:
     return _OnlyWhenPagingEnabled
 
 
+def WarnOnKernelConfigRandstruct(function: Callable[P, T]) -> Callable[P, T | None]:
+    @functools.wraps(function)
+    def _WarnOnKernelConfigRandstruct(*a: P.args, **kw: P.kwargs) -> T | None:
+        if (
+            not pwndbg.aglib.kernel.has_debug_info()
+            and "CONFIG_RANDSTRUCT" in pwndbg.aglib.kernel.kconfig()
+        ):
+            log.warning("command output may be inaccurate because CONFIG_RANDSTRUCT=y")
+        return function(*a, **kw)
+
+    return _WarnOnKernelConfigRandstruct
+
+
 def OnlyWhenRunning(function: Callable[P, T]) -> Callable[P, T | None]:
     @functools.wraps(function)
     def _OnlyWhenRunning(*a: P.args, **kw: P.kwargs) -> T | None:

--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -512,6 +512,15 @@ class CommandObj:
                 print("Feel free to re-enable manually.")
             else:
                 print()
+        except pwndbg.aglib.kernel.TypeNotRecovered as e:
+            print(message.warn(f"recovering {e.name} failed with error:\n{e}"))
+            kconfig = pwndbg.aglib.kernel.kconfig()
+            if kconfig and "CONFIG_RANDSTRUCT" in kconfig:
+                print(
+                    message.warn(
+                        "please note that some structs may not be recoverable when CONFIG_RANDSTRUCT=y"
+                    )
+                )
 
         except Exception:
             pwndbg.exception.handle(self.function.__name__)

--- a/pwndbg/commands/buddydump.py
+++ b/pwndbg/commands/buddydump.py
@@ -340,8 +340,7 @@ def buddydump(
     if not node_data:
         log.warning("WARNING: Symbol 'node_data' not found")
         return
-    if not pwndbg.aglib.kernel.buddydump.load_buddydump_typeinfo():
-        return
+    pwndbg.aglib.kernel.buddydump.recover_buddydump_typeinfo()
     if not pwndbg.aglib.kernel.has_debug_info():
         node_data = pwndbg.aglib.memory.get_typed_pointer("node_data_t", node_data)
     pba = ParsedBuddyArgs(zone, order, mtype.lower() if mtype is not None else None, cpu, find)
@@ -352,7 +351,8 @@ def buddydump(
         if node is not None and node_idx != node:
             continue
         zones = None
-        if "CONFIG_NUMA" in pwndbg.aglib.kernel.kconfig():
+        kconfig = pwndbg.aglib.kernel.kconfig()
+        if kconfig and "CONFIG_NUMA" in kconfig:
             # only display one node per invocation is probably sufficient under most use cases
             zones = node_data.dereference()[node_idx]["node_zones"]
         else:

--- a/pwndbg/commands/buddydump.py
+++ b/pwndbg/commands/buddydump.py
@@ -340,8 +340,9 @@ def buddydump(
     if not node_data:
         log.warning("WARNING: Symbol 'node_data' not found")
         return
+    if not pwndbg.aglib.kernel.buddydump.load_buddydump_typeinfo():
+        return
     if not pwndbg.aglib.kernel.has_debug_info():
-        pwndbg.aglib.kernel.buddydump.load_buddydump_typeinfo()
         node_data = pwndbg.aglib.memory.get_typed_pointer("node_data_t", node_data)
     pba = ParsedBuddyArgs(zone, order, mtype.lower() if mtype is not None else None, cpu, find)
     cbp = CurrentBuddyParams(

--- a/pwndbg/commands/cymbol.py
+++ b/pwndbg/commands/cymbol.py
@@ -221,6 +221,7 @@ def load_custom_structure(custom_structure_name: str, custom_structure_path: str
     pwndbg.dbg.selected_inferior().add_symbol_file(pwndbg_debug_symbols_output_file)
     loaded_symbols[custom_structure_name] = pwndbg_debug_symbols_output_file
     print(message.success(f"Loaded custom symbols! (from {custom_structure_path})"))
+    os.unlink(pwndbg_debug_symbols_output_file)
 
 
 @OnlyWhenStructFileExists

--- a/pwndbg/commands/cymbol.py
+++ b/pwndbg/commands/cymbol.py
@@ -60,7 +60,7 @@ def create_temp_header_file(content: str) -> str:
 def unload_loaded_symbol(custom_structure_name: str) -> None:
     custom_structure_symbols_file = loaded_symbols.get(custom_structure_name)
     if custom_structure_symbols_file is not None:
-        pwndbg.dbg.selected_inferior().remove_symbol_file("custom_structure_symbols_file")
+        pwndbg.dbg.selected_inferior().remove_symbol_file(custom_structure_symbols_file)
         loaded_symbols.pop(custom_structure_name)
 
 

--- a/pwndbg/commands/cymbol.py
+++ b/pwndbg/commands/cymbol.py
@@ -22,7 +22,6 @@ import sys
 import tempfile
 from typing import TypeVar
 
-import gdb
 from typing_extensions import ParamSpec
 from typing_extensions import Protocol
 
@@ -61,7 +60,7 @@ def create_temp_header_file(content: str) -> str:
 def unload_loaded_symbol(custom_structure_name: str) -> None:
     custom_structure_symbols_file = loaded_symbols.get(custom_structure_name)
     if custom_structure_symbols_file is not None:
-        gdb.execute(f"remove-symbol-file {custom_structure_symbols_file}")
+        pwndbg.dbg.selected_inferior().remove_symbol_file("custom_structure_symbols_file")
         loaded_symbols.pop(custom_structure_name)
 
 

--- a/pwndbg/commands/dumpargs.py
+++ b/pwndbg/commands/dumpargs.py
@@ -25,7 +25,7 @@ def dumpargs(force: bool = False) -> None:
     else:
         print("Couldn't resolve call arguments from registers.")
         print(
-            f"Detected ABI: {pwndbg.aglib.arch.name} ({pwndbg.aglib.arch.ptrsize * 8} bit) either doesn't pass arguments through registers or is not implemented. Maybe they are passed on the stack?"
+            f"Detected ABI: {pwndbg.aglib.arch.name} ({pwndbg.aglib.arch.ptrbits} bit) either doesn't pass arguments through registers or is not implemented. Maybe they are passed on the stack?"
         )
 
 

--- a/pwndbg/commands/kbase.py
+++ b/pwndbg/commands/kbase.py
@@ -28,7 +28,7 @@ def kbase(rebase=False, verbose=False) -> None:
         print(message.error("kbase does not work when kernel-vmmap is set to none"))
         return
 
-    base = pwndbg.aglib.kernel.arch_paginginfo().kbase
+    base = pwndbg.aglib.kernel.kbase()
 
     if base is None:
         print(message.error("Unable to locate the kernel base"))

--- a/pwndbg/commands/kbpf.py
+++ b/pwndbg/commands/kbpf.py
@@ -10,6 +10,7 @@ import pwndbg
 import pwndbg.aglib.kernel
 import pwndbg.aglib.kernel.bpf
 import pwndbg.aglib.memory
+import pwndbg.aglib.typeinfo
 import pwndbg.color.message as message
 import pwndbg.commands
 from pwndbg.commands import CommandCategory
@@ -236,8 +237,7 @@ def print_bpf_maps(verbose):
 @pwndbg.commands.OnlyWhenPagingEnabled
 @pwndbg.commands.WarnOnKernelConfigRandstruct
 def kbpf(verbose: int, print_progs: bool, print_maps: bool) -> None:
-    if not pwndbg.aglib.kernel.bpf.load_bpf_typeinfo():
-        return
+    pwndbg.aglib.kernel.bpf.recover_bpf_typeinfo()
     if pwndbg.aglib.typeinfo.load("struct idr") is None:
         return
     if not print_progs and not print_maps:

--- a/pwndbg/commands/kbpf.py
+++ b/pwndbg/commands/kbpf.py
@@ -234,9 +234,10 @@ def print_bpf_maps(verbose):
 @pwndbg.commands.OnlyWhenQemuKernel
 @pwndbg.commands.OnlyWithKernelSymbols
 @pwndbg.commands.OnlyWhenPagingEnabled
-def kbpf(verbose: int, print_progs: bool, print_maps: bool):
-    if not pwndbg.aglib.kernel.has_debug_info():
-        pwndbg.aglib.kernel.bpf.load_bpf_typeinfo()
+@pwndbg.commands.WarnOnKernelConfigRandstruct
+def kbpf(verbose: int, print_progs: bool, print_maps: bool) -> None:
+    if not pwndbg.aglib.kernel.bpf.load_bpf_typeinfo():
+        return
     if pwndbg.aglib.typeinfo.load("struct idr") is None:
         return
     if not print_progs and not print_maps:

--- a/pwndbg/commands/kdmabuf.py
+++ b/pwndbg/commands/kdmabuf.py
@@ -65,7 +65,7 @@ def print_sgl(sgl, indent):
 @pwndbg.commands.OnlyWhenQemuKernel
 @pwndbg.commands.OnlyWithKernelSymbols
 @pwndbg.commands.OnlyWhenPagingEnabled
-def kdmabuf():
+def kdmabuf() -> None:
     db_name = "db_list"
     if pwndbg.aglib.kernel.krelease() >= (6, 10):
         db_name = "debugfs_list"
@@ -80,8 +80,8 @@ def kdmabuf():
         print(message.warn(f"{db_name} ({hex(int(db_list))}) is empty"))
         return
     indent = IndentContextManager()
-    if not pwndbg.aglib.kernel.has_debug_info():
-        pwndbg.aglib.kernel.dmabuf.load_dmabuf_typeinfo(int(db_list["next"]))
+    if not pwndbg.aglib.kernel.dmabuf.load_dmabuf_typeinfo(int(db_list["next"])):
+        return
     for idx, e in enumerate(for_each_entry(db_list.dereference(), "struct dma_buf", "list_node")):
         print_dmabuf(e, idx, indent)
         priv = e["priv"]

--- a/pwndbg/commands/kdmabuf.py
+++ b/pwndbg/commands/kdmabuf.py
@@ -80,8 +80,7 @@ def kdmabuf() -> None:
         print(message.warn(f"{db_name} ({hex(int(db_list))}) is empty"))
         return
     indent = IndentContextManager()
-    if not pwndbg.aglib.kernel.dmabuf.load_dmabuf_typeinfo(int(db_list["next"])):
-        return
+    pwndbg.aglib.kernel.dmabuf.recover_dmabuf_typeinfo(int(db_list["next"]))
     for idx, e in enumerate(for_each_entry(db_list.dereference(), "struct dma_buf", "list_node")):
         print_dmabuf(e, idx, indent)
         priv = e["priv"]

--- a/pwndbg/commands/klookup.py
+++ b/pwndbg/commands/klookup.py
@@ -62,12 +62,7 @@ def klookup(symbol: str, apply: bool) -> None:
             # Until we implement add_symbol_file for LLDB.
             return
 
-        paging_info = pwndbg.aglib.kernel.arch_paginginfo()
-        if paging_info is None:
-            print(message.error(f"Unsupported architecture {pwndbg.aglib.arch.name}."))
-            return
-
-        base: int | None = paging_info.kbase
+        base: int | None = pwndbg.aglib.kernel.kbase()
 
         if base is None:
             # I would be suprised if this was actually possible, we managed to find kallsyms but not

--- a/pwndbg/commands/paging.py
+++ b/pwndbg/commands/paging.py
@@ -32,11 +32,11 @@ PAGETYPES = (
 )
 
 
-def print_pagetable_entry(ptl: PageTableLevel, level: int, is_last: bool):
-    pageflags = pwndbg.aglib.kernel.arch_paginginfo().pageentry_bitflags(is_last)
+def print_level(level: PageTableLevel):
+    pageflags = pwndbg.aglib.kernel.arch_paginginfo().bitflags(level)
     flags = ""
     arrow_right = pwndbg.chain.c.arrow(f"{pwndbg.chain.config_arrow_right}")
-    name, entry, vaddr, idx = ptl.name, ptl.entry, ptl.virt, ptl.idx
+    name, entry, vaddr, idx = level.name, level.entry, level.virt, level.idx
     if pwndbg.aglib.arch.name == "x86-64":
         name = name.ljust(3, " ")
     nbits = pwndbg.aglib.kernel.arch_ops().page_shift - math.ceil(
@@ -95,24 +95,23 @@ def page_info(page):
 def pagewalk(vaddr, entry=None):
     if entry is not None:
         entry = int(pwndbg.dbg.selected_frame().evaluate_expression(entry))
-    else:
+    elif (kcurrent := pwndbg.commands.kcurrent.get_kcurrent()) is not None:
         # did the user set pgd with kcurrent?
         # safe because pagewalk fallbacks to control regs when entry==None
-        entry = pwndbg.commands.kcurrent.KCURRENT_PGD
+        entry = kcurrent.pgd
+    if pwndbg.aglib.memory.is_kernel(entry):
+        entry = pwndbg.aglib.kernel.pagewalk(entry, virt=False).phys
     vaddr = int(pwndbg.dbg.selected_frame().evaluate_expression(vaddr))
-    levels = pwndbg.aglib.kernel.pagewalk(vaddr, entry)
-    for i in range(len(levels) - 1, 0, -1):
-        curr = levels[i]
-        next = levels[i - 1]
-        if curr.entry is None:
+    result = pwndbg.aglib.kernel.pagewalk(vaddr, entry)
+    for level in result.levels[::-1]:
+        if level.entry is None:
             break
-        print_pagetable_entry(curr, i, next.entry is None or i == 1)
-    vaddr = levels[0].virt
+        print_level(level)
+    vaddr = result.virt
     if vaddr is None:
         print(message.warn("address is not mapped"))
         return
-    pi = pwndbg.aglib.kernel.arch_paginginfo()
-    phys = vaddr - pi.physmap + pi.phys_offset
+    phys = result.phys
     print(f"pagewalk result: {color.green(hex(vaddr))} [phys: {color.yellow(hex(phys))}]")
 
 
@@ -157,7 +156,7 @@ v2p_parser.add_argument("vaddr", type=str, help="")
 @pwndbg.aglib.proc.OnlyWithArch(["x86-64", "aarch64"])
 def v2p(vaddr):
     vaddr = int(pwndbg.dbg.selected_frame().evaluate_expression(vaddr))
-    level = pwndbg.aglib.kernel.pagewalk(vaddr)[0]  # more accurate
+    level = pwndbg.aglib.kernel.pagewalk(vaddr)  # more accurate
     entry, paddr = level.entry, level.virt
     if not entry:
         print(message.warn("virtual to physical address failed, unmapped virtual address?"))

--- a/pwndbg/commands/paging.py
+++ b/pwndbg/commands/paging.py
@@ -13,7 +13,6 @@ import pwndbg.color.context as ctx_color
 import pwndbg.color.message as message
 import pwndbg.commands
 import pwndbg.commands.kcurrent
-from pwndbg.aglib.kernel.paging import PageTableLevel
 from pwndbg.commands import CommandCategory
 
 parser = argparse.ArgumentParser(description="Performs pagewalk.")
@@ -32,22 +31,6 @@ PAGETYPES = (
 )
 
 
-def print_level(level: PageTableLevel) -> None:
-    pageflags = pwndbg.aglib.kernel.arch_paginginfo().bitflags(level)
-    flags = ""
-    arrow_right = pwndbg.chain.c.arrow(f"{pwndbg.chain.config_arrow_right}")
-    name, entry, vaddr, idx = level.name, level.entry, level.virt, level.idx
-    if pwndbg.aglib.arch.name == "x86-64":
-        name = name.ljust(3, " ")
-    nbits = pwndbg.aglib.kernel.arch_ops().page_shift - math.ceil(
-        math.log2(pwndbg.aglib.arch.ptrsize)
-    )  # each idx has that many bits
-    idxlen = len(str((1 << nbits) - 1))
-    if entry is not None:
-        flags = f"[{idx:0{idxlen}}] {arrow_right} {name + 'e'}: {ctx_color.format_flags(entry, pageflags, entry)}"
-    print(f"{color.blue(name)} @ {color.yellow(hex(vaddr))}{flags}")
-
-
 def page_type(page) -> str:
     names = PAGETYPES
     page_type_val = pwndbg.aglib.memory.s32(page + 0x30)
@@ -56,21 +39,22 @@ def page_type(page) -> str:
     if page_type_val >= 0:
         return f"mapcount: {page_type_val}"
     page_type_val = pwndbg.aglib.memory.u32(page + 0x30)
-    if pwndbg.aglib.kernel.krelease() >= (6, 12):
+    krelease = pwndbg.aglib.kernel.krelease()
+    if not krelease or krelease >= (6, 12):
         idx = (page_type_val >> 24) - 0xF0
         if idx < len(names):
             return names[idx]
-    if pwndbg.aglib.kernel.krelease() >= (6, 11):
+    elif krelease >= (6, 11):
         names = names[:-1][::-1]
         for i in range(len(names)):
             if page_type_val & (1 << (i + 24)) == 0:
                 return names[i]
-    if pwndbg.aglib.kernel.krelease() >= (6, 10):
+    elif krelease >= (6, 10):
         names = names[:6]
         for i in range(len(names)):
             if page_type_val & (1 << (7 + i)) == 0:
                 return names[i]
-    if pwndbg.aglib.kernel.krelease() >= (5, 0):
+    elif krelease >= (5, 0):
         names = names[:5]
         for i in range(len(names)):
             if page_type_val & (1 << (7 + i)) == 0:
@@ -100,15 +84,29 @@ def pagewalk(vaddr, entry=None) -> None:
     vaddr = int(pwndbg.dbg.selected_frame().evaluate_expression(vaddr))
     result = pwndbg.aglib.kernel.pagewalk(vaddr, entry)
     for level in result.levels[::-1]:
-        if level.entry is None:
+        name, entry, vaddr, idx = level.name, level.entry, level.virt, level.idx
+        if name is None or entry is None or vaddr is None or idx is None:
             break
-        print_level(level)
+        pageflags = pwndbg.aglib.kernel.bitflags(level)
+        flags = ""
+        arrow_right = pwndbg.chain.c.arrow(f"{pwndbg.chain.config_arrow_right}")
+        if pwndbg.aglib.arch.name == "x86-64":
+            name = name.ljust(3, " ")
+        nbits = pwndbg.aglib.kernel.page_shift() - math.ceil(
+            math.log2(pwndbg.aglib.arch.ptrsize)
+        )  # each idx has that many bits
+        idxlen = len(str((1 << nbits) - 1))
+        if entry is not None:
+            flags = f"[{idx:0{idxlen}}] {arrow_right} {name + 'e'}: {ctx_color.format_flags(entry, pageflags, entry)}"
+        print(f"{color.blue(name)} @ {color.yellow(hex(vaddr))}{flags}")
     vaddr = result.virt
     if vaddr is None:
         print(message.warn("address is not mapped"))
         return
     phys = result.phys
-    print(f"pagewalk result: {color.green(hex(vaddr))} [phys: {color.yellow(hex(phys))}]")
+    if phys:
+        phys = color.yellow(hex(phys))
+    print(f"pagewalk result: {color.green(hex(vaddr))} [phys: {phys}]")
 
 
 def paging_print_helper(name, addr):
@@ -153,13 +151,13 @@ v2p_parser.add_argument("vaddr", type=str, help="")
 def v2p(vaddr) -> None:
     vaddr = int(pwndbg.dbg.selected_frame().evaluate_expression(vaddr))
     result = pwndbg.aglib.kernel.pagewalk(vaddr)  # more accurate
-    entry, paddr = result.entry, result.virt
-    if not entry:
+    entry, paddr = result.entry, result.phys
+    if not entry or paddr is None:
         print(message.warn("virtual to physical address failed, unmapped virtual address?"))
         return
     paging_print_helper("Physmap address", paddr)
     # paddr is the physmap address which is a virtual address
-    page = pwndbg.aglib.kernel.virt_to_page(paddr)
+    page = pwndbg.aglib.kernel.phys_to_page(paddr)
     page_info(page)
 
 

--- a/pwndbg/commands/paging.py
+++ b/pwndbg/commands/paging.py
@@ -95,10 +95,6 @@ def page_info(page):
 def pagewalk(vaddr, entry=None):
     if entry is not None:
         entry = int(pwndbg.dbg.selected_frame().evaluate_expression(entry))
-    elif (kcurrent := pwndbg.commands.kcurrent.get_kcurrent()) is not None:
-        # did the user set pgd with kcurrent?
-        # safe because pagewalk fallbacks to control regs when entry==None
-        entry = kcurrent.pgd
     if pwndbg.aglib.memory.is_kernel(entry):
         entry = pwndbg.aglib.kernel.pagewalk(entry, virt=False).phys
     vaddr = int(pwndbg.dbg.selected_frame().evaluate_expression(vaddr))

--- a/pwndbg/commands/paging.py
+++ b/pwndbg/commands/paging.py
@@ -32,7 +32,7 @@ PAGETYPES = (
 )
 
 
-def print_level(level: PageTableLevel):
+def print_level(level: PageTableLevel) -> None:
     pageflags = pwndbg.aglib.kernel.arch_paginginfo().bitflags(level)
     flags = ""
     arrow_right = pwndbg.chain.c.arrow(f"{pwndbg.chain.config_arrow_right}")
@@ -48,7 +48,7 @@ def print_level(level: PageTableLevel):
     print(f"{color.blue(name)} @ {color.yellow(hex(vaddr))}{flags}")
 
 
-def page_type(page):
+def page_type(page) -> str:
     names = PAGETYPES
     page_type_val = pwndbg.aglib.memory.s32(page + 0x30)
     if page_type_val == -1:
@@ -78,7 +78,7 @@ def page_type(page):
     return "unknown"
 
 
-def page_info(page):
+def page_info(page) -> None:
     try:
         refcount = pwndbg.aglib.memory.u32(page + 0x34)
         print(
@@ -92,7 +92,7 @@ def page_info(page):
 @pwndbg.commands.OnlyWhenQemuKernel
 @pwndbg.commands.OnlyWhenPagingEnabled
 @pwndbg.aglib.proc.OnlyWithArch(["x86-64", "aarch64"])
-def pagewalk(vaddr, entry=None):
+def pagewalk(vaddr, entry=None) -> None:
     if entry is not None:
         entry = int(pwndbg.dbg.selected_frame().evaluate_expression(entry))
     if pwndbg.aglib.memory.is_kernel(entry):
@@ -128,7 +128,7 @@ p2v_parser.add_argument("paddr", type=str, help="")
 @pwndbg.commands.OnlyWithKernelSymbols
 @pwndbg.commands.OnlyWhenPagingEnabled
 @pwndbg.aglib.proc.OnlyWithArch(["x86-64", "aarch64"])
-def p2v(paddr):
+def p2v(paddr) -> None:
     paddr = int(pwndbg.dbg.selected_frame().evaluate_expression(paddr))
     try:
         vaddr = pwndbg.aglib.kernel.phys_to_virt(paddr)
@@ -150,10 +150,10 @@ v2p_parser.add_argument("vaddr", type=str, help="")
 @pwndbg.commands.OnlyWithKernelSymbols
 @pwndbg.commands.OnlyWhenPagingEnabled
 @pwndbg.aglib.proc.OnlyWithArch(["x86-64", "aarch64"])
-def v2p(vaddr):
+def v2p(vaddr) -> None:
     vaddr = int(pwndbg.dbg.selected_frame().evaluate_expression(vaddr))
-    level = pwndbg.aglib.kernel.pagewalk(vaddr)  # more accurate
-    entry, paddr = level.entry, level.virt
+    result = pwndbg.aglib.kernel.pagewalk(vaddr)  # more accurate
+    entry, paddr = result.entry, result.virt
     if not entry:
         print(message.warn("virtual to physical address failed, unmapped virtual address?"))
         return
@@ -174,7 +174,7 @@ page_parser.add_argument("page", type=str, help="")
 @pwndbg.commands.OnlyWithKernelSymbols
 @pwndbg.commands.OnlyWhenPagingEnabled
 @pwndbg.aglib.proc.OnlyWithArch(["x86-64", "aarch64"])
-def pageinfo(page):
+def pageinfo(page) -> None:
     page = int(pwndbg.dbg.selected_frame().evaluate_expression(page))
     try:
         vaddr = pwndbg.aglib.kernel.page_to_virt(page)

--- a/pwndbg/commands/slab.py
+++ b/pwndbg/commands/slab.py
@@ -314,7 +314,7 @@ def slab_contains(address: str) -> None:
 
     try:
         slab_cache = find_containing_slab_cache(addr)
-        assert slab_cache
+        assert slab_cache, "cannot find the kmem_cache the slab belong to"
         print(f"{addr:#x} @", message.hint(f"{slab_cache.name}"))
         slab = slab_cache.find_containing_slab(addr)
         if slab is None:

--- a/pwndbg/commands/slab.py
+++ b/pwndbg/commands/slab.py
@@ -74,8 +74,8 @@ def slab(
     partial_only=False,
     active_only=False,
 ) -> None:
-    if not pwndbg.aglib.kernel.has_debug_info():
-        pwndbg.aglib.kernel.slab.load_slab_typeinfo()
+    if not pwndbg.aglib.kernel.slab.load_slab_typeinfo():
+        return
     if command == "list":
         slab_list(filter_)
     elif command == "info":

--- a/pwndbg/commands/slab.py
+++ b/pwndbg/commands/slab.py
@@ -74,8 +74,7 @@ def slab(
     partial_only=False,
     active_only=False,
 ) -> None:
-    if not pwndbg.aglib.kernel.slab.load_slab_typeinfo():
-        return
+    pwndbg.aglib.kernel.slab.recover_slab_typeinfo()
     if command == "list":
         slab_list(filter_)
     elif command == "info":

--- a/pwndbg/commands/slab.py
+++ b/pwndbg/commands/slab.py
@@ -314,6 +314,7 @@ def slab_contains(address: str) -> None:
 
     try:
         slab_cache = find_containing_slab_cache(addr)
+        assert slab_cache
         print(f"{addr:#x} @", message.hint(f"{slab_cache.name}"))
         slab = slab_cache.find_containing_slab(addr)
         if slab is None:

--- a/tests/library/qemu_system/tests/test_commands_kernel.py
+++ b/tests/library/qemu_system/tests/test_commands_kernel.py
@@ -104,8 +104,6 @@ def test_command_slab_info():
         res = gdb.execute("slab info kmalloc-512", to_string=True)
         assert "may only be run when debugging a Linux kernel with debug" in res
         return
-    if not pwndbg.aglib.kernel.has_debug_info():
-        pwndbg.aglib.kernel.slab.recover_slab_typeinfo()
     for cache in pwndbg.aglib.kernel.slab.caches():
         cache_name = cache.name
         res = gdb.execute(f"slab info {cache_name}", to_string=True)

--- a/tests/library/qemu_system/tests/test_commands_kernel.py
+++ b/tests/library/qemu_system/tests/test_commands_kernel.py
@@ -105,7 +105,7 @@ def test_command_slab_info():
         assert "may only be run when debugging a Linux kernel with debug" in res
         return
     if not pwndbg.aglib.kernel.has_debug_info():
-        pwndbg.aglib.kernel.slab.load_slab_typeinfo()
+        pwndbg.aglib.kernel.slab.recover_slab_typeinfo()
     for cache in pwndbg.aglib.kernel.slab.caches():
         cache_name = cache.name
         res = gdb.execute(f"slab info {cache_name}", to_string=True)
@@ -124,7 +124,7 @@ def test_command_slab_contains():
         assert "may only be run when debugging a Linux kernel with debug" in res
         return
 
-    pwndbg.aglib.kernel.slab.load_slab_typeinfo()
+    pwndbg.aglib.kernel.slab.recover_slab_typeinfo()
     # retrieve a valid slab object address (first address from freelist)
     addrs, slab_cache = get_slab_object_address()
     addr = addrs[0]


### PR DESCRIPTION
- introduced `typeinfo_recovery` decorator
- fixed a pagescan bug
- general refactoring (renamed some functions, etc)

changes are from #3647. those changes are some general refactoring and can be reviewed separately. blocks #3647 