### PR TITLE
LLDB: Move process killing logic into `ProcessDriver`

### DIFF
--- a/pwndbg/dbg_mod/lldb/repl/__init__.py
+++ b/pwndbg/dbg_mod/lldb/repl/__init__.py
@@ -43,7 +43,6 @@ import re
 import shutil
 import signal
 import sys
-import time
 from asyncio import CancelledError
 from collections.abc import Awaitable
 from collections.abc import Callable
@@ -1105,41 +1104,6 @@ process_launch_unsupported = [
 ]
 
 
-def kill_existing_process(driver: ProcessDriver, relay: EventRelay) -> bool:
-    """
-    Kills the existing process if one is running.
-    Returns True if successful or if no process was running.
-    """
-    if not driver.has_process():
-        return True
-
-    process = driver.process
-    error = process.Kill()
-    if not error.Success():
-        print_error(f"failed to kill existing process: {error}")
-        return False
-
-    # Wait for the process to actually exit
-    # LLDB will transition the process state to eStateExited
-    timeout = 5.0  # 5 second timeout
-    start = time.time()
-    while time.time() - start < timeout:
-        state = process.GetState()
-        if state == lldb.eStateExited or state == lldb.eStateDetached:
-            # Manually clean up since we're not in the event loop
-            driver.process = None
-            driver.listener = None
-            if driver.io is not None:
-                driver.io.close()
-                driver.io = None
-            relay.exited()
-            return True
-        time.sleep(0.1)
-
-    print_error("timed out waiting for process to exit")
-    return False
-
-
 def process_launch(
     driver: ProcessDriver, relay: EventRelay, args: list[str], dbg: LLDB, restart: bool = False
 ) -> None:
@@ -1165,7 +1129,10 @@ def process_launch(
 
     if driver.has_process():
         if restart:
-            if not kill_existing_process(driver, relay):
+            print_info("killing running process and starting a fresh one")
+            what = driver.kill()
+            if not what.success:
+                print_error(f"could not kill existing process: {result.description}")
                 return
         else:
             print_error("a process is already being debugged")

--- a/pwndbg/dbg_mod/lldb/repl/proc.py
+++ b/pwndbg/dbg_mod/lldb/repl/proc.py
@@ -185,6 +185,10 @@ class ProcessDriver:
     Drives the execution of a process, responding to its events and handling its
     I/O, and exposes a simple synchronous interface to the REPL interface.
 
+    # Signal Handler Safety
+    With few exceptions, no method in this class is safe to call during signal
+    handlers. Exceptions are always explicitly noted as such.
+
     # IODriver State Machine
     Because LLDB can make Python code from Pwndbg execute while an I/O driver is
     active, and having the I/O driver active while Pwndbg is running leads to
@@ -276,9 +280,35 @@ class ProcessDriver:
         """
         return self._is_core_file
 
+    def kill(self) -> lldb.SBError:
+        """
+        Kills the currently running process.
+        """
+        assert self.has_process(), "called kill() on a driver with no process"
+        with self._suspend_interrupts():
+            e = self.process.Kill()
+            if not e.success:
+                return e
+
+            # Callers expect the process to have already been dropped by the
+            # time this method returns, so we must drive the process to
+            # completion.
+            #
+            # By the time we start driving, there might be pending stop events
+            # that aren't necessarily the ones singnaling the termination of
+            # the inferior. We keep calling _run_until_next_stop until it sees
+            # that the process has been killed, which also clears driver state
+            # for us automatically.
+            while self.has_process():
+                self._run_until_next_stop()
+
+            return lldb.SBError()
+
     def interrupt(self, in_lldb_command_handler: bool = False) -> None:
         """
         Interrupts the currently running process or command.
+
+        This method may be called during a signal handler.
         """
         if not self.has_process():
             return
@@ -311,7 +341,7 @@ class ProcessDriver:
             raise UserCancelledError("user-requested cancellation")
 
     @contextlib.contextmanager
-    def suspend_interrupts(self, interrupt: Callable[[], None] | None = None):
+    def _suspend_interrupts(self, interrupt: Callable[[], None] | None = None):
         """
         Sometimes it's necessary to guard against interruption by
         self.interrupt, especially when being interrupted would lead to bad
@@ -562,7 +592,7 @@ class ProcessDriver:
         """
         assert self.has_process(), "called run_lldb_command() on a driver with no process"
 
-        with self.suspend_interrupts():
+        with self._suspend_interrupts():
             ret = lldb.SBCommandReturnObject()
             self.process.GetTarget().GetDebugger().GetCommandInterpreter().HandleCommand(
                 command, ret
@@ -685,7 +715,7 @@ class ProcessDriver:
 
             # Being interrupted here would be bad for keeping the state of the
             # process consistent.
-            with self.suspend_interrupts(interrupt=queue_cancel):
+            with self._suspend_interrupts(interrupt=queue_cancel):
                 if isinstance(step, YieldSingleStep):
                     self.debug_print("Coroutine: Performing ExecutionController.single_step()")
                     # Pick the currently selected thread and step it forward by one


### PR DESCRIPTION
Currently, the process restarting code for both `starti` and `run` in `pwndbg-lldb` lives outside of `ProcessDriver`. This PR integrates that bit of functionality into the driver and the `pwndbg-lldb` event loop.

This PR also takes the opportunity to clarify a few unrelated bits of method semantics in `ProcessDriver`.