### PR TITLE
Fix reading unmapped pages in idt

### DIFF
--- a/pwndbg/aglib/kernel/__init__.py
+++ b/pwndbg/aglib/kernel/__init__.py
@@ -280,7 +280,7 @@ def get_idt_entries() -> list[pwndbg.lib.kernel.structs.IDTEntry]:
     limit = pwndbg.aglib.regs.idt_limit
 
     size = pwndbg.aglib.arch.ptrsize * 2
-    num_entries = (limit + 1) // size
+    num_entries = min((limit + 1) // size, 256)
 
     entries = []
 


### PR DESCRIPTION
As per the intel [instruction manual](https://www.intel.com/content/www/us/en/developer/articles/technical/intel-sdm.html) and [osdev](https://wiki.osdev.org/Interrupt_Descriptor_Table) the idt can contain a maximum of 256 entries.
For some reason sometimes the limit as declared in the idt register is higher than that. 
```
IDT=     fffffe0000000000 0000ffff
```
On an 64bit system such as mine this limit is equivalent to 512 entries.
Apparently the kernel still knows that that there cannot be any accesses to entries above 256 and does not map those pages. This in turn leads to this error:
```
╭─────────────────────────────── Traceback (most recent call last) ────────────────────────────────╮
│ /nix/store/dfvz9wwaxw1swbmpryac2a6mfp4lp80q-pwndbg-env/lib/python3.13/site-packages/pwndbg/dbg_m │
│ od/gdb/__init__.py:687 in read_memory                                                            │
│                                                                                                  │
│    684 │   │   addr = address                                                                    │
│    685 │   │                                                                                     │
│    686 │   │   try:                                                                              │
│ ❱  687 │   │   │   result = gdb.selected_inferior().read_memory(addr, count)                     │
│    688 │   │   │   return bytearray(result)                                                      │
│    689 │   │   except gdb.error as e:                                                            │
│    690 │   │   │   if not partial:                                                               │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
MemoryError: Cannot access memory at address 0xfffffe0000008000

During handling of the above exception, another exception occurred:

╭─────────────────────────────── Traceback (most recent call last) ────────────────────────────────╮
│ /nix/store/dfvz9wwaxw1swbmpryac2a6mfp4lp80q-pwndbg-env/lib/python3.13/site-packages/pwndbg/comma │
│ nds/__init__.py:498 in __call__                                                                  │
│                                                                                                  │
│    495 │                                                                                         │
│    496 │   def __call__(self, *args: Any, **kwargs: Any) -> str | None:                          │
│    497 │   │   try:                                                                              │
│ ❱  498 │   │   │   return self.function(*args, **kwargs)                                         │
│    499 │   │   except TypeError:                                                                 │
│    500 │   │   │   print(f"{self.command_name}: {self.description}")                             │
│    501 │   │   │   pwndbg.exception.handle(self.function.__name__)                               │
│                                                                                                  │
│ /nix/store/dfvz9wwaxw1swbmpryac2a6mfp4lp80q-pwndbg-env/lib/python3.13/site-packages/pwndbg/comma │
│ nds/context.py:775 in context                                                                    │
│                                                                                                  │
│    772 │   │   │   │   result_settings[target].update(settings)                                  │
│    773 │   │   │   │   with target as out:                                                       │
│    774 │   │   │   │   │   result[target].extend(                                                │
│ ❱  775 │   │   │   │   │   │   func(                                                             │
│    776 │   │   │   │   │   │   │   target=out,                                                   │
│    777 │   │   │   │   │   │   │   width=settings.get("width", None),                            │
│    778 │   │   │   │   │   │   │   height=settings.get("height", None),                          │
│                                                                                                  │
│ /nix/store/dfvz9wwaxw1swbmpryac2a6mfp4lp80q-pwndbg-env/lib/python3.13/site-packages/pwndbg/comma │
│ nds/context.py:417 in _serve_context_history                                                     │
│                                                                                                  │
│    414 │   │   │   ):                                                                            │
│    415 │   │   │   │   current_output = context_history[section_name][-1]                        │
│    416 │   │   │   else:                                                                         │
│ ❱  417 │   │   │   │   current_output = function(*a, **kw)                                       │
│    418 │   │   │   if (                                                                          │
│    419 │   │   │   │   len(context_history[section_name]) == 0                                   │
│    420 │   │   │   │   or context_history[section_name][-1] != current_output                    │
│                                                                                                  │
│ /nix/store/dfvz9wwaxw1swbmpryac2a6mfp4lp80q-pwndbg-env/lib/python3.13/site-packages/pwndbg/comma │
│ nds/context.py:1138 in context_regs                                                              │
│                                                                                                  │
│   1135 │   width: int | None = None,                                                             │
│   1136 │   height: int | None = None,                                                            │
│   1137 ) -> list[str]:                                                                           │
│ ❱ 1138 │   regs = get_regs()                                                                     │
│   1139 │   if pwndbg.config.show_compact_regs.value != CompactRegsOptions.NO.value:              │
│   1140 │   │   regs = compact_regs(regs, target=target, width=width)                             │
│   1141                                                                                           │
│                                                                                                  │
│ /nix/store/dfvz9wwaxw1swbmpryac2a6mfp4lp80q-pwndbg-env/lib/python3.13/site-packages/pwndbg/comma │
│ nds/context.py:1316 in get_regs                                                                  │
│                                                                                                  │
│   1313 │   │   # Resolve "sp" and "pc" to the real architectural register names                  │
│   1314 │   │   reg = pwndbg.aglib.regs.current.resolve_aliases(reg)                              │
│   1315 │   │                                                                                     │
│ ❱ 1316 │   │   desc = rc.register_context_default(reg)                                           │
│   1317 │   │   if desc is not None:                                                              │
│   1318 │   │   │   result.append(desc)                                                           │
│   1319                                                                                           │
│                                                                                                  │
│ /nix/store/dfvz9wwaxw1swbmpryac2a6mfp4lp80q-pwndbg-env/lib/python3.13/site-packages/pwndbg/comma │
│ nds/context.py:1257 in register_context_default                                                  │
│                                                                                                  │
│   1254 │   │   if val is None:                                                                   │
│   1255 │   │   │   return None                                                                   │
│   1256 │   │   desc = ""                                                                         │
│ ❱ 1257 │   │   desc = pwndbg.chain.format(val)                                                   │
│   1258 │   │   prefix = self.get_prefix(reg)                                                     │
│   1259 │   │   return f"{prefix} {desc}"                                                         │
│   1260                                                                                           │
│                                                                                                  │
│ /nix/store/dfvz9wwaxw1swbmpryac2a6mfp4lp80q-pwndbg-env/lib/python3.13/site-packages/pwndbg/chain │
│ .py:148 in format                                                                                │
│                                                                                                  │
│   145 │                                                                                          │
│   146 │   # Colorize the chain                                                                   │
│   147 │   rest = [                                                                               │
│ ❱ 148 │   │   mem_color.get_address_and_symbol(addr, stack_vars) if addr >= 0 else "" for addr   │
│   149 │   ]                                                                                      │
│   150 │                                                                                          │
│   151 │   # If the dereference limit is zero, skip any enhancements.                             │
│                                                                                                  │
│ /nix/store/dfvz9wwaxw1swbmpryac2a6mfp4lp80q-pwndbg-env/lib/python3.13/site-packages/pwndbg/color │
│ /memory.py:43 in get_address_and_symbol                                                          │
│                                                                                                  │
│    40 │   │   │   var = decompiler_stack_variables.get(address)                                  │
│    41 │   │   if var is not None:                                                                │
│    42 │   │   │   symbol = f"{address:#x} {{{var}}}"                                             │
│ ❱  43 │   return get(address, symbol)                                                            │
│    44                                                                                            │
│    45                                                                                            │
│    46 def get_address_or_symbol(address: int, decompiler_stack_variables: dict[int, str]) -> s   │
│                                                                                                  │
│ /nix/store/dfvz9wwaxw1swbmpryac2a6mfp4lp80q-pwndbg-env/lib/python3.13/site-packages/pwndbg/color │
│ /memory.py:90 in get                                                                             │
│                                                                                                  │
│    87 │   """                                                                                    │
│    88 │   address = int(address)                                                                 │
│    89 │   if page is None:  # if we know the containing page, don't bother to find it as an op   │
│ ❱  90 │   │   page = pwndbg.aglib.vmmap.find(address)                                            │
│    91 │                                                                                          │
│    92 │   color: Callable[[str], str]                                                            │
│    93                                                                                            │
│                                                                                                  │
│ /nix/store/dfvz9wwaxw1swbmpryac2a6mfp4lp80q-pwndbg-env/lib/python3.13/site-packages/pwndbg/lib/c │
│ ache.py:221 in decorator                                                                         │
│                                                                                                  │
│   218 │   │   │   │   if cached_value is not _NOT_FOUND_IN_CACHE:                                │
│   219 │   │   │   │   │   return cached_value                                                    │
│   220 │   │   │   │                                                                              │
│ ❱ 221 │   │   │   │   value = func(*a, **kw)                                                     │
│   222 │   │   │   │                                                                              │
│   223 │   │   │   │   # Sanity check: its not perfect and won't cover all cases like ([],)       │
│   224 │   │   │   │   # but it should be good enough                                             │
│                                                                                                  │
│ /nix/store/dfvz9wwaxw1swbmpryac2a6mfp4lp80q-pwndbg-env/lib/python3.13/site-packages/pwndbg/aglib │
│ /vmmap.py:125 in find                                                                            │
│                                                                                                  │
│   122 │   if address < 0:                                                                        │
│   123 │   │   return None                                                                        │
│   124 │                                                                                          │
│ ❱ 125 │   page = get_memory_map().lookup_page(address)                                           │
│   126 │                                                                                          │
│   127 │   if page is not None:                                                                   │
│   128 │   │   return page                                                                        │
│                                                                                                  │
│ /nix/store/dfvz9wwaxw1swbmpryac2a6mfp4lp80q-pwndbg-env/lib/python3.13/site-packages/pwndbg/lib/c │
│ ache.py:221 in decorator                                                                         │
│                                                                                                  │
│   218 │   │   │   │   if cached_value is not _NOT_FOUND_IN_CACHE:                                │
│   219 │   │   │   │   │   return cached_value                                                    │
│   220 │   │   │   │                                                                              │
│ ❱ 221 │   │   │   │   value = func(*a, **kw)                                                     │
│   222 │   │   │   │                                                                              │
│   223 │   │   │   │   # Sanity check: its not perfect and won't cover all cases like ([],)       │
│   224 │   │   │   │   # but it should be good enough                                             │
│                                                                                                  │
│ /nix/store/dfvz9wwaxw1swbmpryac2a6mfp4lp80q-pwndbg-env/lib/python3.13/site-packages/pwndbg/aglib │
│ /vmmap.py:108 in get_memory_map                                                                  │
│                                                                                                  │
│   105                                                                                            │
│   106 @pwndbg.lib.cache.cache_until("start", "stop")                                             │
│   107 def get_memory_map() -> MemoryMap:                                                         │
│ ❱ 108 │   return _refine_memory_map(pwndbg.dbg.selected_inferior().vmmap())                      │
│   109                                                                                            │
│   110                                                                                            │
│   111 @pwndbg.lib.cache.cache_until("start", "stop")                                             │
│                                                                                                  │
│ /nix/store/dfvz9wwaxw1swbmpryac2a6mfp4lp80q-pwndbg-env/lib/python3.13/site-packages/pwndbg/dbg_m │
│ od/gdb/__init__.py:652 in vmmap                                                                  │
│                                                                                                  │
│    649 │   │   │   return GDBMemoryMap(qemu, proc_maps)                                          │
│    650 │   │                                                                                     │
│    651 │   │   pages: list[pwndbg.lib.memory.Page] = []                                          │
│ ❱  652 │   │   pages.extend(kernel_vmmap())                                                      │
│    653 │   │   pages.extend(get_custom_pages())                                                  │
│    654 │   │   pages.sort()                                                                      │
│    655 │   │   return GDBMemoryMap(qemu, pages)                                                  │
│                                                                                                  │
│ /nix/store/dfvz9wwaxw1swbmpryac2a6mfp4lp80q-pwndbg-env/lib/python3.13/site-packages/pwndbg/aglib │
│ /kernel/vmmap.py:436 in kernel_vmmap                                                             │
│                                                                                                  │
│   433 │   │   return ()                                                                          │
│   434 │                                                                                          │
│   435 │   pages = kernel_vmmap_pages()                                                           │
│ ❱ 436 │   kv = KernelVmmap(pages)                                                                │
│   437 │   if kernel_vmmap_mode == "monitor" and pwndbg.aglib.arch.name == "x86-64":              │
│   438 │   │   # TODO: check version here when QEMU displays the x bit for x64                    │
│   439 │   │   # see: https://github.com/pwndbg/pwndbg/pull/3020#issuecomment-2914573242          │
│                                                                                                  │
│ /nix/store/dfvz9wwaxw1swbmpryac2a6mfp4lp80q-pwndbg-env/lib/python3.13/site-packages/pwndbg/aglib │
│ /kernel/vmmap.py:32 in __init__                                                                  │
│                                                                                                  │
│    29 │   │   self.sections: tuple[tuple[str, int], ...] = None                                  │
│    30 │   │   self.pi = pwndbg.aglib.kernel.arch_paginginfo()                                    │
│    31 │   │   if self.pi:                                                                        │
│ ❱  32 │   │   │   self.sections = self.pi.markers()                                              │
│    33 │   │   self.adjust()                                                                      │
│    34 │                                                                                          │
│    35 │   def get_name(self, addr: int) -> str | None:                                           │
│                                                                                                  │
│ /nix/store/dfvz9wwaxw1swbmpryac2a6mfp4lp80q-pwndbg-env/lib/python3.13/site-packages/pwndbg/lib/c │
│ ache.py:221 in decorator                                                                         │
│                                                                                                  │
│   218 │   │   │   │   if cached_value is not _NOT_FOUND_IN_CACHE:                                │
│   219 │   │   │   │   │   return cached_value                                                    │
│   220 │   │   │   │                                                                              │
│ ❱ 221 │   │   │   │   value = func(*a, **kw)                                                     │
│   222 │   │   │   │                                                                              │
│   223 │   │   │   │   # Sanity check: its not perfect and won't cover all cases like ([],)       │
│   224 │   │   │   │   # but it should be good enough                                             │
│                                                                                                  │
│ /nix/store/dfvz9wwaxw1swbmpryac2a6mfp4lp80q-pwndbg-env/lib/python3.13/site-packages/pwndbg/aglib │
│ /kernel/paging.py:492 in markers                                                                 │
│                                                                                                  │
│   489 │   │   │   ("cpu entry", 0xFFFFFE0000000000),                                             │
│   490 │   │   │   (self.ESPSTACK, 0xFFFFFF0000000000),                                           │
│   491 │   │   │   ("EFI", 0xFFFFFFEF00000000),                                                   │
│ ❱ 492 │   │   │   (self.KERNELLAND, self.kbase),                                                 │
│   493 │   │   │   ("fixmap", 0xFFFFFFFFFF000000),                                                │
│   494 │   │   │   ("legacy abi", 0xFFFFFFFFFF600000),                                            │
│   495 │   │   │   (None, 0xFFFFFFFFFFFFFFFF),                                                    │
│                                                                                                  │
│ /nix/store/dfvz9wwaxw1swbmpryac2a6mfp4lp80q-pwndbg-env/lib/python3.13/site-packages/pwndbg/lib/c │
│ ache.py:221 in decorator                                                                         │
│                                                                                                  │
│   218 │   │   │   │   if cached_value is not _NOT_FOUND_IN_CACHE:                                │
│   219 │   │   │   │   │   return cached_value                                                    │
│   220 │   │   │   │                                                                              │
│ ❱ 221 │   │   │   │   value = func(*a, **kw)                                                     │
│   222 │   │   │   │                                                                              │
│   223 │   │   │   │   # Sanity check: its not perfect and won't cover all cases like ([],)       │
│   224 │   │   │   │   # but it should be good enough                                             │
│                                                                                                  │
│ /nix/store/dfvz9wwaxw1swbmpryac2a6mfp4lp80q-pwndbg-env/lib/python3.13/site-packages/pwndbg/aglib │
│ /kernel/paging.py:440 in kbase                                                                   │
│                                                                                                  │
│   437 │   @property                                                                              │
│   438 │   @pwndbg.lib.cache.cache_until("stop")                                                  │
│   439 │   def kbase(self) -> int | None:                                                         │
│ ❱ 440 │   │   idt_entries = pwndbg.aglib.kernel.get_idt_entries()                                │
│   441 │   │   if len(idt_entries) == 0:                                                          │
│   442 │   │   │   return None                                                                    │
│   443 │   │   return self._kbase(idt_entries[0].offset)                                          │
│                                                                                                  │
│ /nix/store/dfvz9wwaxw1swbmpryac2a6mfp4lp80q-pwndbg-env/lib/python3.13/site-packages/pwndbg/aglib │
│ /kernel/__init__.py:271 in get_idt_entries                                                       │
│                                                                                                  │
│   268 │   # TODO: read the entire IDT in one call?                                               │
│   269 │   for i in range(num_entries):                                                           │
│   270 │   │   entry_addr = base + i * size                                                       │
│ ❱ 271 │   │   entry = pwndbg.lib.kernel.structs.IDTEntry(pwndbg.aglib.memory.read(entry_addr,    │
│   272 │   │   entries.append(entry)                                                              │
│   273 │                                                                                          │
│   274 │   return entries                                                                         │
│                                                                                                  │
│ /nix/store/dfvz9wwaxw1swbmpryac2a6mfp4lp80q-pwndbg-env/lib/python3.13/site-packages/pwndbg/aglib │
│ /memory.py:34 in read                                                                            │
│                                                                                                  │
│    31 │   │   `bytearray` The memory at the specified address,                                   │
│    32 │   │   or ``None``.                                                                       │
│    33 │   """                                                                                    │
│ ❱  34 │   return pwndbg.dbg.selected_inferior().read_memory(address=addr, size=count, partial=   │
│    35                                                                                            │
│    36                                                                                            │
│    37 def readtype(type: pwndbg.dbg_mod.Type, addr: int) -> int:                                 │
│                                                                                                  │
│ /nix/store/dfvz9wwaxw1swbmpryac2a6mfp4lp80q-pwndbg-env/lib/python3.13/site-packages/pwndbg/dbg_m │
│ od/gdb/__init__.py:691 in read_memory                                                            │
│                                                                                                  │
│    688 │   │   │   return bytearray(result)                                                      │
│    689 │   │   except gdb.error as e:                                                            │
│    690 │   │   │   if not partial:                                                               │
│ ❱  691 │   │   │   │   raise pwndbg.dbg_mod.Error(e)                                             │
│    692 │   │   │                                                                                 │
│    693 │   │   │   if not pwndbg.aglib.remote.is_remote():                                       │
│    694 │   │   │   │   message = str(e)                                                          │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
Error: Cannot access memory at address 0xfffffe0000008000
```

+ [x] I read the contributing documentation.
+ [x] I am providing a screenshot of the (new feature) / (fixed bug).
