### PR TITLE
always push images from docker tests, even if failing

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -134,7 +134,7 @@ jobs:
           '
 
       - name: Push full image to registry
-        if: github.event_name == 'push'
+        if: ${{ !cancelled() && github.event_name == 'push' }}
         run: docker push ghcr.io/pwndbg/pwndbg:${{ matrix.image }}-amd64
 
   docker_aarch64:
@@ -231,7 +231,7 @@ jobs:
           '
 
       - name: Push full image to registry
-        if: github.event_name == 'push'
+        if: ${{ !cancelled() && github.event_name == 'push' }}
         run: docker push ghcr.io/pwndbg/pwndbg:${{ matrix.image }}-arm64
 
   create_manifest:


### PR DESCRIPTION
+ [x] I read the contributing documentation.
+ [x] I am providing a screenshot of the (new feature) / (fixed bug).

This way, PRs CI will match dev

For example, CI Docker tests on archlinux if run on PRs, pull an image with glibc 2.42, as that is the last time the tests passed, therefore the last time the image was pushed; however, dev uses 2.43. Now they will match, and images will be pushed if merged into main regardless of failed tests.

<img width="1277" height="675" alt="Discord_U0qFD4uf33" src="https://github.com/user-attachments/assets/afde23d6-efa0-428d-9034-7814be13bcf9" />
