### PR TITLE
Set vis-skip-repeating-val to False by default

### DIFF
--- a/docs/configuration/config.md
+++ b/docs/configuration/config.md
@@ -1011,7 +1011,7 @@ Whether to skip repeating lines in vis command output.
 
 
 
-**Default:** on  
+**Default:** off  
 
 ----------
 

--- a/pwndbg/commands/ptmalloc2.py
+++ b/pwndbg/commands/ptmalloc2.py
@@ -18,6 +18,7 @@ import pwndbg.color.memory as mem_color
 import pwndbg.commands
 import pwndbg.commands.hexdump
 import pwndbg.dbg_mod
+import pwndbg.lib.memory
 import pwndbg.libc
 import pwndbg.libc.glibc
 from pwndbg.aglib.heap import heap_chain_limit
@@ -944,7 +945,7 @@ pwndbg.config.add_param(
 
 pwndbg.config.add_param(
     "vis-skip-repeating-val",
-    True,
+    False,
     "whether to skip repeating lines in vis command output",
 )
 
@@ -1131,11 +1132,11 @@ def vis_heap_chunks(
     bin_labels_map: dict[int, list[str]] = bin_labels_mapping(bin_collections)
 
     # For collapsing repeated lines
-    skip_repeating = False if no_skip else pwndbg.config.vis_skip_repeating_val
-    prev_line_content = None
-    repeat_count = 0
-    line_buffer = ""  # Temporary buffer for building current line (holds first cell)
-    saved_line_addr = ""  # Saved address for the current line
+    skip_repeating: bool = False if no_skip else bool(pwndbg.config.vis_skip_repeating_val)
+    prev_line_content: str | None = None
+    repeat_count: int = 0
+    line_buffer: str = ""  # Temporary buffer for building current line (holds first cell)
+    saved_line_addr: str = ""  # Saved address for the current line
 
     def flush_repeats() -> None:
         """Add collapse message for accumulated repeated lines."""


### PR DESCRIPTION
Since it's a bit clunky now (https://github.com/pwndbg/pwndbg/issues/3506) and doesn't play well with an existing arg and we want to cut a release, lets at least set it to False by default.