### PR TITLE
Fix #3150: procinfo: show pipe peers and read/write end

### DIFF
--- a/pwndbg/commands/procinfo.py
+++ b/pwndbg/commands/procinfo.py
@@ -11,6 +11,7 @@ import pwndbg.auxv
 import pwndbg.commands
 import pwndbg.lib.cache
 import pwndbg.lib.net
+import pwndbg.lib.proc_fd
 import pwndbg.lib.sock_diag
 from pwndbg.color import message
 from pwndbg.commands import CommandCategory
@@ -132,6 +133,38 @@ def _augment_unix_peers(connections: list[pwndbg.lib.net.inode]) -> None:
             u.peer_pid = pid
             u.peer_fd = fd
             u.peer_comm = comm or None
+
+
+def _augment_pipes(pipes: list[pwndbg.lib.proc_fd.Pipe], self_pid: int) -> None:
+    """Fill in mode and peer endpoints for each Pipe entry, when running locally.
+
+    Pipe peer info comes from walking /proc/*/fd on the local kernel; for a
+    remote target this would describe the wrong machine, so we silently skip.
+    """
+    if not pipes:
+        return
+    if pwndbg.aglib.remote.is_remote():
+        return
+
+    inodes = {p.inode for p in pipes if p.inode is not None}
+    if not inodes:
+        return
+
+    endpoints = pwndbg.lib.proc_fd.find_pipe_endpoints(inodes)
+
+    for pipe_obj in pipes:
+        if pipe_obj.inode is None:
+            continue
+        eps = endpoints.get(pipe_obj.inode, [])
+        for ep_pid, ep_fd, _comm, mode in eps:
+            if ep_pid == self_pid and ep_fd == pipe_obj.fd:
+                pipe_obj.mode = mode
+                break
+        pipe_obj.peers = [
+            (ep_pid, ep_fd, comm, mode)
+            for (ep_pid, ep_fd, comm, mode) in eps
+            if not (ep_pid == self_pid and ep_fd == pipe_obj.fd)
+        ]
 
 
 class Process:
@@ -263,6 +296,27 @@ class Process:
         _augment_unix_peers(result)
         return tuple(result)
 
+    @property
+    @pwndbg.lib.cache.cache_until("stop")
+    def pipes(self) -> tuple[pwndbg.lib.proc_fd.Pipe, ...]:
+        """Pipe FDs (anonymous pipe(2)) with read/write end + peer info."""
+        result: list[pwndbg.lib.proc_fd.Pipe] = []
+        prefix = "pipe:["
+        for fd, path in self.open_files.items():
+            if not path.startswith(prefix):
+                continue
+            try:
+                inode = int(path[len(prefix) : -1])
+            except ValueError:
+                continue
+            p = pwndbg.lib.proc_fd.Pipe()
+            p.inode = inode
+            p.fd = fd
+            result.append(p)
+
+        _augment_pipes(result, self.pid)
+        return tuple(result)
+
 
 @pwndbg.commands.Command("Gets the pid.", aliases=["getpid"], category=CommandCategory.PROCESS)
 @pwndbg.commands.OnlyWhenRunning
@@ -302,6 +356,10 @@ def procinfo() -> None:
 
     for c in proc.connections:
         files[c.fd] = str(c)
+
+    for p in proc.pipes:
+        if p.fd is not None:
+            files[p.fd] = str(p)
 
     print(f"{'pid':<10} {proc.pid}")
     print(f"{'tid':<10} {proc.tid}")

--- a/pwndbg/lib/proc_fd.py
+++ b/pwndbg/lib/proc_fd.py
@@ -1,0 +1,157 @@
+"""
+Helpers for walking ``/proc/*/fd`` to identify which processes share a given
+kernel object.
+
+Currently used by procinfo to turn an anonymous pipe FD ("pipe:[N]") into a
+list of (pid, fd, comm, mode) endpoints. Like the SOCK_DIAG path this is
+inherently local-only — the data lives in the host kernel's procfs and means
+nothing for a remote / different-kernel target.
+"""
+
+from __future__ import annotations
+
+import os
+
+
+class Pipe:
+    """Anonymous pipe FD as seen from one process.
+
+    ``inode`` and ``fd`` describe our own end. ``mode`` is "r"/"w"/"rw"/"?"
+    derived from /proc/PID/fdinfo. ``peers`` lists every *other* FD across
+    the system that points at the same pipe inode, with the same mode info,
+    so the user can see who's on the other end (or that they hold both ends
+    themselves).
+    """
+
+    inode: int | None = None
+    fd: int | None = None
+    mode: str | None = None
+    peers: list[tuple[int, int, str, str]]
+
+    def __init__(self) -> None:
+        self.peers = []
+
+    def __str__(self) -> str:
+        s = f"pipe:[{self.inode}]"
+        parts: list[str] = []
+        if self.mode and self.mode != "?":
+            parts.append(self.mode)
+        if self.peers:
+            parts.append("peers: " + "; ".join(_format_peer(p) for p in self.peers))
+        if parts:
+            s += " (" + ", ".join(parts) + ")"
+        return s
+
+    def __repr__(self) -> str:
+        return f"Pipe({self})"
+
+
+def _format_peer(peer: tuple[int, int, str, str]) -> str:
+    pid, fd, comm, mode = peer
+    s = f"pid={pid}"
+    if comm:
+        s += f" '{comm}'"
+    s += f" fd={fd}"
+    if mode and mode != "?":
+        s += f" {mode}"
+    return s
+
+
+def _read_fdinfo_mode(pid: int, fd: int) -> str:
+    """Return access mode of an FD from /proc/PID/fdinfo/FD as 'r'/'w'/'rw'.
+
+    Returns '?' if fdinfo can't be read or doesn't carry the flags line. The
+    fdinfo flags field is octal text and contains the original open() flags;
+    the bottom two bits encode the access mode (O_RDONLY / O_WRONLY / O_RDWR).
+    """
+    try:
+        with open(f"/proc/{pid}/fdinfo/{fd}") as f:
+            for line in f:
+                if not line.startswith("flags:"):
+                    continue
+                _, _, value = line.partition(":")
+                value = value.strip()
+                if not value:
+                    return "?"
+                try:
+                    flags = int(value, 8)
+                except ValueError:
+                    return "?"
+                access = flags & 0o3
+                if access == 0:
+                    return "r"
+                if access == 1:
+                    return "w"
+                if access == 2:
+                    return "rw"
+                return "?"
+    except OSError:
+        return "?"
+    return "?"
+
+
+def find_pipe_endpoints(
+    target_inodes: set[int],
+) -> dict[int, list[tuple[int, int, str, str]]]:
+    """For each pipe inode in ``target_inodes``, return all FDs holding it.
+
+    Result maps inode -> list of ``(pid, fd, comm, mode)`` sorted by
+    ``(pid, fd)`` for determinism. Inodes with no discoverable holder
+    are absent (the kernel may report a pipe inode that's only held by a
+    process whose ``/proc/PID/fd`` we can't read).
+
+    Permission errors on individual processes are ignored — this is best
+    effort, the same way ``lsof`` is for non-root users.
+    """
+    if not target_inodes:
+        return {}
+
+    result: dict[int, list[tuple[int, int, str, str]]] = {}
+    try:
+        proc_entries = os.listdir("/proc")
+    except OSError:
+        return {}
+
+    for entry in proc_entries:
+        if not entry.isdigit():
+            continue
+        pid = int(entry)
+        fd_dir = f"/proc/{pid}/fd"
+        try:
+            fd_entries = os.listdir(fd_dir)
+        except OSError:
+            continue
+
+        comm: str | None = None
+        for fd_name in fd_entries:
+            try:
+                fd = int(fd_name)
+            except ValueError:
+                continue
+            try:
+                link = os.readlink(f"{fd_dir}/{fd_name}")
+            except OSError:
+                continue
+            if not link.startswith("pipe:["):
+                continue
+            try:
+                inode = int(link[len("pipe:[") : -1])
+            except ValueError:
+                continue
+            if inode not in target_inodes:
+                continue
+
+            if comm is None:
+                try:
+                    with open(f"/proc/{pid}/comm") as f:
+                        comm = f.read().strip()
+                except OSError:
+                    comm = ""
+
+            mode = _read_fdinfo_mode(pid, fd)
+            result.setdefault(inode, []).append((pid, fd, comm, mode))
+
+    for inode in result:
+        result[inode].sort(key=lambda t: (t[0], t[1]))
+
+    return result

--- a/tests/binaries/host/reference-binary-pipe.native.c
+++ b/tests/binaries/host/reference-binary-pipe.native.c
@@ -1,0 +1,22 @@
+// Creates an anonymous pipe(2) so that pwndbg's procinfo command has a known
+// pair of pipe FDs to introspect: a read end and a write end held by the
+// same process.
+
+#include <stdio.h>
+#include <unistd.h>
+
+void break_here() {};
+
+int main(void) {
+    int fds[2];
+    if (pipe(fds) < 0) {
+        perror("pipe");
+        return 1;
+    }
+
+    break_here();
+
+    close(fds[0]);
+    close(fds[1]);
+    return 0;
+}

--- a/tests/library/dbg/tests/test_command_procinfo.py
+++ b/tests/library/dbg/tests/test_command_procinfo.py
@@ -14,6 +14,7 @@ from . import pwndbg_test
 REFERENCE_BINARY_NET = get_binary("reference-binary-net.native.out")
 REFERENCE_BINARY_NETLINK = get_binary("reference-binary-netlink.native.out")
 REFERENCE_BINARY_SOCKETPAIR = get_binary("reference-binary-socketpair.native.out")
+REFERENCE_BINARY_PIPE = get_binary("reference-binary-pipe.native.out")
 
 
 class TCPServerThread(threading.Thread):
@@ -118,3 +119,36 @@ async def test_command_procinfo_unix_socketpair_peer(ctrl: Controller) -> None:
         assert f"pid={pid}" in line
         assert "fd=" in line
         assert "inode=" in line
+
+
+@pwndbg_test
+async def test_command_procinfo_pipe(ctrl: Controller) -> None:
+    import pwndbg.aglib.proc
+
+    await ctrl.launch(REFERENCE_BINARY_PIPE)
+
+    break_at_sym("break_here")
+    await ctrl.cont()
+
+    pid = pwndbg.aglib.proc.pid()
+    result = await ctrl.execute_and_capture("procinfo")
+
+    # The binary calls pipe(2), which gives us one read end and one write
+    # end held by the same process. procinfo should label them as r/w and
+    # show the same-process peer linkage. We can't pin to specific FDs
+    # because the loader may shuffle them, so we look for the pair shape.
+    pipe_lines = [
+        line
+        for line in result.splitlines()
+        if line.lstrip().startswith("fd[") and "pipe:[" in line and "peers:" in line
+    ]
+    # The binary's own pipe(2) plus inherited stdio pipes from the test
+    # harness can produce >2 lines; require at least one read/write pair
+    # whose peer is in this process.
+    own_lines = [line for line in pipe_lines if f"pid={pid}" in line]
+    assert len(own_lines) >= 2, f"expected >=2 self-peering pipe lines, got: {pipe_lines}"
+
+    has_read = any(" (r," in line for line in own_lines)
+    has_write = any(" (w," in line for line in own_lines)
+    assert has_read, f"no read end found: {own_lines}"
+    assert has_write, f"no write end found: {own_lines}"

--- a/tests/unit_tests/test_proc_fd.py
+++ b/tests/unit_tests/test_proc_fd.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import os
+
+from pwndbg.lib.proc_fd import Pipe
+from pwndbg.lib.proc_fd import _read_fdinfo_mode
+from pwndbg.lib.proc_fd import find_pipe_endpoints
+
+
+def _pipe_inode(fd: int) -> int:
+    return os.stat(f"/proc/self/fd/{fd}").st_ino
+
+
+def test_find_pipe_endpoints_locates_both_ends() -> None:
+    # An anonymous pipe(2) gives us a read end and a write end that share
+    # the same inode but have different access modes. find_pipe_endpoints
+    # must report both, with the correct read/write tag for each.
+    r, w = os.pipe()
+    try:
+        inode = _pipe_inode(r)
+        assert _pipe_inode(w) == inode
+
+        endpoints = find_pipe_endpoints({inode})
+        assert inode in endpoints
+        ends = endpoints[inode]
+        assert len(ends) >= 2
+
+        modes = {fd: mode for (pid, fd, _comm, mode) in ends if pid == os.getpid()}
+        assert modes[r] == "r"
+        assert modes[w] == "w"
+    finally:
+        os.close(r)
+        os.close(w)
+
+
+def test_find_pipe_endpoints_empty_input() -> None:
+    assert find_pipe_endpoints(set()) == {}
+
+
+def test_find_pipe_endpoints_unknown_inode() -> None:
+    # A made-up inode that nothing holds should simply be missing from the
+    # result, not raise.
+    assert find_pipe_endpoints({2**32 - 1}) == {}
+
+
+def test_read_fdinfo_mode_for_pipe_ends() -> None:
+    r, w = os.pipe()
+    try:
+        assert _read_fdinfo_mode(os.getpid(), r) == "r"
+        assert _read_fdinfo_mode(os.getpid(), w) == "w"
+    finally:
+        os.close(r)
+        os.close(w)
+
+
+def test_read_fdinfo_mode_unknown_fd() -> None:
+    # A wildly-invalid fd number gives us '?' instead of raising.
+    assert _read_fdinfo_mode(os.getpid(), 999_999) == "?"
+
+
+def test_pipe_str_renders_self_only() -> None:
+    p = Pipe()
+    p.inode = 12345
+    p.fd = 3
+    p.mode = "r"
+    # No peers (e.g., the other end has been closed): we still render mode.
+    assert str(p) == "pipe:[12345] (r)"
+
+
+def test_pipe_str_renders_peer() -> None:
+    p = Pipe()
+    p.inode = 12345
+    p.fd = 3
+    p.mode = "r"
+    p.peers = [(4242, 7, "writer", "w")]
+    s = str(p)
+    assert "pipe:[12345]" in s
+    assert "r" in s
+    assert "pid=4242" in s
+    assert "'writer'" in s
+    assert "fd=7" in s
+    assert "w" in s
+
+
+def test_pipe_str_renders_multiple_peers() -> None:
+    p = Pipe()
+    p.inode = 12345
+    p.fd = 3
+    p.mode = "r"
+    p.peers = [(100, 4, "a", "w"), (200, 5, "b", "w")]
+    s = str(p)
+    assert "pid=100" in s
+    assert "pid=200" in s
+    # The two peers are joined by "; " so both end up on one line.
+    assert s.count(";") == 1


### PR DESCRIPTION
Walk /proc/*/fd to collect every endpoint of each pipe inode our debuggee holds, read /proc/PID/fdinfo/FD to tag each as the read or the write end (O_RDONLY vs O_WRONLY in the bottom two bits of the open flags), then attach the resulting (pid, fd, comm, mode) list to the corresponding FD in procinfo's output. Same-process peers (e.g. our own pipe(2) pair, or a fork that kept both ends) become obvious because the peer pid matches ours; cross-process peers identify the actual reader or writer.

Like the unix-socket peer feature, this is local-only and gated on aglib.remote.is_remote() so we don't report peers from the wrong kernel when the inferior lives on another machine.

<!--
    Please make sure to read the linting and testing instructions at
    https://pwndbg.re/dev/contributing/ before creating a PR.
-->

+ [x] I read the contributing documentation.
+ [x] I am providing a screenshot of the (new feature) / (fixed bug).
