### PR TITLE
Fix errors in PR #3656 docker tests workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -80,7 +80,7 @@ jobs:
 
       - name: Push full image to registry
         if: github.event_name == 'push'
-        run: docker push ghcr.io/pwndbg/pwndbg:${{ matrix.images }}-arm64
+        run: docker push ghcr.io/pwndbg/pwndbg:${{ matrix.image }}-amd64
 
   docker_aarch64:
     name: docker_aarch64 (${{ matrix.image }})
@@ -132,7 +132,7 @@ jobs:
 
       - name: Push full image to registry
         if: github.event_name == 'push'
-        run: docker push ghcr.io/pwndbg/pwndbg:${{ matrix.images }}-arm64
+        run: docker push ghcr.io/pwndbg/pwndbg:${{ matrix.image }}-arm64
 
   create_manifest:
     needs: [docker_x86-64, docker_aarch64]


### PR DESCRIPTION
+ [x] I read the contributing documentation.
+ [ ] I am providing a screenshot of the (new feature) / (fixed bug).

https://github.com/pwndbg/pwndbg/pull/3656 
had a couple of issues in pushing the images to the registry when running on push because of a few typos that I made when rewriting and copying over what I had written in my organization for testing the workflow. 
This fixes both of those issues, and pushing will now work, and the "Push image to registry" job will succeed now