### PR TITLE
dependabot ignore types-gdb

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -47,6 +47,8 @@ updates:
       - dependency-name: "ropgadget"
       # Git dependency handled separately
       - dependency-name: "pt"
+      # Pinned for supporting gdb 12.1 for ubuntu 22.04
+      - dependency-name: "types-gdb"
 
     labels:
       - "dependencies"


### PR DESCRIPTION
+ [x] I read the contributing documentation.
+ [ ] I am providing a screenshot of the (new feature) / (fixed bug).

add gdb-types to dependabot ignore list to continue supporting gdb 12.1 for ubuntu 22.04
https://github.com/pwndbg/pwndbg/pull/3567#discussion_r2658424425
https://github.com/pwndbg/pwndbg/pull/3661