### PR TITLE
Show debugger output for gdb tests

### DIFF
--- a/pwndbg/dbg_mod/lldb/repl/__init__.py
+++ b/pwndbg/dbg_mod/lldb/repl/__init__.py
@@ -425,6 +425,7 @@ def run(
                                     action._command, output, dbg, driver, relay
                                 )
                                 last_result = output.buffer.getvalue()
+                                print(last_result.decode("utf-8", errors="surrogateescape"))
                         else:
                             should_continue = exec_repl_command(
                                 action._command, sys.stdout, dbg, driver, relay

--- a/tests/host/gdb/pytests_launcher.py
+++ b/tests/host/gdb/pytests_launcher.py
@@ -15,6 +15,21 @@ from ... import host
 
 
 class _GDBController(host.Controller):
+    def _gdb_execute(self, command: str) -> None:
+        """Execute a GDB command and print the command to output."""
+        print(f"pwndbg> {command}")
+        gdb.execute(command)
+
+    def _show_context(self) -> None:
+        """
+        Display context after stops during tests.
+
+        We run the context command directly instead of using prompt_hook()
+        because prompt_hook() also fires events via after_reload(), which
+        can cause event handlers to trigger multiple times.
+        """
+        self._gdb_execute("context")
+
     async def launch(
         self, binary_path: Path, args: list[str] = [], env: dict[str, str] = {}
     ) -> None:
@@ -28,45 +43,52 @@ class _GDBController(host.Controller):
             pytest.skip(f"{os.path.basename(binary_path)} does not exist. Platform not supported.")
 
         os.environ["PWNDBG_IN_TEST"] = "1"
-        gdb.execute(f"file {binary_path}")
-        gdb.execute("set exception-verbose on")
-        gdb.execute("set width 80")
-        gdb.execute("set context-reserve-lines never")
+        self._gdb_execute(f"file {binary_path}")
+        self._gdb_execute("set exception-verbose on")
+        self._gdb_execute("set width 80")
+        self._gdb_execute("set context-reserve-lines never")
         os.environ["COLUMNS"] = "80"
         for k, v in env.items():
-            gdb.execute(f"set environment {k}={v}")
-        gdb.execute("starti " + " ".join(args))
+            self._gdb_execute(f"set environment {k}={v}")
+        self._gdb_execute("starti " + " ".join(args))
+        self._show_context()
 
     async def cont(self) -> None:
-        gdb.execute("continue")
+        self._gdb_execute("continue")
+        self._show_context()
 
     async def execute(self, command: str) -> None:
         from pwndbg.dbg_mod import Error
 
         try:
-            gdb.execute(command)
+            self._gdb_execute(command)
         except gdb.error as e:
             raise Error(e)
 
     async def execute_and_capture(self, command: str) -> str:
-        return gdb.execute(command, to_string=True)
+        print(f"pwndbg> {command}")
+        result = gdb.execute(command, to_string=True)
+        print(result)
+        return result
 
     async def step_instruction(self) -> None:
-        gdb.execute("stepi")
+        self._gdb_execute("stepi")
+        self._show_context()
 
     async def finish(self) -> None:
-        gdb.execute("finish")
+        self._gdb_execute("finish")
+        self._show_context()
 
     async def select_thread(self, tid: int) -> None:
-        gdb.execute(f"thread {tid}")
+        self._gdb_execute(f"thread {tid}")
 
     async def disable_debuginfod(self) -> None:
-        gdb.execute("set debug-file-directory")
-        gdb.execute("set debuginfod enabled off")
+        self._gdb_execute("set debug-file-directory")
+        self._gdb_execute("set debuginfod enabled off")
 
     async def generate_core_file(self, path: Path) -> None:
-        gdb.execute(f"generate-core-file {path}")
-        gdb.execute(f"core-file {path}")
+        self._gdb_execute(f"generate-core-file {path}")
+        self._gdb_execute(f"core-file {path}")
 
 
 def _start(outer: Callable[[host.Controller], Coroutine[Any, Any, None]]) -> None:


### PR DESCRIPTION
+ [x] I read the contributing documentation.
+ [ ] I am providing a screenshot of the (new feature) / (fixed bug).

Fixes Issue: https://github.com/pwndbg/pwndbg/issues/3668

This was already handled for LLDB with the  REPL, which is why LLDB tests showed the nice output in tests, so I made the same thing occur for GDB tests.

I added two helper methods
`_gdb_execute()` to print the command that is being run
`_show_context()` to show context after stops 

I also made `execute_and_capture()` print the command being run and the output, which previously wasn't shown. It can be redundant for test_context_commands because context is then run twice; however, for almost all other tests, it isn't redundant.
LLDB doesn't currently show results of commands run with `execute_and_capture` like GDB now does, if this is something that would also be wanted lmk. You can see an example of what I mean here with my changes made and test_command_telescope set to fail purposefully: https://github.com/Monthly-Recurring-Revenue/pwndbg/actions/runs/21581242815/job/62178853948

