### PR TITLE
Register help subcommands to work with GDB

### DIFF
--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -233,20 +233,53 @@ class CommandObj:
         ) -> None:
             self.invoke(arguments, is_interactive)
 
-        # Keep a handle to the command and its aliases so we can
-        # easily remove them if necessary (not supported with GDB).
+        is_gdb = pwndbg.dbg.is_gdblib_available()
+        is_prefix = bool(self.subcommand_names)
+
         self.handles = [
-            # Tell the debugger about the command...
             pwndbg.dbg.add_command(
-                self.command_name, _handler, self.help_str, self.subcommand_names
+                self.command_name,
+                _handler,
+                self.help_str,
+                self.subcommand_names,
+                is_prefix=is_prefix,
             )
         ]
 
-        # ...and all of its aliases.
-        self.handles.extend(
-            pwndbg.dbg.add_command(alias, _handler, self.help_str, self.subcommand_names)
-            for alias in self.aliases
-        )
+        if is_gdb and is_prefix and self.subcommand_names is not None:
+            import gdb
+
+            subcmd_help = {}
+            for action in self.parser._actions:
+                if isinstance(action, argparse._SubParsersAction):
+                    for name, subparser in action.choices.items():
+                        subcmd_help[name] = subparser.format_help()
+
+            for subcmd in self.subcommand_names:
+                doc = subcmd_help.get(subcmd, f"See help for {self.command_name} {subcmd}")
+
+                def _proxy_handler(
+                    _debugger: pwndbg.dbg_mod.Debugger,
+                    arguments: str,
+                    is_interactive: bool,
+                    sc: str = subcmd,
+                ) -> None:
+                    full_args = f"{sc} {arguments}" if arguments else sc
+                    self.invoke(full_args, is_interactive)
+
+                self.handles.append(
+                    pwndbg.dbg.add_command(
+                        f"{self.command_name} {subcmd}", _proxy_handler, doc, None, is_prefix=False
+                    )
+                )
+
+            for alias in self.aliases:
+                gdb.execute(f"alias {alias} = {self.command_name}")
+        else:
+            self.handles.extend(
+                pwndbg.dbg.add_command(alias, _handler, self.help_str, self.subcommand_names)
+                for alias in self.aliases
+            )
 
         command_names.add(self.command_name)
         commands.append(self)

--- a/pwndbg/dbg_mod/__init__.py
+++ b/pwndbg/dbg_mod/__init__.py
@@ -1254,6 +1254,7 @@ class Debugger:
         handler: Callable[[Debugger, str, bool], None],
         doc: str | None,
         subcommand_names: list[str] | None = None,
+        is_prefix: bool = False,
     ) -> CommandHandle:
         """
         Adds a command with the given name to the debugger, that invokes the

--- a/pwndbg/dbg_mod/gdb/__init__.py
+++ b/pwndbg/dbg_mod/gdb/__init__.py
@@ -1272,16 +1272,17 @@ class GDBCommand(gdb.Command):
         handler: Callable[[pwndbg.dbg_mod.Debugger, str, bool], None],
         doc: str | None,
         subcommand_names: list[str] | None,
+        is_prefix: bool = False,
     ):
         # We can't do `list[str] = []` in the signature because python..
         self.debugger = debugger
         self.handler = handler
         self.__doc__ = doc
         if subcommand_names is None:
-            super().__init__(name, gdb.COMMAND_USER, gdb.COMPLETE_EXPRESSION)
+            super().__init__(name, gdb.COMMAND_USER, gdb.COMPLETE_EXPRESSION, prefix=is_prefix)
         else:
             self.subcommand_names: list[str] = subcommand_names
-            super().__init__(name, gdb.COMMAND_USER)
+            super().__init__(name, gdb.COMMAND_USER, prefix=is_prefix)
 
     def invoke(self, args: str, from_tty: bool) -> None:
         self.handler(self.debugger, args, from_tty)
@@ -1720,8 +1721,9 @@ class GDB(pwndbg.dbg_mod.Debugger):
         handler: Callable[[pwndbg.dbg_mod.Debugger, str, bool], None],
         doc: str | None,
         subcommand_names: list[str] | None = None,
+        is_prefix: bool = False,
     ) -> pwndbg.dbg_mod.CommandHandle:
-        command = GDBCommand(self, name, handler, doc, subcommand_names)
+        command = GDBCommand(self, name, handler, doc, subcommand_names, is_prefix)
         return GDBCommandHandle(command)
 
     @override

--- a/pwndbg/dbg_mod/lldb/__init__.py
+++ b/pwndbg/dbg_mod/lldb/__init__.py
@@ -2176,6 +2176,7 @@ class LLDB(pwndbg.dbg_mod.Debugger):
         handler: Callable[[pwndbg.dbg_mod.Debugger, str, bool], None],
         doc: str | None,
         subcommand_names: list[str] | None = None,
+        is_prefix: bool = False,
     ) -> pwndbg.dbg_mod.CommandHandle:
         debugger = self
 

--- a/tests/library/gdb/tests/test_help.py
+++ b/tests/library/gdb/tests/test_help.py
@@ -17,6 +17,13 @@ def test_command_help_strings(start_binary):
         if command.help_str is None:
             assert help_str.strip() == "This command is not documented."
         else:
+            if command.subcommand_names:
+                # `pwndbg`` adds subcommand list, so the output will also contain subcommand help info
+                # we test if the remaining part is correct
+                subcommand_header_line = f'List of "{command.command_name}" subcommands:'
+                assert subcommand_header_line in help_str
+                help_str = help_str[: help_str.index(subcommand_header_line) - 1]
+
             truth = [
                 line.strip() for line in command.help_str.splitlines() if len(line.strip()) > 0
             ]


### PR DESCRIPTION
Fixes #3547 

Previously, using `help` on subcommands would return the information of the main command. Whereas `<main> <sub>  --help` worked

In order to make `help` work with subcommands, the main command needs to be registered as a prefix command

So I've added an `is_prefix` flag to `dbg.add_command` which gets passed down the chain to `gdb.Command`'s constructor

I'm iterating over `self.parser._actions` to find the subcommand help docs and I'm adding the commands as GDB subcommands with their respective documentation
```py
subcmd_help = {}
for action in self.parser._actions:
    if isinstance(action, argparse._SubParsersAction):
        for name, subparser in action.choices.items():
            subcmd_help[name] = subparser.format_help()

for subcmd in self.subcommand_names:
    doc = subcmd_help.get(subcmd, f"See help for {self.command_name} {subcmd}")

    def _proxy_handler(
        _debugger: pwndbg.dbg_mod.Debugger,
        arguments: str,
        is_interactive: bool,
        sc: str = subcmd,
    ) -> None:
        full_args = f"{sc} {arguments}" if arguments else sc
        self.invoke(full_args, is_interactive)

    self.handles.append(
        pwndbg.dbg.add_command(
            f"{self.command_name} {subcmd}", _proxy_handler, doc, None, is_prefix=False
        )
    )
```

This works with the full command names, but the main command aliases have not been registered, and so I also register the aliases with GDB
```py
for alias in self.aliases:
    gdb.execute(f"alias {alias} = {self.command_name}")
```

```
pwndbg> help di connect
Connect to the decompiler.

The host and port to connect to are governed by the `decompiler-host`
and `decompiler-port` config variables. Try `help set decompiler-host`.

usage: decompiler-integration connect [-h]

options:
  -h, --help  show this help message and exit
pwndbg> 

```

### Test cases
There's an issue with the test cases because by adding the subcommands as *GBD* subcommands, GDB also prints out the subcommand help information. Which creates duplication in help printing

<img width="1142" height="788" alt="image" src="https://github.com/user-attachments/assets/33b9d072-5ea4-4ca0-abd8-46c3a332fcea" />

For the `tests/library/gdb/tests/test_help.py` test case, I simply removed that second part of it and checked with the remaining

But there's also a failing `tests/library/gdb/tests/test_consistent_help.py` which I haven't touched for now, because the only thing to do compatible with my changes is to remove it



### Opinion on duplication
I need an opinion on the help duplication thing? I don't know if there's a way to suppress GDB subcommand help output, but if so it would probably affect builtin commands too? 
It's not my place to decide, but since this is the only way to make `help <main> <sub>` work with GDB (that is, by using prefix and subcommands within GDB) there might not be a way to avoid duplication

So if we want this issue fixed, this is the only way. Or I guess we can just leave it as it is, with `help <main> <sub>` only showing information on the main command 

+ [x] I read the contributing documentation.
+ [x] I am providing a screenshot of the (new feature) / (fixed bug).


