### PR TITLE
Fixed 'vbar' reg in AArch64 which should be `vbar_el1`

### DIFF
--- a/pwndbg/aglib/kernel/paging.py
+++ b/pwndbg/aglib/kernel/paging.py
@@ -667,7 +667,11 @@ class Aarch64PagingInfo(ArchPagingInfo):
     @property
     @pwndbg.lib.cache.cache_until("stop")
     def kbase(self) -> int | None:
-        return self._kbase(pwndbg.aglib.regs.read_reg("vbar_el1"))
+        vbar_reg = pwndbg.aglib.regs.read_reg("vbar")
+        if vbar_reg is None:
+            vbar_reg = pwndbg.aglib.regs.read_reg("vbar_el1")
+
+        return self._kbase(vbar_reg)
 
     @property
     @pwndbg.lib.cache.cache_until("stop")

--- a/pwndbg/aglib/kernel/paging.py
+++ b/pwndbg/aglib/kernel/paging.py
@@ -667,7 +667,7 @@ class Aarch64PagingInfo(ArchPagingInfo):
     @property
     @pwndbg.lib.cache.cache_until("stop")
     def kbase(self) -> int | None:
-        return self._kbase(pwndbg.aglib.regs.read_reg("vbar"))
+        return self._kbase(pwndbg.aglib.regs.read_reg("vbar_el1"))
 
     @property
     @pwndbg.lib.cache.cache_until("stop")


### PR DESCRIPTION
I have been debugging an arm64 kernel, when I've noticed I could not get `kbase` and neither could `context` run correctly. 

I have then debugged it (after setting ptrace_scope to 0), and found out its due to the fact we try to find the `kbase` using the `vbar` register, which seems to be deprecated in aarch64 (https://developer.arm.com/documentation/ddi0601/2025-12/AArch64-Registers).

This is a small change, and so I've not opened an issue on the case or anything, but if it's needed let me know.

The environment in which it occurred was using `qemu-system-aarch64` on an aarch64 compiled android kernel (namely 4.14). After changing to `vbar_el1` it could find the `kbase` and I could debug normally.
