### PR TITLE
Disassembly: indicate when current pc at breakpoint

### DIFF
--- a/docs/configuration/theme.md
+++ b/docs/configuration/theme.md
@@ -875,6 +875,17 @@ Breakpoint marker for nearpc command.
 
 ----------
 
+## **nearpc-current-breakpoint-prefix**
+
+
+Marker for when current instruction is at a breakpoint.
+
+
+
+**Default:** 'b►'  
+
+----------
+
 ## **nearpc-integration-comments-color**
 
 

--- a/pwndbg/aglib/nearpc.py
+++ b/pwndbg/aglib/nearpc.py
@@ -520,26 +520,33 @@ def nearpc(
     breakpoint_prefix = breakpoint_sign.ljust(len(prefix_sign) + 1)
     breakpoint_prefix = c.breakpoint(breakpoint_prefix)
 
+    current_insn_breakpoint_prefix = pwndbg.color.red(c.prefix(f"b{prefix_sign}"))
+
     # Print out each instruction
     for i, (address_str, symbol, instruction, asm) in enumerate(
         zip(addresses, symbols, instructions, assembly_strings)
     ):
-        # Show prefix only on the specified address and don't show it while in repeat-mode
+        # Show a prefix for the instruction that the program counter points to. Don't show it while in repeat-mode
         # or when showing current instruction for the second time
-        show_prefix = instruction.address == pc and not repeat and i == index_of_pc
-        is_breakpoint = False
-        if show_prefix:
-            prefix = current_insn_prefix
-        elif instruction.address in breakpoint_locations:
+        show_pc_prefix = instruction.address == pc and not repeat and i == index_of_pc
+        instruction_has_breakpoint = instruction.address in breakpoint_locations
+
+        is_non_pc_breakpoint = False
+        if show_pc_prefix:
+            if instruction_has_breakpoint:
+                prefix = current_insn_breakpoint_prefix
+            else:
+                prefix = current_insn_prefix
+        elif instruction_has_breakpoint:
             # If the instruction is not the current instruction and a breakpoint,
             # show the breakpoint sign
             prefix = breakpoint_prefix
-            is_breakpoint = True
+            is_non_pc_breakpoint = True
         else:
             prefix = default_prefix
 
         # If this instruction is a breakpoint and not the current pc, highlight it.
-        if is_breakpoint and pwndbg.config.highlight_breakpoints:
+        if is_non_pc_breakpoint and pwndbg.config.highlight_breakpoints:
             address_str = c.breakpoint(address_str)
             symbol = c.breakpoint(symbol)
         # Colorize address and symbol if not highlighted

--- a/pwndbg/aglib/nearpc.py
+++ b/pwndbg/aglib/nearpc.py
@@ -75,6 +75,11 @@ pwndbg.color.theme.add_param("nearpc-prefix", "►", "prefix marker for nearpc c
 pwndbg.color.theme.add_param(
     "nearpc-breakpoint-prefix", "b+", "breakpoint marker for nearpc command"
 )
+pwndbg.color.theme.add_param(
+    "nearpc-current-breakpoint-prefix",
+    "b►",
+    "marker for when current instruction is at a breakpoint",
+)
 pwndbg.config.add_param("left-pad-disasm", True, "whether to left-pad disassembly")
 show_args = pwndbg.config.add_param(
     "nearpc-show-args", True, "whether to show call arguments below instruction"
@@ -511,16 +516,24 @@ def nearpc(
     breakpoint_locations = pwndbg.dbg.breakpoint_locations()
 
     prefix_sign = pwndbg.config.nearpc_prefix
+
+    # Prefix for instruction at the current program counter
     current_insn_prefix = f" {prefix_sign}"
     current_insn_prefix = c.prefix(current_insn_prefix)
+
+    # Prefix for non-breakpoints and non-current instructions
     default_prefix = " " * (len(prefix_sign) + 1)
     default_prefix = c.prefix(default_prefix)
 
+    # Prefix for when instruction is a breakpoint, but not at the current instruction
     breakpoint_sign = pwndbg.config.nearpc_breakpoint_prefix
     breakpoint_prefix = breakpoint_sign.ljust(len(prefix_sign) + 1)
     breakpoint_prefix = c.breakpoint(breakpoint_prefix)
 
-    current_insn_breakpoint_prefix = pwndbg.color.red(c.prefix(f"b{prefix_sign}"))
+    # Prefix for when current instruction is a breakpoint
+    current_breakpoint_sign = pwndbg.config.nearpc_current_breakpoint_prefix
+    current_insn_breakpoint_prefix = current_breakpoint_sign.ljust(len(prefix_sign) + 1)
+    current_insn_breakpoint_prefix = c.breakpoint(c.prefix(current_insn_breakpoint_prefix))
 
     # Print out each instruction
     for i, (address_str, symbol, instruction, asm) in enumerate(

--- a/tests/library/dbg/tests/test_nearpc.py
+++ b/tests/library/dbg/tests/test_nearpc.py
@@ -179,7 +179,6 @@ async def test_nearpc_opcode_seperator(ctrl: Controller, separator_bytes: int) -
 @pwndbg_test
 async def test_nearpc_highlight_breakpoint(ctrl: Controller) -> None:
     import pwndbg.aglib.symbol
-    import pwndbg.color
     from pwndbg.dbg_mod import BreakpointLocation
 
     await ctrl.launch(SYSCALLS_BINARY)

--- a/tests/library/dbg/tests/test_nearpc.py
+++ b/tests/library/dbg/tests/test_nearpc.py
@@ -179,6 +179,7 @@ async def test_nearpc_opcode_seperator(ctrl: Controller, separator_bytes: int) -
 @pwndbg_test
 async def test_nearpc_highlight_breakpoint(ctrl: Controller) -> None:
     import pwndbg.aglib.symbol
+    import pwndbg.color
     from pwndbg.dbg_mod import BreakpointLocation
 
     await ctrl.launch(SYSCALLS_BINARY)
@@ -206,10 +207,11 @@ async def test_nearpc_highlight_breakpoint(ctrl: Controller) -> None:
 
     await ctrl.step_instruction()
     dis = await ctrl.execute_and_capture("nearpc -t 11")
-    # When we stop on a breakpoint, we only highlight it (and not show the "b+" marker)
+
+    # When we stop on a breakpoint, we show a special marker
     expected = (
         "   0x400080 <_start>       mov    eax, 0                 EAX => 0\n"
-        " ► 0x400085 <_start+5>     mov    edi, 0x1337            EDI => 0x1337\n"
+        "b► 0x400085 <_start+5>     mov    edi, 0x1337            EDI => 0x1337\n"
         "   0x40008a <_start+10>    mov    esi, 0xdeadbeef        ESI => 0xdeadbeef\n"
         "   0x40008f <_start+15>    mov    ecx, 0x10              ECX => 0x10\n"
         "   0x400094 <_start+20>    syscall <SYS_read>\n"

--- a/tests/library/qemu_user/tests/test_aarch64.py
+++ b/tests/library/qemu_user/tests/test_aarch64.py
@@ -407,7 +407,7 @@ def test_aarch64_store_instructions(qemu_assembly_run):
     expected = (
         "LEGEND: STACK | HEAP | CODE | DATA | WX | RODATA\n"
         "─────────────────────[ DISASM / aarch64 / set emulate on ]──────────────────────\n"
-        " ► 0x1010180 <stores>       ldr    x4, stores+56     X4, [stores+56] => 0x10201d8 (value1) ◂— 0\n"
+        "b► 0x1010180 <stores>       ldr    x4, stores+56     X4, [stores+56] => 0x10201d8 (value1) ◂— 0\n"
         "   0x1010184 <stores+4>     strb   w0, [x4]          [value1] <= 0xf0\n"
         "   0x1010188 <stores+8>     ldr    x5, stores+64     X5, [stores+64] => 0x10201d9 (value2) ◂— 0\n"
         "   0x101018c <stores+12>    strh   w0, [x5]          [value2] <= 0xdef0\n"
@@ -482,7 +482,7 @@ def test_aarch64_load_instructions(qemu_assembly_run):
     expected = (
         "LEGEND: STACK | HEAP | CODE | DATA | WX | RODATA\n"
         "─────────────────────[ DISASM / aarch64 / set emulate on ]──────────────────────\n"
-        " ► 0x101017c <loads>       ldrb   w9, [x4]          W9, [value1] => 0xf0\n"
+        "b► 0x101017c <loads>       ldrb   w9, [x4]          W9, [value1] => 0xf0\n"
         "   0x1010180 <loads+4>     ldrsb  w10, [x4]         W10, [value1] => 0xfffffff0\n"
         "   0x1010184 <loads+8>     ldrh   w12, [x5]         W12, [value2] => 0xdef0\n"
         "   0x1010188 <loads+12>    ldrsh  w13, [x5]         W13, [value2] => 0xffffdef0\n"

--- a/tests/library/qemu_user/tests/test_mips.py
+++ b/tests/library/qemu_user/tests/test_mips.py
@@ -386,7 +386,7 @@ def test_mips32_load_instructions(qemu_assembly_run, arch):
     expected = (
         "LEGEND: STACK | HEAP | CODE | DATA | WX | RODATA\n"
         "───────────────────────[ DISASM / mips / set emulate on ]───────────────────────\n"
-        " ► 0x20188 <loads>       lw     $t1, 0($s0)     T1, [value1] => 0xffffffff\n"
+        "b► 0x20188 <loads>       lw     $t1, 0($s0)     T1, [value1] => 0xffffffff\n"
         "   0x2018c <loads+4>     lhu    $t2, 0($s1)     T2, [value2] => 0xffff\n"
         "   0x20190 <loads+8>     lbu    $t3, 0($s2)     T3, [value3] => 0xff\n"
         "   0x20194 <loads+12>    lw     $t4, 0($s0)     T4, [value1] => 0xffffffff\n"

--- a/tests/library/qemu_user/tests/test_riscv64.py
+++ b/tests/library/qemu_user/tests/test_riscv64.py
@@ -191,7 +191,7 @@ def test_riscv64_compressed_loads(qemu_assembly_run):
     expected = (
         "LEGEND: STACK | HEAP | CODE | DATA | WX | RODATA\n"
         "───────────────────────[ DISASM / rv64 / set emulate on ]───────────────────────\n"
-        " ► 0x10011b8 <store>       c.sd   a0, 0(a2)          [data] <= 0x1234567890abcdef\n"
+        "b► 0x10011b8 <store>       c.sd   a0, 0(a2)          [data] <= 0x1234567890abcdef\n"
         "   0x10011ba <store+2>     c.ld   a1, 0(a2)          A1, [data] => 0x1234567890abcdef\n"
         "   0x10011bc <store+4>     c.li   a1, 0x10           A1 => 0x10\n"
         "   0x10011be <store+6>     addi   a2, zero, 0x26     A2 => 0x26 (0x0 + 0x26)\n"
@@ -298,7 +298,7 @@ def test_riscv64_jumps(qemu_assembly_run):
         "    ↓\n"
         "   0x1001168 <second>    ✘ blt    t0, t3, 6                   <third>\n"
         " \n"
-        " ► 0x100116c <second+4>    c.nop \n"
+        "b► 0x100116c <second+4>    c.nop \n"
         "   0x100116e <third>     ✔ bge    t0, t4, 6                   <fourth>\n"
         "    ↓\n"
         "   0x1001174 <fourth>    ✔ blt    t5, t0, 6                   <end>\n"


### PR DESCRIPTION
Previously, if the current program counter was at an instruction without a breakpoint, there would be no indication of this in the display. Now, make the prefix red and add a "b" to show that this is the case.

<img width="1408" height="537" alt="image" src="https://github.com/user-attachments/assets/8f71c379-e617-479f-ab14-3a25e361d786" />

Resolves #3783