### PR TITLE
downgrade buildkit-cache-dance action version to fix it and add error handling for delete stale cache step

### DIFF
--- a/.github/workflows/base-image.yml
+++ b/.github/workflows/base-image.yml
@@ -108,14 +108,14 @@ jobs:
             --key "buildkit-${{ matrix.platform_base.tag_name }}-" \
             --json key -q '.[].key' | while read -r key; do
             echo "Deleting stale cache: $key"
-            gh cache delete "$key"
+            gh cache delete "$key" || echo "::warning::Failed to delete stale cache: $key"
           done
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Inject/extract cache mounts
         if: steps.cache.outputs.cache-hit != 'true'
-        uses: reproducible-containers/buildkit-cache-dance@v3.3.1
+        uses: reproducible-containers/buildkit-cache-dance@v3.1.2
         with:
           cache-map: |
             {

--- a/.github/workflows/base-image.yml
+++ b/.github/workflows/base-image.yml
@@ -88,6 +88,7 @@ jobs:
         uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
+        id: buildx
         uses: docker/setup-buildx-action@v3
 
       - name: Restore Docker cache mounts
@@ -115,13 +116,15 @@ jobs:
 
       - name: Inject/extract cache mounts
         if: steps.cache.outputs.cache-hit != 'true'
-        uses: reproducible-containers/buildkit-cache-dance@v3.1.2
+        uses: reproducible-containers/buildkit-cache-dance@v3.3.1
         with:
           cache-map: |
             {
               "uv-${{ matrix.platform_base.tag_name }}": "/root/.cache/uv",
               "cargo-${{ matrix.platform_base.tag_name }}": "/root/.cargo/registry"
             }
+          builder: ${{ steps.buildx.outputs.name }}
+          skip-extraction: ${{ github.event_name == 'pull_request' }}
 
       - name: Build Docker image
         run: |


### PR DESCRIPTION
+ [x] I read the contributing documentation.
+ [ ] I am providing a screenshot of the (new feature) / (fixed bug).

makes https://github.com/pwndbg/pwndbg/pull/3722 actually work
I tested it on v3.1.2 and updated to v3.3.1 when making PR #3722, not realizing
https://github.com/reproducible-containers/buildkit-cache-dance/pull/45
would cause it not to work after 3.1.2
So for now, I shall revert it, so we can have the tests take 1-10m and not hours for every dep update.
the 400 byte buildkit caches will get overwritten with the real ~400mb caches.
I may make a PR, though, to fix the buildkit-cache-dance action itself, because it is kind of annoying.

And somehow the delete stale cache step failed one time, so I added it so it will just warn in GitHub Actions and continue, instead of failing, which I had it set to before, so that I would know if it was broken. It's not a big deal if it bugs out and doesn't remove them a time or two, as GitHub actions cache evicts based on LRU anyways, but it should still be removing them for best practice.
