### PR TITLE
go: fix type `direct_iface` resolution

### DIFF
--- a/pwndbg/aglib/godbg.py
+++ b/pwndbg/aglib/godbg.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import dataclasses
 import json
+import re
 import string
 import struct
 import textwrap
@@ -23,7 +24,6 @@ import pwndbg.aglib.proc
 import pwndbg.aglib.symbol
 import pwndbg.color.memory
 import pwndbg.dintegration
-import pwndbg.hexdump
 import pwndbg.lib.cache
 from pwndbg.color import generateColorFunction
 from pwndbg.color import message
@@ -328,13 +328,13 @@ def get_go_version() -> tuple[int, ...] | None:
             version_string = read_varint_str(buildinfo + 32).decode()
     if version_string == "unknown":
         return None
-    if not version_string.startswith("go"):
+    version_match = re.match(r"^go(\d+)\.(\d+)\.(\d+)", version_string)
+    if version_match is None:
         emit_warning(f"Go version string {version_string!r} doesn't start with 'go'")
         return None
 
-    # Cleanup a string that looks like "go1.25.5 X:nodwarf5"
-    version_string = version_string.split(" ")[0]
-    return tuple(int(x) for x in version_string[2:].split("."))
+    # Cleanup a string that looks like "go1.25.5..."
+    return tuple(map(int, version_match.groups()))
 
 
 @pwndbg.lib.cache.cache_until("objfile")

--- a/pwndbg/aglib/godbg.py
+++ b/pwndbg/aglib/godbg.py
@@ -624,7 +624,8 @@ def _inner_decode_runtime_type(
         addr,
         size=size,
         align=align,
-        direct_iface=(kind_raw & (1 << 5)) != 0,
+        # go 1.26 move direct/indirect flag from Kind to TFlag
+        direct_iface=((kind_raw & (1 << 5)) | tflag & (1 << 5)) != 0,
     )
     cache[addr] = (meta, BackrefType(meta, addr))
     simple_name = kind.get_simple_name()


### PR DESCRIPTION
+ [x] I read the contributing documentation.
+ [ ] I am providing a screenshot of the (new feature) / (fixed bug).

This is a fix for go1.26, which breaks direct_iface behavior. The commit
golang/go@f7d167f
move direct_iface from Kind to TFlag, leading to this error.

This PR is intended to fix go_dump errors on archlinux test.