### PR TITLE
Fix #1875: Improve netlink socket display in procinfo

### DIFF
--- a/pwndbg/lib/net.py
+++ b/pwndbg/lib/net.py
@@ -205,15 +205,65 @@ NETLINK_TYPES = {
     19: "NETLINK_ECRYPTFS",  #
     20: "NETLINK_RDMA",  #
     21: "NETLINK_CRYPTO",  # Crypto layer
+    22: "NETLINK_SMC",  # SMC monitoring
 }
+
+# Multicast group bit flags for NETLINK_ROUTE sockets, matching the legacy
+# RTMGRP_* macros from <linux/rtnetlink.h>. Only NETLINK_ROUTE has a stable
+# kernel-defined mapping for these bits; other netlink families assign meaning
+# to groups in a protocol-specific way, so we don't try to decode them.
+RTMGRP_NAMES = {
+    0x1: "RTMGRP_LINK",
+    0x2: "RTMGRP_NOTIFY",
+    0x4: "RTMGRP_NEIGH",
+    0x8: "RTMGRP_TC",
+    0x10: "RTMGRP_IPV4_IFADDR",
+    0x20: "RTMGRP_IPV4_MROUTE",
+    0x40: "RTMGRP_IPV4_ROUTE",
+    0x80: "RTMGRP_IPV4_RULE",
+    0x100: "RTMGRP_IPV6_IFADDR",
+    0x200: "RTMGRP_IPV6_MROUTE",
+    0x400: "RTMGRP_IPV6_ROUTE",
+    0x800: "RTMGRP_IPV6_IFINFO",
+    0x1000: "RTMGRP_DECnet_IFADDR",
+    0x4000: "RTMGRP_DECnet_ROUTE",
+    0x20000: "RTMGRP_IPV6_PREFIX",
+}
+
+
+def _format_netlink_groups(eth: int, groups: int) -> str:
+    if groups == 0:
+        return "0x0"
+
+    # Only NETLINK_ROUTE has well-known names for individual group bits.
+    if eth != 0:
+        return hex(groups)
+
+    matched = []
+    remaining = groups
+    for bit, name in RTMGRP_NAMES.items():
+        if groups & bit:
+            matched.append(name)
+            remaining &= ~bit
+
+    if not matched:
+        return hex(groups)
+
+    if remaining:
+        matched.append(hex(remaining))
+
+    return "|".join(matched)
 
 
 class Netlink(inode):
     eth: int = 0
     portid: int | None = None
+    groups: int = 0
 
     def __str__(self) -> str:
-        return NETLINK_TYPES.get(self.eth, "(unknown netlink)")
+        family = NETLINK_TYPES.get(self.eth, f"(unknown netlink {self.eth})")
+        groups_str = _format_netlink_groups(self.eth, self.groups)
+        return f"socket:{family} (inode={self.inode}, portid={self.portid}, groups={groups_str})"
 
     def __repr__(self) -> str:
         return f"Netlink({self})"
@@ -225,12 +275,13 @@ def netlink(data: str) -> list[Netlink]:
 
     result: list[Netlink] = []
     for line in data.splitlines()[1:]:
-        # sk       Eth Pid    Groups   Rmem     Wmem     Dump     Locks     Drops     Inode            [10/8747]
+        # sk       Eth Pid    Groups   Rmem     Wmem     Dump     Locks     Drops     Inode
         fields = line.split()
 
         n = Netlink()
         n.eth = int(fields[1])
         n.portid = int(fields[2])  # 'Pid' in Netlink context refers to Port ID, not Process ID
+        n.groups = int(fields[3], 16)
         n.inode = int(fields[9])
         result.append(n)
 

--- a/tests/binaries/host/reference-binary-netlink.native.c
+++ b/tests/binaries/host/reference-binary-netlink.native.c
@@ -1,0 +1,36 @@
+// Opens a NETLINK_ROUTE socket bound to a couple of well-known multicast
+// groups so that pwndbg's procinfo command has something interesting to
+// display.
+
+#include <linux/netlink.h>
+#include <linux/rtnetlink.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+void break_here() {};
+
+int main(void) {
+    int sock = socket(AF_NETLINK, SOCK_RAW, NETLINK_ROUTE);
+    if (sock < 0) {
+        perror("socket");
+        return 1;
+    }
+
+    struct sockaddr_nl addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.nl_family = AF_NETLINK;
+    addr.nl_groups = RTMGRP_LINK | RTMGRP_IPV4_IFADDR;
+
+    if (bind(sock, (struct sockaddr*)&addr, sizeof(addr)) < 0) {
+        perror("bind");
+        close(sock);
+        return 1;
+    }
+
+    break_here();
+
+    close(sock);
+    return 0;
+}

--- a/tests/library/dbg/tests/test_command_procinfo.py
+++ b/tests/library/dbg/tests/test_command_procinfo.py
@@ -12,6 +12,7 @@ from . import get_binary
 from . import pwndbg_test
 
 REFERENCE_BINARY_NET = get_binary("reference-binary-net.native.out")
+REFERENCE_BINARY_NETLINK = get_binary("reference-binary-netlink.native.out")
 
 
 class TCPServerThread(threading.Thread):
@@ -70,3 +71,22 @@ async def test_command_procinfo_net(ctrl: Controller, ip_connect: str) -> None:
 
     # Close tcp server
     server.stop()
+
+
+@pwndbg_test
+async def test_command_procinfo_netlink(ctrl: Controller) -> None:
+    await ctrl.launch(REFERENCE_BINARY_NETLINK)
+
+    break_at_sym("break_here")
+    await ctrl.cont()
+
+    result = await ctrl.execute_and_capture("procinfo")
+
+    # The reference binary opens a NETLINK_ROUTE socket bound to
+    # RTMGRP_LINK | RTMGRP_IPV4_IFADDR. procinfo should decode the
+    # protocol family and the well-known group bits.
+    assert "socket:NETLINK_ROUTE" in result
+    assert "RTMGRP_LINK" in result
+    assert "RTMGRP_IPV4_IFADDR" in result
+    assert "inode=" in result
+    assert "portid=" in result

--- a/tests/unit_tests/test_net.py
+++ b/tests/unit_tests/test_net.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from pwndbg.lib.net import _format_netlink_groups
+from pwndbg.lib.net import netlink
+
+# Sample data based on real /proc/net/netlink output. The header line is
+# always present and is skipped by the parser; subsequent lines describe one
+# socket each. Reference:
+#   sk               Eth Pid        Groups   Rmem     Wmem     Dump  Locks    Drops    Inode
+NETLINK_SAMPLE = """\
+sk               Eth Pid        Groups   Rmem     Wmem     Dump  Locks    Drops    Inode
+00000000e4931d0c 0   2362       00000140 0        0        0     2        0        23942
+00000000a1b2c3d4 12  4096       00000000 0        0        0     2        0        12345
+00000000deadbeef 15  0          ffffffff 0        0        0     2        0        99999
+"""
+
+
+def test_netlink_parses_all_fields() -> None:
+    sockets = netlink(NETLINK_SAMPLE)
+    assert len(sockets) == 3
+
+    route, nf, uevent = sockets
+
+    assert route.eth == 0
+    assert route.portid == 2362
+    assert route.groups == 0x140
+    assert route.inode == 23942
+
+    assert nf.eth == 12
+    assert nf.portid == 4096
+    assert nf.groups == 0
+    assert nf.inode == 12345
+
+    assert uevent.eth == 15
+    assert uevent.portid == 0
+    assert uevent.groups == 0xFFFFFFFF
+    assert uevent.inode == 99999
+
+
+def test_netlink_str_route_decodes_named_groups() -> None:
+    sockets = netlink(NETLINK_SAMPLE)
+    rendered = str(sockets[0])
+    # NETLINK_ROUTE has well-known RTMGRP_* names, so groups=0x140 should be
+    # decoded as RTMGRP_IPV4_ROUTE | RTMGRP_IPV6_IFADDR.
+    assert "socket:NETLINK_ROUTE" in rendered
+    assert "inode=23942" in rendered
+    assert "portid=2362" in rendered
+    assert "RTMGRP_IPV4_ROUTE" in rendered
+    assert "RTMGRP_IPV6_IFADDR" in rendered
+
+
+def test_netlink_str_non_route_uses_hex_groups() -> None:
+    sockets = netlink(NETLINK_SAMPLE)
+    nf = sockets[1]
+    rendered = str(nf)
+    # NETLINK_NETFILTER has no kernel-defined name table for group bits,
+    # so we should fall back to a raw hex value.
+    assert "socket:NETLINK_NETFILTER" in rendered
+    assert "groups=0x0" in rendered
+
+    uevent_rendered = str(sockets[2])
+    assert "socket:NETLINK_KOBJECT_UEVENT" in uevent_rendered
+    assert "groups=0xffffffff" in uevent_rendered
+
+
+def test_netlink_empty_input() -> None:
+    assert netlink("") == []
+
+
+def test_format_netlink_groups_zero() -> None:
+    assert _format_netlink_groups(0, 0) == "0x0"
+    assert _format_netlink_groups(12, 0) == "0x0"
+
+
+def test_format_netlink_groups_route_known_bits() -> None:
+    assert _format_netlink_groups(0, 0x1) == "RTMGRP_LINK"
+    assert _format_netlink_groups(0, 0x10 | 0x40) == "RTMGRP_IPV4_IFADDR|RTMGRP_IPV4_ROUTE"
+
+
+def test_format_netlink_groups_route_with_unknown_bits() -> None:
+    # If there are bits we don't recognize, we still decode the known ones
+    # and append the residual as hex.
+    formatted = _format_netlink_groups(0, 0x1 | 0x80000000)
+    assert formatted.startswith("RTMGRP_LINK|")
+    assert "0x80000000" in formatted
+
+
+def test_format_netlink_groups_non_route_is_hex() -> None:
+    assert _format_netlink_groups(12, 0x140) == "0x140"
+    assert _format_netlink_groups(15, 0x1) == "0x1"


### PR DESCRIPTION
Decode NETLINK_ROUTE multicast group bits to RTMGRP_* names, fall back to hex for other netlink families, and surface the inode and portid alongside the protocol so users don't need to cross-reference /proc/PID/net/netlink themselves.

Before: fd[3]      NETLINK_ROUTE
After:  fd[3]      socket:NETLINK_ROUTE (inode=23942, portid=2362, groups=RTMGRP_LINK|RTMGRP_IPV4_IFADDR)

<!--
    Please make sure to read the linting and testing instructions at
    https://pwndbg.re/dev/contributing/ before creating a PR.
-->

+ [x] I read the contributing documentation.
+ [x] I am providing a screenshot of the (new feature) / (fixed bug).
