### PR TITLE
Use pull_policy always for local dev

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -99,7 +99,7 @@ jobs:
 
       - name: Run Tests (GDB, DBG-GDB, DBG-LLDB in parallel) on ${{ matrix.image }}
         run: |
-          docker compose run -T --rm --quiet-pull -v $(pwd):/pwndbg ${{ matrix.image }} bash -c '
+          docker compose run -T --rm --pull never -v $(pwd):/pwndbg ${{ matrix.image }} bash -c '
             set -euo pipefail
             # Needed to prevent race conditions - prebuild binaries and create libpython symlink
             make -C /pwndbg/tests/binaries/host -j4 all
@@ -197,7 +197,7 @@ jobs:
 
       - name: Run Tests (Cross, DBG-GDB, DBG-LLDB in parallel) on ${{ matrix.image }}
         run: |
-          docker compose run -T --rm --quiet-pull -v $(pwd):/pwndbg ${{ matrix.image }} bash -c '
+          docker compose run -T --rm --pull never -v $(pwd):/pwndbg ${{ matrix.image }} bash -c '
             set -euo pipefail
             # Needed to prevent race conditions - prebuild binaries
             make -C /pwndbg/tests/binaries/host -j4 all

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
   ubuntu22.04:
     <<: *base-spec
     image: ghcr.io/pwndbg/pwndbg:ubuntu22.04
-    pull_policy: missing
+    pull_policy: always
     build:
       context: .
       dockerfile: Dockerfile
@@ -23,7 +23,7 @@ services:
   ubuntu24.04:
     <<: *base-spec
     image: ghcr.io/pwndbg/pwndbg:ubuntu24.04
-    pull_policy: missing
+    pull_policy: always
     build:
       context: .
       dockerfile: Dockerfile
@@ -33,7 +33,7 @@ services:
   ubuntu24.04-mount:
     <<: *base-spec
     image: ghcr.io/pwndbg/pwndbg:ubuntu24.04
-    pull_policy: missing
+    pull_policy: always
     build:
       context: .
       target: base
@@ -46,7 +46,7 @@ services:
   debian12:
     <<: *base-spec
     image: ghcr.io/pwndbg/pwndbg:debian12
-    pull_policy: missing
+    pull_policy: always
     build:
       context: .
       dockerfile: Dockerfile
@@ -56,7 +56,7 @@ services:
   archlinux:
     <<: *base-spec
     image: ghcr.io/pwndbg/pwndbg:archlinux
-    pull_policy: missing
+    pull_policy: always
     build:
       context: .
       dockerfile: Dockerfile.arch
@@ -66,7 +66,7 @@ services:
   fedora41:
     <<: *base-spec
     image: ghcr.io/pwndbg/pwndbg:fedora41
-    pull_policy: missing
+    pull_policy: always
     build:
       context: .
       dockerfile: Dockerfile.dnf
@@ -76,7 +76,7 @@ services:
   fedora42:
     <<: *base-spec
     image: ghcr.io/pwndbg/pwndbg:fedora42
-    pull_policy: missing
+    pull_policy: always
     build:
       context: .
       dockerfile: Dockerfile.dnf
@@ -86,7 +86,7 @@ services:
   fedora43:
     <<: *base-spec
     image: ghcr.io/pwndbg/pwndbg:fedora43
-    pull_policy: missing
+    pull_policy: always
     build:
       context: .
       dockerfile: Dockerfile.dnf


### PR DESCRIPTION
+ [x] I read the contributing documentation.
+ [ ] I am providing a screenshot of the (new feature) / (fixed bug).

Change pull_policy to always, so local dev always pulls the latest image instead of having to run docker compose pull to update if you have old images. 
This way, deps will never have to sync, unless you're updating them in your PR.

Also, override with --pull never in CI to keep using locally built images.