### PR TITLE
switch --pull never to --pull missing for docker tests

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -99,7 +99,7 @@ jobs:
 
       - name: Run Tests (GDB, DBG-GDB, DBG-LLDB in parallel) on ${{ matrix.image }}
         run: |
-          docker compose run -T --rm --pull never -v $(pwd):/pwndbg ${{ matrix.image }} bash -c '
+          docker compose run -T --rm --pull missing -v $(pwd):/pwndbg ${{ matrix.image }} bash -c '
             set -euo pipefail
             # Needed to prevent race conditions - prebuild binaries and create libpython symlink
             make -C /pwndbg/tests/binaries/host -j4 all
@@ -197,7 +197,7 @@ jobs:
 
       - name: Run Tests (Cross, DBG-GDB, DBG-LLDB in parallel) on ${{ matrix.image }}
         run: |
-          docker compose run -T --rm --pull never -v $(pwd):/pwndbg ${{ matrix.image }} bash -c '
+          docker compose run -T --rm --pull missing -v $(pwd):/pwndbg ${{ matrix.image }} bash -c '
             set -euo pipefail
             # Needed to prevent race conditions - prebuild binaries
             make -C /pwndbg/tests/binaries/host -j4 all


### PR DESCRIPTION
+ [x] I read the contributing documentation.
+ [ ] I am providing a screenshot of the (new feature) / (fixed bug).

`--pull never` caused docker compose run to fall back to building from the Dockerfile because I forgot that I had previously set it up to skip the build step on PRs unless changes were made to setup scripts or the Dockerfile itself, to save time, since it wasn't needed to build, and rather just mount and test the code changes.

<img width="757" height="107" alt="chrome_bpnuIIBSHK" src="https://github.com/user-attachments/assets/ce68e2b5-4c31-4aee-9dd1-26775beef351" />
I had just noticed it when checking on my other PR, why these were going past 20 minutes, and realized they were building the image.