### PR TITLE
Fix test_musl_dynamic_detection when ASLR cannot be disabled

### DIFF
--- a/tests/host/gdb/pytests_launcher.py
+++ b/tests/host/gdb/pytests_launcher.py
@@ -48,6 +48,12 @@ class _GDBController(host.Controller):
         os.environ["COLUMNS"] = "80"
         for k, v in env.items():
             self._gdb_execute(f"set environment {k}={v}")
+        # Clear breakpoints from any prior launch. The debugger abstraction
+        # layer sets breakpoints by resolved address (not by symbol name), so
+        # GDB won't re-resolve them on relaunch. With ASLR, stale address
+        # breakpoints point to invalid memory and cause "Cannot access memory"
+        # errors on starti.
+        self._gdb_execute("delete breakpoints")
         self._gdb_execute("starti " + " ".join(args))
         self._show_context()
 


### PR DESCRIPTION
When the user lacks privileges to disable ASLR (e.g. in unprivileged containers), the `test_musl_dynamic_detection` test (run with `./tests.sh -d gdb -g dbg test_musl_dynamic_detection`) fails on the second `ctrl.launch()` call with:

```
  gdb.error: Warning:
  Cannot insert breakpoint 1.
  Cannot access memory at address 0xc3dc30e606f0
```

This happens because `launch_to()` sets breakpoints by resolved address (via the debugger abstraction layer's `BreakpointLocation`), not by symbol name. GDB does not re-resolve address breakpoints on relaunch, so with ASLR the binary loads at a different address and stale breakpoints become invalid.

Fix this by clearing all breakpoints in the GDB test controller's `launch()` method before calling the `starti` command.
