### PR TITLE
Fixed shell dialect mismatch bug in portable.nix env check

### DIFF
--- a/nix/portable.nix
+++ b/nix/portable.nix
@@ -20,48 +20,46 @@ let
       ''
   );
   ldLoader = if pkgs.stdenv.isLinux then "\"$dir/lib/${ldName}\"" else "";
+
   riskEnvsCheck = ''
-    if [[ "$*" != *"--quiet"* ]] && [[ "$*" != *"-q"* ]]; then
-        detected=0
-        platform=$(uname -s)
-
-        if [[ "$platform" == "Darwin" ]]; then
-            if [[ -n "$DYLD_LIBRARY_PATH" ]] || [[ -n "$DYLD_INSERT_LIBRARIES" ]] || \
-              [[ -n "$DYLD_FALLBACK_LIBRARY_PATH" ]] || [[ -n "$DYLD_FRAMEWORK_PATH" ]]; then
-                detected=1
-            fi
+    quiet=0
+    case " $* " in
+      *" --quiet "*|*" -q "*) quiet=1 ;;
+    esac
+  
+    if [ "$quiet" -eq 0 ]; then
+      detected=0
+      platform=$(uname -s)
+  
+      if [ "$platform" = "Darwin" ]; then
+        if [ -n "$DYLD_LIBRARY_PATH" ] || \
+           [ -n "$DYLD_INSERT_LIBRARIES" ] || \
+           [ -n "$DYLD_FALLBACK_LIBRARY_PATH" ] || \
+           [ -n "$DYLD_FRAMEWORK_PATH" ]; then
+          detected=1
+        fi
+      else
+        if [ -n "$LD_LIBRARY_PATH" ] || [ -n "$LD_PRELOAD" ]; then
+          detected=1
+        fi
+      fi
+  
+      if [ "$detected" -eq 1 ]; then
+        echo
+        echo "WARNING: Potentially problematic environment variables detected!"
+        echo "These may cause library loading issues with debugging tools like pwndbg."
+        echo
+  
+        if [ "$platform" = "Darwin" ]; then
+          [ -n "$DYLD_LIBRARY_PATH" ] && echo "DYLD_LIBRARY_PATH is set to: $DYLD_LIBRARY_PATH"
+          [ -n "$DYLD_INSERT_LIBRARIES" ] && echo "DYLD_INSERT_LIBRARIES is set to: $DYLD_INSERT_LIBRARIES"
         else
-            if [[ -n "$LD_LIBRARY_PATH" ]] || [[ -n "$LD_PRELOAD" ]]; then
-                detected=1
-            fi
+          [ -n "$LD_LIBRARY_PATH" ] && echo "LD_LIBRARY_PATH is set to: $LD_LIBRARY_PATH"
+          [ -n "$LD_PRELOAD" ] && echo "LD_PRELOAD is set to: $LD_PRELOAD"
         fi
-
-        if [[ $detected -eq 1 ]]; then
-            echo
-            echo "WARNING: Potentially problematic environment variables detected!"
-            echo "These may cause library loading issues with debugging tools like pwndbg."
-            echo
-
-            if [[ "$platform" == "Darwin" ]]; then
-                if [[ -n "$DYLD_LIBRARY_PATH" ]]; then
-                    echo "DYLD_LIBRARY_PATH is set to: $DYLD_LIBRARY_PATH"
-                fi
-
-                if [[ -n "$DYLD_INSERT_LIBRARIES" ]]; then
-                    echo "DYLD_INSERT_LIBRARIES is set to: $DYLD_INSERT_LIBRARIES"
-                fi
-            else
-                if [[ -n "$LD_LIBRARY_PATH" ]]; then
-                    echo "LD_LIBRARY_PATH is set to: $LD_LIBRARY_PATH"
-                fi
-
-                if [[ -n "$LD_PRELOAD" ]]; then
-                    echo "LD_PRELOAD is set to: $LD_PRELOAD"
-                fi
-            fi
-
-            echo
-        fi
+  
+        echo
+      fi
     fi
   '';
   commonEnvs =


### PR DESCRIPTION
# Issue

After installing pwndbg `2026.02.17` system-wide using `curl
 --proto '=https' --tlsv1.2 -LsSf 'https://install.pwndbg.re' | sh -s -- -t pwndbg-gdb` and running pwndbg, an error is displayed on line 9 in `/usr/local/bin/pwndbg` and the presence of potentially unsafe environment vars is not checked:

<img width="1265" height="287" alt="image" src="https://github.com/user-attachments/assets/c92f51b8-d90a-4191-a428-7512217e3709" />

# Cause

Commit 0da1a7cfb3896344abeb78bb813c22c9a7551729 in `nix/portable.nix` implements the detection of  unsafe environment vars and warns the user if such env vars are present:

```bash
    if [[ "$*" != *"--quiet"* ]] && [[ "$*" != *"-q"* ]]; then
        detected=0
        platform=$(uname -s)

        if [[ "$platform" == "Darwin" ]]; then
            if [[ -n "$DYLD_LIBRARY_PATH" ]] || [[ -n "$DYLD_INSERT_LIBRARIES" ]] ||
              ...
```

The checks are done using Bash-specific if statements (i.e. [[ ... ]]). But on Nix-built portable bundles, `/bin/sh` is used in the wrapper for portability purposes:

```bash
    pkgs.writeScript "pwndbg-wrapper-bin" ''
      #!/bin/sh
      dir="$(cd -- "$(dirname "$(dirname "$(realpath "$0")")")" >/dev/null 2>&1 ; pwd -P)"
      ...
```

`/bin/sh` interprets the wrapper, but the check uses Bash syntax, triggering the displayed error in line 9 and skipping the warning.

The resulting `/usr/local/bin/pwndbg` looks like this:

```sh
#!/bin/sh # <----- /bin/sh shebang
dir="$(cd -- "$(dirname "$(dirname "$(realpath "$0")")")" >/dev/null 2>&1 ; pwd -P)"
export TERMINFO_DIRS=/etc/terminfo:/lib/terminfo:/usr/share/terminfo:/run/current-system/sw/share/terminfo:$dir/share/terminfo
export PYTHONNOUSERSITE=1
export PYTHONHOME="$dir"
export PYTHONPATH=""
export PATH="$dir/bin/:$PATH"

if [[ "$*" != *"--quiet"* ]] && [[ "$*" != *"-q"* ]]; then  # <----- bash syntax
  ...
```

# Fix

This PR rewrites the checks in `nix/portable.nix` using proper POSIX /bin/sh syntax in the if statements.

```sh
quiet=0
    case " $* " in
      *" --quiet "*|*" -q "*) quiet=1 ;;
    esac
  
    if [ "$quiet" -eq 0 ]; then
      ...
```

With the proper POSIX /bin/sh syntax, the script is interpreted correctly and a warning is displayed:

<img width="1251" height="383" alt="image" src="https://github.com/user-attachments/assets/bba382f9-faf4-45f5-90ec-f46c4de73019" />

Thank you!

