### PR TITLE
fix(slab): add ptrmask to convert signed addr into unsigned integer

### DIFF
--- a/pwndbg/commands/slab.py
+++ b/pwndbg/commands/slab.py
@@ -307,7 +307,10 @@ def slab_contains(address: str) -> None:
 
     addr = None
     try:
-        addr = int(pwndbg.dbg.selected_frame().evaluate_expression(address)) & pwndbg.aglib.arch.ptrmask
+        addr = (
+            int(pwndbg.dbg.selected_frame().evaluate_expression(address))
+            & pwndbg.aglib.arch.ptrmask
+        )
     except pwndbg.dbg_mod.Error as e:
         print(message.error(f"Could not parse '{address}'"))
         print(message.error(f"Message: {e}"))

--- a/pwndbg/commands/slab.py
+++ b/pwndbg/commands/slab.py
@@ -307,10 +307,7 @@ def slab_contains(address: str) -> None:
 
     addr = None
     try:
-        addr = (
-            int(pwndbg.dbg.selected_frame().evaluate_expression(address))
-            & pwndbg.aglib.arch.ptrmask
-        )
+        addr = int(pwndbg.dbg.selected_frame().evaluate_expression(address)) & ((1 << 64) - 1)
     except pwndbg.dbg_mod.Error as e:
         print(message.error(f"Could not parse '{address}'"))
         print(message.error(f"Message: {e}"))

--- a/pwndbg/commands/slab.py
+++ b/pwndbg/commands/slab.py
@@ -307,7 +307,7 @@ def slab_contains(address: str) -> None:
 
     addr = None
     try:
-        addr = int(pwndbg.dbg.selected_frame().evaluate_expression(address))
+        addr = int(pwndbg.dbg.selected_frame().evaluate_expression(address)) & pwndbg.aglib.arch.ptrmask
     except pwndbg.dbg_mod.Error as e:
         print(message.error(f"Could not parse '{address}'"))
         print(message.error(f"Message: {e}"))


### PR DESCRIPTION
As shown in below image, it seems that pwndbg evaluates register values as signed integer. 
It leads to `indent.print(f"{addr:#x} @", message.hint(f"{slab_cache.name}"))` displays `addr` as negative hex value even if the `addr` should be perceived as unsigned integer. 

<img width="258" height="75" alt="image" src="https://github.com/user-attachments/assets/1e60c6dc-8b84-4933-8902-b0fa742e0028" />

I added bitwise and operation with `ptrmask` so that python interprets the `addr` as unsigned integer. The fixed result is as follows.
<img width="327" height="75" alt="image" src="https://github.com/user-attachments/assets/ffeb20cf-185a-4ae2-bfb6-00113eb91961" />


