### PR TITLE
[dintegration] Fix off-by-one in decompilation output

### DIFF
--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -1451,7 +1451,7 @@ def get_filename_and_formatted_source(height: int | None = None) -> tuple[str, l
         return "", [], closest_line
 
     nlines = max(int(source_disasm_lines), height or 0)
-    formatted_source = pretty_print.format_source(list(source), nlines, closest_line)
+    formatted_source = pretty_print.format_source(list(source), nlines, closest_line - 1)
 
     return filename, formatted_source, closest_line
 

--- a/pwndbg/lib/pretty_print.py
+++ b/pwndbg/lib/pretty_print.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import pwndbg
 import pwndbg.color
+import pwndbg.color.context
 import pwndbg.color.memory
 import pwndbg.lib.config
 from pwndbg.color import theme
@@ -303,7 +304,7 @@ def format_source(source: list[str], nlines: int, interesting_line: int) -> list
     Arguments:
         source: Already highlighted source code. List of lines.
         nlines: The amount of lines we want back.
-        interesting_line: The line around which to center the output.
+        interesting_line: The line around which to center the output (0-indexed).
     """
     start, end = nlines_to_range(nlines, interesting_line, len(source))
     num_width = len(str(end))
@@ -317,6 +318,8 @@ def format_source(source: list[str], nlines: int, interesting_line: int) -> list
 
     # Format the output
     formatted_source = []
+    # line_number is 1-indexed (as source code usually is)
+    interesting_line1dx: int = interesting_line + 1
     for line_number, code in enumerate(source, start=start + 1):
         # Honor the tab-size setting.
         if pwndbg.config.context_code_tabstop > 0:
@@ -327,11 +330,11 @@ def format_source(source: list[str], nlines: int, interesting_line: int) -> list
 
         fmt = " {prefix_sign:{prefix_width}} {line_number:>{num_width}} {code}"
 
-        if pwndbg.config.highlight_source and line_number == interesting_line:
+        if pwndbg.config.highlight_source and line_number == interesting_line1dx:
             fmt = pwndbg.color.context.highlight(fmt)
 
         line = fmt.format(
-            prefix_sign=prefix_sign if line_number == interesting_line else "",
+            prefix_sign=prefix_sign if line_number == interesting_line1dx else "",
             prefix_width=prefix_width,
             line_number=line_number,
             num_width=num_width,


### PR DESCRIPTION
Closes: https://github.com/pwndbg/pwndbg/issues/3758 .

Honestly it's a pretty bad bug UX wise, I wish I fixed it before the release. Oh well.

+ [x] I read the contributing documentation.
+ [x] I am providing a screenshot of the (new feature) / (fixed bug).

Before:

<img width="558" height="470" alt="image" src="https://github.com/user-attachments/assets/7bbcb55d-def5-471c-983a-a5a34f3c314f" />

After:

<img width="699" height="392" alt="image" src="https://github.com/user-attachments/assets/af29fcb2-eded-485e-86d0-53acb89c32a0" />
