### PR TITLE
Fix stale Docker image manifests

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -236,7 +236,7 @@ jobs:
 
   create_manifest:
     needs: [docker_x86-64, docker_aarch64]
-    if: github.event_name == 'push'
+    if: ${{ !cancelled() && github.event_name == 'push' }}
     runs-on: ubuntu-latest
     steps:
       - name: Set up Docker Buildx


### PR DESCRIPTION
+ [x] I read the contributing documentation.
+ [x] I am providing a screenshot of the (new feature) / (fixed bug).

Update `create_manifest` job to run even when upstream jobs fail, so successful images still get their manifests updated, and one failing Docker test won't keep them all stale.

related to issue #3851 
https://docs.github.com/en/actions/reference/workflows-and-actions/expressions
<img width="787" height="294" alt="chrome_EYHq7V9bjb" src="https://github.com/user-attachments/assets/eda1af44-26cc-4490-a062-9098d9db21da" />
