### PR TITLE
Add cache mounts for build base image tests

### DIFF
--- a/.github/workflows/base-image.yml
+++ b/.github/workflows/base-image.yml
@@ -92,7 +92,7 @@ jobs:
 
       - name: Restore Docker cache mounts
         id: cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             uv-${{ matrix.platform_base.tag_name }}

--- a/.github/workflows/base-image.yml
+++ b/.github/workflows/base-image.yml
@@ -23,6 +23,7 @@ concurrency:
 permissions:
   contents: read
   packages: write
+  actions: write
 
 jobs:
   base-image:
@@ -89,6 +90,39 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Restore Docker cache mounts
+        id: cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            uv-${{ matrix.platform_base.tag_name }}
+            cargo-${{ matrix.platform_base.tag_name }}
+          key: buildkit-${{ matrix.platform_base.tag_name }}-${{ hashFiles('uv.lock') }}
+          restore-keys: |
+            buildkit-${{ matrix.platform_base.tag_name }}-
+
+      - name: Delete stale cache
+        if: steps.cache.outputs.cache-hit != 'true' && github.event_name != 'pull_request'
+        run: |
+          gh cache list \
+            --key "buildkit-${{ matrix.platform_base.tag_name }}-" \
+            --json key -q '.[].key' | while read -r key; do
+            echo "Deleting stale cache: $key"
+            gh cache delete "$key"
+          done
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Inject/extract cache mounts
+        if: steps.cache.outputs.cache-hit != 'true'
+        uses: reproducible-containers/buildkit-cache-dance@v3.3.1
+        with:
+          cache-map: |
+            {
+              "uv-${{ matrix.platform_base.tag_name }}": "/root/.cache/uv",
+              "cargo-${{ matrix.platform_base.tag_name }}": "/root/.cargo/registry"
+            }
+
       - name: Build Docker image
         run: |
           docker buildx build \
@@ -99,6 +133,7 @@ jobs:
             -f ./Dockerfile.base-apt \
             -t ghcr.io/pwndbg/base-apt:latest-${{ matrix.platform_base.tag_name }} \
             .
+
       - name: Push Docker image
         if: github.ref == 'refs/heads/dev'
         run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -52,7 +52,7 @@ jobs:
           - { image: fedora43, dockerfile: Dockerfile.dnf, base: fedora:43 }
 
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
         with:

--- a/Dockerfile.base-apt
+++ b/Dockerfile.base-apt
@@ -55,17 +55,12 @@ RUN python3 -m venv /venv && \
     rm -rf ~/.cache/
 
 WORKDIR /pwndbg
-COPY ./uv.lock /pwndbg/
-COPY ./pyproject.toml /pwndbg/
 
-# pyproject.toml requires these files, pip install would fail
-RUN touch README.md && mkdir pwndbg && touch pwndbg/empty.py
-
-RUN . /venv/bin/activate && \
-    uv sync --all-groups --all-extras && \
-    rm -rf ~/.cargo/registry/ && \
-    rm -rf ~/.cache/
-
-RUN rm README.md && rm -rf pwndbg
+RUN --mount=type=cache,target=/root/.cache/uv,sharing=locked \
+    --mount=type=cache,target=/root/.cargo/registry,sharing=locked \
+    --mount=type=bind,source=uv.lock,target=uv.lock \
+    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
+    . /venv/bin/activate && \
+    uv sync --locked --no-install-project --all-groups --all-extras
 
 ENV PATH="${PWNDBG_VENV_PATH}/bin:${PATH}"


### PR DESCRIPTION
+ [x] I read the contributing documentation.
+ [x] I am providing a screenshot of the (new feature) / (fixed bug).

When Dependabot creates PRs or dependencies are updated, the build base pwndbg image workflows can take up to 3 hours because they must build from source for many packages on all arches except amd64 and arm64, with these packages specifically taking exceptionally long. 
<img width="369" height="220" alt="chrome_277gnUbdTZ" src="https://github.com/user-attachments/assets/6782ffcd-24a0-4ebb-99e7-7b7f5bcab598" />

This uses 8/20 concurrent jobs, and Dependabot usually opens a couple of PRs at once, which takes up almost all concurrent job capacity for hours. This can be tedious if you just pushed a PR after, as you have to wait hours for your jobs to finally start.

Unlike the registry cache, where a change invalidates the entire layer, the same doesn't apply to cache mounts; only the changed deps will be rebuilt, as everything else will still be cached using GitHub Actions Cache.

It uses roughly 3.6GB of cache across all arches, with a limit of 10GB of free cache for public repos. So this is fine, and qemu images are our only other large cache, being 3.2GB. Leaving us at about 6.8GB with the rest being smaller caches that don't have deletion setup for stale cache, which is fine because least recently used will automatically be deleted when the limit is reached, but it may be something I clean up later for good practice with some of the other workflows.

https://docs.astral.sh/uv/guides/integration/docker/#caching
https://github.com/reproducible-containers/buildkit-cache-dance