### PR TITLE
consistency between workflows, cancelling in-progress runs on PRs

### DIFF
--- a/.github/workflows/base-image.yml
+++ b/.github/workflows/base-image.yml
@@ -16,7 +16,7 @@ on:
 
 concurrency:
   # Pushes (dev): queue sequentially (prevent cache corruption)
-  # PRs: cancel old commits (only test latest)
+  # PRs: cancel in-progress runs (only test latest)
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,7 +20,7 @@ on:
 
 concurrency:
   # Pushes (dev): queue sequentially (prevent cache corruption)
-  # PRs: cancel old commits (only test latest)
+  # PRs: cancel in-progress runs (only test latest)
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,12 @@ on:
       - "!mkdocs.yml"
       - "!docs/**"
       - "!*.md"
+  workflow_dispatch:
+
+concurrency:
+  # PRs: cancel in-progress runs (only test latest)
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   lint:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,7 +6,6 @@ on:
       - "!mkdocs.yml"
       - "!docs/**"
       - "!*.md"
-  workflow_dispatch:
 
 concurrency:
   # PRs: cancel in-progress runs (only test latest)

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -15,6 +15,11 @@ on:
       - "!docs/**"
       - "!*.md"
 
+concurrency:
+  # PRs: cancel in-progress runs (only test latest)
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   check_release_build-gdb:
     strategy:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,6 +14,12 @@ on:
       - "!mkdocs.yml"
       - "!docs/**"
       - "!*.md"
+
+concurrency:
+  # PRs: cancel in-progress runs (only test latest)
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   tests-using-nix:
     strategy:


### PR DESCRIPTION
+ [x] I read the contributing documentation.
+ [ ] I am providing a screenshot of the (new feature) / (fixed bug).

This is to have consistency between the workflows, instead of just the docker tests, and build base image workflows, cancelling in-progress on PRs.



> Maybe we should go with cancelling the old push runs too?

@disconnect3d, would you still want that ^^? idk personally, I think it should just be done on PRs, and on push runs, it should just follow through and finish. I just think that way if somehow a test did fail, it is good for attribution sake, especially on push runs, because we are sacrificing it on PR runs already for speed, which there I think is fine. 
https://github.com/pwndbg/pwndbg/pull/3614#discussion_r2694025818
