### PR TITLE
Fixes #1563: inferior call stale cache

### DIFF
--- a/pwndbg/dbg_mod/gdb/hooks.py
+++ b/pwndbg/dbg_mod/gdb/hooks.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 import gdb
 
 import pwndbg
@@ -99,6 +101,29 @@ def on_exit() -> None:
 
 import pwndbg.lib.cache
 from pwndbg.lib.cache import CacheUntilEvent
+
+
+def _on_inferior_call_post(event: Any) -> None:
+    """Clear stop-caches after GDB completes an inferior function call.
+
+    GDB does not fire ``gdb.events.stop`` for inferior function calls (e.g.
+    ``call malloc(0x20)`` from the GDB prompt or ``gdb.execute('call ...')``
+    from Python).  This means caches keyed on "stop" — most importantly vmmap —
+    become stale when the inferior's memory layout changes during such calls
+    (e.g. ``brk`` expanding the heap).
+
+    By listening on ``gdb.events.inferior_call`` we can transparently invalidate
+    these caches so that subsequent reads see up-to-date state.
+    """
+    if type(event).__name__ == "InferiorCallPostEvent":
+        pwndbg.lib.cache.clear_cache(CacheUntilEvent.STOP)
+
+
+# gdb.events.inferior_call was added in GDB 13.  On older versions we simply
+# skip — the worst case is the pre-existing stale-cache behaviour.
+if hasattr(gdb.events, "inferior_call"):
+    gdb.events.inferior_call.connect(_on_inferior_call_post)
+
 
 pwndbg.lib.cache.connect_clear_caching_events(
     {

--- a/tests/library/gdb/tests/heap/test_inferior_call_cache.py
+++ b/tests/library/gdb/tests/heap/test_inferior_call_cache.py
@@ -38,6 +38,7 @@ def test_heap_after_many_inferior_mallocs(start_binary):
     assert isinstance(allocator, GlibcMemoryAllocator)
 
     # Use a large size (0x10000) to force brk expansion quickly.
-    for _  in range(10):
-        gdb.execute('call (void *)malloc(0x10000)')
-        print((pwndbg.aglib.heap.current.thread_arena))
+    print("Will print next thread arenas, their sizes should increase gradually")
+    for _ in range(10):
+        gdb.execute("call (void *)malloc(0x10000)", to_string=True)
+        print(pwndbg.aglib.heap.current.thread_arena)

--- a/tests/library/gdb/tests/heap/test_inferior_call_cache.py
+++ b/tests/library/gdb/tests/heap/test_inferior_call_cache.py
@@ -41,4 +41,4 @@ def test_heap_after_many_inferior_mallocs(start_binary):
     print("Will print next thread arenas, their sizes should increase gradually")
     for _ in range(10):
         gdb.execute("call (void *)malloc(0x10000)", to_string=True)
-        print(pwndbg.aglib.heap.current.thread_arena)
+        print(pwndbg.aglib.heap.current.thread_arena)  # type: ignore[union-attr]

--- a/tests/library/gdb/tests/heap/test_inferior_call_cache.py
+++ b/tests/library/gdb/tests/heap/test_inferior_call_cache.py
@@ -1,0 +1,43 @@
+"""Regression test for https://github.com/pwndbg/pwndbg/issues/1563
+
+Calling inferior functions (e.g. ``malloc``) from Python via
+``gdb.execute('call ...')`` does not fire ``gdb.events.stop``, so caches
+keyed on "stop" — most importantly vmmap — used to become stale.  After
+enough ``malloc`` calls the heap would grow via ``brk``, and pwndbg's
+cached memory map would no longer cover the new region, causing
+``thread_arena`` / ``heap`` to crash with "Cannot build heap object on
+an unmapped address".
+
+The fix hooks ``gdb.events.inferior_call`` to clear stop-caches after
+each inferior function call completes.
+"""
+
+from __future__ import annotations
+
+import gdb
+
+import pwndbg.aglib.heap
+from pwndbg.aglib.heap.ptmalloc import GlibcMemoryAllocator
+
+from .. import get_binary
+
+REFERENCE_BINARY = get_binary("reference_bin_pie.native.out")
+
+
+def test_heap_after_many_inferior_mallocs(start_binary):
+    """thread_arena must remain accessible after many inferior malloc calls.
+
+    Reproducer from issue #1563: repeatedly call malloc from Python and
+    read ``thread_arena`` between calls.  Without the inferior_call cache
+    fix this crashes after the heap outgrows the cached vmmap.
+    """
+    start_binary(REFERENCE_BINARY)
+    gdb.execute("entry")
+
+    allocator = pwndbg.aglib.heap.current
+    assert isinstance(allocator, GlibcMemoryAllocator)
+
+    # Use a large size (0x10000) to force brk expansion quickly.
+    for _  in range(10):
+        gdb.execute('call (void *)malloc(0x10000)')
+        print((pwndbg.aglib.heap.current.thread_arena))


### PR DESCRIPTION
Fixes #1563 - a bug where if you execute something like this:

```
$ gdb /bin/ls
pwndbg> entry
pwndbg> ipi
In [1]: import gdb
 ...: for _  in range(1000):
 ...:     gdb.execute('call (void *)malloc(0x10000)')
 ...:     print((pwndbg.aglib.heap.current.thread_arena))
```

We crashed because we cache certain values like `vmmap` result and the cache is stale in the whole loop iteration because no STOP events are fired by GDB in here (and we clear the cache on GDB STOP events). As a result, the `pwndbg.aglib.heap.current.thread_arena` property call ends up using some stale values and incorrectly computing the heap state since the cache was not invalidated.

The fix works by hooking up an inferior call post event hook in GDB. This event was added in GDB 13, so it won't work with GDB 12 which we still support, but we should just accept that.

No idea if this issue exists in pwndbg-lldb: not sure how to check it.


### Bug reproducer

Before the fix - the test fails:
```
dc@jctf:~/pwndbg$ git ll -n 4
* 70446e259 - (HEAD -> fix/inferior-call-stale-cache, origin/fix/inferior-call-stale-cache) Add prints to tests (6 minutes ago) <Disconnect3d>
* a042fe991 - Clear stop-caches after inferior function calls via `gdb.events.inferior_call` (6 minutes ago) <Dominik 'Disconnect3d' Czarnota>
* ead37a987 - Add regression test for stale cache after inferior function calls (#1563) (6 minutes ago) <Dominik 'Disconnect3d' Czarnota>
* 2b1c3b4f9 - (origin/dev, origin/HEAD, dev) Detect musl libc in statically linked binaries (#3798) (62 minutes ago) <Disconnect3d>
dc@jctf:~/pwndbg$ git checkout ead37a987 >/dev/null 2>&1
dc@jctf:~/pwndbg$ ./tests.sh -d gdb -g gdb test_heap_after_many_inferior_mallocs
glibc version: 2.39
[*] Local Pwndbg root: /home/dc/pwndbg
[+] make -C /home/dc/pwndbg/tests/binaries/host -j8 all
make: Nothing to be done for 'all'.

Running tests in parallel
tests/library/gdb/tests/heap/test_inferior_call_cache.py::test_heap_after_many_inferior_mallocs      FAILED 1.12s

warning: `/home/dc/.cache/debuginfod_client/6eb9ab22bb6ab248166c13a71005d61b70470a6f/debuginfo': can't read symbols: file format not recognized.
warning: `/home/dc/.cache/debuginfod_client/6eb9ab22bb6ab248166c13a71005d61b70470a6f/debuginfo': can't read symbols: file format not recognized.

pwndbg: loaded 194 pwndbg commands. Type pwndbg [filter] for a list.
pwndbg: created 9 GDB functions (can be used with print/break). Type help function to see them.
Launching pytest with args: ['tests/library/gdb/tests/heap/test_inferior_call_cache.py::test_heap_after_many_inferior_mallocs', '-vvv', '-s', '--showlocals', '--color=yes']
================================================================================================= test session starts =================================================================================================
platform linux -- Python 3.12.3, pytest-8.0.2, pluggy-1.6.0 -- /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-python3-x86_64-unknown-linux-gnu-3.12.11/bin/python
cachedir: .pytest_cache
rootdir: /home/dc/pwndbg
collecting ... collected 1 item

tests/library/gdb/tests/heap/test_inferior_call_cache.py::test_heap_after_many_inferior_mallocs
Program stopped.
0x00007ffff7fe4540 in _start () from /lib64/ld-linux-x86-64.so.2

Program stopped.
0x00007ffff7fe4540 in _start () from /lib64/ld-linux-x86-64.so.2
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
$1 = (void *) 0x5555555582a0
[  0x7ffff7e03ac0]    [  0x555555558000]    0x555555558000     0x555555579000 rw-p    21000       0 [heap]
$2 = (void *) 0x5555555682b0
[  0x7ffff7e03ac0]    [  0x555555558000]    0x555555558000     0x555555579000 rw-p    21000       0 [heap]
$3 = (void *) 0x5555555782c0
Warning: Avoided exploring possible address 0x5555555882c0.
You can explicitly explore it with `vmmap-explore 0x555555588000` or disable automatic exploration with `set auto-explore-pages no`.
FAILED

=================================== FAILURES ===================================
____________________ test_heap_after_many_inferior_mallocs _____________________

start_binary = <function start_binary.<locals>._start_binary at 0x763c586137e0>

    def test_heap_after_many_inferior_mallocs(start_binary):
        """thread_arena must remain accessible after many inferior malloc calls.

        Reproducer from issue #1563: repeatedly call malloc from Python and
        read ``thread_arena`` between calls.  Without the inferior_call cache
        fix this crashes after the heap outgrows the cached vmmap.
        """
        start_binary(REFERENCE_BINARY)
        gdb.execute("entry")

        allocator = pwndbg.aglib.heap.current
        assert isinstance(allocator, GlibcMemoryAllocator)

        # Use a large size (0x10000) to force brk expansion quickly.
        for _  in range(10):
            gdb.execute('call (void *)malloc(0x10000)')
>           print((pwndbg.aglib.heap.current.thread_arena))

_          = 2
allocator  = <pwndbg.aglib.heap.ptmalloc.DebugSymsHeap object at 0x763c58d7f170>
start_binary = <function start_binary.<locals>._start_binary at 0x763c586137e0>

tests/library/gdb/tests/heap/test_inferior_call_cache.py:43:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
pwndbg/aglib/heap/ptmalloc.py:795: in __str__
    res = [message.hint(prefix_fmt.format(hex(self.address))) + str(self.heaps[0])]
        prefix_fmt = '[{:>16s}]    '
        prefix_len = 22
        self       = <pwndbg.aglib.heap.ptmalloc.Arena object at 0x763c584a5ee0>
        width      = 16
pwndbg/aglib/heap/ptmalloc.py:754: in heaps
    heap = self.active_heap
        self       = <pwndbg.aglib.heap.ptmalloc.Arena object at 0x763c584a5ee0>
pwndbg/aglib/heap/ptmalloc.py:747: in active_heap
    self._active_heap = Heap(self.top, arena=self)
        self       = <pwndbg.aglib.heap.ptmalloc.Arena object at 0x763c584a5ee0>
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <pwndbg.aglib.heap.ptmalloc.Heap object at 0x763c584a1360>
addr = 93824992445120
arena = <pwndbg.aglib.heap.ptmalloc.Arena object at 0x763c584a5ee0>

    def __init__(self, addr: int, arena: Arena | None = None) -> None:
        """Build a Heap object given an address on that heap.
        Heap regions are treated differently depending on their arena:
        1) main_arena - uses the sbrk heap
        2) non-main arena - heap starts after its heap_info struct (and possibly an arena)
        3) non-contiguous main_arena - just a memory region
        4) no arena - for fake/mmapped chunks
        """
        allocator = pwndbg.aglib.heap.current
        assert isinstance(allocator, GlibcMemoryAllocator)
        main_arena = allocator.main_arena

        sbrk_region = allocator.get_sbrk_heap_region()
        if sbrk_region is not None and addr in sbrk_region:
            # Case 1; main_arena.
            self.arena = main_arena if arena is None else arena
            self._memory_region = sbrk_region
            self._gdbValue = None
        else:
            heap_region = allocator.get_region(addr)
            if heap_region is None:
>               raise ValueError(f"Cannot build heap object on an unmapped address ({hex(addr)})")
E               ValueError: Cannot build heap object on an unmapped address (0x5555555882c0)

addr       = 93824992445120
allocator  = <pwndbg.aglib.heap.ptmalloc.DebugSymsHeap object at 0x763c58d7f170>
arena      = <pwndbg.aglib.heap.ptmalloc.Arena object at 0x763c584a5ee0>
heap_region = None
main_arena = <pwndbg.aglib.heap.ptmalloc.Arena object at 0x763c584a4540>
sbrk_region = Page('    0x555555558000     0x555555579000 rw-p    21000       0 [heap]')
self       = <pwndbg.aglib.heap.ptmalloc.Heap object at 0x763c584a1360>

pwndbg/aglib/heap/ptmalloc.py:506: ValueError
=========================== short test summary info ============================
FAILED tests/library/gdb/tests/heap/test_inferior_call_cache.py::test_heap_after_many_inferior_mallocs - ValueError: Cannot build heap object on an unmapped address (0x5555555882c0)
============================== 1 failed in 0.35s ===============================
--------------------------------------------------------------------------------
If you want to debug tests locally, run ./tests.sh with the --pdb flag
--------------------------------------------------------------------------------


*********************************
********* TESTS SUMMARY *********
*********************************
Time Spent   : 1.96s (cumulative: 1.12s)
Tests Passed : 0
Tests Skipped: 0
Tests Failed : 1

Failing tests:
- tests/library/gdb/tests/heap/test_inferior_call_cache.py::test_heap_after_many_inferior_mallocs
```

After the fix:
```
dc@jctf:~/pwndbg$ git checkout -
Previous HEAD position was ead37a987 Add regression test for stale cache after inferior function calls (#1563)
Switched to branch 'fix/inferior-call-stale-cache'
Your branch is up to date with 'origin/fix/inferior-call-stale-cache'.
dc@jctf:~/pwndbg$ ./tests.sh -d gdb -g gdb test_heap_after_many_inferior_mallocs
glibc version: 2.39
[*] Local Pwndbg root: /home/dc/pwndbg
[+] make -C /home/dc/pwndbg/tests/binaries/host -j8 all
make: Nothing to be done for 'all'.

Running tests in parallel
tests/library/gdb/tests/heap/test_inferior_call_cache.py::test_heap_after_many_inferior_mallocs      PASSED 0.96s

*********************************
********* TESTS SUMMARY *********
*********************************
Time Spent   : 1.81s (cumulative: 0.96s)
Tests Passed : 1
Tests Skipped: 0
Tests Failed : 0
```
