### PR TITLE
Add gdbinit.py into venv/share/ dir

### DIFF
--- a/gdbinit.py
+++ b/gdbinit.py
@@ -33,6 +33,7 @@ def fixup_paths(src_root: Path, venv_path: Path):
     # sys.prefix must be changed to point to the virtual environment.
     # This is what python expect: https://docs.python.org/3/library/sys.html#sys.prefix
     sys.prefix = str(venv_path)
+    sys.exec_prefix = str(venv_path)
 
 
 def get_venv_path(src_root: Path):

--- a/gdbinit.py
+++ b/gdbinit.py
@@ -39,6 +39,16 @@ def get_venv_path(src_root: Path):
     venv_path_env = os.environ.get("PWNDBG_VENV_PATH")
     if venv_path_env:
         return Path(venv_path_env).expanduser().resolve()
+
+    # Handle case when `gdbinit.py` is running from inside venv, eg: `venv/share/pwndbg/gdbinit.py`
+    # See, example usage: https://github.com/pwndbg/pwndbg/pull/3737
+    if (
+        src_root.parent.name == "share"
+        and src_root.name == "pwndbg"
+        and (src_root / "../../pyvenv.cfg").exists()
+    ):
+        return src_root.parent.parent
+
     return src_root / ".venv"
 
 

--- a/pwndbginit/pwndbg_gdb.py
+++ b/pwndbginit/pwndbg_gdb.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import os
 import shutil
+import site
 import subprocess
 import sys
 import sysconfig
@@ -71,8 +72,15 @@ def main():
 
     envs = os.environ.copy()
     envs["PYTHONNOUSERSITE"] = "1"
-    envs["PYTHONPATH"] = ":".join(sys.path)
-    envs["PYTHONHOME"] = f"{sys.prefix}:{sys.exec_prefix}"
+    envs["PYTHONPATH"] = ":".join(site.getsitepackages())
+
+    # sys.prefix/sys.exec_prefix must point to the virtual environment,
+    # otherwise our auto-upgrade mechanism won't work when the package is installed in editable mode
+    prefix_cmd = (
+        f"py import sys; sys.prefix = {sys.prefix!r}; sys.exec_prefix = {sys.exec_prefix!r}"
+    )
+    sys.argv.insert(1, prefix_cmd)
+    sys.argv.insert(1, "-iex")
 
     expected = (sysconfig.get_config_var("INSTSONAME"), sysconfig.get_config_var("VERSION"))
     have = get_gdb_version(gdb_path)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,10 +168,13 @@ required-imports = ["from __future__ import annotations"]
 allow-direct-references = true
 
 [tool.hatch.build.targets.sdist]
-include = ["/pwndbg", "/pwndbginit"]
+include = ["/pwndbg", "/pwndbginit", "gdbinit.py"]
 
 [tool.hatch.build.targets.wheel]
 include = ["/pwndbg", "/pwndbginit"]
+
+[tool.hatch.build.targets.wheel.shared-data]
+"gdbinit.py" = "share/pwndbg/gdbinit.py"
 
 [project.scripts]
 pwndbg = "pwndbginit.pwndbg_gdb:main"


### PR DESCRIPTION
Why we want add `gdbinit.py` to ./share directory?
- To support something like (ubuntu24.04):  
```bash
apt update
apt install -y git curl gdb python3

curl -LsSf https://astral.sh/uv/install.sh | sh
source $HOME/.local/bin/env

PY_VER=$(gdb -nx --batch -iex 'py import sysconfig; print(sysconfig.get_config_var("VERSION"))')
uv tool install --python=$PY_VER --no-managed-python git+https://github.com/pwndbg/pwndbg

echo "source $(uv tool dir)/pwndbg/share/pwndbg/gdbinit.py" >> ~/.gdbinit

gdb
```
Example1:
<img width="730" height="382" alt="image" src="https://github.com/user-attachments/assets/1f22f7f5-0a9d-4f85-9533-840b65338a4b" />

Example2:
<img width="919" height="283" alt="image" src="https://github.com/user-attachments/assets/d0079a5f-052c-49f6-90eb-c9b612184350" />
