### PR TITLE
Add register-name aliases to read_reg (refactor)

### DIFF
--- a/pwndbg/aglib/kernel/__init__.py
+++ b/pwndbg/aglib/kernel/__init__.py
@@ -549,11 +549,7 @@ class Aarch64Ops(ArchOps):
 
     @staticmethod
     def paging_enabled() -> bool:
-        sctlr_reg = pwndbg.aglib.regs.read_reg("SCTLR")
-        if sctlr_reg is None:
-            sctlr_reg = pwndbg.aglib.regs.read_reg("SCTLR_EL1")
-
-        return int(sctlr_reg) & BIT(0) != 0
+        return int(pwndbg.aglib.regs.read_reg("SCTLR", "SCTLR_EL1")) & BIT(0) != 0
 
 
 @pwndbg.lib.cache.cache_until("start")

--- a/pwndbg/aglib/kernel/__init__.py
+++ b/pwndbg/aglib/kernel/__init__.py
@@ -549,7 +549,11 @@ class Aarch64Ops(ArchOps):
 
     @staticmethod
     def paging_enabled() -> bool:
-        return int(pwndbg.aglib.regs.read_reg("SCTLR", "SCTLR_EL1")) & BIT(0) != 0
+        # AArch64 system control register: newer QEMU releases (tested on
+        # 10.2.0) expose it as `SCTLR_EL1`; older releases used the generic
+        # `SCTLR`. Bit 0 (M) is the MMU-enable flag in either case. See
+        # #3871 / #3875.
+        return int(pwndbg.aglib.regs.read_reg("SCTLR_EL1", "SCTLR")) & BIT(0) != 0
 
 
 @pwndbg.lib.cache.cache_until("start")

--- a/pwndbg/aglib/kernel/paging.py
+++ b/pwndbg/aglib/kernel/paging.py
@@ -667,7 +667,10 @@ class Aarch64PagingInfo(ArchPagingInfo):
     @property
     @pwndbg.lib.cache.cache_until("stop")
     def kbase(self) -> int | None:
-        return self._kbase(pwndbg.aglib.regs.read_reg("vbar", "vbar_el1"))
+        # AArch64 vector base: QEMU >= ~8.x exposes it as `vbar_el1`; older
+        # QEMU releases (and some non-EL1 contexts) expose it as the generic
+        # `vbar`. See #3869 / #3875.
+        return self._kbase(pwndbg.aglib.regs.read_reg("vbar_el1", "vbar"))
 
     @property
     @pwndbg.lib.cache.cache_until("stop")

--- a/pwndbg/aglib/kernel/paging.py
+++ b/pwndbg/aglib/kernel/paging.py
@@ -667,11 +667,7 @@ class Aarch64PagingInfo(ArchPagingInfo):
     @property
     @pwndbg.lib.cache.cache_until("stop")
     def kbase(self) -> int | None:
-        vbar_reg = pwndbg.aglib.regs.read_reg("vbar")
-        if vbar_reg is None:
-            vbar_reg = pwndbg.aglib.regs.read_reg("vbar_el1")
-
-        return self._kbase(vbar_reg)
+        return self._kbase(pwndbg.aglib.regs.read_reg("vbar", "vbar_el1"))
 
     @property
     @pwndbg.lib.cache.cache_until("stop")

--- a/pwndbg/aglib/regs_mod.py
+++ b/pwndbg/aglib/regs_mod.py
@@ -59,7 +59,18 @@ class RegisterManager:
 
         return None
 
-    def read_reg_uncached_in_frame(self, reg: str, frame: pwndbg.dbg_mod.Frame) -> int | None:
+    def read_reg_uncached_in_frame(
+        self, reg: str, frame: pwndbg.dbg_mod.Frame, *aliases: str
+    ) -> int | None:
+        for name in (reg, *aliases):
+            value = self._read_single_reg_uncached_in_frame(name, frame)
+            if value is not None:
+                return value
+        return None
+
+    def _read_single_reg_uncached_in_frame(
+        self, reg: str, frame: pwndbg.dbg_mod.Frame
+    ) -> int | None:
         reg = reg.lstrip("$")
         try:
             value = self.get_register(reg, frame)
@@ -85,23 +96,36 @@ class RegisterManager:
         except (ValueError, pwndbg.dbg_mod.Error):
             return None
 
-    def read_reg_uncached(self, reg: str) -> int | None:
+    def read_reg_uncached(self, reg: str, *aliases: str) -> int | None:
         frame = pwndbg.dbg.selected_frame()
         if frame is None:
             return None
-        return self.read_reg_uncached_in_frame(reg, frame)
+        return self.read_reg_uncached_in_frame(reg, frame, *aliases)
 
-    @pwndbg.lib.cache.cache_until("stop")
-    def read_reg_in_frame(self, reg: str, frame: pwndbg.dbg_mod.Frame) -> int | None:
+    def read_reg_in_frame(self, reg: str, frame: pwndbg.dbg_mod.Frame, *aliases: str) -> int | None:
         """
         Same as read_reg() except for the provided frame, rather than the currently
         selected frame.
         """
-        return self.read_reg_uncached_in_frame(reg, frame)
+        for name in (reg, *aliases):
+            value = self._read_single_reg_in_frame(name, frame)
+            if value is not None:
+                return value
+        return None
 
-    def read_reg(self, reg: str) -> int | None:
+    @pwndbg.lib.cache.cache_until("stop")
+    def _read_single_reg_in_frame(self, reg: str, frame: pwndbg.dbg_mod.Frame) -> int | None:
+        return self._read_single_reg_uncached_in_frame(reg, frame)
+
+    def read_reg(self, reg: str, *aliases: str) -> int | None:
         """
         Query the underlying debugger for the value of a register.
+
+        If `aliases` are provided, each is tried in turn after `reg` until one
+        returns a non-None value. This is useful for architectural registers
+        whose exposed names differ across debugger backends, runtime
+        environments, or toolchain versions (for example, `vbar` vs
+        `vbar_el1` on AArch64).
 
         Note that in some rare cases, debuggers won't directly expose the values of some special model specific registers.
         Although we can sometimes determine these by other indirect means, this function does not run any extra logic to handle these special cases.
@@ -116,7 +140,7 @@ class RegisterManager:
         frame = pwndbg.dbg.selected_frame()
         if frame is None:
             return None
-        return self.read_reg_in_frame(reg, frame)
+        return self.read_reg_in_frame(reg, frame, *aliases)
 
     def write_reg(self, reg: str, value: int) -> None:
         if not pwndbg.dbg.selected_frame().reg_write(reg, value):

--- a/pwndbg/aglib/regs_mod.py
+++ b/pwndbg/aglib/regs_mod.py
@@ -63,38 +63,33 @@ class RegisterManager:
         self, reg: str, frame: pwndbg.dbg_mod.Frame, *aliases: str
     ) -> int | None:
         for name in (reg, *aliases):
-            value = self._read_single_reg_uncached_in_frame(name, frame)
-            if value is not None:
-                return value
+            name = name.lstrip("$")
+            try:
+                value = self.get_register(name, frame)
+                if value is None and name.lower() == "xpsr":
+                    value = self.get_register("xPSR", frame)
+                if value is None:
+                    # Register not exposed by the debugger under this name;
+                    # try the next alias, if any.
+                    continue
+                value = int(value)
+                if name == "eip" and pwndbg.aglib.arch.name == "i8086":
+                    cs = self.get_register("cs", frame)
+                    if cs is None:
+                        continue
+                    value += int(cs) * 0x10
+
+                # The value that the native debugger returns can be negative.
+                # We convert this to the unsigned bit representation by masking it
+                reg_definition = pwndbg.aglib.regs.current.reg_definitions.get(name.lower())
+                if reg_definition and reg_definition.mask is not None:
+                    mask = reg_definition.mask
+                else:
+                    mask = pwndbg.aglib.arch.ptrmask
+                return int(value) & mask
+            except (ValueError, pwndbg.dbg_mod.Error):
+                continue
         return None
-
-    def _read_single_reg_uncached_in_frame(
-        self, reg: str, frame: pwndbg.dbg_mod.Frame
-    ) -> int | None:
-        reg = reg.lstrip("$")
-        try:
-            value = self.get_register(reg, frame)
-            if value is None and reg.lower() == "xpsr":
-                value = self.get_register("xPSR", frame)
-            if value is None:
-                return None
-            value = int(value)
-            if reg == "eip" and pwndbg.aglib.arch.name == "i8086":
-                cs = self.get_register("cs", frame)
-                if cs is None:
-                    return None
-                value += int(cs) * 0x10
-
-            # The value that the native debugger returns can be negative.
-            # We convert this to the unsigned bit representation by masking it
-            reg_definition = pwndbg.aglib.regs.current.reg_definitions.get(reg.lower())
-            if reg_definition and reg_definition.mask is not None:
-                mask = reg_definition.mask
-            else:
-                mask = pwndbg.aglib.arch.ptrmask
-            return int(value) & mask
-        except (ValueError, pwndbg.dbg_mod.Error):
-            return None
 
     def read_reg_uncached(self, reg: str, *aliases: str) -> int | None:
         frame = pwndbg.dbg.selected_frame()
@@ -102,20 +97,13 @@ class RegisterManager:
             return None
         return self.read_reg_uncached_in_frame(reg, frame, *aliases)
 
+    @pwndbg.lib.cache.cache_until("stop")
     def read_reg_in_frame(self, reg: str, frame: pwndbg.dbg_mod.Frame, *aliases: str) -> int | None:
         """
         Same as read_reg() except for the provided frame, rather than the currently
         selected frame.
         """
-        for name in (reg, *aliases):
-            value = self._read_single_reg_in_frame(name, frame)
-            if value is not None:
-                return value
-        return None
-
-    @pwndbg.lib.cache.cache_until("stop")
-    def _read_single_reg_in_frame(self, reg: str, frame: pwndbg.dbg_mod.Frame) -> int | None:
-        return self._read_single_reg_uncached_in_frame(reg, frame)
+        return self.read_reg_uncached_in_frame(reg, frame, *aliases)
 
     def read_reg(self, reg: str, *aliases: str) -> int | None:
         """
@@ -123,9 +111,10 @@ class RegisterManager:
 
         If `aliases` are provided, each is tried in turn after `reg` until one
         returns a non-None value. This is useful for architectural registers
-        whose exposed names differ across debugger backends, runtime
-        environments, or toolchain versions (for example, `vbar` vs
-        `vbar_el1` on AArch64).
+        whose exposed names differ across debugger backends or QEMU versions
+        (for example, newer QEMU exposes `vbar_el1` on AArch64 while older
+        releases exposed it as `vbar`). Pass the most-likely-current name
+        first; less-likely names last.
 
         Note that in some rare cases, debuggers won't directly expose the values of some special model specific registers.
         Although we can sometimes determine these by other indirect means, this function does not run any extra logic to handle these special cases.


### PR DESCRIPTION
Refs #3875

### What

Extend `RegisterManager.read_reg` (and its `_in_frame` / `_uncached` siblings) with a `*aliases: str` varargs. The first name whose read returns a non-None value wins; any trailing names are probed only on miss:

```python
pwndbg.aglib.regs.read_reg("vbar", "vbar_el1")
pwndbg.aglib.regs.read_reg("SCTLR", "SCTLR_EL1")
```

This is the `*aliases` shape proposed by @jxuanli in https://github.com/pwndbg/pwndbg/pull/3869#issuecomment-4255805541.

### Why

Different debugger backends, QEMU versions, and toolchains expose the same architectural register under different names. Recent fixes for AArch64 (#3869 for `vbar`/`vbar_el1`, #3871 for `SCTLR`/`SCTLR_EL1`) each added an inline `if X is None: try Y` fallback. This PR introduces a generic mechanism for that pattern and folds the two existing callsites onto it.

### Changes

- `pwndbg/aglib/regs_mod.py`: add `*aliases` to `read_reg`, `read_reg_in_frame`, `read_reg_uncached`, and `read_reg_uncached_in_frame`. The per-name cache (`@cache_until("stop")`) is preserved by delegating each name to a private `_read_single_reg_in_frame` helper — single-name calls behave identically to before.
- `pwndbg/aglib/kernel/paging.py`: collapse the `vbar` / `vbar_el1` fallback in `Aarch64PagingInfo.kbase` onto `read_reg("vbar", "vbar_el1")`.
- `pwndbg/aglib/kernel/__init__.py`: same for `SCTLR` / `SCTLR_EL1` in `Aarch64Ops.paging_enabled`.

Purely additive API change — every existing caller that passes a single name continues to behave exactly as before.

### Out of scope

- Not touching other ARM sysreg callsites (`TCR_EL1`, `ID_AA64MMFR2_EL1`, `TTBR{0,1}_EL1`, `sp_el0`, `TPIDR_EL0`) — no reported mismatches there yet.
- Not building a `RegisterSet.aliases` registry — @OBarronCS noted per-callsite handling is fine for now; `*aliases` keeps that option open.
- Not touching `pwndbg/emu/emulator.py`'s unicorn `read_register` (orthogonal).

### Testing

- `./lint.sh --check` equivalent: ✅ ruff format, ruff check, custom-lint, mypy, vermin all clean.
- `tests/unit_tests/`: ✅ 46 passed, 4 skipped.
- **Not manually run against an aarch64 QEMU kernel locally** — relying on the existing `tests/library/qemu_system` suite in CI to cover that path. A maintainer smoke-test of `kbase` / `context` / `vmmap` on an aarch64 kernel session would be appreciated.

### PR checklist

+ [x] I read the contributing documentation.
+ [ ] I am providing a screenshot of the (new feature) / (fixed bug). (N/A — internal API refactor with no user-visible UI change; the user-visible outcome was captured in the screenshots on #3869.)