### PR TITLE
fix: handle GDB builds without debuginfod support

### DIFF
--- a/pwndbg/dbg_mod/gdb/__init__.py
+++ b/pwndbg/dbg_mod/gdb/__init__.py
@@ -1729,7 +1729,6 @@ class GDB(pwndbg.dbg_mod.Debugger):
         set step-mode on
         set print pretty on
         set output-radix 16
-        set debuginfod enabled on
         handle SIGALRM nostop print nopass
         handle SIGBUS  stop   print nopass
         handle SIGPIPE nostop print nopass
@@ -1738,6 +1737,12 @@ class GDB(pwndbg.dbg_mod.Debugger):
 
         for line in pre_commands.strip().splitlines():
             gdb.execute(line)
+
+        # debuginfod may not be compiled in (e.g. bare-metal cross GDB)
+        try:
+            gdb.execute("set debuginfod enabled on")
+        except gdb.error:
+            pass
 
         # This may throw an exception, see pwndbg/pwndbg#27
         try:


### PR DESCRIPTION
Some GDB builds (e.g. `riscv64-elf-gdb`) are compiled without `debuginfod` support, causing set `debuginfod` enabled on to raise `gdb.error` and abort pwndbg initialization.

Move the command out of the bulk loop and wrap it in try/except gdb.error.

The problematic environment is `riscv64-elf-gdb` on **mac host**.

```
riscv64-elf-gdb kernel/kernel
GNU gdb (GDB) 16.3
Copyright (C) 2024 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Type "show copying" and "show warranty" for details.
This GDB was configured as "--host=aarch64-apple-darwin24.4.0 --target=riscv64-elf".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<https://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
    <http://www.gnu.org/software/gdb/documentation/>.

For help, type "help".
Type "apropos word" to search for commands related to "word"...
Traceback (most recent call last):
  File "/Users/jun/opt/pwndbg/pwndbginit/gdbinit.py", line 90, in main_try
    main()
    ~~~~^^
  File "/Users/jun/opt/pwndbg/pwndbginit/gdbinit.py", line 68, in main
    pwndbg.dbg.setup()
    ~~~~~~~~~~~~~~~~^^
  File "/Users/jun/opt/pwndbg/pwndbg/dbg_mod/gdb/__init__.py", line 1739, in setup
    gdb.execute(line)
    ~~~~~~~~~~~^^^^^^
gdb.error: Support for debuginfod is not compiled into GDB.
```