### PR TITLE
kernel/slab: fix slab list field name for pre-5.8 kernels

### DIFF
--- a/pwndbg/aglib/kernel/slab.py
+++ b/pwndbg/aglib/kernel/slab.py
@@ -46,7 +46,7 @@ def slab_struct_type() -> str:
 
 
 def slab_list_field() -> str:
-    # In kernels older than ~5.8, struct page uses 'lru' instead of 'slab_list' for the node partial slab list.
+    # In kernels older than 4.18, struct page uses 'lru' instead of 'slab_list' for the node partial slab list.
     page_type = pwndbg.aglib.typeinfo.load(f"struct {slab_struct_type()}")
     if page_type is not None and page_type.offsetof("slab_list") is not None:
         return "slab_list"

--- a/pwndbg/aglib/kernel/slab.py
+++ b/pwndbg/aglib/kernel/slab.py
@@ -45,6 +45,14 @@ def slab_struct_type() -> str:
     return "page"
 
 
+def slab_list_field() -> str:
+    # In kernels older than ~5.8, struct page uses 'lru' instead of 'slab_list' for the node partial slab list.
+    page_type = pwndbg.aglib.typeinfo.load(f"struct {slab_struct_type()}")
+    if page_type is not None and page_type.offsetof("slab_list") is not None:
+        return "slab_list"
+    return "lru"
+
+
 OO_SHIFT = 16
 OO_MASK = (1 << OO_SHIFT) - 1
 
@@ -324,7 +332,7 @@ class NodeCache:
     def partial_slabs(self) -> list[Slab]:
         ret = []
         for slab in for_each_entry(
-            self._node_cache["partial"], f"struct {slab_struct_type()}", "slab_list"
+            self._node_cache["partial"], f"struct {slab_struct_type()}", slab_list_field()
         ):
             ret.append(Slab(slab.dereference(), node_cache=self))
         return ret


### PR DESCRIPTION
In kernels older than ~5.8, struct page uses the 'lru' field as the linked list head for node partial slabs. The 'slab_list' name was only introduced when the slab-specific fields in struct page were explicitly named (later backported into struct slab in 5.17).

NodeCache.partial_slabs hardcoded "slab_list" as the field passed to container_of(), causing offsetof() to return None on old kernels and a TypeError crash:
  unsupported operand type(s) for -: 'int' and 'NoneType'

Fix by probing at runtime whether the slab struct actually has a 'slab_list' field, falling back to 'lru' if not.

Fixes: slab list crashing on kernel 4.4.x and other pre-5.8 kernels

I attach crash/after-fix screenshot to below
<img width="727" height="75" alt="Screenshot 2026-02-27 at 4 38 58 PM" src="https://github.com/user-attachments/assets/8826aa15-f60a-4812-81eb-e84cd2562110" />
<img width="540" height="606" alt="Screenshot 2026-02-27 at 4 40 08 PM" src="https://github.com/user-attachments/assets/29997901-a283-49fb-87ea-b60ffd2c28e6" />


<!--
    Please make sure to read the linting and testing instructions at
    https://pwndbg.re/dev/contributing/ before creating a PR.
-->

+ [O] I read the contributing documentation.
+ [O] I am providing a screenshot of the (new feature) / (fixed bug).
