### PR TITLE
tests/lldb: disable debuginfod to avoid flaky CachedFileStream abort

### DIFF
--- a/tests/host/lldb/launch_guest.py
+++ b/tests/host/lldb/launch_guest.py
@@ -34,6 +34,12 @@ async def _run(ctrl: Any, outer: Callable[..., Coroutine[Any, Any, None]]) -> No
                 pytest.skip(f"{os.path.basename(binary)} does not exist. Platform not supported.")
 
             await self.pc.execute("set context-reserve-lines never")
+            # Disable debuginfod globally for LLDB tests: a partial/laggy
+            # download triggers `LLVM ERROR: CachedFileStream was not committed`
+            # which aborts the whole process and makes CI flaky (commonly seen
+            # on the fedora43 image, which ships LLDB 21 + system-wide
+            # debuginfod URLs). See https://github.com/llvm/llvm-project/issues/184728
+            await self.pc.execute("settings clear plugin.symbol-locator.debuginfod.server-urls")
             await self.pc.execute(f"target create {binary}")
             env_args = " ".join((f"-E{k}={v}" for k, v in env.items()))
             await self.pc.execute(


### PR DESCRIPTION
Partial/laggy debuginfod downloads in LLDB 20+ abort the whole process with "LLVM ERROR: CachedFileStream was not committed" (upstream bug https://github.com/llvm/llvm-project/issues/184728), which makes the fedora43 CI job flaky since it ships LLDB 21 + system-wide debuginfod URLs. Tests don't need debuginfod, so disable it for every LLDB test launch instead of relying on per-test opt-in via disable_debuginfod().

<!--
    Please make sure to read the linting and testing instructions at
    https://pwndbg.re/dev/contributing/ before creating a PR.
-->
