### PR TITLE
build base pwndbg image workflow: always inject buildkit cache mounts regardless of cache hit

### DIFF
--- a/.github/workflows/base-image.yml
+++ b/.github/workflows/base-image.yml
@@ -115,7 +115,6 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Inject/extract cache mounts
-        if: steps.cache.outputs.cache-hit != 'true'
         uses: reproducible-containers/buildkit-cache-dance@v3.3.2
         with:
           cache-map: |


### PR DESCRIPTION
+ [x] I read the contributing documentation.
+ [x] I am providing a screenshot of the (new feature) / (fixed bug).

https://github.com/reproducible-containers/buildkit-cache-dance/pull/61
After fixing an upstream issue in buildkit-cache-dance that caused the action to hang during extraction (released in v3.3.2 and adopted here in PR #3806 by dependabot), the workflow now works properly. So, emulated arches can run in minutes rather than hours even when registry cache is invalidated. 

ex: https://github.com/pwndbg/pwndbg/actions/runs/23828715881
<table>
<tr>
<td><img width="370" alt="chrome_NT3bfO58Dq" src="https://github.com/user-attachments/assets/63501ddd-ba2b-4456-9fa3-0afe09189f76" /></td>
<td><img width="337" alt="chrome_KEKYZN2Jl1" src="https://github.com/user-attachments/assets/2285d270-1ab4-4bd2-a2a6-607df240428e" /></td>
</tr>
</table>

---

There is just one bug that needs to be fixed, though

`if: steps.cache.outputs.cache-hit != 'true'` 
This needs to be removed; otherwise, for example, in this PR from dependabot https://github.com/pwndbg/pwndbg/pull/3858, where `uv.lock` wasn't updated, the cache wasn't injected, and the registry cache only stores image layers, not the mount, which is the actual purpose of buildkit-cache-dance anyways, so it just always needs to be injected instead.

