### PR TITLE
`Process.is_core_file` API

### DIFF
--- a/pwndbg/aglib/proc.py
+++ b/pwndbg/aglib/proc.py
@@ -44,6 +44,13 @@ def alive() -> bool:
     return pwndbg.dbg.selected_inferior().alive()
 
 
+def is_core_file() -> bool:
+    """
+    Returns whether the loaded program is a corefile
+    """
+    return pwndbg.dbg.selected_inferior().is_core_file()
+
+
 def stopped_with_signal() -> bool:
     """
     Returns whether the program has stopped with a signal

--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -831,16 +831,24 @@ def WarnOnKernelConfigRandstruct(function: Callable[P, T]) -> Callable[P, T | No
     return _WarnOnKernelConfigRandstruct
 
 
-def OnlyWhenRunning(function: Callable[P, T]) -> Callable[P, T | None]:
-    @functools.wraps(function)
-    def _OnlyWhenRunning(*a: P.args, **kw: P.kwargs) -> T | None:
-        # TODO: Properly support OnlyWhenRunning without `gdblib`.
-        if pwndbg.aglib.proc.alive():
-            return function(*a, **kw)
-        log.error(f"{func_name(function)}: The program is not being run.")
-        return None
+def OnlyWhenRunning(
+    func_when_decorator_kwargs: Callable[P, T] | None = None, *, allow_core: bool = True
+) -> Callable[[Callable[P, T]], Callable[P, T | None]] | Callable[P, T | None]:
+    def decorator(func: Callable[P, T]) -> Callable[P, T | None]:
+        @functools.wraps(func)
+        def _OnlyWhenRunning(*a: P.args, **kw: P.kwargs) -> T | None:
+            if pwndbg.aglib.proc.alive() and not (
+                not allow_core and pwndbg.aglib.proc.is_core_file()
+            ):
+                return func(*a, **kw)
+            log.error(f"{func_name(func)}: The program is not being run.")
+            return None
 
-    return _OnlyWhenRunning
+        return _OnlyWhenRunning
+
+    if func_when_decorator_kwargs is None:
+        return decorator
+    return decorator(func_when_decorator_kwargs)
 
 
 def OnlyWithTcache(function: Callable[P, T]) -> Callable[P, T | None]:

--- a/pwndbg/dbg_mod/__init__.py
+++ b/pwndbg/dbg_mod/__init__.py
@@ -434,6 +434,12 @@ class Process:
         """
         raise NotImplementedError()
 
+    def is_core_file(self) -> bool:
+        """
+        Returns whether this process is a coredump file.
+        """
+        raise NotImplementedError()
+
     def stopped_with_signal(self) -> bool:
         """
         Returns whether this process was stopped by a signal.

--- a/pwndbg/dbg_mod/gdb/__init__.py
+++ b/pwndbg/dbg_mod/gdb/__init__.py
@@ -604,6 +604,15 @@ class GDBProcess(pwndbg.dbg_mod.Process):
         return gdb.selected_thread() is not None
 
     @override
+    def is_core_file(self) -> bool:
+        inferior = gdb.selected_inferior()
+        return (
+            hasattr(inferior, "connection")
+            and inferior.connection is not None
+            and inferior.connection.type == "core"
+        )
+
+    @override
     def stopped_with_signal(self) -> bool:
         return "It stopped with signal " in gdb.execute("info program", to_string=True)
 

--- a/pwndbg/dbg_mod/lldb/__init__.py
+++ b/pwndbg/dbg_mod/lldb/__init__.py
@@ -983,6 +983,10 @@ class LLDBProcess(pwndbg.dbg_mod.Process):
         )
 
     @override
+    def is_core_file(self) -> bool:
+        return bool(self.process.GetCoreFile().IsValid())
+
+    @override
     def stopped_with_signal(self) -> bool:
         return self.process.GetState() == lldb.eStateStopped and any(
             thread.GetStopReason() == lldb.eStopReasonSignal for thread in self.process.threads

--- a/tests/host/__init__.py
+++ b/tests/host/__init__.py
@@ -215,6 +215,15 @@ class Controller:
         """
         raise NotImplementedError()
 
+    async def generate_core_file(self, path: Path) -> None:
+        """
+        Generate a core file at `path` and switch the debugger
+        to debugging that core file.
+
+        After this returns `pwndbg.dbg.selected_inferior().is_core_file()` must be True
+        """
+        raise NotImplementedError()
+
 
 def start(controller: Callable[[Controller], Coroutine[Any, Any, None]]) -> None:
     """

--- a/tests/host/gdb/pytests_launcher.py
+++ b/tests/host/gdb/pytests_launcher.py
@@ -64,6 +64,10 @@ class _GDBController(host.Controller):
         gdb.execute("set debug-file-directory")
         gdb.execute("set debuginfod enabled off")
 
+    async def generate_core_file(self, path: Path) -> None:
+        gdb.execute(f"generate-core-file {path}")
+        gdb.execute(f"core-file {path}")
+
 
 def _start(outer: Callable[[host.Controller], Coroutine[Any, Any, None]]) -> None:
     # The GDB controller is entirely synchronous, so keep advancing the

--- a/tests/host/lldb/launch_guest.py
+++ b/tests/host/lldb/launch_guest.py
@@ -69,6 +69,11 @@ async def _run(ctrl: Any, outer: Callable[..., Coroutine[Any, Any, None]]) -> No
             # Could also consider disabling `symbols.enable-external-lookup`
             await self.pc.execute("settings set plugin.symbol-locator.debuginfod.server-urls {}")
 
+        async def generate_core_file(self, path: Path) -> None:
+            await self.pc.execute(f"process save-core {path}")
+            await self.pc.execute("target delete")
+            await self.pc.execute(f"target create --core {path}")
+
     await outer(_LLDBController(ctrl))
 
 

--- a/tests/library/dbg/tests/test_is_core_file.py
+++ b/tests/library/dbg/tests/test_is_core_file.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from ....host import Controller
+from . import get_binary
+from . import pwndbg_test
+
+CRASH_SIMPLE_BINARY = get_binary("crash_simple.native.out")
+
+
+@pwndbg_test
+async def test_is_core_file(ctrl: Controller) -> None:
+    """
+    Ensure Process.is_core_file() correctly distinguishes between
+    a live inferior and a loaded core file.
+    """
+    import pwndbg
+
+    await ctrl.launch(CRASH_SIMPLE_BINARY)
+
+    proc = pwndbg.dbg.selected_inferior()
+    assert proc is not None
+    assert proc.is_core_file() is False
+
+    await ctrl.cont()
+
+    with tempfile.NamedTemporaryFile(delete=False) as f:
+        core_path = Path(f.name)
+
+    try:
+        await ctrl.generate_core_file(Path(core_path))
+
+        proc = pwndbg.dbg.selected_inferior()
+        assert proc is not None
+        assert proc.is_core_file() is True
+
+    finally:
+        if core_path.exists():
+            core_path.unlink()


### PR DESCRIPTION
Following #3675, there is a lack of a standard API for both GDB and LLDB to determine whether a coredump file has been loaded

This is useful to know for e.g: when you want to prevent a certain command from being run on a corefile

+ [x] I read the contributing documentation.
