### PR TITLE
Print nested field offsets recursively in dt

### DIFF
--- a/pwndbg/aglib/dt.py
+++ b/pwndbg/aglib/dt.py
@@ -74,9 +74,8 @@ def _append_field_lines(
                             extra = " ".join(f"{b:02x}" for b in data)
                     elif not is_nested_aggregate:
                         extra = nested_obj.value_to_human_readable()
-            except pwndbg.dbg_mod.Error as e:
-                rv.append(f"{e}\nIs the provided address near a page boundary?")
-                return
+            except pwndbg.dbg_mod.Error:
+                raise
 
         if is_nested_aggregate:
             extra = f"{extra} {{"

--- a/pwndbg/aglib/dt.py
+++ b/pwndbg/aglib/dt.py
@@ -75,7 +75,7 @@ def _append_field_lines(
                     elif not is_nested_aggregate:
                         extra = nested_obj.value_to_human_readable()
             except pwndbg.dbg_mod.Error as e:
-                rv.append(f"{e}\nIs the provided address near a page boundry?")
+                rv.append(f"{e}\nIs the provided address near a page boundary?")
                 return
 
         if is_nested_aggregate:

--- a/pwndbg/aglib/dt.py
+++ b/pwndbg/aglib/dt.py
@@ -25,6 +25,91 @@ def _field_to_human(
     return t.name_to_human_readable
 
 
+def _append_field_lines(
+    rv: list[str],
+    t: pwndbg.dbg_mod.Type,
+    obj: pwndbg.dbg_mod.Value | None,
+    *,
+    base_offset: int,
+    base_address: int | None,
+    indent: str,
+) -> None:
+    for field in t.fields():
+        field_name = field.name
+        field_label = field_name if field_name is not None else "<anonymous>"
+
+        # Offset into the top-level structure.
+        offset = field.bitpos // 8
+        absolute_offset = base_offset + offset
+        bitpos = field.bitpos % 8
+        ftype = field.type.strip_typedefs()
+        extra = _field_to_human(field)
+        is_nested_aggregate = ftype.code in (
+            pwndbg.dbg_mod.TypeCode.STRUCT,
+            pwndbg.dbg_mod.TypeCode.UNION,
+        )
+        nested_obj: pwndbg.dbg_mod.Value | None = None
+
+        if obj and obj.type.strip_typedefs().code in (
+            pwndbg.dbg_mod.TypeCode.STRUCT,
+            pwndbg.dbg_mod.TypeCode.UNION,
+        ):
+            try:
+                if field_name is not None:
+                    nested_obj = obj[field_name]
+
+                if nested_obj is not None:
+                    if ftype.code == pwndbg.dbg_mod.TypeCode.INT:
+                        extra = hex(int(nested_obj))
+                    elif (
+                        ftype.code
+                        in (pwndbg.dbg_mod.TypeCode.POINTER, pwndbg.dbg_mod.TypeCode.ARRAY)
+                        and ftype.target() == pwndbg.aglib.typeinfo.uchar
+                    ):
+                        # Flexible array members have size 0, skip reading memory for them.
+                        if ftype.sizeof == 0:
+                            extra = "[]"
+                        else:
+                            data = pwndbg.aglib.memory.read(int(nested_obj.address), ftype.sizeof)
+                            extra = " ".join(f"{b:02x}" for b in data)
+                    elif not is_nested_aggregate:
+                        extra = nested_obj.value_to_human_readable()
+            except pwndbg.dbg_mod.Error as e:
+                rv.append(f"{e}\nIs the provided address near a page boundry?")
+                return
+
+        if is_nested_aggregate:
+            extra = f"{extra} {{"
+
+        # Adjust trailing lines in 'extra' to line up.
+        extra_lines: list[str] = []
+        for i, line in enumerate(str(extra).splitlines()):
+            if i == 0:
+                extra_lines.append(line)
+            else:
+                extra_lines.append((len(indent) + 31) * " " + line)
+        extra = "\n".join(extra_lines)
+
+        bitpos_str = "" if not bitpos else (f".{bitpos}")
+
+        if base_address is not None:
+            line = f"{indent}0x{base_address + absolute_offset:016x} +0x{absolute_offset:04x}{bitpos_str} {field_label:<20} : {extra}"
+        else:
+            line = f"{indent}+0x{absolute_offset:04x}{bitpos_str} {field_label:<20} : {extra}"
+        rv.append(line)
+
+        if is_nested_aggregate:
+            _append_field_lines(
+                rv,
+                ftype,
+                nested_obj,
+                base_offset=absolute_offset,
+                base_address=base_address,
+                indent=indent + "    ",
+            )
+            rv.append(f"{indent}}}")
+
+
 def dt(
     name: str = "",
     addr: int | pwndbg.dbg_mod.Value | None = None,
@@ -69,55 +154,13 @@ def dt(
         header = f"{header} @ {hex(int(obj.address))}"
     rv.append(header)
 
-    iter_fields = [(field.name, field) for field in t.fields()]
-
-    for field_name, field in iter_fields:
-        # Offset into the parent structure
-        offset = field.bitpos // 8
-        bitpos = field.bitpos % 8
-        ftype = field.type.strip_typedefs()
-        extra = _field_to_human(field)
-
-        if obj and obj.type.strip_typedefs().code in (
-            pwndbg.dbg_mod.TypeCode.STRUCT,
-            pwndbg.dbg_mod.TypeCode.UNION,
-        ):
-            try:
-                obj_value = obj[field_name]
-                if ftype.code == pwndbg.dbg_mod.TypeCode.INT:
-                    extra = hex(int(obj_value))
-                elif (
-                    ftype.code in (pwndbg.dbg_mod.TypeCode.POINTER, pwndbg.dbg_mod.TypeCode.ARRAY)
-                    and ftype.target() == pwndbg.aglib.typeinfo.uchar
-                ):
-                    # Flexible array members have size 0, skip reading memory for them
-                    if ftype.sizeof == 0:
-                        extra = "[]"
-                    else:
-                        data = pwndbg.aglib.memory.read(int(obj_value.address), ftype.sizeof)
-                        extra = " ".join(f"{b:02x}" for b in data)
-                else:
-                    extra = obj_value.value_to_human_readable()
-            except pwndbg.dbg_mod.Error as e:
-                return f"{e}\nIs the provided address near a page boundry?"
-
-        # Adjust trailing lines in 'extra' to line up
-        # This is necessary when there are nested structures.
-        # Ideally we'd expand recursively if the type is complex.
-        extra_lines: list[str] = []
-        for i, line in enumerate(str(extra).splitlines()):
-            if i == 0:
-                extra_lines.append(line)
-            else:
-                extra_lines.append(35 * " " + line)
-        extra = "\n".join(extra_lines)
-
-        bitpos_str = "" if not bitpos else (f".{bitpos}")
-
-        if obj:
-            line = f"    0x{int(obj.address) + offset:016x} +0x{offset:04x}{bitpos_str} {field_name:<20} : {extra}"
-        else:
-            line = f"    +0x{offset:04x}{bitpos_str} {field_name:<20} : {extra}"
-        rv.append(line)
+    _append_field_lines(
+        rv,
+        t,
+        obj,
+        base_offset=0,
+        base_address=int(obj.address) if obj else None,
+        indent="    ",
+    )
 
     return "\n".join(rv)

--- a/tests/binaries/host/dt_recursive_offsets.native.c
+++ b/tests/binaries/host/dt_recursive_offsets.native.c
@@ -1,0 +1,30 @@
+struct dt3807_inner
+{
+    int a;
+    int b;
+};
+
+struct dt3807_outer
+{
+    int x;
+    struct dt3807_inner in;
+    int y;
+};
+
+struct dt3807_outer global_outer = {
+    .x = 0x11,
+    .in =
+        {
+            .a = 0x22,
+            .b = 0x33,
+        },
+    .y = 0x44,
+};
+
+void break_here(void) {}
+
+int main(void)
+{
+    break_here();
+    return 0;
+}

--- a/tests/library/dbg/tests/test_command_dt.py
+++ b/tests/library/dbg/tests/test_command_dt.py
@@ -10,6 +10,7 @@ from . import launch_to
 from . import pwndbg_test
 
 HEAP_MALLOC_CHUNK = get_binary("heap_malloc_chunk.native.out")
+DT_RECURSIVE_OFFSETS = get_binary("dt_recursive_offsets.native.out")
 
 
 @pwndbg_test
@@ -53,3 +54,21 @@ async def test_command_dt_works_with_no_address(ctrl: Controller) -> None:
         "    \\+0x[0-9a-f]{4} entries +: +tcache_entry ?\\*\\[(64|76)\\]\n"
     )
     assert re.match(exp_regex, out)
+
+
+@pwndbg_test
+async def test_command_dt_recursively_prints_nested_offsets(ctrl: Controller) -> None:
+    await launch_to(ctrl, DT_RECURSIVE_OFFSETS, "break_here")
+
+    global_outer = await ctrl.execute_and_capture("print &global_outer")
+    match = re.search(r"0x[0-9a-f]+", global_outer)
+    assert match is not None
+    global_outer_addr = match.group(0)
+
+    out = await ctrl.execute_and_capture(f'dt "struct dt3807_outer" {global_outer_addr}')
+
+    assert re.search(r"\+0x0000 x\s+: 0x11", out)
+    assert re.search(r"\+0x0004 in\s+: dt3807_inner \{", out)
+    assert re.search(r"\+0x0004 a\s+: 0x22", out)
+    assert re.search(r"\+0x0008 b\s+: 0x33", out)
+    assert re.search(r"\+0x000c y\s+: 0x44", out)


### PR DESCRIPTION
<!--
    Please make sure to read the linting and testing instructions at
    https://pwndbg.re/dev/contributing/ before creating a PR.
-->

+ [x] I read the contributing documentation.
+ [x] I am providing a screenshot of the (new feature) / (fixed bug).

This PR updates `dt` to recursively print offsets for nested struct and union fields instead of only showing offsets for top-level fields.

Previously, nested aggregate members were rendered as a single pretty-printed value, so their child fields did not get individual `+0x...` offsets.

## Changes

```
Using a nested struct like:

  ```c
  struct dt3807_inner {
      int a;
      int b;
  };

  struct dt3807_outer {
      int x;
      struct dt3807_inner in;
      int y;
  };
```

### Output before patch

```
pwndbg> dt "struct outer" &global_outer
struct outer @ 0x404010
    0x0000000000404010 +0x0000 x                    : 0x11
    0x0000000000404014 +0x0004 in                   : {
                                     a = 34,
                                     b = 51
                                   }
    0x000000000040401c +0x000c y                    : 0x44
```

### Output after patch

```
pwndbg> dt "struct outer" &global_outer
struct outer @ 0x404010
    0x0000000000404010 +0x0000 x                    : 0x11
    0x0000000000404014 +0x0004 in                   : inner {
        0x0000000000404014 +0x0004 a                    : 0x22
        0x0000000000404018 +0x0008 b                    : 0x33
    }
    0x000000000040401c +0x000c y                    : 0x44
```

Also added a test case covering recursive nested offsets in `dt` with a sample binary and source code.

This PR closes #3807.