### PR TITLE
Make cyclic consistent with pwntools

### DIFF
--- a/docs/commands/misc/cyclic.md
+++ b/docs/commands/misc/cyclic.md
@@ -22,7 +22,7 @@ Cyclic pattern creator/finder.
 | :--- | :--- | :--- |
 |-h|--help|show this help message and exit|
 |-a|--alphabet|The alphabet to use in the cyclic pattern (default: abcdefghijklmnopqrstuvwxyz)|
-|-n|--length|Size of the unique subsequences (defaults to the pointer size for the current arch)|
+|-n|--length|Size of the unique subsequences (default: 4)|
 |-t|--timeout|Timeout in seconds for --detect (default: 2)|
 |-o|--lookup|Do a lookup instead of printing the sequence (accepts constant values as well as expressions)|
 |-d|--detect|Detect cyclic patterns in registers (Immediate values and memory pointed to by registers)|

--- a/pwndbg/commands/cyclic.py
+++ b/pwndbg/commands/cyclic.py
@@ -171,11 +171,12 @@ def cyclic_cmd(alphabet, length: int, lookup, detect, count=100, filename="", ti
                 lookup = lookup[:length]
         elif isinstance(lookup, str):
             lookup = bytes(lookup, "utf-8")
+            lookup = lookup[:length]
 
         if len(lookup) != length:
             print(
                 message.error(
-                    f"Lookup pattern must be {length} bytes (use `-n <length>` to lookup pattern of different length)"
+                    f"Lookup pattern must be at least {length} bytes (use `-n <length>` to lookup pattern of different length)"
                 )
             )
             return

--- a/pwndbg/commands/cyclic.py
+++ b/pwndbg/commands/cyclic.py
@@ -100,8 +100,9 @@ parser.add_argument(
     "-n",
     "--length",
     metavar="length",
+    default=4,
     type=int,
-    help="Size of the unique subsequences (defaults to the pointer size for the current arch)",
+    help="Size of the unique subsequences",
 )
 
 parser.add_argument(
@@ -168,7 +169,11 @@ def cyclic_cmd(
         lookup = pwndbg.commands.fix(lookup, sloppy=True)
 
         if isinstance(lookup, (pwndbg.dbg_mod.Value, int)):
-            lookup = int(lookup).to_bytes(length, pwndbg.aglib.arch.endian)
+            try:
+                lookup = int(lookup).to_bytes(length, pwndbg.aglib.arch.endian)
+            except OverflowError:
+                lookup = int(lookup).to_bytes(pwndbg.aglib.arch.ptrsize, pwndbg.aglib.arch.endian)
+                lookup = lookup[:length]
         elif isinstance(lookup, str):
             lookup = bytes(lookup, "utf-8")
 

--- a/pwndbg/commands/cyclic.py
+++ b/pwndbg/commands/cyclic.py
@@ -155,12 +155,7 @@ parser.add_argument(
     category=CommandCategory.MISC,
     notes="If you want to write the cyclic pattern to memory, use the `spray` command!",
 )
-def cyclic_cmd(
-    alphabet, length: int | None, lookup, detect, count=100, filename="", timeout=2
-) -> None:
-    if length is None:
-        length = pwndbg.aglib.arch.ptrsize
-
+def cyclic_cmd(alphabet, length: int, lookup, detect, count=100, filename="", timeout=2) -> None:
     if detect:
         detect_register_patterns(alphabet, length, timeout)
         return

--- a/tests/library/dbg/tests/test_command_cyclic.py
+++ b/tests/library/dbg/tests/test_command_cyclic.py
@@ -20,12 +20,12 @@ async def test_command_cyclic_value(ctrl: Controller) -> None:
 
     ptr_size = pwndbg.aglib.arch.ptrsize
     test_offset = 37
-    pattern = cyclic(length=80, n=ptr_size)
+    pattern = cyclic(length=80)
     val = int.from_bytes(pattern[test_offset : test_offset + ptr_size], pwndbg.aglib.arch.endian)
     out = await ctrl.execute_and_capture(f"cyclic -l {hex(val)}")
 
     assert out == (
-        "Finding cyclic pattern of 8 bytes: b'aaafaaaa' (hex: 0x6161616661616161)\n"
+        "Finding cyclic pattern of 4 bytes: b'aaak' (hex: 0x6161616b)\n"
         "Found at offset 37\n"
     )
 
@@ -45,7 +45,7 @@ async def test_command_cyclic_register(ctrl: Controller) -> None:
     ptr_size = pwndbg.aglib.arch.ptrsize
 
     test_offset = 45
-    pattern = cyclic(length=80, n=ptr_size)
+    pattern = cyclic(length=80)
     pwndbg.aglib.regs.write_reg(
         reg_name,
         int.from_bytes(pattern[test_offset : test_offset + ptr_size], pwndbg.aglib.arch.endian),
@@ -53,7 +53,7 @@ async def test_command_cyclic_register(ctrl: Controller) -> None:
     out = await ctrl.execute_and_capture(f"cyclic -l ${reg_name}")
 
     assert out == (
-        "Finding cyclic pattern of 8 bytes: b'aaagaaaa' (hex: 0x6161616761616161)\n"
+        "Finding cyclic pattern of 4 bytes: b'aaam' (hex: 0x6161616d)\n"
         "Found at offset 45\n"
     )
 
@@ -71,14 +71,13 @@ async def test_command_cyclic_address(ctrl: Controller) -> None:
     await ctrl.launch(REFERENCE_BINARY)
 
     addr = pwndbg.aglib.regs.sp
-    ptr_size = pwndbg.aglib.arch.ptrsize
     test_offset = 48
-    pattern = cyclic(length=80, n=ptr_size)
+    pattern = cyclic(length=80)
     pwndbg.aglib.memory.write(addr, pattern)
     out = await ctrl.execute_and_capture(f"cyclic -l '*(unsigned long*){hex(addr + test_offset)}'")
 
     assert out == (
-        "Finding cyclic pattern of 8 bytes: b'gaaaaaaa' (hex: 0x6761616161616161)\n"
+        "Finding cyclic pattern of 4 bytes: b'maaa' (hex: 0x6d616161)\n"
         "Found at offset 48\n"
     )
 
@@ -89,7 +88,7 @@ async def test_command_cyclic_wrong_alphabet(ctrl: Controller) -> None:
 
     out = await ctrl.execute_and_capture("cyclic -l 1234")
     assert out == (
-        "Finding cyclic pattern of 8 bytes: b'\\xd2\\x04\\x00\\x00\\x00\\x00\\x00\\x00' (hex: 0xd204000000000000)\n"
+        "Finding cyclic pattern of 4 bytes: b'\\xd2\\x04\\x00\\x00' (hex: 0xd2040000)\n"
         "Pattern contains characters not present in the alphabet\n"
     )
 
@@ -98,7 +97,7 @@ async def test_command_cyclic_wrong_alphabet(ctrl: Controller) -> None:
 async def test_command_cyclic_wrong_length(ctrl: Controller) -> None:
     await ctrl.launch(REFERENCE_BINARY)
 
-    out = await ctrl.execute_and_capture("cyclic -l qwerty")
+    out = await ctrl.execute_and_capture("cyclic -l qwe")
     assert out == (
-        "Lookup pattern must be 8 bytes (use `-n <length>` to lookup pattern of different length)\n"
+        "Lookup pattern must be at least 4 bytes (use `-n <length>` to lookup pattern of different length)\n"
     )

--- a/tests/library/dbg/tests/test_command_cyclic.py
+++ b/tests/library/dbg/tests/test_command_cyclic.py
@@ -25,8 +25,7 @@ async def test_command_cyclic_value(ctrl: Controller) -> None:
     out = await ctrl.execute_and_capture(f"cyclic -l {hex(val)}")
 
     assert out == (
-        "Finding cyclic pattern of 4 bytes: b'aaak' (hex: 0x6161616b)\n"
-        "Found at offset 37\n"
+        "Finding cyclic pattern of 4 bytes: b'aaak' (hex: 0x6161616b)\nFound at offset 37\n"
     )
 
 
@@ -53,8 +52,7 @@ async def test_command_cyclic_register(ctrl: Controller) -> None:
     out = await ctrl.execute_and_capture(f"cyclic -l ${reg_name}")
 
     assert out == (
-        "Finding cyclic pattern of 4 bytes: b'aaam' (hex: 0x6161616d)\n"
-        "Found at offset 45\n"
+        "Finding cyclic pattern of 4 bytes: b'aaam' (hex: 0x6161616d)\nFound at offset 45\n"
     )
 
 
@@ -77,8 +75,7 @@ async def test_command_cyclic_address(ctrl: Controller) -> None:
     out = await ctrl.execute_and_capture(f"cyclic -l '*(unsigned long*){hex(addr + test_offset)}'")
 
     assert out == (
-        "Finding cyclic pattern of 4 bytes: b'maaa' (hex: 0x6d616161)\n"
-        "Found at offset 48\n"
+        "Finding cyclic pattern of 4 bytes: b'maaa' (hex: 0x6d616161)\nFound at offset 48\n"
     )
 
 

--- a/tests/library/gdb/tests/test_command_cyclic.py
+++ b/tests/library/gdb/tests/test_command_cyclic.py
@@ -13,6 +13,7 @@ REFERENCE_BINARY = get_binary("reference-binary.native.out")
 
 # WARN: Function not yet ported to dbg/
 
+
 def test_command_cyclic_detect(start_binary):
     """
     Tests the `cyclic --detect` command for:

--- a/tests/library/gdb/tests/test_command_cyclic.py
+++ b/tests/library/gdb/tests/test_command_cyclic.py
@@ -11,78 +11,7 @@ from . import get_binary
 REFERENCE_BINARY = get_binary("reference-binary.native.out")
 
 
-def test_command_cyclic_value(start_binary):
-    """
-    Tests lookup on a constant value
-    """
-    start_binary(REFERENCE_BINARY)
-
-    ptr_size = pwndbg.aglib.arch.ptrsize
-    test_offset = 37
-    pattern = cyclic(length=80, n=ptr_size)
-    val = int.from_bytes(pattern[test_offset : test_offset + ptr_size], pwndbg.aglib.arch.endian)
-    out = gdb.execute(f"cyclic -l {hex(val)}", to_string=True)
-
-    assert out == (
-        "Finding cyclic pattern of 8 bytes: b'aaafaaaa' (hex: 0x6161616661616161)\n"
-        "Found at offset 37\n"
-    )
-
-
-def test_command_cyclic_register(start_binary):
-    """
-    Tests lookup on a register
-    """
-    start_binary(REFERENCE_BINARY)
-
-    ptr_size = pwndbg.aglib.arch.ptrsize
-    test_offset = 45
-    pattern = cyclic(length=80, n=ptr_size)
-    pwndbg.aglib.regs.write_reg(
-        "rdi",
-        int.from_bytes(pattern[test_offset : test_offset + ptr_size], pwndbg.aglib.arch.endian),
-    )
-    out = gdb.execute("cyclic -l $rdi", to_string=True)
-
-    assert out == (
-        "Finding cyclic pattern of 8 bytes: b'aaagaaaa' (hex: 0x6161616761616161)\n"
-        "Found at offset 45\n"
-    )
-
-
-def test_command_cyclic_address(start_binary):
-    """
-    Tests lookup on a memory address
-    """
-    start_binary(REFERENCE_BINARY)
-
-    addr = pwndbg.aglib.regs.sp
-    ptr_size = pwndbg.aglib.arch.ptrsize
-    test_offset = 48
-    pattern = cyclic(length=80, n=ptr_size)
-    pwndbg.aglib.memory.write(addr, pattern)
-    out = gdb.execute(f"cyclic -l '{{unsigned long}}{hex(addr + test_offset)}'", to_string=True)
-
-    assert out == (
-        "Finding cyclic pattern of 8 bytes: b'gaaaaaaa' (hex: 0x6761616161616161)\n"
-        "Found at offset 48\n"
-    )
-
-
-def test_command_cyclic_wrong_alphabet():
-    out = gdb.execute("cyclic -l 1234", to_string=True)
-    assert out == (
-        "Finding cyclic pattern of 4 bytes: b'\\xd2\\x04\\x00\\x00' (hex: 0xd2040000)\n"
-        "Pattern contains characters not present in the alphabet\n"
-    )
-
-
-def test_command_cyclic_wrong_length():
-    out = gdb.execute("cyclic -l qwerty", to_string=True)
-    assert out == (
-        "Lookup pattern must be 4 bytes (use `-n <length>` to lookup pattern of different length)\n"
-    )
-
+# WARN: Function not yet ported to dbg/
 
 def test_command_cyclic_detect(start_binary):
     """

--- a/tests/library/gdb/tests/test_command_cyclic.py
+++ b/tests/library/gdb/tests/test_command_cyclic.py
@@ -27,7 +27,7 @@ def test_command_cyclic_detect(start_binary):
     endian = pwndbg.aglib.arch.endian
 
     offset_rax = 20
-    pattern_default = cyclic(length=100, n=ptr_size)
+    pattern_default = cyclic(length=100)
     value_rax = int.from_bytes(pattern_default[offset_rax : offset_rax + ptr_size], endian)
     pwndbg.aglib.regs.write_reg("rax", value_rax)
 
@@ -40,7 +40,7 @@ def test_command_cyclic_detect(start_binary):
 
     offset_rcx = 15
     alphabet_custom = b"0123456789ABCDEF"
-    pattern_custom = cyclic(length=100, n=ptr_size, alphabet=alphabet_custom)
+    pattern_custom = cyclic(length=100, alphabet=alphabet_custom)
     value_rcx = int.from_bytes(pattern_custom[offset_rcx : offset_rcx + ptr_size], endian)
     pwndbg.aglib.regs.write_reg("rcx", value_rcx)
 


### PR DESCRIPTION
reapply https://github.com/pwndbg/pwndbg/pull/2826 .
cc: @Arusekk 

copy-pasting 8-byte numbers works. I have no complaints on that implementation. Fixes a long-standing UX trap.