### PR TITLE
use dorny/paths-filter instead of on.paths

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,17 +4,7 @@ on:
   push:
     branches:
       - dev
-    paths:
-      - "**"
-      - "!mkdocs.yml"
-      - "!docs/**"
-      - "!*.md"
   pull_request:
-    paths:
-      - "**"
-      - "!mkdocs.yml"
-      - "!docs/**"
-      - "!*.md"
 
 concurrency:
   # Pushes (dev): queue sequentially (prevent cache corruption)
@@ -27,7 +17,27 @@ permissions:
   packages: write
 
 jobs:
+  # Use dorny/paths-filter instead of on.paths so that skipped jobs report
+  # as passed to branch protection, allowing docs-only PRs to merge.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            code:
+              - '**'
+              - '!mkdocs.yml'
+              - '!docs/**'
+              - '!*.md'
+
   docker_x86-64:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     name: docker_x86-64 (${{ matrix.image }})
     strategy:
       fail-fast: false
@@ -42,7 +52,7 @@ jobs:
           - { image: fedora43, dockerfile: Dockerfile.dnf, base: fedora:43 }
 
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
         with:
@@ -127,6 +137,8 @@ jobs:
         run: docker push ghcr.io/pwndbg/pwndbg:${{ matrix.image }}-amd64
 
   docker_aarch64:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     name: docker_aarch64 (${{ matrix.image }})
     strategy:
       fail-fast: false

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,11 +1,6 @@
 name: Lint
 on:
   pull_request:
-    paths:
-      - "**"
-      - "!mkdocs.yml"
-      - "!docs/**"
-      - "!*.md"
 
 concurrency:
   # PRs: cancel in-progress runs (only test latest)
@@ -13,7 +8,26 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  # Use dorny/paths-filter instead of on.paths so that skipped jobs report
+  # as passed to branch protection, allowing docs-only PRs to merge.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            code:
+              - '**'
+              - '!mkdocs.yml'
+              - '!docs/**'
+              - '!*.md'
+
   lint:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -3,17 +3,7 @@ on:
   push:
     branches:
       - dev
-    paths:
-      - "**"
-      - "!mkdocs.yml"
-      - "!docs/**"
-      - "!*.md"
   pull_request:
-    paths:
-      - "**"
-      - "!mkdocs.yml"
-      - "!docs/**"
-      - "!*.md"
 
 concurrency:
   # PRs: cancel in-progress runs (only test latest)
@@ -21,7 +11,27 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  # Use dorny/paths-filter instead of on.paths so that skipped jobs report
+  # as passed to branch protection, allowing docs-only PRs to merge.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            code:
+              - '**'
+              - '!mkdocs.yml'
+              - '!docs/**'
+              - '!*.md'
+
   check_release_build-gdb:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -57,6 +67,8 @@ jobs:
         run: nix develop --accept-flake-config
 
   check_release_build-lldb:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -92,6 +104,8 @@ jobs:
         run: nix develop --accept-flake-config
 
   lock_flake:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 60
     steps:
@@ -104,6 +118,8 @@ jobs:
         run: nix flake lock --no-update-lock-file
 
   lock_uv:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 60
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,17 +3,7 @@ on:
   push:
     branches:
       - dev
-    paths:
-      - "**"
-      - "!mkdocs.yml"
-      - "!docs/**"
-      - "!*.md"
   pull_request:
-    paths:
-      - "**"
-      - "!mkdocs.yml"
-      - "!docs/**"
-      - "!*.md"
 
 concurrency:
   # PRs: cancel in-progress runs (only test latest)
@@ -21,7 +11,27 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  # Use dorny/paths-filter instead of on.paths so that skipped jobs report
+  # as passed to branch protection, allowing docs-only PRs to merge.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            code:
+              - '**'
+              - '!mkdocs.yml'
+              - '!docs/**'
+              - '!*.md'
+
   tests-using-nix:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -94,6 +104,8 @@ jobs:
           ./kernel-tests.sh --nix
 
   qemu-system-tests:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: [ubuntu-22.04]
     timeout-minutes: 40
     steps:


### PR DESCRIPTION
+ [x] I read the contributing documentation.
+ [x] I am providing a screenshot of the (new feature) / (fixed bug).

When only docs are changed in a PR, branch protection will sit and wait for the checks to report back, but they will never run because using on.paths won't mark the workflow as skipped, but rather just never start it, as it should, but I think that this should differ for branch protection expected checks; however, it doesn't. So we have to work around it.

<img width="799" height="366" alt="chrome_7BrszAWhQC" src="https://github.com/user-attachments/assets/29d8ad81-d914-4064-9955-5b238c1343f4" />

So there are three options.
1. Keep as is and just bypass branch protection; this is what is done for docs-only PRs currently. not optimal
2. Remove !docs from on.paths, and run tests even on docs-only PRs. also not optimal

3. What is done in this PR, which I think is the best option we have, is to use the dorny/path-filter action instead of on.paths so that the workflows will start, and then be skipped, which will be considered pass and auto-merge to work fine and branch protection to pass. I don't like that it adds another job though...

I added it to the Docker tests as well. Even though it isn't included in the required branch protection tests, I wanted it to be consistent.
