### PR TITLE
heap: add --count and address range limits

### DIFF
--- a/docs/commands/glibc_ptmalloc2_heap/heap.md
+++ b/docs/commands/glibc_ptmalloc2_heap/heap.md
@@ -2,24 +2,34 @@
 # heap
 
 ```text
-usage: heap [-h] [-v] [-s] [addr]
+usage: heap [-h] [-n COUNT] [-v] [-s] [addr_start] [addr_end]
 
 ```
 
 Iteratively print chunks on a heap.
 
 Default to the current thread's active heap.
+
+Usage:
+  heap
+  heap --count <N>
+  heap <addr_start>
+  heap <addr_start> <addr_end> (includes chunks with start address <= addr_end)
+
+Range mode can be combined with --count; walking stops when either limit is hit first.
 ### Positional arguments
 
 |Positional Argument|Help|
 | :--- | :--- |
-|addr|Address of the first chunk (malloc_chunk struct start, prev_size field).|
+|addr_start|Address of the first chunk (malloc_chunk struct start, prev_size field).|
+|addr_end|Optional inclusive upper bound for chunk start addresses.|
 
 ### Optional arguments
 
 |Short|Long|Help|
 | :--- | :--- | :--- |
 |-h|--help|show this help message and exit|
+|-n|--count|Maximum number of chunks to print.|
 |-v|--verbose|Print all chunk fields, even unused ones.|
 |-s|--simple|Simply print malloc_chunk struct's contents.|
 

--- a/docs/commands/glibc_ptmalloc2_heap/heap.md
+++ b/docs/commands/glibc_ptmalloc2_heap/heap.md
@@ -2,7 +2,7 @@
 # heap
 
 ```text
-usage: heap [-h] [-n COUNT] [-v] [-s] [addr_start] [addr_end]
+usage: heap [-h] [-c COUNT] [-v] [-s] [addr_start] [addr_end]
 
 ```
 
@@ -29,7 +29,7 @@ Range mode can be combined with --count; walking stops when either limit is hit 
 |Short|Long|Help|
 | :--- | :--- | :--- |
 |-h|--help|show this help message and exit|
-|-n|--count|Maximum number of chunks to print.|
+|-c|--count|Maximum number of chunks to print.|
 |-v|--verbose|Print all chunk fields, even unused ones.|
 |-s|--simple|Simply print malloc_chunk struct's contents.|
 

--- a/pwndbg/commands/ptmalloc2.py
+++ b/pwndbg/commands/ptmalloc2.py
@@ -220,13 +220,10 @@ def heap(
         print(message.error("`--count` must be greater than 0."))
         return
 
-    if addr_end is not None:
-        if addr_start is None:
-            print(message.error("`addr_end` requires `addr_start`."))
-            return
-        if addr_end <= addr_start:
-            print(message.error("`addr_end` must be greater than `addr_start`."))
-            return
+    assert addr_end is None or addr_start is not None
+    if addr_end is not None and addr_end <= addr_start:
+        print(message.error("`addr_end` must be greater than `addr_start`."))
+        return
 
     printed_chunks = 0
 

--- a/pwndbg/commands/ptmalloc2.py
+++ b/pwndbg/commands/ptmalloc2.py
@@ -185,7 +185,7 @@ parser.add_argument(
     help="Optional inclusive upper bound for chunk start addresses.",
 )
 parser.add_argument(
-    "-n",
+    "-c",
     "--count",
     type=int,
     default=None,

--- a/pwndbg/commands/ptmalloc2.py
+++ b/pwndbg/commands/ptmalloc2.py
@@ -160,14 +160,36 @@ def print_no_tcache_bins_found_error(tid: int | None = None) -> None:
 parser = argparse.ArgumentParser(
     description="""Iteratively print chunks on a heap.
 
-Default to the current thread's active heap.""",
+Default to the current thread's active heap.
+
+Usage:
+  heap
+  heap --count <N>
+  heap <addr_start>
+  heap <addr_start> <addr_end> (includes chunks with start address <= addr_end)
+
+Range mode can be combined with --count; walking stops when either limit is hit first.""",
 )
 parser.add_argument(
-    "addr",
+    "addr_start",
     nargs="?",
     type=int,
     default=None,
     help="Address of the first chunk (malloc_chunk struct start, prev_size field).",
+)
+parser.add_argument(
+    "addr_end",
+    nargs="?",
+    type=int,
+    default=None,
+    help="Optional inclusive upper bound for chunk start addresses.",
+)
+parser.add_argument(
+    "-n",
+    "--count",
+    type=int,
+    default=None,
+    help="Maximum number of chunks to print.",
 )
 parser.add_argument(
     "-v", "--verbose", action="store_true", help="Print all chunk fields, even unused ones."
@@ -181,28 +203,62 @@ parser.add_argument(
 @pwndbg.commands.OnlyWithResolvedHeapSyms
 @pwndbg.commands.OnlyWhenHeapIsInitialized
 @pwndbg.commands.OnlyWhenUserspace
-def heap(addr: int | None = None, verbose: bool = False, simple: bool = False) -> None:
+def heap(
+    addr_start: int | None = None,
+    addr_end: int | None = None,
+    count: int | None = None,
+    verbose: bool = False,
+    simple: bool = False,
+) -> None:
     """Iteratively print chunks on a heap, default to the current thread's
     active heap.
     """
     allocator = pwndbg.aglib.heap.current
     assert isinstance(allocator, GlibcMemoryAllocator)
 
-    if addr is not None:
-        chunk = Chunk(addr)
-        while chunk is not None:
-            malloc_chunk(chunk.address, verbose=verbose, simple=simple)
-            chunk = chunk.next_chunk()
-    else:
-        arena = allocator.thread_arena
-        # arena might be None if the current thread doesn't allocate the arena
-        if arena is None:
-            print_no_arena_found_error()
-            return
-        h = arena.active_heap
+    if count is not None and count <= 0:
+        print(message.error("`--count` must be greater than 0."))
+        return
 
-        for chunk in h:
+    if addr_end is not None:
+        if addr_start is None:
+            print(message.error("`addr_end` requires `addr_start`."))
+            return
+        if addr_end <= addr_start:
+            print(message.error("`addr_end` must be greater than `addr_start`."))
+            return
+
+    printed_chunks = 0
+
+    def should_stop(chunk_addr: int) -> bool:
+        if count is not None and printed_chunks >= count:
+            return True
+        if addr_end is not None and chunk_addr > addr_end:
+            return True
+        return False
+
+    if addr_start is not None:
+        chunk = Chunk(addr_start)
+        while chunk is not None:
+            if should_stop(chunk.address):
+                break
             malloc_chunk(chunk.address, verbose=verbose, simple=simple)
+            printed_chunks += 1
+            chunk = chunk.next_chunk()
+        return
+
+    arena = allocator.thread_arena
+    # arena might be None if the current thread doesn't allocate the arena
+    if arena is None:
+        print_no_arena_found_error()
+        return
+    h = arena.active_heap
+
+    for chunk in h:
+        if should_stop(chunk.address):
+            break
+        malloc_chunk(chunk.address, verbose=verbose, simple=simple)
+        printed_chunks += 1
 
 
 parser = argparse.ArgumentParser(

--- a/tests/library/dbg/tests/test_heap.py
+++ b/tests/library/dbg/tests/test_heap.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from typing import Any
 
 import pytest
@@ -12,6 +13,17 @@ from . import pwndbg_test
 
 HEAP_MALLOC_CHUNK = get_binary("heap_malloc_chunk.native.out")
 HEAP_MALLOC_CHUNK_DUMP = get_binary("heap_malloc_chunk_dump.native.out")
+
+ADDR_RE = re.compile(r"^Addr: (0x[0-9a-f]+)$")
+
+
+def extract_chunk_addrs(output: str) -> list[int]:
+    chunk_addrs: list[int] = []
+    for line in output.splitlines():
+        match = ADDR_RE.match(line)
+        if match:
+            chunk_addrs.append(int(match.group(1), 16))
+    return chunk_addrs
 
 
 def generate_expected_malloc_chunk_output(chunks: dict[str, Any]) -> dict[str, Any]:
@@ -135,6 +147,61 @@ def generate_expected_malloc_chunk_output(chunks: dict[str, Any]) -> dict[str, A
     ]
 
     return expected
+
+
+@pwndbg_test
+async def test_heap_command_count(ctrl: Controller) -> None:
+    import pwndbg.aglib
+
+    await launch_to(ctrl, HEAP_MALLOC_CHUNK, "break_here")
+    if pwndbg.aglib.arch.name != "x86-64":
+        pytest.skip("TODO multiarch")
+
+    count_output = await ctrl.execute_and_capture("heap allocated_chunk --count 2")
+    count_addrs = extract_chunk_addrs(count_output)
+    assert len(count_addrs) == 2
+
+
+@pwndbg_test
+async def test_heap_command_range_and_count(ctrl: Controller) -> None:
+    import pwndbg.aglib
+    import pwndbg.aglib.symbol
+    from pwndbg.aglib.heap.ptmalloc import Chunk
+
+    await launch_to(ctrl, HEAP_MALLOC_CHUNK, "break_here")
+    if pwndbg.aglib.arch.name != "x86-64":
+        pytest.skip("TODO multiarch")
+
+    chunk_start_addr = pwndbg.aglib.symbol.lookup_symbol_value("allocated_chunk")
+    assert chunk_start_addr is not None
+
+    first_chunk = Chunk(chunk_start_addr)
+    second_chunk = first_chunk.next_chunk()
+    assert second_chunk is not None
+    third_chunk = second_chunk.next_chunk()
+    assert third_chunk is not None
+    fourth_chunk = third_chunk.next_chunk()
+    assert fourth_chunk is not None
+
+    range_start = first_chunk.address
+    range_end = third_chunk.address
+
+    range_output = await ctrl.execute_and_capture(f"heap {range_start:#x} {range_end:#x}")
+    range_addrs = extract_chunk_addrs(range_output)
+
+    assert range_addrs == [first_chunk.address, second_chunk.address, third_chunk.address]
+    assert all(addr <= range_end for addr in range_addrs)
+    assert fourth_chunk.address not in range_addrs
+
+    range_count_output = await ctrl.execute_and_capture(
+        f"heap {range_start:#x} {fourth_chunk.address:#x} --count 2"
+    )
+    range_count_addrs = extract_chunk_addrs(range_count_output)
+
+    assert range_count_addrs == [first_chunk.address, second_chunk.address]
+
+    invalid_range_output = await ctrl.execute_and_capture(f"heap {range_start:#x} {range_start:#x}")
+    assert "`addr_end` must be greater than `addr_start`." in invalid_range_output
 
 
 @pwndbg_test


### PR DESCRIPTION
<!--
    Please make sure to read the linting and testing instructions at
    https://pwndbg.re/dev/contributing/ before creating a PR.
-->

+ [√] I read the contributing documentation.
+ [ ] I am providing a screenshot of the (new feature) / (fixed bug).

### Summary
This PR adds output limiting controls to the `heap` command:
- `heap --count N`: stop after printing N chunks
- `heap <addr_start> <addr_end>`: stop when `chunk.address > addr_end`
- range and `--count` can be combined; whichever condition triggers first stops the walk

### Motivation
When inspecting heaps with many chunks, it’s useful to limit output for a single invocation without scrolling to the top chunk.

### Testing
- `./lint.sh`
- `./tests.sh -g dbg -d gdb heap`

### Examples

Limit by count:

```text
pwndbg> heap -n 2
Allocated chunk | PREV_INUSE
Addr: 0x1004000
Size: 0x290 (with flag bits: 0x291)

Free chunk (tcachebins) | PREV_INUSE
Addr: 0x1004290
Size: 0x20 (with flag bits: 0x21)
fd: 0x1004
```

Limit by address range (end is inclusive: chunks with chunk.address <= addr_end are printed):
```text
pwndbg> heap 0x1004000 0x10042b0
Allocated chunk | PREV_INUSE
Addr: 0x1004000
Size: 0x290 (with flag bits: 0x291)

Free chunk (tcachebins) | PREV_INUSE
Addr: 0x1004290
Size: 0x20 (with flag bits: 0x21)
fd: 0x1004

Free chunk (tcachebins) | PREV_INUSE
Addr: 0x10042b0
Size: 0x20 (with flag bits: 0x21)
fd: 0x10052a4
```

### Related
Related to #2376 and #2397 (discussion about per-command limiting for heap-related output). This PR adds walk/output limits (--count, <start> <end>) without changing heap-dereference-limit behavior.