### PR TITLE
Increase macos CI timeout from 60 to 120 minutes

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -109,7 +109,7 @@ jobs:
           pwndbg-gdb-portable-tarball,
         ]
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 60
+    timeout-minutes: 120
     permissions:
       contents: write  # IMPORTANT: this permission is mandatory for github-release upload
     steps:


### PR DESCRIPTION
Change releases-macos build time to 120 min since it times out e.g. here: https://github.com/pwndbg/pwndbg/actions/runs/24897271535/job/72940787519?pr=3728

<!--
    Please make sure to read the linting and testing instructions at
    https://pwndbg.re/dev/contributing/ before creating a PR.
-->

+ [x] I read the contributing documentation.
