### PR TITLE
Fix is_paging_enabled in aarch64

### DIFF
--- a/pwndbg/aglib/kernel/__init__.py
+++ b/pwndbg/aglib/kernel/__init__.py
@@ -549,7 +549,11 @@ class Aarch64Ops(ArchOps):
 
     @staticmethod
     def paging_enabled() -> bool:
-        return int(pwndbg.aglib.regs.read_reg("SCTLR")) & BIT(0) != 0
+        sctlr_reg = pwndbg.aglib.regs.read_reg("SCTLR")
+        if sctlr_reg is None:
+            sctlr_reg = pwndbg.aglib.regs.read_reg("SCTLR_EL1")
+
+        return int(sctlr_reg) & BIT(0) != 0
 
 
 @pwndbg.lib.cache.cache_until("start")

--- a/pwndbg/aglib/kernel/paging.py
+++ b/pwndbg/aglib/kernel/paging.py
@@ -667,7 +667,11 @@ class Aarch64PagingInfo(ArchPagingInfo):
     @property
     @pwndbg.lib.cache.cache_until("stop")
     def kbase(self) -> int | None:
-        return self._kbase(pwndbg.aglib.regs.read_reg("vbar_el1"))
+        vbar_reg = pwndbg.aglib.regs.read_reg("vbar")
+        if vbar_reg is None:
+            vbar_reg = pwndbg.aglib.regs.read_reg("vbar_el1")
+
+        return self._kbase(vbar_reg)
 
     @property
     @pwndbg.lib.cache.cache_until("stop")

--- a/pwndbg/aglib/kernel/paging.py
+++ b/pwndbg/aglib/kernel/paging.py
@@ -667,7 +667,7 @@ class Aarch64PagingInfo(ArchPagingInfo):
     @property
     @pwndbg.lib.cache.cache_until("stop")
     def kbase(self) -> int | None:
-        return self._kbase(pwndbg.aglib.regs.read_reg("vbar"))
+        return self._kbase(pwndbg.aglib.regs.read_reg("vbar_el1"))
 
     @property
     @pwndbg.lib.cache.cache_until("stop")


### PR DESCRIPTION
This is directly related to #3869.
It seems that in newer versions of QEMU, some registers that are used in `pwndbg` are deprecated and unused, and instead these in the newer versions of arm64 are used instead.

This is another needed fix, this time for `is_paging_enabled`, that seems to use the `SCTLR` register instead of `SCTLR_EL1`.

It might be worthwhile to look for other examples of these regs. I did not encounter any other ones that caused trouble for me; otherwise I'd have fixed them too.

The changes check whether the reg `SCTLR` is None. If it is, and it has no integer value, we instead switch to `SCTLR_EL1`. I checked to validate that the bit in index 0 still signifies whether the MMU is enabled, [and it does](https://developer.arm.com/documentation/ddi0595/2020-12/AArch64-Registers/SCTLR-EL1--System-Control-Register--EL1-?lang=en#fieldset_0-0_0).