### PR TITLE
Correcting parameter name for `commands.OnlyWhenRunning` decorator

### DIFF
--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -831,7 +831,7 @@ def WarnOnKernelConfigRandstruct(function: Callable[P, T]) -> Callable[P, T | No
 
 
 def OnlyWhenRunning(
-    func_when_decorator_kwargs: Callable[P, T] | None = None, *, allow_core: bool = True
+    func_when_no_kwargs: Callable[P, T] | None = None, *, allow_core: bool = True
 ) -> Callable[[Callable[P, T]], Callable[P, T | None]] | Callable[P, T | None]:
     def decorator(func: Callable[P, T]) -> Callable[P, T | None]:
         @functools.wraps(func)
@@ -845,9 +845,9 @@ def OnlyWhenRunning(
 
         return _OnlyWhenRunning
 
-    if func_when_decorator_kwargs is None:
+    if func_when_no_kwargs is None:
         return decorator
-    return decorator(func_when_decorator_kwargs)
+    return decorator(func_when_no_kwargs)
 
 
 def OnlyWithTcache(function: Callable[P, T]) -> Callable[P, T | None]:


### PR DESCRIPTION
Fixing tiny naming mistake in #3674 

I apologize, in the heat of the moment my rationale was that "when `func_when_decorator_kwargs` is `<Some Default>` that means it hasn't been altered and hence we should trigger the case when the user has provided decorator kwargs"

But in this case, that `<Some Default>` is `None`. And so instead it reads like:
```py
if func_when_decorator_kwargs is None:  # reads like decorator kwargs are NOT supplied
    # do the condition for decorator kwargs IS being supplied
```

but actually, the `func_when_decorator_kwargs` parameter is only `None` when decorator kwargs ARE being assigned, so it should be called `func_when_no_decorator_kwargs` or shorter `func_when_no_kwargs`

Now, it reads like
```py
if func_when_no_kwargs is None:  # reads like kwargs ARE being supplied
    # do the condition when the kwargs ARE supplied
```

so this is more correct

+ [x] I read the contributing documentation.
