### PR TITLE
Ensure hexdump count > 0

### DIFF
--- a/pwndbg/commands/hexdump.py
+++ b/pwndbg/commands/hexdump.py
@@ -103,7 +103,7 @@ def hexdump(
     address: str | int, count: int = int(pwndbg.config.hexdump_bytes), code: str | None = None
 ) -> None:
     if count <= 0:
-        print(f"`count` must be larger than 0 (is {count}).")
+        print(f"count must be larger than 0 (is {count}).")
         return
 
     if hexdump.repeat:

--- a/pwndbg/commands/hexdump.py
+++ b/pwndbg/commands/hexdump.py
@@ -102,6 +102,10 @@ parser.add_argument(
 def hexdump(
     address: str | int, count: int = int(pwndbg.config.hexdump_bytes), code: str | None = None
 ) -> None:
+    if count <= 0:
+        print(f"`count` must be larger than 0 (is {count}).")
+        return
+
     if hexdump.repeat:
         address = hexdump.last_address
     else:


### PR DESCRIPTION
Otherwise you get an exception:
```
│    704 │   │   addr = address                                                                    │
│    705 │   │                                                                                     │
│    706 │   │   try:                                                                              │
│ ❱  707 │   │   │   result = gdb.selected_inferior().read_memory(addr, count)                     │
│    708 │   │   │   return bytearray(result)                                                      │
│    709 │   │   except gdb.error as e:                                                            │
│    710 │   │   │   if not partial:                                                               │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
ValueError: Argument 'count' should be greater than zero
```