### PR TITLE
dt: handle flexible array members in struct display

### DIFF
--- a/pwndbg/aglib/dt.py
+++ b/pwndbg/aglib/dt.py
@@ -90,8 +90,12 @@ def dt(
                     ftype.code in (pwndbg.dbg_mod.TypeCode.POINTER, pwndbg.dbg_mod.TypeCode.ARRAY)
                     and ftype.target() == pwndbg.aglib.typeinfo.uchar
                 ):
-                    data = pwndbg.aglib.memory.read(int(obj_value.address), ftype.sizeof)
-                    extra = " ".join(f"{b:02x}" for b in data)
+                    # Flexible array members have size 0, skip reading memory for them
+                    if ftype.sizeof == 0:
+                        extra = "[]"
+                    else:
+                        data = pwndbg.aglib.memory.read(int(obj_value.address), ftype.sizeof)
+                        extra = " ".join(f"{b:02x}" for b in data)
                 else:
                     extra = obj_value.value_to_human_readable()
             except pwndbg.dbg_mod.Error as e:


### PR DESCRIPTION
Fixes #3080

## Summary
The `dt` command crashes when displaying structs containing flexible array members (e.g., `unsigned char storage[]`). These members have a `sizeof` of 0, and attempting to read 0 bytes of memory causes GDB to raise an error.

## Changes
- Added a check in `pwndbg/aglib/dt.py` to detect flexible array members (where `ftype.sizeof == 0`)
- For such members, display `"[]"` instead of attempting to read memory

## Testing
- Verified the fix handles the case where `ftype.sizeof == 0` without crashing
- Ruff format and lint checks pass on the modified file

## Diff stats
```
 pwndbg/aglib/dt.py | 8 ++++++--
 1 file changed, 6 insertions(+), 2 deletions(-)
```