### PR TITLE
Add --profile flag to tests.sh for profiling test cases

### DIFF
--- a/tests/host/__init__.py
+++ b/tests/host/__init__.py
@@ -127,7 +127,13 @@ class TestResult:
 
 
 class TestHost:
-    def run(self, case: str, coverage_out: Path | None, interactive: bool) -> TestResult:
+    def run(
+        self,
+        case: str,
+        coverage_out: Path | None,
+        interactive: bool,
+        profile_out: Path | None = None,
+    ) -> TestResult:
         """
         Runs a single test case of given name.
 
@@ -141,6 +147,9 @@ class TestHost:
 
         Collection of code coverage data may be enabled for the test by
         specifying a coverage file path in `coverage_out`.
+
+        Profiling of the test may be enabled by specifying a directory path in
+        `profile_out`. Profile data will be saved to files in this directory.
         """
         raise NotImplementedError()
 

--- a/tests/host/gdb/__init__.py
+++ b/tests/host/gdb/__init__.py
@@ -53,6 +53,7 @@ class GDBTestHost(TestHost):
         case: str,
         coverage_out: Path | None,
         interactive: bool,
+        profile_out: Path | None = None,
     ) -> TestResult:
         gdb_args_before = []
         if coverage_out is not None:
@@ -73,6 +74,10 @@ class GDBTestHost(TestHost):
         env["TEST_BINARIES_ROOT"] = str(self._binaries_root)
         if interactive:
             env["USE_PDB"] = "1"
+        if profile_out is not None:
+            # Sanitize the test case name for use in the profile filename
+            safe_name = case.replace("/", "_").replace("::", "_")
+            env["PWNDBG_PROFILE_OUT"] = str(profile_out / f"{safe_name}.prof")
 
         # Run the test to completion and time it.
         started_at = time.monotonic_ns()

--- a/tests/host/gdb/pytests_launcher.py
+++ b/tests/host/gdb/pytests_launcher.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import cProfile
 import os
+import pstats
 import sys
 from collections.abc import Callable
 from collections.abc import Coroutine
@@ -121,7 +123,16 @@ if use_pdb:
 
 print(f"Launching pytest with args: {args}")
 
-return_code = pytest.main(args)
+# Check if profiling is enabled
+profile_out = os.environ.get("PWNDBG_PROFILE_OUT")
+if profile_out:
+    # Run pytest with profiling
+    profiler = cProfile.Profile()
+    return_code = profiler.runcall(pytest.main, args)
+    profiler.dump_stats(profile_out)
+    print(f"Profile data saved to: {profile_out}")
+else:
+    return_code = pytest.main(args)
 
 if return_code != 0:
     print("-" * 80)

--- a/tests/host/gdb/pytests_launcher.py
+++ b/tests/host/gdb/pytests_launcher.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import cProfile
 import os
-import pstats
 import sys
 from collections.abc import Callable
 from collections.abc import Coroutine

--- a/tests/host/lldb/__init__.py
+++ b/tests/host/lldb/__init__.py
@@ -33,6 +33,7 @@ class LLDBTestHost(TestHost):
         test_name: str | None,
         capture: bool,
         pdb: bool,
+        profile_out: Path | None = None,
     ) -> subprocess.CompletedProcess[str]:
         assert op in ("RUN-TEST", "COLLECT")
         assert op != "RUN-TEST" or test_name is not None
@@ -50,6 +51,10 @@ class LLDBTestHost(TestHost):
         env["PWNDBG_IN_TEST"] = "1"
         if test_name is not None:
             env["TEST_NAME"] = test_name
+        if profile_out is not None and test_name is not None:
+            # Sanitize the test case name for use in the profile filename
+            safe_name = test_name.replace("/", "_").replace("::", "_")
+            env["PWNDBG_PROFILE_OUT"] = str(profile_out / f"{safe_name}.prof")
 
         return subprocess.run(
             [interpreter, "-m", "tests.host.lldb.launch_guest"],
@@ -66,9 +71,15 @@ class LLDBTestHost(TestHost):
         # We execute from Pwndbg root, so we need to prepend tests/ to the names.
         return [f"tests/{name}" for name in names]
 
-    def run(self, case: str, coverage_out: Path | None, interactive: bool) -> TestResult:
+    def run(
+        self,
+        case: str,
+        coverage_out: Path | None,
+        interactive: bool,
+        profile_out: Path | None = None,
+    ) -> TestResult:
         beg = time.monotonic_ns()
-        result = self._launch("RUN-TEST", case, not interactive, interactive)
+        result = self._launch("RUN-TEST", case, not interactive, interactive, profile_out)
         end = time.monotonic_ns()
 
         return _result_from_pytest(result, end - beg)

--- a/tests/host/lldb/launch_guest.py
+++ b/tests/host/lldb/launch_guest.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import cProfile
 import os
-import pstats
 import shlex
 import sys
 from collections.abc import Callable

--- a/tests/host/lldb/launch_guest.py
+++ b/tests/host/lldb/launch_guest.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import cProfile
 import os
+import pstats
 import shlex
 import sys
 from collections.abc import Callable
@@ -148,7 +150,15 @@ if __name__ == "__main__":
             pytest_plugins = None
 
     # Start the test, proper.
-    status = run(pytest_args, pytest_plugins)
+    profile_out = os.environ.get("PWNDBG_PROFILE_OUT")
+    if profile_out:
+        # Run with profiling
+        profiler = cProfile.Profile()
+        status = profiler.runcall(run, pytest_args, pytest_plugins)
+        profiler.dump_stats(profile_out)
+        print(f"Profile data saved to: {profile_out}")
+    else:
+        status = run(pytest_args, pytest_plugins)
 
     if op == Operation.COLLECT:
         for nodeid in pytest_plugins[0].collected:

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -39,6 +39,11 @@ def main() -> None:
     if args.cov:
         print("Will run codecov")
         coverage_out = Path(".cov/coverage")
+    profile_out = None
+    if args.profile:
+        print("Will profile test cases")
+        profile_out = Path(".profile")
+        profile_out.mkdir(parents=True, exist_ok=True)
     if args.pdb:
         print("Will run tests in serial and with Python debugger")
         args.serial = True
@@ -86,6 +91,7 @@ def main() -> None:
         force_serial or args.serial,
         args.verbose,
         coverage_out,
+        profile_out,
     )
 
 
@@ -96,6 +102,7 @@ def run_tests_and_print_stats(
     serial: bool,
     verbose: bool,
     coverage_out: Path | None,
+    profile_out: Path | None,
 ) -> None:
     """
     Runs all the tests made available by a given test host.
@@ -117,13 +124,13 @@ def run_tests_and_print_stats(
     if serial:
         print("\nRunning tests in series")
         for test in tests_list:
-            result = host.run(test, coverage_out, pdb)
+            result = host.run(test, coverage_out, pdb, profile_out)
             stats.handle_test_result(test, result, verbose)
     else:
         print("\nRunning tests in parallel")
         with concurrent.futures.ThreadPoolExecutor(max_workers=os.cpu_count()) as executor:
             for test in tests_list:
-                executor.submit(host.run, test, coverage_out, pdb).add_done_callback(
+                executor.submit(host.run, test, coverage_out, pdb, profile_out).add_done_callback(
                     # `test=test` forces the variable to bind early. This will
                     # change the type of the lambda, however, so we have to
                     # assure MyPy we know what we're doing.
@@ -322,6 +329,11 @@ def parse_args() -> argparse.Namespace:
         help="enable pdb (Python debugger) post mortem debugger on failed tests",
     )
     parser.add_argument("-c", "--cov", action="store_true", help="enable codecov")
+    parser.add_argument(
+        "--profile",
+        action="store_true",
+        help="enable profiling of test cases using cProfile",
+    )
     parser.add_argument(
         "-v",
         "--verbose",


### PR DESCRIPTION
Fixes #2486

## Summary
This PR adds a `--profile` flag to `tests.sh` that enables profiling of Pwndbg test cases using Python's `cProfile` module. When enabled, each test case is profiled and the profile data is saved to `.profile/<test_name>.prof` files.

## Changes
- Added `--profile` argument to the test runner argument parser in `tests/tests.py`
- Updated `TestHost.run()` signature to accept optional `profile_out` parameter
- Modified `GDBTestHost` and `LLDBTestHost` to pass profiling environment variables
- Updated `pytests_launcher.py` (GDB) to wrap pytest execution with cProfile when profiling is enabled
- Updated `launch_guest.py` (LLDB) to wrap pytest execution with cProfile when profiling is enabled

## Usage
```bash
# Run tests with profiling enabled
./tests.sh -d gdb -g dbg --profile

# Profile data will be saved to .profile/ directory
# Analyze with pstats:
python3 -m pstats .profile/tests_library_dbg_tests_test_commands.prof
```

The profile files are standard cProfile `.prof` files that can be analyzed with Python's `pstats` module or visualization tools like `snakeviz`.

## Testing
Verified that all modified Python files parse correctly without syntax errors.

```
 tests/host/__init__.py             | 11 ++++++++++-
 tests/host/gdb/__init__.py         |  5 +++++
 tests/host/gdb/pytests_launcher.py | 13 ++++++++++++-
 tests/host/lldb/__init__.py        | 15 +++++++++++++--
 tests/host/lldb/launch_guest.py    | 12 +++++++++++-
 tests/tests.py                     | 16 ++++++++++++++--
 6 files changed, 65 insertions(+), 7 deletions(-)
```