### PR TITLE
Update vmmap.py

### DIFF
--- a/pwndbg/commands/vmmap.py
+++ b/pwndbg/commands/vmmap.py
@@ -411,8 +411,8 @@ def vmmap_explore(address: int) -> None:
 
 
 @pwndbg.commands.Command(
-    "Clear the vmmap cache.", category=CommandCategory.MEMORY
-)  # TODO is this accurate?
+    "Clear custom vmmap entries added by vmmap_add and vmmap_explore and reset caches.", category=CommandCategory.MEMORY
+)  
 @pwndbg.commands.OnlyWhenRunning
 def vmmap_clear() -> None:
     pwndbg.aglib.vmmap_custom.clear_custom_page()


### PR DESCRIPTION

+ [X] I read the contributing documentation.
+ [ n/a ] I am providing a screenshot of the (new feature) / (fixed bug).

The vmmap_clear command description said "Clear the vmmap cache." with a TODO questioning whether it is accurate.
Looking at the implementation, `vmmap_clear` calls `clear_custom_page()` in `pwndbg/aglib/vmmap_custom.py` which does two things:

- Clears custom pages added by `vmmap_add` and `vmmap_explore`
- Resets all caches via `pwndbg.lib.cache.clear_caches()`

Updated the description to accurately reflect this behaviour and removed TODO.