### PR TITLE
Cleanup installation from source

### DIFF
--- a/docs/contributing/setup-pwndbg-dev.md
+++ b/docs/contributing/setup-pwndbg-dev.md
@@ -2,7 +2,7 @@
 
 ## Installing Pwndbg from source
 
-To run pwndbg from source, please see [these instructions](../setup.md#installation-from-source)
+To run pwndbg from source, please see [these instructions](../setup.md#really-from-source)
 
 Officially supported is Ubuntu 22.04 and later, but the setup script also supports the following distributions:
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -200,9 +200,9 @@ git clone https://github.com/pwndbg/pwndbg
 cd pwndbg
 ./setup.sh
 ```
-will get you the same setup as in [I want to use my system GDB / LLDB](#i-want-to-use-my-system-gdb-lldb). You can update with `git pull`.
+will get you the same setup as in [System GDB, but not like that](#system-gdb-but-not-like-that). You can update with `git pull`.
 
-And in general, if you have the repository cloned you can run the same commands as in the above sections, but replacing `git+https://github.com/pwndbg/pwndbg` with `.` (the current folder) and adding `--editable` so changes in the source are reflected in the installation.
+In general, if you have the repository cloned you can run the same commands as in the above sections, but replacing `git+https://github.com/pwndbg/pwndbg` with `.` (the current folder) and adding `--editable` so changes in the source are reflected in the installation.
 
 ## Setup for development
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -161,6 +161,12 @@ Assuming that the files were extracted to a folder called `pwndbg`.
 
 ## Installing from source
 
+First things first, you need to have [uv installed](https://docs.astral.sh/uv/getting-started/installation/#standalone-installer) (and git and curl):
+```{.bash .copy}
+curl -LsSf https://astral.sh/uv/install.sh | sh
+source $HOME/.local/bin/env
+```
+
 If you just want the most up-to-date Pwndbg, the simplest thing to do is just:
 ```{.bash .copy}
 uv tool install git+https://github.com/pwndbg/pwndbg[gdb,lldb]

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -161,37 +161,42 @@ Assuming that the files were extracted to a folder called `pwndbg`.
 
 ## Installing from source
 
-### GDB plugin
-To install `pwndbg` as a GDB plugin, so that pwndbg is loaded whenever `gdb` is invoked, you can run the following setup script. This allows you to use pwndbg with the version of GDB provided by your distribution:
+If you just want the most up-to-date Pwndbg, the simplest thing to do is just:
+```{.bash .copy}
+uv tool install git+https://github.com/pwndbg/pwndbg[gdb,lldb]
+```
+which gives you the `pwndbg` and `pwndbg-lldb` binaries. If you want to update, just re-run this command.
 
+### I want to use my system GDB / LLDB
+
+If you don't want Pwndbg to use our up-to-date packaged+patched [GDB and LLDB](https://github.com/pwndbg/pypi-for-pwndbg), but rather the GDB / LLDB from your system / package manager, you can install Pwndbg with:
+```{.bash .copy}
+# Assuming that your LLDB and GDB are compiled with the same python version :)
+PY_VER=$(gdb -nx --batch -iex 'py import sysconfig; print(sysconfig.get_config_var("VERSION"))')
+uv tool install --python=$PY_VER  git+https://github.com/pwndbg/pwndbg
+```
+To view supported GDB and LLDB versions and compiling GDB from source, see [these instructions](contributing/setup-pwndbg-dev.md#installing-pwndbg-from-source).
+
+### System GDB, but not like that
+
+If you want the "classic" setup, where you run the `gdb` binary and Pwndbg is sourced from `~/.gdbinit` you can do that like this:
+```{.bash .copy}
+PY_VER=$(gdb -nx --batch -iex 'py import sysconfig; print(sysconfig.get_config_var("VERSION"))')
+uv tool install --python=$PY_VER  git+https://github.com/pwndbg/pwndbg
+echo "source $(uv tool dir)/pwndbg/share/pwndbg/gdbinit.py" >> ~/.gdbinit
+```
+
+### Really from source
+
+Running this:
 ```{.bash .copy}
 git clone https://github.com/pwndbg/pwndbg
 cd pwndbg
 ./setup.sh
 ```
+will get you the same setup as in [I want to use my system GDB / LLDB](#i-want-to-use-my-system-gdb-lldb). You can update with `git pull`.
 
-This will edit your `~/.gdbinit` file to load pwndbg alongside GDB.
-
-To view supported GDB versions and compiling GDB from source, see [these instructions](contributing/setup-pwndbg-dev.md#installing-pwndbg-from-source).
-
-
-### `pwndbg`/`pwndbg-lldb` commands from source
-To install the `pwndbg` or `pwndbg-lldb` commands while still running from source, you can do the following. Note that a c++ compiler is required as some dependencies need to be compiled
-```{.bash .copy}
-git clone https://github.com/pwndbg/pwndbg
-cd pwndbg
-
-# Install with uv
-uv tool install --editable .[lldb,gdb] --force
-
-# Or, install with pipx
-pipx install --editable .[lldb,gdb] --force
-```
-
-Note that these version of commands use a [fork of GDB/LLDB that we maintain](https://github.com/pwndbg/pypi-for-pwndbg) that fixes some bugs and provide a predictable experience.
-
-### Updating while installed from source
-To upgrade, run `git pull` in the cloned repository to get the latest changes.
+And in general, if you have the repository cloned you can run the same commands as in the above sections, but replacing `git+https://github.com/pwndbg/pwndbg` with `.` (the current folder) and adding `--editable` so changes in the source are reflected in the installation.
 
 ## Setup for development
 

--- a/docs/tutorials/pwndbg-users.md
+++ b/docs/tutorials/pwndbg-users.md
@@ -29,7 +29,7 @@ Here is a non-exhaustive list of Pwndbg mentions found in the wild. Feel free to
 + [decomp2dbg implements a Pwndbg client](https://github.com/mahaloz/decomp2dbg/blob/36d4b5bbb0ec1d3751d1b4a0e011a4fabf59f26c/decomp2dbg/clients/gdb/pwndbg_client.py) (though we implement our own integration now :) )
 + [An (outdated :( ) pwndbg plugin for scudo exploitation](https://github.com/HexHive/scudo-exploitation/blob/main/gdb-plugin/scudo-pwndbg.py)
 + [gdb-peda-pwndbg-gef](https://github.com/apogiatzis/gdb-peda-pwndbg-gef) - A script that installs those tools
-+ [splitmind]((https://github.com/jerdna-regeiz/splitmind)) - Better organization of Pwndbg contexts via tmux splits
++ [splitmind](https://github.com/jerdna-regeiz/splitmind) - Better organization of Pwndbg contexts via tmux splits
 + [hyperpwn](https://github.com/bet4it/hyperpwn) - Similar as splitmind, but for the hypr terminal
 + [epictreasure](https://github.com/praetorian-inc/epictreasure) - A [vagrant](https://developer.hashicorp.com/vagrant) box that includes Pwndbg
 + [pwn-init-env](https://github.com/giantbranch/pwn-env-init) - A pwn environment that includes Pwndbg

--- a/nix/pyenv.nix
+++ b/nix/pyenv.nix
@@ -396,7 +396,7 @@ let
 
   pyenv = pythonSet.mkVirtualEnv "pwndbg-env" {
     pwndbg =
-      [ "decomp2dbg" ]
+      [ ]
       ++ lib.optionals isDev [
         "dev"
         "tests"
@@ -408,7 +408,7 @@ let
 
   pyenvEditable = editablePythonSet.mkVirtualEnv "pwndbg-editable-env" {
     pwndbg =
-      [ "decomp2dbg" ]
+      [ ]
       ++ lib.optionals isDev [
         "dev"
         "tests"

--- a/pwndbg/dbg_mod/gdb/__init__.py
+++ b/pwndbg/dbg_mod/gdb/__init__.py
@@ -1720,6 +1720,7 @@ class GDB(pwndbg.dbg_mod.Debugger):
         set backtrace past-main on
         set step-mode on
         set print pretty on
+        set debuginfod enabled on
         handle SIGALRM nostop print nopass
         handle SIGBUS  stop   print nopass
         handle SIGPIPE nostop print nopass

--- a/pwndbg/dbg_mod/gdb/__init__.py
+++ b/pwndbg/dbg_mod/gdb/__init__.py
@@ -1720,7 +1720,6 @@ class GDB(pwndbg.dbg_mod.Debugger):
         set backtrace past-main on
         set step-mode on
         set print pretty on
-        set debuginfod enabled on
         handle SIGALRM nostop print nopass
         handle SIGBUS  stop   print nopass
         handle SIGPIPE nostop print nopass

--- a/pwndbginit/common.py
+++ b/pwndbginit/common.py
@@ -30,9 +30,9 @@ def run_uv_install(
         tool_name = venv_path.name
         command: list[str] = [str(binary_path), "tool", "upgrade", tool_name]
     else:
-        # We don't want to quietly uninstall dependencies by just specifying
-        # `--extra gdb` so we will be conservative and pull all extras in.
-        command = [str(binary_path), "sync", "--all-extras"]
+        # --inexact makes it so any installed extras aren't uninstalled
+        # (it will also leave in dropped deps, but what can you do /shrug)
+        command = [str(binary_path), "sync", "--inexact"]
         if dev:
             command.append("--all-groups")
     logging.debug(f"Updating deps with command: {' '.join(command)}")

--- a/pwndbginit/common.py
+++ b/pwndbginit/common.py
@@ -30,9 +30,9 @@ def run_uv_install(
         tool_name = venv_path.name
         command: list[str] = [str(binary_path), "tool", "upgrade", tool_name]
     else:
-        # --inexact makes it so any installed extras aren't uninstalled
-        # (it will also leave in dropped deps, but what can you do /shrug)
-        command = [str(binary_path), "sync", "--inexact"]
+        # We don't want to quietly uninstall dependencies by just specifying
+        # `--extra gdb` so we will be conservative and pull all extras in.
+        command = [str(binary_path), "sync", "--all-extras"]
         if dev:
             command.append("--all-groups")
     logging.debug(f"Updating deps with command: {' '.join(command)}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,10 @@ dependencies = [
     "ziglang==0.14.1 ; (platform_system == 'Linux' and platform_machine != 'loongarch64') or platform_system != 'Linux'",
     # Used for symbol syncing (e.g. klookup --apply and decompiler integration)
     "niche-elf==0.3.6",
+    # This dep is optional.
+    # For installing the decompiler plugins (we don't actually use it as a python library).
+    # If you bump this, also bump the pwndbg/commands/decompiler_integration.py:d2d_required* variables.
+    "decomp2dbg==3.14.1",
 ]
 
 [project.optional-dependencies]
@@ -44,11 +48,6 @@ lldb = [
 ]
 gdb = [
     "gdb-for-pwndbg==17.1.0.post2",
-]
-decomp2dbg = [
-    # For installing the decompiler plugins (we don't actually use it as a python library).
-    # If you bump this, also bump the pwndbg/commands/decompiler_integration.py:d2d_required* variables.
-    "decomp2dbg==3.14.1",
 ]
 
 [dependency-groups]

--- a/setup.sh
+++ b/setup.sh
@@ -75,12 +75,6 @@ install_pacman() {
         sudo pacman -Syu || true
     fi
     sudo pacman -S --noconfirm --needed git gdb python which debuginfod curl gcc make patch
-    if [ -z "$UPDATE_MODE" ]; then
-        if ! grep -qs "^set debuginfod enabled on" ~/.gdbinit; then
-            echo "set debuginfod enabled on" >> ~/.gdbinit
-            echo "[*] Added 'set debuginfod enabled on' to ~/.gdbinit"
-        fi
-    fi
 }
 
 install_freebsd() {
@@ -213,18 +207,19 @@ source ${PWNDBG_VENV_PATH}/bin/activate
 # Install uv inside the venv
 pip install uv
 
-# Install dependencies
+# Install dependencies.
+# We don't use the vendored GDB / LLDB by default so contributors test out Pwndbg
+# on the packaged GDB / LLDB. Non-contributor users shouldn't be running this script
+# normally.
 echo "Installing dependencies.."
-uv sync --extra gdb --extra lldb
+uv sync
 
-if [ -z "$UPDATE_MODE" ]; then
-    if grep -qs '^[^#]*source.*pwndbg/gdbinit.py' ~/.gdbinit; then
-        echo 'Pwndbg is already sourced in ~/.gdbinit .'
-    else
-        # Load Pwndbg into GDB on every launch.
-        echo "source $PWD/gdbinit.py" >> ~/.gdbinit
-        echo "[*] Added 'source $PWD/gdbinit.py' to ~/.gdbinit so that Pwndbg will be loaded on every launch of GDB."
-    fi
-    echo "Please set the PWNDBG_NO_AUTOUPDATE environment variable to any value"
-    echo "to disable the automatic updating of dependencies when Pwndbg is loaded."
+# Install pwndbg and pwndbg-lldb
+uv tool install . --force --editable
+
+if grep -qs '^[^#]*source.*pwndbg/gdbinit.py' ~/.gdbinit; then
+    echo 'Pwndbg is sourced in ~/.gdbinit . You will likely want to remove this line.'
 fi
+
+echo "Set the PWNDBG_NO_AUTOUPDATE environment variable to any value"
+echo "to disable the automatic updating of dependencies when Pwndbg is loaded."

--- a/setup.sh
+++ b/setup.sh
@@ -83,16 +83,11 @@ install_freebsd() {
 }
 
 usage() {
-    echo "Usage: $0 [--update]"
-    echo "  --update: Install/update dependencies without checking ~/.gdbinit"
+    echo "Usage: $0"
 }
 
-UPDATE_MODE=
 for arg in "$@"; do
     case $arg in
-        --update)
-            UPDATE_MODE=1
-            ;;
         -h | --help)
             set +x
             usage

--- a/setup.sh
+++ b/setup.sh
@@ -75,12 +75,6 @@ install_pacman() {
         sudo pacman -Syu || true
     fi
     sudo pacman -S --noconfirm --needed git gdb python which debuginfod curl gcc make patch
-    if [ -z "$UPDATE_MODE" ]; then
-        if ! grep -qs "^set debuginfod enabled on" ~/.gdbinit; then
-            echo "set debuginfod enabled on" >> ~/.gdbinit
-            echo "[*] Added 'set debuginfod enabled on' to ~/.gdbinit"
-        fi
-    fi
 }
 
 install_freebsd() {
@@ -209,8 +203,10 @@ source ${PWNDBG_VENV_PATH}/bin/activate
 pip install uv
 
 # Install dependencies
+# No need to install vendored GDB / LLDB since they won't be used
+# with this setup.
 echo "Installing dependencies.."
-uv sync --extra gdb --extra lldb
+uv sync
 
 if [ -z "$UPDATE_MODE" ]; then
     if grep -qs '^[^#]*source.*pwndbg/gdbinit.py' ~/.gdbinit; then
@@ -220,6 +216,7 @@ if [ -z "$UPDATE_MODE" ]; then
         echo "source $PWD/gdbinit.py" >> ~/.gdbinit
         echo "[*] Added 'source $PWD/gdbinit.py' to ~/.gdbinit so that Pwndbg will be loaded on every launch of GDB."
     fi
-    echo "Please set the PWNDBG_NO_AUTOUPDATE environment variable to any value"
-    echo "to disable the automatic updating of dependencies when Pwndbg is loaded."
 fi
+
+echo "Set the PWNDBG_NO_AUTOUPDATE environment variable to any value"
+echo "to disable the automatic updating of dependencies when Pwndbg is loaded."

--- a/setup.sh
+++ b/setup.sh
@@ -75,6 +75,12 @@ install_pacman() {
         sudo pacman -Syu || true
     fi
     sudo pacman -S --noconfirm --needed git gdb python which debuginfod curl gcc make patch
+    if [ -z "$UPDATE_MODE" ]; then
+        if ! grep -qs "^set debuginfod enabled on" ~/.gdbinit; then
+            echo "set debuginfod enabled on" >> ~/.gdbinit
+            echo "[*] Added 'set debuginfod enabled on' to ~/.gdbinit"
+        fi
+    fi
 }
 
 install_freebsd() {
@@ -202,19 +208,18 @@ source ${PWNDBG_VENV_PATH}/bin/activate
 # Install uv inside the venv
 pip install uv
 
-# Install dependencies.
-# We don't use the vendored GDB / LLDB by default so contributors test out Pwndbg
-# on the packaged GDB / LLDB. Non-contributor users shouldn't be running this script
-# normally.
+# Install dependencies
 echo "Installing dependencies.."
-uv sync
+uv sync --extra gdb --extra lldb
 
-# Install pwndbg and pwndbg-lldb
-uv tool install . --force --editable
-
-if grep -qs '^[^#]*source.*pwndbg/gdbinit.py' ~/.gdbinit; then
-    echo 'Pwndbg is sourced in ~/.gdbinit . You will likely want to remove this line.'
+if [ -z "$UPDATE_MODE" ]; then
+    if grep -qs '^[^#]*source.*pwndbg/gdbinit.py' ~/.gdbinit; then
+        echo 'Pwndbg is already sourced in ~/.gdbinit .'
+    else
+        # Load Pwndbg into GDB on every launch.
+        echo "source $PWD/gdbinit.py" >> ~/.gdbinit
+        echo "[*] Added 'source $PWD/gdbinit.py' to ~/.gdbinit so that Pwndbg will be loaded on every launch of GDB."
+    fi
+    echo "Please set the PWNDBG_NO_AUTOUPDATE environment variable to any value"
+    echo "to disable the automatic updating of dependencies when Pwndbg is loaded."
 fi
-
-echo "Set the PWNDBG_NO_AUTOUPDATE environment variable to any value"
-echo "to disable the automatic updating of dependencies when Pwndbg is loaded."

--- a/setup.sh
+++ b/setup.sh
@@ -87,6 +87,7 @@ usage() {
     echo "  --update: Install/update dependencies without checking ~/.gdbinit"
 }
 
+UPDATE_MODE=
 for arg in "$@"; do
     case $arg in
         --update)

--- a/setup.sh
+++ b/setup.sh
@@ -83,11 +83,15 @@ install_freebsd() {
 }
 
 usage() {
-    echo "Usage: $0"
+    echo "Usage: $0 [--update]"
+    echo "  --update: Install/update dependencies without checking ~/.gdbinit"
 }
 
 for arg in "$@"; do
     case $arg in
+        --update)
+            UPDATE_MODE=1
+            ;;
         -h | --help)
             set +x
             usage

--- a/uv.lock
+++ b/uv.lock
@@ -1768,6 +1768,7 @@ version = "2025.10.20"
 source = { editable = "." }
 dependencies = [
     { name = "capstone6pwndbg" },
+    { name = "decomp2dbg" },
     { name = "ipython" },
     { name = "niche-elf" },
     { name = "psutil" },
@@ -1789,9 +1790,6 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
-decomp2dbg = [
-    { name = "decomp2dbg" },
-]
 gdb = [
     { name = "gdb-for-pwndbg", version = "17.1.0.post2", source = { registry = "https://mirrors.loong64.com/pypi/simple" }, marker = "platform_machine == 'loongarch64' and sys_platform == 'linux'" },
     { name = "gdb-for-pwndbg", version = "17.1.0.post2", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'loongarch64' or sys_platform != 'linux'" },
@@ -1843,7 +1841,7 @@ tests = [
 [package.metadata]
 requires-dist = [
     { name = "capstone6pwndbg", specifier = "==6.0.0a6" },
-    { name = "decomp2dbg", marker = "extra == 'decomp2dbg'", specifier = "==3.14.1" },
+    { name = "decomp2dbg", specifier = "==3.14.1" },
     { name = "gdb-for-pwndbg", marker = "platform_machine == 'loongarch64' and sys_platform == 'linux' and extra == 'gdb'", specifier = "==17.1.0.post2", index = "https://mirrors.loong64.com/pypi/simple" },
     { name = "gdb-for-pwndbg", marker = "(platform_machine != 'loongarch64' and extra == 'gdb') or (sys_platform != 'linux' and extra == 'gdb')", specifier = "==17.1.0.post2" },
     { name = "gnureadline", marker = "sys_platform != 'win32' and extra == 'lldb'", specifier = ">=8.2.13,<9" },
@@ -1869,7 +1867,7 @@ requires-dist = [
     { name = "uv", marker = "platform_machine == 'loongarch64' and sys_platform == 'linux'", specifier = ">=0.8.14", index = "https://mirrors.loong64.com/pypi/simple" },
     { name = "ziglang", marker = "platform_machine != 'loongarch64' or sys_platform != 'linux'", specifier = "==0.14.1" },
 ]
-provides-extras = ["lldb", "gdb", "decomp2dbg"]
+provides-extras = ["lldb", "gdb"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
+ Explain to the users that they don't actually have to clone the repo
+ Partial revert of https://github.com/pwndbg/pwndbg/pull/3761
    + I realize it makes more sense to just leave decomp2dbg in the main deps, since all installations where we control the installation should actually just always install decomp2dbg, and distros dont care about pyproject.toml (probably?)
+ ~~Make `setup.sh` install pwndbg via uv instead of doing the gdb source dance~~