### PR TITLE
procinfo: show peer process for unix-domain sockets

### DIFF
--- a/pwndbg/commands/procinfo.py
+++ b/pwndbg/commands/procinfo.py
@@ -6,10 +6,12 @@ import string
 import pwndbg.aglib.file
 import pwndbg.aglib.proc
 import pwndbg.aglib.qemu
+import pwndbg.aglib.remote
 import pwndbg.auxv
 import pwndbg.commands
 import pwndbg.lib.cache
 import pwndbg.lib.net
+import pwndbg.lib.sock_diag
 from pwndbg.color import message
 from pwndbg.commands import CommandCategory
 
@@ -95,6 +97,41 @@ def unix(tid: int):
 def netlink(tid: int):
     data = pwndbg.aglib.file.get(f"/proc/{tid}/net/netlink").decode()
     return pwndbg.lib.net.netlink(data)
+
+
+def _augment_unix_peers(connections: list[pwndbg.lib.net.inode]) -> None:
+    """Attach peer-process info to UnixSocket entries when running locally.
+
+    SOCK_DIAG and /proc/*/fd are kernel-local: for any non-local target the
+    answers would describe the wrong machine, so we silently skip.
+    """
+    unix_socks = [c for c in connections if isinstance(c, pwndbg.lib.net.UnixSocket)]
+    if not unix_socks:
+        return
+    if pwndbg.aglib.remote.is_remote():
+        return
+
+    peers = pwndbg.lib.sock_diag.get_unix_peers()
+    if not peers:
+        return
+
+    peer_inodes: set[int] = set()
+    for u in unix_socks:
+        peer = peers.get(u.inode) if u.inode is not None else None
+        if peer:
+            u.peer_inode = peer
+            peer_inodes.add(peer)
+
+    if not peer_inodes:
+        return
+
+    owners = pwndbg.lib.sock_diag.find_socket_inode_owners(peer_inodes)
+    for u in unix_socks:
+        if u.peer_inode and u.peer_inode in owners:
+            pid, fd, comm = owners[u.peer_inode]
+            u.peer_pid = pid
+            u.peer_fd = fd
+            u.peer_comm = comm or None
 
 
 class Process:
@@ -223,6 +260,7 @@ class Process:
                         x.fd = fd
                         result.append(x)
 
+        _augment_unix_peers(result)
         return tuple(result)
 
 

--- a/pwndbg/lib/net.py
+++ b/pwndbg/lib/net.py
@@ -56,9 +56,28 @@ class Connection(inode):
 
 class UnixSocket(inode):
     path = "(anonymous)"
+    peer_inode: int | None = None
+    peer_pid: int | None = None
+    peer_fd: int | None = None
+    peer_comm: str | None = None
 
     def __str__(self) -> str:
-        return f"unix {self.path!r}"
+        s = f"unix {self.path!r}"
+        parts: list[str] = []
+        if self.inode is not None:
+            parts.append(f"inode={self.inode}")
+        if self.peer_pid is not None:
+            owner = f"pid={self.peer_pid}"
+            if self.peer_comm:
+                owner += f" '{self.peer_comm}'"
+            if self.peer_fd is not None:
+                owner += f" fd={self.peer_fd}"
+            parts.append(f"peer {owner}")
+        elif self.peer_inode:
+            parts.append(f"peer_inode={self.peer_inode}")
+        if parts:
+            s += " (" + ", ".join(parts) + ")"
+        return s
 
     def __repr__(self) -> str:
         return f"UnixSocket({self})"

--- a/pwndbg/lib/sock_diag.py
+++ b/pwndbg/lib/sock_diag.py
@@ -1,0 +1,210 @@
+"""
+Lightweight wrapper around the kernel SOCK_DIAG netlink subsystem.
+
+Right now we only expose the unix-domain peer lookup, which procinfo uses to
+turn an anonymous unix socket FD into a "this end is connected to PID X" line.
+There is no /proc file that exposes peer information, so this can only run
+against the *local* kernel: callers must skip it for remote / cross-machine
+debugging targets.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import struct
+
+# Netlink + SOCK_DIAG protocol constants. These are stable kernel ABI values
+# from <linux/netlink.h> and <linux/sock_diag.h> / <linux/unix_diag.h>; we
+# re-declare them here so we don't depend on socket module additions in newer
+# Python versions.
+_NETLINK_SOCK_DIAG = 4
+_SOCK_DIAG_BY_FAMILY = 20
+
+_NLM_F_REQUEST = 0x1
+_NLM_F_ROOT = 0x100
+_NLM_F_MATCH = 0x200
+_NLM_F_DUMP = _NLM_F_ROOT | _NLM_F_MATCH
+
+_NLMSG_ERROR = 2
+_NLMSG_DONE = 3
+
+_AF_UNIX = 1
+_UDIAG_SHOW_PEER = 0x4
+# enum unix_diag_attrs: UNIX_DIAG_NAME=0, UNIX_DIAG_VFS=1, UNIX_DIAG_PEER=2, ...
+_UNIX_DIAG_PEER = 2
+
+_NLMSG_HDR_FMT = "IHHII"  # len, type, flags, seq, pid
+_NLMSG_HDR_SIZE = struct.calcsize(_NLMSG_HDR_FMT)
+
+# struct unix_diag_req: u8 family, u8 protocol, u16 pad, u32 states, u32 ino,
+#                      u32 show, u32 cookie[2]
+_UNIX_DIAG_REQ_FMT = "BBHIIIII"
+_UNIX_DIAG_REQ_SIZE = struct.calcsize(_UNIX_DIAG_REQ_FMT)
+
+# struct unix_diag_msg: u8 family, u8 type, u8 state, u8 pad, u32 ino,
+#                      u32 cookie[2]
+_UNIX_DIAG_MSG_FMT = "BBBBIII"
+_UNIX_DIAG_MSG_SIZE = struct.calcsize(_UNIX_DIAG_MSG_FMT)
+
+
+def _nlmsg_align(length: int) -> int:
+    return (length + 3) & ~3
+
+
+def get_unix_peers() -> dict[int, int]:
+    """Return ``{inode: peer_inode}`` for unix sockets on the local kernel.
+
+    Sockets without a peer (e.g. listening or unconnected) are simply absent
+    from the returned mapping. Returns an empty dict if the kernel doesn't
+    speak NETLINK_SOCK_DIAG, if we lack permission, or if anything goes wrong
+    while parsing — callers should treat the absence of an entry as "unknown",
+    not as "no peer".
+    """
+    try:
+        sock = socket.socket(socket.AF_NETLINK, socket.SOCK_RAW, _NETLINK_SOCK_DIAG)
+    except OSError:
+        return {}
+
+    try:
+        sock.settimeout(2.0)
+
+        # Dump every unix socket regardless of state, asking the kernel to
+        # include the peer attribute. ino=0 with NLM_F_DUMP means "all".
+        diag_req = struct.pack(
+            _UNIX_DIAG_REQ_FMT,
+            _AF_UNIX,
+            0,
+            0,
+            0xFFFFFFFF,  # all states
+            0,  # ino: 0 = dump all
+            _UDIAG_SHOW_PEER,
+            0xFFFFFFFF,
+            0xFFFFFFFF,  # cookie ~0
+        )
+        nlmsg_len = _NLMSG_HDR_SIZE + _UNIX_DIAG_REQ_SIZE
+        request = (
+            struct.pack(
+                _NLMSG_HDR_FMT,
+                nlmsg_len,
+                _SOCK_DIAG_BY_FAMILY,
+                _NLM_F_REQUEST | _NLM_F_DUMP,
+                1,  # seq
+                0,  # pid (kernel)
+            )
+            + diag_req
+        )
+
+        try:
+            sock.send(request)
+        except OSError:
+            return {}
+
+        peers: dict[int, int] = {}
+        done = False
+        while not done:
+            try:
+                data = sock.recv(65536)
+            except OSError:
+                break
+            if not data:
+                break
+
+            offset = 0
+            while offset + _NLMSG_HDR_SIZE <= len(data):
+                msg_len, msg_type, _flags, _seq, _pid = struct.unpack_from(
+                    _NLMSG_HDR_FMT, data, offset
+                )
+                if msg_len < _NLMSG_HDR_SIZE or offset + msg_len > len(data):
+                    done = True
+                    break
+                if msg_type == _NLMSG_DONE or msg_type == _NLMSG_ERROR:
+                    done = True
+                    break
+                if msg_type == _SOCK_DIAG_BY_FAMILY:
+                    _peers_from_msg(data, offset + _NLMSG_HDR_SIZE, offset + msg_len, peers)
+
+                offset += _nlmsg_align(msg_len)
+
+        return peers
+    finally:
+        sock.close()
+
+
+def _peers_from_msg(buf: bytes, msg_start: int, msg_end: int, out: dict[int, int]) -> None:
+    if msg_start + _UNIX_DIAG_MSG_SIZE > msg_end:
+        return
+    _family, _type, _state, _pad, inode, _c0, _c1 = struct.unpack_from(
+        _UNIX_DIAG_MSG_FMT, buf, msg_start
+    )
+
+    # struct nlattr: u16 nla_len, u16 nla_type
+    attr_offset = msg_start + _UNIX_DIAG_MSG_SIZE
+    while attr_offset + 4 <= msg_end:
+        attr_len, attr_type = struct.unpack_from("HH", buf, attr_offset)
+        if attr_len < 4 or attr_offset + attr_len > msg_end:
+            return
+        if attr_type == _UNIX_DIAG_PEER and attr_len >= 8:
+            (peer_inode,) = struct.unpack_from("I", buf, attr_offset + 4)
+            if peer_inode:
+                out[inode] = peer_inode
+        attr_offset += _nlmsg_align(attr_len)
+
+
+def find_socket_inode_owners(inodes: set[int]) -> dict[int, tuple[int, int, str]]:
+    """For each inode in ``inodes``, find a process holding it as a socket FD.
+
+    Returns ``{inode: (pid, fd, comm)}`` for the *first* owner discovered per
+    inode (peer ownership is 1-to-1 for connected unix sockets, so a single
+    owner is enough). Inodes with no discoverable owner are absent.
+
+    This walks ``/proc/*/fd`` directly, so it only makes sense on a local
+    target. Permission errors on individual processes are ignored.
+    """
+    if not inodes:
+        return {}
+
+    result: dict[int, tuple[int, int, str]] = {}
+    try:
+        proc_entries = os.listdir("/proc")
+    except OSError:
+        return {}
+
+    for entry in proc_entries:
+        if not entry.isdigit():
+            continue
+        if not inodes - result.keys():
+            break
+        pid = int(entry)
+        fd_dir = f"/proc/{pid}/fd"
+        try:
+            fd_entries = os.listdir(fd_dir)
+        except OSError:
+            continue
+
+        comm: str | None = None
+        for fd_name in fd_entries:
+            try:
+                fd = int(fd_name)
+            except ValueError:
+                continue
+            try:
+                link = os.readlink(f"{fd_dir}/{fd_name}")
+            except OSError:
+                continue
+            if not link.startswith("socket:["):
+                continue
+            try:
+                inode = int(link[len("socket:[") : -1])
+            except ValueError:
+                continue
+            if inode in inodes and inode not in result:
+                if comm is None:
+                    try:
+                        with open(f"/proc/{pid}/comm") as f:
+                            comm = f.read().strip()
+                    except OSError:
+                        comm = ""
+                result[inode] = (pid, fd, comm)
+
+    return result

--- a/tests/binaries/host/reference-binary-socketpair.native.c
+++ b/tests/binaries/host/reference-binary-socketpair.native.c
@@ -1,0 +1,22 @@
+// Creates a unix-domain socketpair so that pwndbg's procinfo command has a
+// pair of connected anonymous unix sockets to introspect peer info on.
+
+#include <sys/socket.h>
+#include <stdio.h>
+#include <unistd.h>
+
+void break_here() {};
+
+int main(void) {
+    int fds[2];
+    if (socketpair(AF_UNIX, SOCK_STREAM, 0, fds) < 0) {
+        perror("socketpair");
+        return 1;
+    }
+
+    break_here();
+
+    close(fds[0]);
+    close(fds[1]);
+    return 0;
+}

--- a/tests/library/dbg/tests/test_command_procinfo.py
+++ b/tests/library/dbg/tests/test_command_procinfo.py
@@ -13,6 +13,7 @@ from . import pwndbg_test
 
 REFERENCE_BINARY_NET = get_binary("reference-binary-net.native.out")
 REFERENCE_BINARY_NETLINK = get_binary("reference-binary-netlink.native.out")
+REFERENCE_BINARY_SOCKETPAIR = get_binary("reference-binary-socketpair.native.out")
 
 
 class TCPServerThread(threading.Thread):
@@ -90,3 +91,30 @@ async def test_command_procinfo_netlink(ctrl: Controller) -> None:
     assert "RTMGRP_IPV4_IFADDR" in result
     assert "inode=" in result
     assert "portid=" in result
+
+
+@pwndbg_test
+async def test_command_procinfo_unix_socketpair_peer(ctrl: Controller) -> None:
+    import pwndbg.aglib.proc
+
+    await ctrl.launch(REFERENCE_BINARY_SOCKETPAIR)
+
+    break_at_sym("break_here")
+    await ctrl.cont()
+
+    pid = pwndbg.aglib.proc.pid()
+    result = await ctrl.execute_and_capture("procinfo")
+
+    # The reference binary creates a unix SOCK_STREAM socketpair, so we expect
+    # two anonymous unix sockets in the FD list, each carrying peer info that
+    # points back to the same process. SOCK_DIAG is local-only; this test
+    # exercises the local code path on the test machine's kernel.
+    anon_lines = [
+        line for line in result.splitlines() if "unix '(anonymous)'" in line and "peer" in line
+    ]
+    assert len(anon_lines) == 2, f"expected 2 unix peer lines, got: {anon_lines}"
+
+    for line in anon_lines:
+        assert f"pid={pid}" in line
+        assert "fd=" in line
+        assert "inode=" in line

--- a/tests/unit_tests/test_sock_diag.py
+++ b/tests/unit_tests/test_sock_diag.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import os
+import socket
+
+from pwndbg.lib.sock_diag import find_socket_inode_owners
+from pwndbg.lib.sock_diag import get_unix_peers
+
+
+def _socket_inode(fd: int) -> int:
+    return os.stat(f"/proc/self/fd/{fd}").st_ino
+
+
+def test_get_unix_peers_resolves_socketpair() -> None:
+    # socketpair() is the easiest way to materialize a connected unix pair
+    # the kernel knows about. Each end's inode should map to the other end's.
+    a, b = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+    try:
+        ino_a = _socket_inode(a.fileno())
+        ino_b = _socket_inode(b.fileno())
+        assert ino_a != ino_b
+
+        peers = get_unix_peers()
+        assert peers.get(ino_a) == ino_b
+        assert peers.get(ino_b) == ino_a
+    finally:
+        a.close()
+        b.close()
+
+
+def test_get_unix_peers_after_close() -> None:
+    # Closing one end of the pair makes the kernel forget the peer mapping
+    # for the still-open end. We don't promise the entry vanishes, but it
+    # must not point to a stale inode that's been reused.
+    a, b = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+    ino_b = _socket_inode(b.fileno())
+    a.close()
+    try:
+        peers = get_unix_peers()
+        # The remaining socket may still appear, but its peer should be gone
+        # or at least not the inode of the closed end.
+        assert peers.get(ino_b) != ino_b
+    finally:
+        b.close()
+
+
+def test_find_socket_inode_owners_locates_self() -> None:
+    a, b = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+    try:
+        ino_a = _socket_inode(a.fileno())
+        ino_b = _socket_inode(b.fileno())
+
+        owners = find_socket_inode_owners({ino_a, ino_b})
+        assert ino_a in owners
+        assert ino_b in owners
+
+        pid_a, fd_a, _comm_a = owners[ino_a]
+        pid_b, fd_b, _comm_b = owners[ino_b]
+        assert pid_a == os.getpid()
+        assert pid_b == os.getpid()
+        assert fd_a == a.fileno()
+        assert fd_b == b.fileno()
+    finally:
+        a.close()
+        b.close()
+
+
+def test_find_socket_inode_owners_empty_input() -> None:
+    assert find_socket_inode_owners(set()) == {}
+
+
+def test_find_socket_inode_owners_unknown_inode() -> None:
+    # An inode that no process has open should simply be absent from the
+    # returned dict, not raise.
+    assert find_socket_inode_owners({2**32 - 1}) == {}


### PR DESCRIPTION
For local debug targets, query the kernel via NETLINK_SOCK_DIAG to map each unix socket inode to its peer inode, then resolve that peer back to a (pid, fd, comm) tuple by walking /proc/*/fd. This turns lines like "unix '(anonymous)'" into "unix '(anonymous)' (inode=N, peer pid=M 'comm' fd=K)", which is the missing piece for understanding which processes a debuggee is actually talking to.

SOCK_DIAG is netlink-only (no /proc fallback), so the lookup is gated on aglib.remote.is_remote(): for gdbserver-on-another-machine and QEMU-system targets we silently skip rather than reporting peers from the wrong kernel. Same kernel for kernel-mode targets is a separate problem (walk unix_sock->peer) and is left for later.

<!--
    Please make sure to read the linting and testing instructions at
    https://pwndbg.re/dev/contributing/ before creating a PR.
-->

+ [x] I read the contributing documentation.
+ [x] I am providing a screenshot of the (new feature) / (fixed bug).
