### PR TITLE
refactor: move wrappers/readelf.py to lib/got.py

### DIFF
--- a/pwndbg/commands/got.py
+++ b/pwndbg/commands/got.py
@@ -14,10 +14,10 @@ import pwndbg.color.memory as mem_color
 import pwndbg.commands
 import pwndbg.lib.memory
 import pwndbg.wrappers.checksec
-import pwndbg.wrappers.readelf
+import pwndbg.lib.got
 from pwndbg.color import message
 from pwndbg.commands import CommandCategory
-from pwndbg.wrappers.readelf import RelocationType
+from pwndbg.lib.got import RelocationType
 
 parser = argparse.ArgumentParser(
     description="Show the state of the Global Offset Table.",
@@ -115,7 +115,7 @@ def _got(path: str, accept_readonly: bool, symbol_filter: str) -> None:
 
     relro_status = pwndbg.wrappers.checksec.relro_status(local_path)
     pie_status = pwndbg.wrappers.checksec.pie_status(local_path)
-    got_entry = pwndbg.wrappers.readelf.get_got_entry(local_path)
+    got_entry = pwndbg.lib.got.get_got_entry(local_path)
 
     # The following code is inspired by the "got" command of https://github.com/bata24/gef/blob/dev/gef.py by @bata24, thank you!
     # TODO/FIXME: Maybe a -v option to show more information will be better
@@ -127,7 +127,7 @@ def _got(path: str, accept_readonly: bool, symbol_filter: str) -> None:
         assert page is not None, f"unable to find vmmap entry for objfile: {path}"
         bin_base_offset = page.start
 
-    # Parse the output of readelf line by line
+    # Parse the GOT entries by category
     for category, entries in got_entry.items():
         for entry in entries:
             offset = entry["offset"]

--- a/pwndbg/lib/got.py
+++ b/pwndbg/lib/got.py
@@ -5,7 +5,6 @@ from enum import Enum
 from elftools.elf.elffile import ELFFile
 from elftools.elf.relocation import RelocationSection
 
-cmd_name = "readelf"
 
 
 class RelocationType(Enum):


### PR DESCRIPTION
## Problem

As discussed in #3470 (comment), the GOT entry parsing logic in `pwndbg/wrappers/readelf.py` does not depend on any debugger API (GDB/LLDB). It should be moved to `pwndbg/lib/` per the project convention for debugger-independent code.

## Solution

- Moved `pwndbg/wrappers/readelf.py` → `pwndbg/lib/got.py`
- Updated all imports in `pwndbg/commands/got.py` to use the new module path
- Removed the unused `cmd_name` variable (no longer a wrapper)
- Updated a stale comment that referenced "readelf output"

## Files Changed

- `pwndbg/wrappers/readelf.py` → `pwndbg/lib/got.py` (renamed)
- `pwndbg/commands/got.py` (import updates)

Closes #3844