### PR TITLE
LLDB + Hexagon: do not immediately crash 

### DIFF
--- a/pwndbg/aglib/arch_mod.py
+++ b/pwndbg/aglib/arch_mod.py
@@ -386,6 +386,18 @@ class S390xArch(PwndbgArchitecture):
         return (CS_ARCH_SYSTEMZ, 0)
 
 
+class HexagonArch(PwndbgArchitecture):
+    max_instruction_size = 16
+    instruction_alignment = 4
+
+    def __init__(self) -> None:
+        super().__init__("hexagon")
+
+    @override
+    def get_capstone_constants(self, address: int) -> tuple[int, int] | None:
+        return None
+
+
 # Register the architecture classes
 all_arches = [
     AMD64Arch(),
@@ -401,6 +413,7 @@ all_arches = [
     MipsArch(),
     Loongarch64Arch(),
     S390xArch(),
+    HexagonArch(),
 ]
 
 for arch in all_arches:

--- a/pwndbg/aglib/disasm/instruction.py
+++ b/pwndbg/aglib/disasm/instruction.py
@@ -710,7 +710,7 @@ class ManualPwndbgInstruction(PwndbgInstruction):
         self.address = address
         self.size = ins["length"]
 
-        self.mnemonic = asm[0].strip()
+        self.mnemonic = asm[0].strip() if len(asm) > 0 else ""
         self.op_str = asm[1].strip() if len(asm) > 1 else ""
         self.groups = set()
 

--- a/pwndbg/aglib/disasm/instruction.py
+++ b/pwndbg/aglib/disasm/instruction.py
@@ -60,6 +60,7 @@ from capstone6pwndbg.x86 import X86_INS_RET
 from capstone6pwndbg.x86 import X86Op
 from typing_extensions import override
 
+import pwndbg
 from pwndbg.dbg_mod import DisassembledInstruction
 
 # Architecture specific instructions that mutate the instruction pointer unconditionally

--- a/pwndbg/lib/arch.py
+++ b/pwndbg/lib/arch.py
@@ -41,7 +41,7 @@ PWNDBG_SUPPORTED_ARCHITECTURES_TYPE = Literal[
     "powerpc",
     "loongarch64",
     "s390x",
-    "hexagon"
+    "hexagon",
 ]
 
 PWNDBG_SUPPORTED_ARCHITECTURES: list[PWNDBG_SUPPORTED_ARCHITECTURES_TYPE] = list(

--- a/pwndbg/lib/arch.py
+++ b/pwndbg/lib/arch.py
@@ -41,6 +41,7 @@ PWNDBG_SUPPORTED_ARCHITECTURES_TYPE = Literal[
     "powerpc",
     "loongarch64",
     "s390x",
+    "hexagon"
 ]
 
 PWNDBG_SUPPORTED_ARCHITECTURES: list[PWNDBG_SUPPORTED_ARCHITECTURES_TYPE] = list(

--- a/pwndbg/lib/regs.py
+++ b/pwndbg/lib/regs.py
@@ -1331,5 +1331,5 @@ reg_sets: dict[PWNDBG_SUPPORTED_ARCHITECTURES_TYPE, RegisterSet] = {
     "powerpc": powerpc,
     "loongarch64": loongarch64,
     "s390x": s390x,
-    "hexagon": hexagon
+    "hexagon": hexagon,
 }

--- a/pwndbg/lib/regs.py
+++ b/pwndbg/lib/regs.py
@@ -1276,6 +1276,47 @@ s390x = RegisterSet(
     retval="r2",
 )
 
+hexagon = RegisterSet(
+    stack=Reg("sp"),
+    frame=Reg("fp"),
+    retaddr=(Reg("lr"),),
+    gpr=(
+        Reg("r0"),
+        Reg("r1"),
+        Reg("r2"),
+        Reg("r3"),
+        Reg("r4"),
+        Reg("r5"),
+        Reg("r6"),
+        Reg("r7"),
+        Reg("r8"),
+        Reg("r9"),
+        Reg("r10"),
+        Reg("r11"),
+        Reg("r12"),
+        Reg("r13"),
+        Reg("r14"),
+        Reg("r15"),
+        Reg("r16"),
+        Reg("r17"),
+        Reg("r18"),
+        Reg("r19"),
+        Reg("r20"),
+        Reg("r21"),
+        Reg("r22"),
+        Reg("r23"),
+        Reg("r24"),
+        Reg("r25"),
+        Reg("r26"),
+        Reg("r27"),
+        Reg("r28"),
+        Reg("r29"),
+        Reg("r30"),
+        Reg("r31"),
+    ),
+)
+
+
 reg_sets: dict[PWNDBG_SUPPORTED_ARCHITECTURES_TYPE, RegisterSet] = {
     "i386": i386,
     "i8086": i386,
@@ -1290,4 +1331,5 @@ reg_sets: dict[PWNDBG_SUPPORTED_ARCHITECTURES_TYPE, RegisterSet] = {
     "powerpc": powerpc,
     "loongarch64": loongarch64,
     "s390x": s390x,
+    "hexagon": hexagon
 }


### PR DESCRIPTION
A quick patch to not crash when debugging Hexagon with LLDB.

Note that I had to do the following for this to work, assuming you are running Hexagon through qemu locally:
```sh
cd pwndbg
uv run pwndbg-lldb

# This is necessary for it not to crash immediately
target create --arch hexagon /absolute/path/to/hexagon/executable

# Make debugging errors easier
set exception-verbose on

gdb-remote localhost:1234
```

Capstone does not support Hexagon as a disassembly target, so we fallback to displaying what LLDB would display using it's internal disassembler (what you get with the `dis` command). Hexagon is a VLIW architecture which can bundle instructions into "packets" of instructions that can run in parallel. The disassembler doesn't appear take this into account, so the output contains a lot of "empty instructions" 

LLDB disassembler output: <img width="692" height="270" alt="image" src="https://github.com/user-attachments/assets/0372eb87-db21-4660-8456-c6bd211f0207" />

We copy this directly to our output:
<img width="731" height="295" alt="image" src="https://github.com/user-attachments/assets/6ec615bb-9f3d-46cc-94bf-ea6a150c9877" />


There are some intro docs to the Hexagon architecture here: <https://github.com/programa-stic/hexag00n/blob/master/docs/intro_to_hexagon.rst>

In the current state, this is very incomplete, but allows for pwndbg to at least not crash with Hexagon.