### PR TITLE
fix: guard save_signal against missing thread on detach

### DIFF
--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -1744,7 +1744,14 @@ def save_signal() -> None:
     if not process:
         return
 
-    if not (process.stopped_with_signal() or process.stopped_at_breakpoint()):
+    if pwndbg.dbg.is_gdblib_available():
+        try:
+            stopped = process.stopped_with_signal() or process.stopped_at_breakpoint()
+        except gdb.error:
+            return
+    else:
+        stopped = process.stopped_with_signal() or process.stopped_at_breakpoint()
+    if not stopped:
         return
 
     signal = pwndbg.aglib.signal.get_last_signal()


### PR DESCRIPTION
## Summary
Fixes #3718.
**Root cause:** Event handler calls stopped_with_signal after detach when no thread is selected, raising gdb.error.
**Fix:** Guard the signal check with a try/except for gdb.error.
## Changes
- `pwndbg/commands/context.py`: catch gdb.error in save_signal when querying stopped state under GDB.
## Testing
- Detach/exit in a container no longer raises from this handler.