### PR TITLE
Add hint to access subcommand help information

### DIFF
--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -233,6 +233,13 @@ class CommandObj:
         ) -> None:
             self.invoke(arguments, is_interactive)
 
+        if self.subcommand_names is not None and len(self.subcommand_names) > 0:
+            # In order to add `help <main> <sub>` support, the main
+            # command needs to be registered as a prefix command in
+            # GDB. Since this causes help info duplication, for now
+            # we simply show a hint to use `--help`
+            self.help_str += f"\nHint: Use `{self.command_name} <subcmd> --help` if you want to see subcommand information"
+
         # Keep a handle to the command and its aliases so we can
         # easily remove them if necessary (not supported with GDB).
         self.handles = [

--- a/tests/library/gdb/tests/test_consistent_help.py
+++ b/tests/library/gdb/tests/test_consistent_help.py
@@ -17,5 +17,12 @@ def test_consistent_help():
         gdb_out = gdb.execute(f"help {name}", to_string=True)
         argparse_out = gdb.execute(f"{name} -h", to_string=True)
 
+        if cmd.subcommand_names:
+            # `help <main>` adds a hint to access subcommand information
+            # we test if the remaining part is correct
+            hint_header_line = f"\nHint: Use `{cmd.command_name} <subcmd> --help` if you want to see subcommand information"
+            assert hint_header_line in gdb_out
+            gdb_out = gdb_out[: gdb_out.index(hint_header_line)]
+
         # I would rather not strip, but gdb is inconsistent between versions.
         assert gdb_out.rstrip() == argparse_out.rstrip()


### PR DESCRIPTION
Fixes #3547
See #3682 for rationale

It flew over my head when I suggested a hint for subcommand information that if it were possible to detect when the builtin `help <main> <sub>` were being used WITHOUT registering the main command as prefix command, we could have just printed the help information that way instead of a hint message 

So the only remaining way to add a hint is in every `help <main>` command in `CommandObj.register_command` for all pwndbg commands which have subcommands

<img width="1201" height="903" alt="image" src="https://github.com/user-attachments/assets/427502f5-bbff-44a7-9073-e3c86b016c48" />


+ [x] I read the contributing documentation.
+ [x] I am providing a screenshot of the (new feature) / (fixed bug).
