### PR TITLE
slab: display object count on its own line in slab_contains output

### DIFF
--- a/pwndbg/commands/slab.py
+++ b/pwndbg/commands/slab.py
@@ -323,7 +323,7 @@ def slab_contains(address: str) -> None:
         slab = slab_cache.find_containing_slab(addr)
         objcnt = ""
         if slab:
-            objcnt = f"[{slab.inuse}/{slab.object_count}]"
+            objcnt = f"{slab.inuse}/{slab.object_count}"
             if addr in slab.free_objects:
                 inuse = "free"
             elif addr in slab.objects:
@@ -339,6 +339,7 @@ def slab_contains(address: str) -> None:
         else:
             inuse = "in-use"
         indent.print("slab:", message.hint(f"{hex(base)}"), desc)
-        indent.print("status:", message.hint(inuse), objcnt)
+        indent.print("status:", message.hint(inuse))
+        indent.print("In-Use:", message.hint(objcnt))
     except Exception as e:
         print(message.warn(f"address does not belong to a SLUB cache: {e}"))

--- a/pwndbg/commands/slab.py
+++ b/pwndbg/commands/slab.py
@@ -321,9 +321,8 @@ def slab_contains(address: str) -> None:
         desc = "[inactive]"
         inuse = f"[something went wrong: {hex(addr)}]"
         slab = slab_cache.find_containing_slab(addr)
-        objcnt = ""
         if slab:
-            objcnt = f"{slab.inuse}/{slab.object_count}"
+            objcnt = f"{slab.inuse}/{slab.object_count} in-use"
             if addr in slab.free_objects:
                 inuse = "free"
             elif addr in slab.objects:
@@ -336,10 +335,10 @@ def slab_contains(address: str) -> None:
                     desc = f"[partial, cpu {slab.cpu_cache.cpu}]"
                 else:
                     desc = f"[partial, node {slab.node_cache.node}]"
+            desc = desc[:-1] + ", " + objcnt + "]"
         else:
             inuse = "in-use"
         indent.print("slab:", message.hint(f"{hex(base)}"), desc)
         indent.print("status:", message.hint(inuse))
-        indent.print("In-Use:", message.hint(objcnt))
     except Exception as e:
         print(message.warn(f"address does not belong to a SLUB cache: {e}"))

--- a/pwndbg/commands/slab.py
+++ b/pwndbg/commands/slab.py
@@ -321,7 +321,6 @@ def slab_contains(address: str) -> None:
         inuse = f"[something went wrong: {hex(addr)}]"
         slab = slab_cache.find_containing_slab(addr)
         if slab:
-            objcnt = f"{slab.inuse}/{slab.object_count} in-use"
             if addr in slab.free_objects:
                 inuse = "free"
             elif addr in slab.objects:
@@ -333,10 +332,14 @@ def slab_contains(address: str) -> None:
                     location = f"partial, cpu {slab.cpu_cache.cpu}"
                 else:
                     location = f"partial, node {slab.node_cache.node}"
+            if slab.inuse == slab.object_count:
+                objcnt = "full"
+            else:
+                objcnt = f"{slab.inuse}/{slab.object_count} in-use"
             desc = f"[{location}, {objcnt}]"
         else:
             inuse = "in-use"
-            desc = "[full]"
+            desc = "[inactive, full]"
         indent.print("slab:", message.hint(f"{hex(base)}"), desc)
         indent.print("status:", message.hint(inuse))
     except Exception as e:

--- a/pwndbg/commands/slab.py
+++ b/pwndbg/commands/slab.py
@@ -318,7 +318,6 @@ def slab_contains(address: str) -> None:
         assert base and slab_cache, "cannot find the kmem_cache the address belongs to."
         addr = base + ((addr - base) // slab_cache.size) * slab_cache.size
         indent.print(f"{addr:#x} @", message.hint(f"{slab_cache.name}"))
-        desc = "[inactive]"
         inuse = f"[something went wrong: {hex(addr)}]"
         slab = slab_cache.find_containing_slab(addr)
         if slab:
@@ -328,16 +327,16 @@ def slab_contains(address: str) -> None:
             elif addr in slab.objects:
                 inuse = "in-use"
             if slab.is_active:
-                if slab.is_cpu:
-                    desc = f"[active, cpu {slab.cpu_cache.cpu}]"
+                location = f"active, cpu {slab.cpu_cache.cpu}"
             else:
                 if slab.is_cpu:
-                    desc = f"[partial, cpu {slab.cpu_cache.cpu}]"
+                    location = f"partial, cpu {slab.cpu_cache.cpu}"
                 else:
-                    desc = f"[partial, node {slab.node_cache.node}]"
-            desc = desc[:-1] + ", " + objcnt + "]"
+                    location = f"partial, node {slab.node_cache.node}"
+            desc = f"[{location}, {objcnt}]"
         else:
             inuse = "in-use"
+            desc = "[full]"
         indent.print("slab:", message.hint(f"{hex(base)}"), desc)
         indent.print("status:", message.hint(inuse))
     except Exception as e:


### PR DESCRIPTION
- Display the inuse/total object count on a separate "In-Use:" line instead of appending it to the status line
- Remove square brackets around the count for cleaner output

Follow-up to #3830

<img width="269" height="63" alt="image" src="https://github.com/user-attachments/assets/578bab2e-0829-4ae7-aa68-2326bfd250cb" />
