### PR TITLE
[docs] Make docs generate properly with "normal" google-style docstring return annotations

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -130,6 +130,8 @@ plugins:
               ignore_init_summary: true
               trim_doctest_flags: true
               warn_unknown_params: true
+              # https://github.com/mkdocstrings/mkdocstrings/issues/817#issuecomment-3927886394
+              returns_multiple_items: false
 
   # Generate the whole Source page magically (hooks into mkdocstrings)
   - api-autonav:


### PR DESCRIPTION
re: https://github.com/mkdocstrings/mkdocstrings/issues/817#issuecomment-3927886394

Before:
<img width="1021" height="164" alt="image" src="https://github.com/user-attachments/assets/cbe45f79-eea5-4d4b-9119-0d00fb716499" />

After:
<img width="781" height="143" alt="image" src="https://github.com/user-attachments/assets/686445be-8d07-4746-8e88-52fccb08da3f" />
