### PR TITLE
Parallelize docker tests

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -69,20 +69,40 @@ jobs:
             -t ghcr.io/pwndbg/pwndbg:${{ matrix.image }} \
             .
 
-      - name: Run GDB Tests on ${{ matrix.image }}
-        run: docker compose run --rm ${{ matrix.image }} ./tests.sh -d gdb -g gdb
-
-      - name: Run DBG Tests (DBG-GDB & DBG-LLDB in parallel) on ${{ matrix.image }}
+      - name: Run Tests (GDB, DBG-GDB, DBG-LLDB in parallel) on ${{ matrix.image }}
         run: |
-          docker compose run --rm ${{ matrix.image }} bash -c '
+          docker compose run -T --rm ${{ matrix.image }} bash -c '
             set -euo pipefail
+            # Needed to prevent race conditions - prebuild binaries and create libpython symlink
             make -C /pwndbg/tests/binaries/host -j4 all
+            gdb --batch
+
             set +e
-            ( ./tests.sh -d gdb -g dbg 2>&1 | sed -u "s/^/[DBG-GDB] /" ) & gdbpid=$!
-            ( ./tests.sh -d lldb -g dbg 2>&1 | sed -u "s/^/[DBG-LLDB] /" ) & lldbpid=$!
-            wait $gdbpid; gdbexitcode=$?;
-            wait $lldbpid; lldbexitcode=$?;
-            exit $((gdbexitcode|lldbexitcode))
+            echo "Running generic tests on gdb, generic tests on lldb, and gdb-only tests on gdb at the same time. This should take ~6-9 minutes, results outputted at the end..."
+            ./tests.sh -d gdb -g gdb > /tmp/gdb.log 2>&1 & gdb_pid=$!
+            ./tests.sh -d gdb -g dbg > /tmp/dbg-gdb.log 2>&1 & dbg_gdb_pid=$!
+            ./tests.sh -d lldb -g dbg > /tmp/dbg-lldb.log 2>&1 & dbg_lldb_pid=$!
+            wait $gdb_pid; gdb_exit=$?
+            wait $dbg_gdb_pid; dbg_gdb_exit=$?
+            wait $dbg_lldb_pid; dbg_lldb_exit=$?
+            set -e
+
+            sed "s/^/[GDB] /" /tmp/gdb.log
+            sed "s/^/[DBG-GDB] /" /tmp/dbg-gdb.log
+            sed "s/^/[DBG-LLDB] /" /tmp/dbg-lldb.log
+
+            echo ""
+            echo "========================================"
+            echo "       COMBINED TEST SUMMARY"
+            echo "========================================"
+            echo ""
+            sed -n "/^\*\*\*/,\$p" /tmp/gdb.log | sed "s/^/[GDB] /"
+            echo ""
+            sed -n "/^\*\*\*/,\$p" /tmp/dbg-gdb.log | sed "s/^/[DBG-GDB] /"
+            echo ""
+            sed -n "/^\*\*\*/,\$p" /tmp/dbg-lldb.log | sed "s/^/[DBG-LLDB] /"
+
+            exit $((gdb_exit | dbg_gdb_exit | dbg_lldb_exit))
           '
 
       - name: Push full image to registry
@@ -128,20 +148,39 @@ jobs:
             -t ghcr.io/pwndbg/pwndbg:${{ matrix.image }} \
             .
 
-      - name: Run Cross Tests on GDB on ${{ matrix.image }}
-        run: docker compose run --rm ${{ matrix.image }} ./tests.sh -d gdb -g cross-arch-user
-
-      - name: Run DBG Tests (DBG-GDB & DBG-LLDB in parallel) on ${{ matrix.image }}
+      - name: Run Tests (Cross, DBG-GDB, DBG-LLDB in parallel) on ${{ matrix.image }}
         run: |
-          docker compose run --rm ${{ matrix.image }} bash -c '
+          docker compose run -T --rm ${{ matrix.image }} bash -c '
             set -euo pipefail
+            # Needed to prevent race conditions - prebuild binaries
             make -C /pwndbg/tests/binaries/host -j4 all
+
             set +e
-            ( ./tests.sh -d gdb -g dbg 2>&1 | sed -u "s/^/[DBG-GDB] /" ) & gdbpid=$!
-            ( ./tests.sh -d lldb -g dbg 2>&1 | sed -u "s/^/[DBG-LLDB] /" ) & lldbpid=$!
-            wait $gdbpid; gdbexitcode=$?;
-            wait $lldbpid; lldbexitcode=$?;
-            exit $((gdbexitcode|lldbexitcode))
+            echo "Running generic tests on gdb, generic tests on lldb, and cross-arch tests at the same time. This should take ~6-9 minutes, results outputted at the end..."
+            ./tests.sh -d gdb -g cross-arch-user > /tmp/cross.log 2>&1 & cross_pid=$!
+            ./tests.sh -d gdb -g dbg > /tmp/dbg-gdb.log 2>&1 & dbg_gdb_pid=$!
+            ./tests.sh -d lldb -g dbg > /tmp/dbg-lldb.log 2>&1 & dbg_lldb_pid=$!
+            wait $cross_pid; cross_exit=$?
+            wait $dbg_gdb_pid; dbg_gdb_exit=$?
+            wait $dbg_lldb_pid; dbg_lldb_exit=$?
+            set -e
+
+            sed "s/^/[CROSS] /" /tmp/cross.log
+            sed "s/^/[DBG-GDB] /" /tmp/dbg-gdb.log
+            sed "s/^/[DBG-LLDB] /" /tmp/dbg-lldb.log
+
+            echo ""
+            echo "========================================"
+            echo "       COMBINED TEST SUMMARY"
+            echo "========================================"
+            echo ""
+            sed -n "/^\*\*\*/,\$p" /tmp/cross.log | sed "s/^/[CROSS] /"
+            echo ""
+            sed -n "/^\*\*\*/,\$p" /tmp/dbg-gdb.log | sed "s/^/[DBG-GDB] /"
+            echo ""
+            sed -n "/^\*\*\*/,\$p" /tmp/dbg-lldb.log | sed "s/^/[DBG-LLDB] /"
+
+            exit $((cross_exit | dbg_gdb_exit | dbg_lldb_exit))
           '
 
       - name: Push full image to registry

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -61,22 +61,29 @@ jobs:
         run: |
           docker buildx build \
             --load \
-            --cache-from type=registry,ref=ghcr.io/pwndbg/cache:${{ matrix.image }} \
-            ${{ github.event_name == 'push' && format('--cache-to type=registry,ref=ghcr.io/pwndbg/cache:{0},mode=max', matrix.image) || '' }} \
+            --cache-from type=registry,ref=ghcr.io/pwndbg/cache:${{ matrix.image }}-amd64 \
+            ${{ github.event_name == 'push' && format('--cache-to type=registry,ref=ghcr.io/pwndbg/cache:{0}-amd64,mode=max', matrix.image) || '' }} \
             -f ${{ matrix.dockerfile }} \
             --build-arg image=${{ matrix.base }} \
             -t ghcr.io/pwndbg/pwndbg:${{ matrix.image }}-amd64 \
             -t ghcr.io/pwndbg/pwndbg:${{ matrix.image }} \
             .
-      
+
       - name: Run GDB Tests on ${{ matrix.image }}
-        run: docker compose run ${{ matrix.image }} ./tests.sh -d gdb -g gdb
-      
-      - name: Run DBG Tests on GDB on ${{ matrix.image }}
-        run: docker compose run ${{ matrix.image }} ./tests.sh -d gdb -g dbg
-      
-      - name: Run DBG Tests on LLDB on ${{ matrix.image }}
-        run: docker compose run ${{ matrix.image }} ./tests.sh -d lldb -g dbg
+        run: docker compose run --rm ${{ matrix.image }} ./tests.sh -d gdb -g gdb
+
+      - name: Run DBG Tests (DBG-GDB & DBG-LLDB in parallel) on ${{ matrix.image }}
+        run: |
+          docker compose run --rm ${{ matrix.image }} bash -c '
+            set -euo pipefail
+            make -C /pwndbg/tests/binaries/host -j4 all
+            set +e
+            ( ./tests.sh -d gdb -g dbg 2>&1 | sed -u "s/^/[DBG-GDB] /" ) & gdbpid=$!
+            ( ./tests.sh -d lldb -g dbg 2>&1 | sed -u "s/^/[DBG-LLDB] /" ) & lldbpid=$!
+            wait $gdbpid; gdbexitcode=$?;
+            wait $lldbpid; lldbexitcode=$?;
+            exit $((gdbexitcode|lldbexitcode))
+          '
 
       - name: Push full image to registry
         if: github.event_name == 'push'
@@ -120,15 +127,22 @@ jobs:
             -t ghcr.io/pwndbg/pwndbg:${{ matrix.image }}-arm64 \
             -t ghcr.io/pwndbg/pwndbg:${{ matrix.image }} \
             .
-      
+
       - name: Run Cross Tests on GDB on ${{ matrix.image }}
-        run: docker compose run ${{ matrix.image }} ./tests.sh -d gdb -g cross-arch-user
-      
-      - name: Run DBG Tests on GDB on ${{ matrix.image }}
-        run: docker compose run ${{ matrix.image }} ./tests.sh -d gdb -g dbg
-      
-      - name: Run DBG Tests on LLDB on ${{ matrix.image }}
-        run: docker compose run ${{ matrix.image }} ./tests.sh -d lldb -g dbg
+        run: docker compose run --rm ${{ matrix.image }} ./tests.sh -d gdb -g cross-arch-user
+
+      - name: Run DBG Tests (DBG-GDB & DBG-LLDB in parallel) on ${{ matrix.image }}
+        run: |
+          docker compose run --rm ${{ matrix.image }} bash -c '
+            set -euo pipefail
+            make -C /pwndbg/tests/binaries/host -j4 all
+            set +e
+            ( ./tests.sh -d gdb -g dbg 2>&1 | sed -u "s/^/[DBG-GDB] /" ) & gdbpid=$!
+            ( ./tests.sh -d lldb -g dbg 2>&1 | sed -u "s/^/[DBG-LLDB] /" ) & lldbpid=$!
+            wait $gdbpid; gdbexitcode=$?;
+            wait $lldbpid; lldbexitcode=$?;
+            exit $((gdbexitcode|lldbexitcode))
+          '
 
       - name: Push full image to registry
         if: github.event_name == 'push'


### PR DESCRIPTION
+ [x] I read the contributing documentation.
+ [ ] I am providing a screenshot of the (new feature) / (fixed bug).

This PR parallelizes the DBG-GDB and DBG-LLDB tests to speed up CI.

There are 2 options besides keeping as is, so I'd appreciate opinions.

1. Current state of this PR, parallelize DBG-GDB and DBG-LLDB
~12m 20s > ~8m 34s for the full test suite to run, including GDB tests
Example with a purposeful test failure: https://github.com/Monthly-Recurring-Revenue/pwndbg/actions/runs/21532428557/job/62051170529

2. Parallelize GDB, DBG-GDB, and DBG-LLDB
~12m 20s > ~7m 25s for the full test suite to run
Here, the benefits start to slow down because of CPU limitations, but it still saves an extra minute, surprisingly.
Example with a purposeful test failure: https://github.com/Monthly-Recurring-Revenue/pwndbg/actions/runs/21532428592/job/62051159246
Cons: Non-realtime, output is printed after tests are run, otherwise it is interweaved, which can be slightly confusing and not worth it imo. I'm not sure if people sit there and watch the workflow run, and want to see the tests run in real time. I don't really, but maybe some people do, and in that case, this could be a negative and not worth the extra time savings.

3. Keep as is 

Though if we choose option 2, or maybe even 1, we should have an entire summary at the end, so there is no need for scrolling up and down.