### PR TITLE
Add pwndbg to Sponsor this project section of the repo

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,3 @@
 # These are supported funding model platforms
 
-github: disconnect3d # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
+github: [pwndbg] # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]


### PR DESCRIPTION
<!--
    Please make sure to read the linting and testing instructions at
    https://pwndbg.re/dev/contributing/ before creating a PR.
-->

+ [ ] I read the contributing documentation.
+ [ ] I am providing a screenshot of the (new feature) / (fixed bug).

Hi @disconnect3d 

Reg. our chat -  the “Sponsor this project” section is [enabled in the settings](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository?versionId=free-pro-team%40latest&productId=sponsors&restPage=getting-started-with-github-sponsors%2Cnavigating-your-sponsors-dashboard#displaying-a-sponsor-button-in-your-repository), and the sponsor buttons and links in the “Sponsor this project” section are [configured via FUNDING.yml](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository#about-funding-files). AFAICT you’ve had a sponsorship profile, but then moved to use the pwndbg sponsorship profile instead, and that’s why the section doesn’t render any buttons/links. This PR adds a link to sponsor pwndbg.

Side note: If you’d like to add org-wide sponsor button to all repos under the pwndbg org instead, you could do so with FUNDING.yml in the pwndbg org’s `.github` repo (see: https://github.blog/open-source/maintainers/getting-started-with-github-sponsors/#:~:text=How%20do%20I%20add,.github%20repository%20instead.). To give an example, [here’s](https://github.com/scipy/.github/blob/8f86054be7938ba02974d40fc36b343731022b22/FUNDING.yml) how SciPy enabled it org-wide.

I had hoped to contribute to pwndbg some day; didn’t expect it would be such a small contribution, but I’ll take what I can get :joy: