### PR TITLE
Tls vmap label

### DIFF
--- a/docs/commands/index.md
+++ b/docs/commands/index.md
@@ -146,7 +146,7 @@
 -  [search](memory/search.md) - Search memory for byte sequences, strings, pointers, and integer values.
 -  [telescope](memory/telescope.md) - Recursively dereferences pointers starting at the specified address.
 -  [vmmap-add](memory/vmmap-add.md) - Add virtual memory map page.
--  [vmmap-clear](memory/vmmap-clear.md) - Clear the vmmap cache.
+-  [vmmap-clear](memory/vmmap-clear.md) - Clear custom vmmap entries added by vmmap_add and vmmap_explore and reset caches.
 -  [vmmap-explore](memory/vmmap-explore.md) - Explore a page, trying to guess permissions.
 -  [vmmap](memory/vmmap.md) - Print virtual memory map pages.
 -  [xinfo](memory/xinfo.md) - Shows offsets of the specified address from various useful locations.

--- a/docs/commands/memory/vmmap-clear.md
+++ b/docs/commands/memory/vmmap-clear.md
@@ -6,7 +6,7 @@ usage: vmmap-clear [-h]
 
 ```
 
-Clear the vmmap cache.
+Clear custom vmmap entries added by vmmap_add and vmmap_explore and reset caches.
 ### Optional arguments
 
 |Short|Long|Help|

--- a/pwndbg/commands/vmmap.py
+++ b/pwndbg/commands/vmmap.py
@@ -411,7 +411,8 @@ def vmmap_explore(address: int) -> None:
 
 
 @pwndbg.commands.Command(
-    "Clear custom vmmap entries added by vmmap_add and vmmap_explore and reset caches.", category=CommandCategory.MEMORY
+    "Clear custom vmmap entries added by vmmap_add and vmmap_explore and reset caches.",
+    category=CommandCategory.MEMORY
 )
 @pwndbg.commands.OnlyWhenRunning
 def vmmap_clear() -> None:

--- a/pwndbg/commands/vmmap.py
+++ b/pwndbg/commands/vmmap.py
@@ -412,7 +412,7 @@ def vmmap_explore(address: int) -> None:
 
 @pwndbg.commands.Command(
     "Clear custom vmmap entries added by vmmap_add and vmmap_explore and reset caches.",
-    category=CommandCategory.MEMORY
+    category=CommandCategory.MEMORY,
 )
 @pwndbg.commands.OnlyWhenRunning
 def vmmap_clear() -> None:

--- a/pwndbg/commands/vmmap.py
+++ b/pwndbg/commands/vmmap.py
@@ -411,8 +411,8 @@ def vmmap_explore(address: int) -> None:
 
 
 @pwndbg.commands.Command(
-    "Clear the vmmap cache.", category=CommandCategory.MEMORY
-)  # TODO is this accurate?
+    "Clear custom vmmap entries added by vmmap_add and vmmap_explore and reset caches.", category=CommandCategory.MEMORY
+)
 @pwndbg.commands.OnlyWhenRunning
 def vmmap_clear() -> None:
     pwndbg.aglib.vmmap_custom.clear_custom_page()


### PR DESCRIPTION

+ [X] I read the contributing documentation.
+ [ n/a ] I am providing a screenshot of the (new feature) / (fixed bug).

The vmmap_clear command description said "Clear the vmmap cache." with a TODO questioning whether it is accurate.
Looking at the implementation, `vmmap_clear` calls `clear_custom_page()` in `pwndbg/aglib/vmmap_custom.py` which does two things:

- Clears custom pages added by `vmmap_add` and `vmmap_explore`
- Resets all caches via `pwndbg.lib.cache.clear_caches()`

Updated the description to accurately reflect this behaviour and removed TODO.