### PR TITLE
Update docs for writing tests (we should have done this like half a year ago)

### DIFF
--- a/docs/contributing/writing-tests.md
+++ b/docs/contributing/writing-tests.md
@@ -5,13 +5,18 @@
 !!! note
     This is written under the assumption you already know how to [run the tests](../contributing/index.md#running-tests).
 
-In Pwndbg we have four types of tests: extensive x86_64 GDB tests, cross-architecture tests, linux kernel tests
+In Pwndbg we have four types of tests: extensive (mostly x86_64) userspace tests, cross-architecture tests, linux kernel tests
 and unit-tests. They are all located in subdirectories of [`./tests`](https://github.com/pwndbg/pwndbg/tree/dev/tests).
 
-The x86_64 tests encompass most of the Pwndbg testing suite. If your tests do not belong in any of the other
-categories, they should go here. Since we do not yet perform testing on LLDB, these are run from inside GDB
-and are located in the [`./tests/library/gdb`](https://github.com/pwndbg/pwndbg/tree/dev/tests/library/gdb/)
-directory. They can be run with `./tests.sh -d gdb -g gdb`.
+The userspace tests encompass most of the Pwndbg testing suite. If your tests do not belong in any of the other
+categories, they should go here. We run the same tests under both GDB and LLDB, and thus they use an abstraction layer to
+perform stuff like "set a breakpoint" or "continue execution". They are located in the [`./tests/library/dbg`](https://github.com/pwndbg/pwndbg/tree/dev/tests/library/dbg) directory and can be run with `./tests.sh --driver gdb --group dbg` and `./tests.sh -d lldb -g dbg`.
+
+These tests are also run on an aarch64 host in the Pwndbg CI, and most of them should be architecture agnostic. There are also
+gdb tests which you can run by `./tests.sh --driver gdb --group gdb`, located in the [`./tests/library/gdb`](https://github.com/pwndbg/pwndbg/tree/dev/tests/library/gdb) folder. These are mostly tests which have simply not yet been ported over to the new `./tests/library/dbg` system. We would
+ideally like to reduce the `gdb/` tests to only a minimal set which test truly gdb-only features. If you encounter a function which
+is implemented equivalently in both `gdb/` and `dbg/`, you should remove it from the `gdb/` file, there is no need to run the same
+test twice (duplicates were left during the porting process, to ensure it goes smoothly).
 
 The cross-architecture tests are run using qemu-user emulation. They test architecture-specific logic and
 are located in the [`./tests/library/qemu-user`](https://github.com/pwndbg/pwndbg/tree/dev/tests/library/qemu-user)
@@ -25,9 +30,9 @@ The unit tests are not run from within a debugger, but rather directly with pyte
 in the [`./tests/unit_tests/`](https://github.com/pwndbg/pwndbg/tree/dev/tests/unit-tests)
 directory.
 
-Here are the options supported by `./tests.sh` which you can get by running `./tests.sh -h`.
+Here are the options supported by `./tests.sh` which you can get by running `./tests.sh --help`.
 ```
-usage: tests.py [-h] -g {gdb,dbg,cross-arch-user} -d {gdb} [-p] [-c] [-v] [-s] [--nix] [--collect-only] [test_name_filter]
+usage: tests.py [-h] -g {gdb,lldb,dbg,cross-arch-user} -d {gdb,lldb} [-p] [-c] [-v] [-s] [--nix] [--collect-only] [--clean] [test_name_filter]
 
 Run tests.
 
@@ -36,61 +41,102 @@ positional arguments:
 
 options:
   -h, --help            show this help message and exit
-  -g {gdb,dbg,cross-arch-user}, --group {gdb,dbg,cross-arch-user}
-  -d {gdb}, --driver {gdb}
+  -g {gdb,lldb,dbg,cross-arch-user}, --group {gdb,lldb,dbg,cross-arch-user}
+  -d {gdb,lldb}, --driver {gdb,lldb}
   -p, --pdb             enable pdb (Python debugger) post mortem debugger on failed tests
   -c, --cov             enable codecov
   -v, --verbose         display all test output instead of just failing test output
   -s, --serial          run tests one at a time instead of in parallel
   --nix                 run tests using built for nix environment
   --collect-only        only show the output of test collection, don't run any tests
+  --clean               clean (delete) all the test binaries
 ```
 ## Writing tests
 
-Each test is a Python function that runs inside of an isolated GDB session.
-Using a [`pytest`](https://docs.pytest.org/en/latest/) fixture at the beginning of each test,
-GDB will attach to a [`binary`](https://github.com/pwndbg/pwndbg/tree/dev/tests/library/gdb/conftest.py)
-or connect to a [`QEMU instance`](https://github.com/pwndbg/pwndbg/tree/dev/tests/library/qemu-user/conftest.py).
-Each test runs some commands and uses Python `assert` statements to verify correctness. We can access Pwndbg
-library code like `pwndbg.aglib.regs.sp` as well as execute GDB commands with `gdb.execute()`.
+Each test is a Python function that runs inside of an isolated debugger session which is dispatched through the [`@pwndbg_test`](https://github.com/pwndbg/pwndbg/tree/dev/tests/library/dbg/tests/__init__.py) decorator. The cross-arch-user QEMU tests are passed an appropriate starting function using [`pytest`](https://docs.pytest.org/en/latest/) [`fixtures`](https://github.com/pwndbg/pwndbg/tree/dev/tests/library/qemu_user/conftest.py). Each test runs some commands and uses Python `assert` statements to verify correctness. We can access Pwndbg library code like `pwndbg.aglib.regs.sp`, execute common debugger actions through the test control API like `await ctrl.cont()`, or use the same to execute Pwndbg commands e.g. `await ctrl.execute_and_capture("telescope")`. Do not `ctrl.execute()` debugger-specific commands! - add a new function to the `Controller` in [`tests/host/__init__.py`](https://github.com/pwndbg/pwndbg/blob/dev/tests/host/__init__.py) if you need it.
 
-We can take a look at [`tests/library/gdb/tests/test_symbol.py`](https://github.com/pwndbg/pwndbg/tree/dev/tests/library/gdb/tests/test_symbol.py)
-for an example of a simple test. Looking at a simplified version of the top-level code, we have this:
+We can take a look at [`tests/library/dbg/tests/test_mallocng.py`](https://github.com/pwndbg/pwndbg/tree/dev/tests/library/dbg/tests/test_mallocng.py)
+as an example test file.
 
 ```python
-import gdb
-import pwndbg
-import tests
+from __future__ import annotations
 
-BINARY = tests.get_binary("symbol_1600_and_752.native.out")
+import re
+from pathlib import Path
+
+import pytest
+
+from ....host import Controller
+from . import break_at_sym
+from . import get_binary
+from . import launch_to
+from . import pwndbg_test
+
+HEAP_MALLOCNG_DYN = get_binary("heap_musl_dyn.native.out")
+HEAP_MALLOCNG_STATIC = get_binary("heap_musl_static.native.out")
+
+# Userland only
+re_addr = r"0x[0-9a-fA-F]{1,12}"
 ```
 
-Since these tests run inside GDB, we can import the `gdb` Python library. We also import the `tests` module,
-which makes it easy to get the path to the test binaries located in [`tests/gdb-tests/tests/binaries`](https://github.com/pwndbg/pwndbg/tree/dev/tests/gdb-tests/tests/binaries).
-You should be able to reuse the binaries in this folder for most tests, but if not feel free to add a new one.
+We import some convenience functions provided to us by [`tests/library/dbg/tests/__init__.py`](https://github.com/pwndbg/pwndbg/tree/dev/tests/library/dbg/tests/__init__.py) and the [`Controller`](https://github.com/pwndbg/pwndbg/blob/dev/tests/host/__init__.py) class which implements the debugger-agnostic control. The `get_binary` function returns a [`pathlib.Path`](https://docs.python.org/3/library/pathlib.html#pathlib.Path) from the [`binaries`](https://github.com/pwndbg/pwndbg/tree/dev/tests/binaries/host) directory. You should be able to reuse the binaries in this folder for most tests, but if not feel free to add a new one.
 
-Here's a small snippet of the actual test:
+Here's a function form the file:
 
 ```python
-def test_hexdump(start_binary):
-    start_binary(BINARY)
-    pwndbg.config.hexdump_group_width.value = -1
+@pwndbg_test
+@pytest.mark.parametrize(
+    "binary", [HEAP_MALLOCNG_DYN, HEAP_MALLOCNG_STATIC], ids=["dynamic", "static"]
+)
+async def test_mallocng_slot_start(ctrl: Controller, binary: Path):
+    import pwndbg.color as color
 
-    gdb.execute("set hexdump-byte-separator")
-    stack_addr = pwndbg.aglib.regs.sp - 0x100
+    await launch_to(ctrl, binary, "break_here")
+    await ctrl.finish()
+
+    # Check ng-slots is the same as ng-slotu when p == start
+    # and that they aren't the same when p != start.
+
+    slotu_buffer2_out = color.strip(await ctrl.execute_and_capture("ng-slotu buffer2"))
+    slots_buffer2_out = color.strip(await ctrl.execute_and_capture("ng-slots buffer2"))
+    slotu_buffer5_out = color.strip(await ctrl.execute_and_capture("ng-slotu buffer5"))
+    slots_buffer5_out = color.strip(await ctrl.execute_and_capture("ng-slots buffer5"))
+
+    assert "not cyclic" in slotu_buffer2_out
+    assert slotu_buffer2_out == slots_buffer2_out
+
+    if binary == HEAP_MALLOCNG_STATIC:
+        assert "not cyclic" not in slotu_buffer5_out
+        # Doing `ng-slots buffer5` will give you garbage since buffer5 is not
+        # a valid slot start.
+        assert slotu_buffer5_out != slots_buffer5_out
 ```
 
-`pytest` will run any function that starts with `test_` as a new test, so there is no need to register your new
-test anywhere. The `start_binary` argument is a function that will run the binary you give it, and it will set
-some common options before starting the binary. Using `start_binary` is recommended if you don't need any
-additional customization to GDB settings before starting the binary, but if you do it's fine to not use it.
+`pytest` will run any function that starts with `test_` as a new test. We decorate our test function with `@pwndbg_test` as explained before. Furthermore, as we want to run this specific function both for the dynamically compiled binary and the statically compiled binary, we decorate it with `@pytest.mark.parametrize` as well. We put all pwndbg imports inside the function itself - putting them at the top of the test file is currently not supported. We use `launch_to` to run the binary until our `break_here` function, and then exit from that helper function back to main with `ctrl.finish()`. Finally, we assert on the output of `ctrl.execute_and_capture` to check whether the output of our command is as expected.
+
+Here is what [`heap_musl.native.c`](https://github.com/pwndbg/pwndbg/blob/dev/tests/binaries/host/heap_musl.native.c) looks like:
+
+```c
+#include <stdlib.h>
+#include <string.h>
+
+void break_here() {};
+
+int main () {
+  char* buffer1 = malloc(0x50);
+  char* buffer2 = malloc(0x50);
+  char* buffer3 = malloc(0x50);
+  char* buffer4 = malloc(0x211);
+  char* buffer5 = malloc(0x211);
+
+  break_here();
+
+  memset(buffer1, 0xA, 0x50);
+  memset(buffer2, 0xB, 0x50);
+  // ....
+}
+```
 
 ## QEMU Tests
 
-Our `gdb` tests run in x86. To debug other architectures, we use QEMU for emulation and attach to its debug
-port. These tests are located in
-[`tests/library/qemu-user/tests`](https://github.com/pwndbg/pwndbg/tree/dev/tests/library/qemu-user/tests).
-Test creation is identical to our x86 tests - create a Python function with a Pytest fixture name as
-the parameter (it matches based on the name), and call the argument to start debugging a binary. The
-`qemu_assembly_run` fixture takes in a Python string of assembly code, compiles it in the
-appropriate architecture, and runs it - no need to create an external file or edit a Makefile.
+To test architecture specific features, like disassembly annotations, we use emulate the appropriate architecure with qemu-user and attach to its debug port. These tests are located in [`tests/library/qemu-user/tests`](https://github.com/pwndbg/pwndbg/tree/dev/tests/library/qemu_user/tests). They are currently `gdb-only` and thus follow the same format as the `gdb/` tests. They require a Python function with a Pytest fixture name as the parameter (it matches based on the name). You call the argument/fixture to start debugging a binary. The `qemu_assembly_run` fixture takes in a Python string of assembly code, compiles it in the appropriate architecture, and runs it - no need to create an external file or edit a Makefile.

--- a/docs/contributing/writing-tests.md
+++ b/docs/contributing/writing-tests.md
@@ -13,21 +13,21 @@ categories, they should go here. We run the same tests under both GDB and LLDB, 
 perform stuff like "set a breakpoint" or "continue execution". They are located in the [`./tests/library/dbg`](https://github.com/pwndbg/pwndbg/tree/dev/tests/library/dbg) directory and can be run with `./tests.sh --driver gdb --group dbg` and `./tests.sh -d lldb -g dbg`.
 
 These tests are also run on an aarch64 host in the Pwndbg CI, and most of them should be architecture agnostic. There are also
-gdb tests which you can run by `./tests.sh --driver gdb --group gdb`, located in the [`./tests/library/gdb`](https://github.com/pwndbg/pwndbg/tree/dev/tests/library/gdb) folder. These are mostly tests which have simply not yet been ported over to the new `./tests/library/dbg` system. We would
+gdb tests which you can run with `./tests.sh --driver gdb --group gdb`, located in the [`./tests/library/gdb`](https://github.com/pwndbg/pwndbg/tree/dev/tests/library/gdb) folder. These are mostly tests which have simply not yet been ported over to the new `./tests/library/dbg` system. We would
 ideally like to reduce the `gdb/` tests to only a minimal set which test truly gdb-only features. If you encounter a function which
 is implemented equivalently in both `gdb/` and `dbg/`, you should remove it from the `gdb/` file, there is no need to run the same
 test twice (duplicates were left during the porting process, to ensure it goes smoothly).
 
 The cross-architecture tests are run using qemu-user emulation. They test architecture-specific logic and
-are located in the [`./tests/library/qemu-user`](https://github.com/pwndbg/pwndbg/tree/dev/tests/library/qemu-user)
+are located in the [`./tests/library/qemu_user`](https://github.com/pwndbg/pwndbg/tree/dev/tests/library/qemu_user)
 directory. They can be run with `./tests.sh -d gdb -g cross-arch-user`.
 
 The linux kernel tests are run using qemu-system emulation. They are located in the
-[`./tests/library/qemu_system`](https://github.com/pwndbg/pwndbg/tree/dev/tests/library/qemu-system)
+[`./tests/library/qemu_system`](https://github.com/pwndbg/pwndbg/tree/dev/tests/library/qemu_system)
 directory and run for a variety kernel configurations and architectures.
 
 The unit tests are not run from within a debugger, but rather directly with pytest. They are located
-in the [`./tests/unit_tests/`](https://github.com/pwndbg/pwndbg/tree/dev/tests/unit-tests)
+in the [`./tests/unit_tests/`](https://github.com/pwndbg/pwndbg/tree/dev/tests/unit_tests)
 directory.
 
 Here are the options supported by `./tests.sh` which you can get by running `./tests.sh --help`.
@@ -139,4 +139,4 @@ int main () {
 
 ## QEMU Tests
 
-To test architecture specific features, like disassembly annotations, we use emulate the appropriate architecure with qemu-user and attach to its debug port. These tests are located in [`tests/library/qemu-user/tests`](https://github.com/pwndbg/pwndbg/tree/dev/tests/library/qemu_user/tests). They are currently `gdb-only` and thus follow the same format as the `gdb/` tests. They require a Python function with a Pytest fixture name as the parameter (it matches based on the name). You call the argument/fixture to start debugging a binary. The `qemu_assembly_run` fixture takes in a Python string of assembly code, compiles it in the appropriate architecture, and runs it - no need to create an external file or edit a Makefile.
+To test architecture specific features, like disassembly annotations, we use emulate the appropriate architecure with qemu-user and attach to its debug port. These tests are located in [`tests/library/qemu_user/tests`](https://github.com/pwndbg/pwndbg/tree/dev/tests/library/qemu_user/tests). They are currently `gdb-only` and thus follow the same format as the `gdb/` tests. They require a Python function with a Pytest fixture name as the parameter (it matches based on the name). You call the argument/fixture to start debugging a binary. The `qemu_assembly_run` fixture takes in a Python string of assembly code, compiles it in the appropriate architecture, and runs it - no need to create an external file or edit a Makefile.

--- a/tests/library/dbg/tests/test_command_xor.py
+++ b/tests/library/dbg/tests/test_command_xor.py
@@ -18,6 +18,7 @@ async def test_command_xor_with_dbg_execute(ctrl: Controller) -> None:
     await ctrl.launch(REFERENCE_BINARY)
 
     before = pwndbg.aglib.regs.sp
+    assert before is not None
     pwndbg.aglib.memory.write(before, b"aaaaaaaa")
     await ctrl.execute("xor $sp ' ' 4")
     after = pwndbg.aglib.memory.read(before, 8)
@@ -35,7 +36,7 @@ async def test_command_xor_with_int(ctrl: Controller) -> None:
     await ctrl.launch(REFERENCE_BINARY)
 
     before = pwndbg.aglib.regs.sp
-    assert isinstance(before, int)
+    assert before is not None
     pwndbg.aglib.memory.write(before, b"aaaaaaaa")
     await ctrl.execute(f"xor {before} ' ' 4")
     after = pwndbg.aglib.memory.read(before, 8)
@@ -53,6 +54,7 @@ async def test_command_xor_with_hex(ctrl: Controller) -> None:
     await ctrl.launch(REFERENCE_BINARY)
 
     before = pwndbg.aglib.regs.sp
+    assert before is not None
     before_hex = hex(before)
     assert isinstance(before_hex, str)
     pwndbg.aglib.memory.write(before, b"aaaaaaaa")
@@ -70,6 +72,7 @@ async def test_command_memfrob(ctrl: Controller) -> None:
     await ctrl.launch(REFERENCE_BINARY)
 
     before = pwndbg.aglib.regs.sp
+    assert before is not None
     pwndbg.aglib.memory.write(before, b"aaaaaaaa")
     memfrob(before, 4)
     after = pwndbg.aglib.memory.read(before, 8)

--- a/tests/library/dbg/tests/test_mallocng.py
+++ b/tests/library/dbg/tests/test_mallocng.py
@@ -346,7 +346,6 @@ async def test_mallocng_malloc_context(ctrl: Controller, binary: Path):
 )
 async def test_mallocng_find(ctrl: Controller, binary: Path):
     import pwndbg
-    import pwndbg.aglib
     import pwndbg.color as color
 
     await launch_to(ctrl, binary, "break_here")

--- a/tests/library/dbg/tests/test_symbol.py
+++ b/tests/library/dbg/tests/test_symbol.py
@@ -22,7 +22,11 @@ async def test_symbol_get(ctrl: Controller) -> None:
         # and it will be set by the program copying from register to the stack
         # (we pass `to_string=True` to suppress the context output)
         await ctrl.execute_and_capture("nextret")
-        p = int(pwndbg.dbg.selected_frame().evaluate_expression("p"))
+
+        frame = pwndbg.dbg.selected_frame()
+        assert frame is not None
+        p = int(frame.evaluate_expression("p"))
+
         return pwndbg.dbg.selected_inferior().symbol_name_at_address(p)
 
     assert (await get_next_ptr()) == "main"


### PR DESCRIPTION
I now understand why contributors make `gdb/` tests all the time. It all makes sense now.