### PR TITLE
Fix curl error handling in setup-dev.sh for jemalloc download

### DIFF
--- a/setup-dev.sh
+++ b/setup-dev.sh
@@ -195,7 +195,7 @@ install_jemalloc() {
             ACTUAL_SHA256=$(sha256sum "${JEMALLOC_TAR_PATH}" | cut -d' ' -f1)
             if [ "${ACTUAL_SHA256}" != "${JEMALLOC_TAR_SHA256}" ]; then
                 echo "Jemalloc tarball exists but has incorrect checksum. Re-downloading..."
-                curl --location --output "${JEMALLOC_TAR_PATH}" "${JEMALLOC_TAR_URL}"
+                curl --fail --location --retry 3 --retry-connrefused --output "${JEMALLOC_TAR_PATH}" "${JEMALLOC_TAR_URL}"
                 ACTUAL_SHA256=$(sha256sum "${JEMALLOC_TAR_PATH}" | cut -d' ' -f1)
                 if [ "${ACTUAL_SHA256}" != "${JEMALLOC_TAR_SHA256}" ]; then
                     echo "Jemalloc binary checksum mismatch after re-download."
@@ -208,7 +208,7 @@ install_jemalloc() {
             fi
         else
             echo "Downloading jemalloc..."
-            curl --location --output "${JEMALLOC_TAR_PATH}" "${JEMALLOC_TAR_URL}"
+            curl --fail --location --retry 3 --retry-connrefused --output "${JEMALLOC_TAR_PATH}" "${JEMALLOC_TAR_URL}"
             ACTUAL_SHA256=$(sha256sum "${JEMALLOC_TAR_PATH}" | cut -d' ' -f1)
             if [ "${ACTUAL_SHA256}" != "${JEMALLOC_TAR_SHA256}" ]; then
                 echo "Jemalloc binary checksum mismatch"


### PR DESCRIPTION
<!--
    Please make sure to read the linting and testing instructions at
    https://pwndbg.re/dev/contributing/ before creating a PR.
-->

+ [x] I read the contributing documentation.
+ [x] I am providing a screenshot of the (new feature) / (fixed bug).

<img width="983" height="617" alt="스크린샷 2026-02-17 145751" src="https://github.com/user-attachments/assets/073aa927-f38c-491e-adff-71d2c2f6c0d0" />

Fixes #3185

## Summary
`setup-dev.sh` downloads the jemalloc tarball with `curl` and then validates it via SHA256.
When the server returns an HTTP error page (4xx/5xx), `curl` may still exit successfully and write the error page to the output path. This results in a confusing “checksum mismatch” instead of a clear download failure.

This PR makes the jemalloc download step fail fast on HTTP errors and retries transient failures.

## Problem
- HTTP error pages can be saved as the jemalloc tarball
- The subsequent SHA256 check fails with “checksum mismatch”
- This can look like tampering, while the root cause is a failed download

## Changes
Updated both jemalloc download `curl` invocations in `setup-dev.sh` to use:
- `--fail` (`-f`): fail on HTTP errors (4xx/5xx)
- `--retry 3`: retry transient failures up to 3 times
- `--retry-connrefused`: include connection refused in retry logic