### PR TITLE
Docker tests - only build on PRs when Dockerfiles or setup scripts change

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -42,7 +42,7 @@ jobs:
           - { image: fedora43, dockerfile: Dockerfile.dnf, base: fedora:43 }
 
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -45,8 +45,24 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check for Dockerfile or setup changes
+        id: build-check
+        if: github.event_name == 'pull_request'
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"
+          if git diff --name-only "origin/${{ github.base_ref }}...${{ github.event.pull_request.head.sha }}" | \
+             grep -qE '^(Dockerfile.*|setup\.sh|setup-dev\.sh|scripts/common\.sh)$'; then
+            echo "needed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "needed=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Set up Docker Buildx
+        if: github.event_name == 'push' || steps.build-check.outputs.needed == 'true'
         uses: docker/setup-buildx-action@v3
 
       - name: Login to GHCR
@@ -58,6 +74,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Docker Buildx ${{ matrix.image }} (cache-enabled)
+        if: github.event_name == 'push' || steps.build-check.outputs.needed == 'true'
         run: |
           docker buildx build \
             --load \
@@ -71,7 +88,7 @@ jobs:
 
       - name: Run Tests (GDB, DBG-GDB, DBG-LLDB in parallel) on ${{ matrix.image }}
         run: |
-          docker compose run -T --rm ${{ matrix.image }} bash -c '
+          docker compose run -T --rm --quiet-pull -v $(pwd):/pwndbg ${{ matrix.image }} bash -c '
             set -euo pipefail
             # Needed to prevent race conditions - prebuild binaries and create libpython symlink
             make -C /pwndbg/tests/binaries/host -j4 all
@@ -124,8 +141,24 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check for Dockerfile or setup changes
+        id: build-check
+        if: github.event_name == 'pull_request'
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"
+          if git diff --name-only "origin/${{ github.base_ref }}...${{ github.event.pull_request.head.sha }}" | \
+             grep -qE '^(Dockerfile.*|setup\.sh|setup-dev\.sh|scripts/common\.sh)$'; then
+            echo "needed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "needed=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Set up Docker Buildx
+        if: github.event_name == 'push' || steps.build-check.outputs.needed == 'true'
         uses: docker/setup-buildx-action@v3
 
       - name: Login to GHCR
@@ -137,6 +170,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Docker Buildx ${{ matrix.image }} (cache-enabled)
+        if: github.event_name == 'push' || steps.build-check.outputs.needed == 'true'
         run: |
           docker buildx build \
             --load \
@@ -150,7 +184,7 @@ jobs:
 
       - name: Run Tests (Cross, DBG-GDB, DBG-LLDB in parallel) on ${{ matrix.image }}
         run: |
-          docker compose run -T --rm ${{ matrix.image }} bash -c '
+          docker compose run -T --rm --quiet-pull -v $(pwd):/pwndbg ${{ matrix.image }} bash -c '
             set -euo pipefail
             # Needed to prevent race conditions - prebuild binaries
             make -C /pwndbg/tests/binaries/host -j4 all


### PR DESCRIPTION
+ [x] I read the contributing documentation.
+ [ ] I am providing a screenshot of the (new feature) / (fixed bug).

Just some finishing touches I wanted to make. 

Now that pulling images is available and is the default in the docs for running the Docker tests, I made the workflow no longer build on PRs unless any Dockerfile or setup scripts are changed. 

This way, they are built only on pushes (to push the latest dev image), unless needed. This also reduces time by an additional ~10%, roughly ~1m.

This PR also reduces the timeout-minutes from 30m > 15m to accurately reflect after how long something is wrong, and we should just timeout.

https://www.kenmuse.com/blog/the-many-shas-of-a-github-pull-request/#a-sha-for-every-occasion
https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#setting-an-output-parameter