### PR TITLE
disable debuginfod in mallocng tests to fix flaky Fedora failures

### DIFF
--- a/tests/library/dbg/tests/test_mallocng.py
+++ b/tests/library/dbg/tests/test_mallocng.py
@@ -25,6 +25,8 @@ re_addr = r"0x[0-9a-fA-F]{1,12}"
 async def test_mallocng_slot_user(ctrl: Controller, binary: Path):
     import pwndbg.color as color
 
+    # Disable debuginfod to avoid musl debug info triggering GDB frame tracking errors.
+    await ctrl.disable_debuginfod()
     await launch_to(ctrl, binary, "break_here")
     # Get out of the break_here() function.
     await ctrl.finish()
@@ -174,6 +176,7 @@ async def test_mallocng_slot_user(ctrl: Controller, binary: Path):
 async def test_mallocng_slot_start(ctrl: Controller, binary: Path):
     import pwndbg.color as color
 
+    await ctrl.disable_debuginfod()
     await launch_to(ctrl, binary, "break_here")
     await ctrl.finish()
 
@@ -202,6 +205,7 @@ async def test_mallocng_slot_start(ctrl: Controller, binary: Path):
 async def test_mallocng_group(ctrl: Controller, binary: Path):
     import pwndbg.color as color
 
+    await ctrl.disable_debuginfod()
     await launch_to(ctrl, binary, "break_here")
     await ctrl.finish()
 
@@ -279,6 +283,7 @@ async def test_mallocng_group(ctrl: Controller, binary: Path):
 async def test_mallocng_meta(ctrl: Controller, binary: Path):
     import pwndbg.color as color
 
+    await ctrl.disable_debuginfod()
     await launch_to(ctrl, binary, "break_here")
     await ctrl.finish()
 
@@ -348,6 +353,7 @@ async def test_mallocng_find(ctrl: Controller, binary: Path):
     import pwndbg
     import pwndbg.color as color
 
+    await ctrl.disable_debuginfod()
     await launch_to(ctrl, binary, "break_here")
     await ctrl.finish()
 
@@ -396,6 +402,7 @@ async def test_mallocng_find(ctrl: Controller, binary: Path):
 async def test_mallocng_metaarea(ctrl: Controller, binary: Path):
     import pwndbg.color as color
 
+    await ctrl.disable_debuginfod()
     await launch_to(ctrl, binary, "break_here")
     await ctrl.finish()
 
@@ -429,6 +436,7 @@ async def test_mallocng_metaarea(ctrl: Controller, binary: Path):
 async def test_mallocng_vis(ctrl: Controller, binary: Path):
     import pwndbg.color as color
 
+    await ctrl.disable_debuginfod()
     await launch_to(ctrl, binary, "break_here")
 
     break_at_sym("break_here")
@@ -501,6 +509,7 @@ async def test_mallocng_vis(ctrl: Controller, binary: Path):
     "binary", [HEAP_MALLOCNG_DYN, HEAP_MALLOCNG_STATIC], ids=["dynamic", "static"]
 )
 async def test_mallocng_dump(ctrl: Controller, binary: Path):
+    await ctrl.disable_debuginfod()
     await launch_to(ctrl, binary, "break_here")
     await ctrl.finish()
 


### PR DESCRIPTION
+ [x] I read the contributing documentation.
+ [ ] I am providing a screenshot of the (new feature) / (fixed bug).

Disable debuginfod in mallocng tests before launching test binaries to fix  `"finish" not meaningful in the outermost frame` gdb.error on Fedora.
```
[DBG-GDB] tests/library/dbg/tests/test_mallocng.py::test_mallocng_slot_user[dynamic]
[DBG-GDB] tests/library/dbg/tests/test_mallocng.py::test_mallocng_group[dynamic]
[DBG-GDB] tests/library/dbg/tests/test_mallocng.py::test_mallocng_slot_start[dynamic]
[DBG-GDB] tests/library/dbg/tests/test_mallocng.py::test_mallocng_meta[dynamic]
[DBG-GDB] tests/library/dbg/tests/test_mallocng.py::test_mallocng_vis[dynamic]
[DBG-GDB] tests/library/dbg/tests/test_mallocng.py::test_mallocng_dump[dynamic]
[DBG-GDB] tests/library/dbg/tests/test_mallocng.py::test_mallocng_find[dynamic]
```
`gdb.error: "finish" not meaningful in the outermost frame.`
An example of one of them
https://github.com/pwndbg/pwndbg/actions/runs/24397585645/job/71259255128?pr=3854 

After applying the fix to only the first 3 in the list that had failed, the next 4 in the list failed 
https://github.com/Monthly-Recurring-Revenue/pwndbg/actions/runs/24527109480 
So I applied `disable_debuginfod` to all of the mallocng tests

Though, maybe it should be a pytest autouse fixture instead of disabling debug info in 9 places?

It happens ~4% of the time. After running tests on various commits, the root cause isn't tied to any specific commit. It appears to be related to Fedora's or the gdb-for-pwndbg zig debuginfod server or something else. Either way, this fixes the issue, as it shouldn't need to pull debug info anyway. This passes ~500 times, though, without any failures from mallocng tests with the fix.