### PR TITLE
update dorny/paths-filter action for path ignoring

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,9 +25,10 @@ jobs:
       code: ${{ steps.filter.outputs.code }}
     steps:
       - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@668c092af3649c4b664c54e4b704aa46782f6f7c # master (unreleased, for predicate-quantifier)
         id: filter
         with:
+          predicate-quantifier: 'every'
           filters: |
             code:
               - '**'
@@ -52,7 +53,7 @@ jobs:
           - { image: fedora43, dockerfile: Dockerfile.dnf, base: fedora:43 }
 
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,9 +15,10 @@ jobs:
     outputs:
       code: ${{ steps.filter.outputs.code }}
     steps:
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@668c092af3649c4b664c54e4b704aa46782f6f7c # master (unreleased, for predicate-quantifier)
         id: filter
         with:
+          predicate-quantifier: 'every'
           filters: |
             code:
               - '**'

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -19,9 +19,10 @@ jobs:
       code: ${{ steps.filter.outputs.code }}
     steps:
       - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@668c092af3649c4b664c54e4b704aa46782f6f7c # master (unreleased, for predicate-quantifier)
         id: filter
         with:
+          predicate-quantifier: 'every'
           filters: |
             code:
               - '**'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,9 +19,10 @@ jobs:
       code: ${{ steps.filter.outputs.code }}
     steps:
       - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@668c092af3649c4b664c54e4b704aa46782f6f7c # master (unreleased, for predicate-quantifier)
         id: filter
         with:
+          predicate-quantifier: 'every'
           filters: |
             code:
               - '**'


### PR DESCRIPTION
+ [x] I read the contributing documentation.
+ [x] I am providing a screenshot of the (new feature) / (fixed bug).

GitHub Actions Workflow syntax doesn't behave the same as the dorny/paths-filter by default

<img width="762" height="549" alt="TQrgGhrWCq" src="https://github.com/user-attachments/assets/ff7057b2-682a-478d-b67d-5b74049de3f8" />

We need 

<img width="685" height="371" alt="MdgR2b3Kca" src="https://github.com/user-attachments/assets/b0462649-5c32-4bf2-ad66-593f0df96101" />

Which was unreleased and only available in https://github.com/dorny/paths-filter/commit/209e61402dbca8aa44f967535da6666b284025ed, so I pinned the version to the latest master commit.

I really wish we could just use `paths-ignore` with GHA, but unfortunately, it still causes the same issue with branch protection, forever expected checks, just as with `paths`.

This also temporarily raises the Docker test timeout to 20m from 15m, since it needs an extra 30 seconds when it has to fully rebuild. I'll lower this back once I make some more of my optimizations and get my kernel tests PR finished, so everything can be around 10m for full CI with 15m timeouts. 