### PR TITLE
slab: show inuse/total object count in slab_contains output

### DIFF
--- a/pwndbg/commands/slab.py
+++ b/pwndbg/commands/slab.py
@@ -321,7 +321,9 @@ def slab_contains(address: str) -> None:
         desc = "[inactive]"
         inuse = f"[something went wrong: {hex(addr)}]"
         slab = slab_cache.find_containing_slab(addr)
+        objcnt = ""
         if slab:
+            objcnt = f"[{slab.inuse}/{slab.object_count}]"
             if addr in slab.free_objects:
                 inuse = "free"
             elif addr in slab.objects:
@@ -337,6 +339,6 @@ def slab_contains(address: str) -> None:
         else:
             inuse = "in-use"
         indent.print("slab:", message.hint(f"{hex(base)}"), desc)
-        indent.print("status:", message.hint(inuse))
+        indent.print("status:", message.hint(inuse), objcnt)
     except Exception as e:
         print(message.warn(f"address does not belong to a SLUB cache: {e}"))


### PR DESCRIPTION
I made "slab contains [addr]" command display the number of inuse/total objects as well.
It would help kernel debugging because the number of inuse/total objects are displayed only in slab info command, which has very long output.

<img width="269" height="50" alt="image" src="https://github.com/user-attachments/assets/f043619d-c5ab-461a-b730-c20ec430cdb1" />

