### PR TITLE
Fix #3495: 该 Issue 旨在解决 pwndbg 测试套件中大量测试在 aarch64 架构上被标记为 SKIPPED 的问题...

### DIFF
--- a/tests/binaries/host/makefile
+++ b/tests/binaries/host/makefile
@@ -67,7 +67,7 @@ ifeq ($(HAVE_MUSL),yes)
 ALL_MUSL_TARGETS += heap_musl_dyn.native.out heap_musl_static.native.out heap_musl_static_stripped.native.out
 endif
 
-CUSTOM_TARGETS = heap_find_fake_fast.native.out reference_bin_pie.native.out reference_bin_nopie.native.out reference_bin_nopie.i386.out symbol_1600_and_752.native.out initialized_heap.x86-64.out initialized_heap_big.i386.out linked_lists.native.out onegadget.x86-64.out onegadget.i386.out heap_musl_dyn.native.out heap_musl_static.native.out heap_musl_static_stripped.native.out gosample.i386.out gosample.x86-64.out
+CUSTOM_TARGETS = heap_find_fake_fast.native.out reference_bin_pie.native.out reference_bin_nopie.native.out reference_bin_nopie.i386.out symbol_1600_and_752.native.out initialized_heap.x86-64.out initialized_heap.aarch64.out initialized_heap_big.i386.out linked_lists.native.out onegadget.x86-64.out onegadget.i386.out heap_musl_dyn.native.out heap_musl_static.native.out heap_musl_static_stripped.native.out gosample.i386.out gosample.x86-64.out
 NATIVE_CUSTOM_TARGETS  := $(filter %.native.out %.$(HOST_ARCH).out %.$(HOST_ARCH_32).out,$(CUSTOM_TARGETS))
 
 ALL_TARGETS := $(LINKED_C) $(LINKED_ASM) $(LINKED_GO) $(NATIVE_CUSTOM_TARGETS) \
@@ -249,6 +249,13 @@ initialized_heap.x86-64.out: initialized_heap.native.c
 	${ZIGCC} \
 	${CFLAGS} \
 	-target x86_64-linux-gnu \
+	-o $@ $?
+
+initialized_heap.aarch64.out: initialized_heap.native.c
+	@echo "[+] Building '$@'"
+	${ZIGCC} \
+	${CFLAGS} \
+	-target aarch64-linux-gnu \
 	-o $@ $?
 
 onegadget.x86-64.out: onegadget.native.c

--- a/tests/library/dbg/tests/test_command_dt.py
+++ b/tests/library/dbg/tests/test_command_dt.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 import re
 
-import pytest
-
 from ....host import Controller
 from . import get_binary
 from . import launch_to
@@ -14,12 +12,7 @@ HEAP_MALLOC_CHUNK = get_binary("heap_malloc_chunk.native.out")
 
 @pwndbg_test
 async def test_command_dt_works_with_address(ctrl: Controller) -> None:
-    import pwndbg.aglib
-
     await launch_to(ctrl, HEAP_MALLOC_CHUNK, "break_here")
-
-    if pwndbg.aglib.arch.name != "x86-64":
-        pytest.skip("TODO multiarch")
 
     tcache = await ctrl.execute_and_capture("print tcache")
 
@@ -38,12 +31,7 @@ async def test_command_dt_works_with_address(ctrl: Controller) -> None:
 
 @pwndbg_test
 async def test_command_dt_works_with_no_address(ctrl: Controller) -> None:
-    import pwndbg.aglib
-
     await launch_to(ctrl, HEAP_MALLOC_CHUNK, "break_here")
-
-    if pwndbg.aglib.arch.name != "x86-64":
-        pytest.skip("TODO multiarch")
 
     out = await ctrl.execute_and_capture('dt "struct tcache_perthread_struct"')
 

--- a/tests/library/dbg/tests/test_command_search.py
+++ b/tests/library/dbg/tests/test_command_search.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 import re
 
-import pytest
-
 from ....host import Controller
 from . import get_binary
 from . import launch_to
@@ -19,12 +17,7 @@ async def test_command_search_literal(ctrl: Controller) -> None:
     """
     Searches for a string literal in a few different ways
     """
-    import pwndbg.aglib
-
     await launch_to(ctrl, SEARCH_BINARY, "break_here")
-
-    if pwndbg.aglib.arch.name != "x86-64":
-        pytest.skip("TODO weird bug only on github-ci")
 
     # Perform three equivalent searches, and chop off the first line of verbosity.
     result0 = (await ctrl.execute_and_capture("search -t bytes Hello!")).splitlines()[1:]

--- a/tests/library/dbg/tests/test_heap_bins.py
+++ b/tests/library/dbg/tests/test_heap_bins.py
@@ -201,7 +201,17 @@ async def test_largebins_size_range_64bit(ctrl: Controller) -> None:
     Ensure the "largebins" command displays the correct largebin size ranges.
     This test targets 64-bit architectures.
     """
-    await launch_to(ctrl, get_binary("initialized_heap.x86-64.out"), "break_here")
+    import pwndbg.aglib
+
+    arch = pwndbg.aglib.arch.name
+    if arch == "x86-64":
+        binary = get_binary("initialized_heap.x86-64.out")
+    elif arch == "aarch64":
+        binary = get_binary("initialized_heap.aarch64.out")
+    else:
+        pytest.skip(f"Test not supported on {arch}")
+
+    await launch_to(ctrl, binary, "break_here")
 
     command_output = (await ctrl.execute_and_capture("largebins --verbose")).splitlines()[1:]
 
@@ -361,7 +371,17 @@ async def test_smallbins_sizes_64bit(ctrl: Controller) -> None:
     Ensure the "smallbins" command displays the correct smallbin sizes.
     This test targets 64-bit architectures.
     """
-    await launch_to(ctrl, get_binary("initialized_heap.x86-64.out"), "break_here")
+    import pwndbg.aglib
+
+    arch = pwndbg.aglib.arch.name
+    if arch == "x86-64":
+        binary = get_binary("initialized_heap.x86-64.out")
+    elif arch == "aarch64":
+        binary = get_binary("initialized_heap.aarch64.out")
+    else:
+        pytest.skip(f"Test not supported on {arch}")
+
+    await launch_to(ctrl, binary, "break_here")
 
     command_output = (await ctrl.execute_and_capture("smallbins --verbose")).splitlines()[1:]
 

--- a/tests/library/dbg/tests/test_heap_bins.py
+++ b/tests/library/dbg/tests/test_heap_bins.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from ....host import Controller
 from . import get_binary
 from . import launch_to


### PR DESCRIPTION
Fixes #3495

## Summary

Fix for #3495: 该 Issue 旨在解决 pwndbg 测试套件中大量测试在 aarch64 架构上被标记为 SKIPPED 的问题。由于现有测试包含 x86-64 特有的假设（如寄存器名称、ABI 细节等），需要将其重构为架构无关的测试，以便在 x86-64 和 aarch64 上都能运行。

## Changes

```
tests/binaries/host/makefile                   |  9 ++++++++-
 tests/library/dbg/tests/test_command_dt.py     | 12 ------------
 tests/library/dbg/tests/test_command_search.py |  7 -------
 tests/library/dbg/tests/test_heap_bins.py      | 24 ++++++++++++++++++++++--
 4 files changed, 30 insertions(+), 22 deletions(-)
```
