### PR TITLE
Disassemble backwards in variable width instruction sets

### DIFF
--- a/docs/configuration/config.md
+++ b/docs/configuration/config.md
@@ -228,6 +228,17 @@ Number of spaces that a <tab> in the source code counts for.
 
 ----------
 
+## **context-disasm-back-linear-lines**
+
+
+Maximum number of lines to disassemble backwards linearly in memory.
+
+
+
+**Default:** 'auto'  
+
+----------
+
 ## **context-disasm-lines**
 
 

--- a/docs/configuration/config.md
+++ b/docs/configuration/config.md
@@ -659,6 +659,17 @@ The soft line width for go-dump pretty printing.
 
 ----------
 
+## **heuristic-backwards-disasm**
+
+
+Toggle backwards linear disassembly during emulation.
+
+
+
+**Default:** on  
+
+----------
+
 ## **hexdump-bytes**
 
 

--- a/pwndbg/aglib/disasm/disassembly.py
+++ b/pwndbg/aglib/disasm/disassembly.py
@@ -576,6 +576,7 @@ def near(
     show_prev_insns=True,
     use_cache=False,
     linear=False,
+    max_backwards_linear_count: int | None = None,
 ) -> tuple[list[PwndbgInstruction], int, int]:
     """
     Disassembles instructions near given `address`. Passing `emulate` makes use of
@@ -665,6 +666,7 @@ def near(
     # The assumption is that the instruction list will start with the linear instructions, and then transition to the emulated one
     index_of_last_linearly_disassembled_instruction = -1
 
+    count_backwards_linear = 0
     if show_prev_insns:
         saveptr = InstructionSequenceSavePointer(None)
 
@@ -675,6 +677,12 @@ def near(
             insn, was_linear = prev_instruction_fetch
 
             if was_linear:
+                count_backwards_linear += 1
+                if (
+                    max_backwards_linear_count is not None
+                    and count_backwards_linear > max_backwards_linear_count
+                ):
+                    break
                 index_of_last_linearly_disassembled_instruction += 1
 
             if DEBUG_ENHANCEMENT:
@@ -684,7 +692,10 @@ def near(
             insns.append(insn)
 
             prev_instruction_fetch = get_previous_instruction(
-                insn.address, use_cache=use_cache, linear=linear, saveptr=saveptr
+                insn.address,
+                use_cache=use_cache,
+                linear=linear,
+                saveptr=saveptr,
             )
         insns.reverse()
 

--- a/pwndbg/aglib/disasm/disassembly.py
+++ b/pwndbg/aglib/disasm/disassembly.py
@@ -572,10 +572,10 @@ def near(
     backward_count: int = 0,
     total_count: int | None = None,
     end_address: int | None = None,
-    emulate=False,
-    show_prev_insns=True,
-    use_cache=False,
-    linear=False,
+    emulate: bool = False,
+    show_prev_insns: bool = True,
+    use_cache: bool = False,
+    linear: bool = False,
     max_backwards_linear_count: int | None = None,
 ) -> tuple[list[PwndbgInstruction], int, int]:
     """

--- a/pwndbg/aglib/disasm/disassembly.py
+++ b/pwndbg/aglib/disasm/disassembly.py
@@ -55,6 +55,14 @@ Enabling this may make disassembly slower.
 """,
 )
 
+# This global flag is used in tests to disable heuristic-based linear backwards disassembly
+heuristic_backwards_linear_disassembly_enabled = pwndbg.config.add_param(
+    "heuristic-backwards-disasm",
+    True,
+    "toggle backwards linear disassembly during emulation",
+    param_class=pwndbg.lib.config.PARAM_BOOLEAN,
+)
+
 # Caching strategy:
 # To ensure we don't have stale register/memory information in our cached PwndbgInstruction,
 # we clear the cache whenever we DON'T do a `stepi`, `nexti`, `step`, or `next` command.
@@ -238,7 +246,7 @@ def get_previous_instruction(
 HEURISTIC_INSTRUCTION_ALIGN_COUNT = 10
 
 
-def get_previous_linear_address_with_heuristic(current_address: int) -> int:
+def get_previous_linear_address_with_heuristic(current_address: int) -> int | None:
     """
     Return the address at which the previous instruction starts.
 
@@ -256,6 +264,9 @@ def get_previous_linear_address_with_heuristic(current_address: int) -> int:
 
     if pwndbg.aglib.arch.constant_instruction_size:
         return current_address - pwndbg.aglib.arch.max_instruction_size
+
+    if not heuristic_backwards_linear_disassembly_enabled:
+        return None
 
     max_instruction_size = pwndbg.aglib.arch.max_instruction_size
 
@@ -602,6 +613,8 @@ def near(
 
     pc = pwndbg.aglib.regs.pc
 
+    disassembling_from_pc = pc == address
+
     # Some architecture aren't emulated yet
     if not pwndbg.emu or pwndbg.aglib.arch.name not in pwndbg.emu.emulator.arch_to_UC:
         emulate = False
@@ -633,7 +646,7 @@ def near(
         address,
         emu,
         put_cache=True,
-        put_linear_backward_cache=False,
+        put_linear_backward_cache=disassembling_from_pc,
         assistant=assistant,
         linear=linear,
     )
@@ -730,6 +743,9 @@ def near(
         if end_address is not None and target >= end_address:
             break
 
+        populate_backward_linear_cache: bool = (
+            disassembling_from_pc or len(insns) >= HEURISTIC_INSTRUCTION_ALIGN_COUNT
+        )
         # Emulation may have failed or been disabled in the last call to one()
         if emu:
             if not emu.last_step_succeeded or not emu.valid:
@@ -768,7 +784,7 @@ def near(
                 split_insn = one(
                     delay_slot_address,
                     emu=None,
-                    put_linear_backward_cache=len(insns) >= HEURISTIC_INSTRUCTION_ALIGN_COUNT,
+                    put_linear_backward_cache=populate_backward_linear_cache,
                     put_cache=True,
                     linear=linear,
                 )
@@ -834,7 +850,7 @@ def near(
             target,
             emu,
             put_cache=True,
-            put_linear_backward_cache=len(insns) >= HEURISTIC_INSTRUCTION_ALIGN_COUNT,
+            put_linear_backward_cache=populate_backward_linear_cache,
             assistant=assistant,
             linear=linear,
         )

--- a/pwndbg/aglib/disasm/disassembly.py
+++ b/pwndbg/aglib/disasm/disassembly.py
@@ -133,7 +133,7 @@ class InstructionSequenceSavePointer:
 # Dict of Address -> previous instruction sequentially in memory
 # Some architectures don't have fixed-sized instructions, so this is used
 # to disassemble backwards linearly in memory for those cases
-linear_backward_address_cache: collections.defaultdict[int, int] = collections.defaultdict(
+linear_backward_address_cache: collections.defaultdict[int, int | None] = collections.defaultdict(
     lambda: None
 )
 

--- a/pwndbg/aglib/disasm/disassembly.py
+++ b/pwndbg/aglib/disasm/disassembly.py
@@ -99,12 +99,6 @@ def clear_on_reg_mem_change() -> None:
     next_addresses_cache.clear()
 
 
-# Dict of Address -> previous instruction sequentially in memory
-# Some architectures don't have fixed-sized instructions, so this is used
-# to disassemble backwards linearly in memory for those cases
-linear_backward_cache: collections.defaultdict[int, int] = collections.defaultdict(lambda: None)
-
-
 # In order to track the sequence of instructions at runtime, we maintain a linked list, where each
 # entry points to the previous instruction that was executed.
 # This is populated speculatively using emulation.
@@ -128,6 +122,14 @@ class InstructionSequenceSavePointer:
     node: InstructionSequenceNode | None
 
 
+# Dict of Address -> previous instruction sequentially in memory
+# Some architectures don't have fixed-sized instructions, so this is used
+# to disassemble backwards linearly in memory for those cases
+linear_backward_address_cache: collections.defaultdict[int, int] = collections.defaultdict(
+    lambda: None
+)
+
+
 # Map addresses to their entry in the linked list.
 # While the emulation may encounter this address multiple times, this map only contains a mapping for the first
 # time the instruction is executed.
@@ -136,11 +138,12 @@ instruction_sequence_linked_list_map: collections.defaultdict[
 ] = collections.defaultdict(lambda: None)
 
 
-# In case the linked list method fails (we cannot be 100% certain of instruction order),
-# it is still nice to be able to display instructions behind the instruction pointer.
 # This tracks the order of instructions based on the last time we disassembled them.
+# It is only used in a specific case: if the linked list method fails (we cannot be 100% certain of instruction order),
+# it is still nice to be able to display instructions behind the instruction pointer. For dynamic cases,
+# it's most likely that we arrived at a location the same way we previously arrived there, which this tracks.
 # Map of address to previous address
-fallback_backward_cache: collections.defaultdict[int, int | None] = collections.defaultdict(
+dynamic_backward_address_cache: collections.defaultdict[int, int | None] = collections.defaultdict(
     lambda: None
 )
 
@@ -176,13 +179,10 @@ def get_previous_instruction(
     Retrieve the instruction prior to the instruction at `address`.
     """
     if linear:
-        prev_address = linear_backward_cache[address]
-
-        if prev_address is None:
-            prev_address = get_previous_address_heuristic(address)
+        prev_address = get_previous_address_with_heuristic(address)
 
         return (
-            one(prev_address, from_cache=use_cache, put_backward_cache=False, linear=linear)
+            one(prev_address, from_cache=use_cache, put_linear_backward_cache=False, linear=linear)
             if prev_address
             else None
         )
@@ -195,91 +195,125 @@ def get_previous_instruction(
         if prev_node is not None:
             return prev_node.instruction
 
-    prev_address = fallback_backward_cache[address]
+    prev_address = dynamic_backward_address_cache[address]
 
     if prev_address is None:
-        prev_address = get_previous_address_heuristic(address)
+        prev_address = get_previous_address_with_heuristic(address)
 
     return (
-        one(prev_address, from_cache=use_cache, put_backward_cache=False) if prev_address else None
+        one(
+            prev_address,
+            from_cache=use_cache,
+            put_linear_backward_cache=False,
+            put_dynamic_backward_cache=False,
+        )
+        if prev_address
+        else None
     )
 
 
-def get_previous_address_heuristic(current_instruction_address: int) -> int:
+# If we start disassembling at a given address (which may be in the middle of a instruction),
+# how many instructions will it take for the instruction sequence to align with true instruction boundaries?
+# This is a highly conservative to avoid incorrect disassembly in the view.
+HEURISTIC_INSTRUCTION_ALIGN_COUNT = 10
+
+
+def get_previous_address_with_heuristic(current_address: int) -> int:
     """
     Return the address at which the previous instruction starts.
 
-    On variable width instructions sets like x86, disassembling backwards requires some hueristics, since instructions are
+    On variable width instructions sets like x86, disassembling backwards requires some heuristics, since instructions are
     not self-synchronizing.
 
     However, in practice, long sequences of instructions are self-aligning. If we start disassembling many bytes into the past,
     we can have confidence that the instruction sequence will align with the true instruction boundaries eventually.
 
-    While doing this, we populate the `linear_backward_cache` to avoid calling this function too many times.
+    While doing this, we populate the `linear_backward_address_cache` to avoid calling this function too many times.
     """
 
+    if (prev_address := linear_backward_address_cache[current_address]) is not None:
+        return prev_address
+
     if pwndbg.aglib.arch.constant_instruction_size:
-        return current_instruction_address - pwndbg.aglib.arch.max_instruction_size
+        return current_address - pwndbg.aglib.arch.max_instruction_size
 
     max_instruction_size = pwndbg.aglib.arch.max_instruction_size
 
-    # Start disassembling 30 instructions worth of byte behind the PC, assuming the worst case that all instructions are max width.
-    # However, we will have confidence that the last 20 instructions are aligned correctly.
+    # Start disassembling 20 instructions worth of byte behind the PC, assuming the worst case that all instructions are max width.
+    # However, we will have confidence that the last 10 instructions are aligned correctly.
     # This is highly conservative to give high confidence that instruction boundaries have aligned.
-    HUERISTIC_INSTRUCTION_COUNT = 30
-    CONFIDENCE_INSTRUCTION_COUNT = 20
+    HEURISTIC_START_N_INSTRUCTION_IN_PAST = 20
+    CONFIDENCE_INSTRUCTION_COUNT = (
+        HEURISTIC_START_N_INSTRUCTION_IN_PAST - HEURISTIC_INSTRUCTION_ALIGN_COUNT
+    )
 
-    START_BYTE_OFFSET = max_instruction_size * HUERISTIC_INSTRUCTION_COUNT
+    START_BYTE_OFFSET = max_instruction_size * HEURISTIC_START_N_INSTRUCTION_IN_PAST
 
-    # At what offset behind the PC do we no longer want to try to start disassembling from?
-    LAST_SAFE_ADDRESS_OFFSET = max_instruction_size * CONFIDENCE_INSTRUCTION_COUNT
+    # Start disassembling here
+    heuristic_start_address = current_address - START_BYTE_OFFSET
 
-    cs_info = pwndbg.aglib.arch.get_capstone_constants(current_instruction_address)
-    if cs_info is None:
-        # This means capstone disassembler is not supported
-        return None
-
-    md = get_disassembler(cs_info)
-
+    byte_sequence: bytearray = None
+    # Extract the maximal viable byte sequence that we will disassemble within
     for guess_disassembly_address in range(
-        current_instruction_address - START_BYTE_OFFSET,
-        current_instruction_address - LAST_SAFE_ADDRESS_OFFSET,
+        heuristic_start_address,
+        current_address,
     ):
-        # If we encounter errors while disassembling, this loop allows us to move
-        # forward one byte and try again
-
         # Make sure we are in an executable page
         page = pwndbg.aglib.vmmap.find(guess_disassembly_address)
         if page is None or not page.execute:
             continue
 
         try:
-            data = pwndbg.aglib.memory.read(
-                guess_disassembly_address, current_instruction_address - guess_disassembly_address
+            byte_sequence = pwndbg.aglib.memory.read(
+                guess_disassembly_address, current_address - guess_disassembly_address
             )
-
-            capstone_instructions = list(md.disasm(bytes(data), guess_disassembly_address))
-
-            # Capstone returns empty list or truncated list when it fails to disassemble an instruction
-            # In this case, just move up one byte until it doesn't fail
-            if len(capstone_instructions) < CONFIDENCE_INSTRUCTION_COUNT:
-                continue
-
-            instructions = capstone_instructions[-CONFIDENCE_INSTRUCTION_COUNT:]
-
-            if instructions[-1].address + instructions[-1].size != current_instruction_address:
-                # In the unlikely case that these instruction don't lead to the current one, keep trying
-                continue
-
-            # Setup cache values
-            for insn in instructions:
-                linear_backward_cache[insn.address + insn.size] = insn.address
-
-            return instructions[-1].address
-
+            heuristic_start_address = guess_disassembly_address
+            break
         except pwndbg.dbg_mod.Error:
             # The memory read might fail (reading around address space boundary, for example)
             continue
+
+    # Unable to read bytes
+    if byte_sequence is None:
+        return None
+
+    cs_info = pwndbg.aglib.arch.get_capstone_constants(current_address)
+    if cs_info is None:
+        # This means capstone disassembler is not supported
+        return None
+
+    md = get_disassembler(cs_info)
+
+    # In most cases, this loop will run at most `max_instruction_size` times.
+    # However, in case the bytes have inline data that cause disassembly failure, this will
+    # continue loop until it moves past those bytes
+    for offset, guess_disassembly_address in enumerate(
+        range(
+            heuristic_start_address,
+            current_address,
+        )
+    ):
+        # If we encounter errors while disassembling, this loop allows us to move
+        # forward one byte and try again
+        capstone_instructions = list(md.disasm(byte_sequence[offset:], guess_disassembly_address))
+
+        # Capstone returns empty list or truncated list when it fails to disassemble an instruction
+        # In this case, just move up one byte until it doesn't fail
+        if len(capstone_instructions) < HEURISTIC_START_N_INSTRUCTION_IN_PAST:
+            continue
+
+        instructions = capstone_instructions[-CONFIDENCE_INSTRUCTION_COUNT:]
+
+        if instructions[-1].address + instructions[-1].size != current_address:
+            # This case is very likely if `current_address` is not at a real instruction boundary
+            # If this is the case, the disassembled instructions will never lead to the current instruction
+            continue
+
+        # Setup cache values
+        for insn in instructions:
+            linear_backward_address_cache[insn.address + insn.size] = insn.address
+
+        return instructions[-1].address
 
     return None
 
@@ -311,7 +345,8 @@ def one(
     assistant: DisassemblyAssistant | None = None,
     from_cache: bool = False,
     put_cache: bool = False,
-    put_backward_cache: bool = True,
+    put_linear_backward_cache: bool = True,
+    put_dynamic_backward_cache: bool = True,
     linear: bool = False,
 ) -> PwndbgInstruction | None:
     """
@@ -335,11 +370,11 @@ def one(
         if put_cache:
             computed_instruction_cache[address] = insn
 
-        if put_backward_cache:
-            linear_backward_cache[insn.address + insn.size] = insn.address
+        if put_linear_backward_cache:
+            linear_backward_address_cache[insn.address + insn.size] = insn.address
 
-            if not linear:
-                fallback_backward_cache[insn.next] = insn.address
+        if put_dynamic_backward_cache and not linear:
+            dynamic_backward_address_cache[insn.next] = insn.address
         return insn
 
     return None
@@ -570,7 +605,14 @@ def near(
                 assistant.manual_register_values.write_register(reg, reg_value)
 
     # Start at the current instruction using emulation if available.
-    current = one(address, emu, put_cache=True, assistant=assistant, linear=linear)
+    current = one(
+        address,
+        emu,
+        put_cache=True,
+        put_linear_backward_cache=False,
+        assistant=assistant,
+        linear=linear,
+    )
 
     if DEBUG_ENHANCEMENT:
         if emu and not emu.last_step_succeeded:
@@ -680,7 +722,13 @@ def near(
                 # Therefore, we must disassemble the delay slot instructions here as the normal codeflow will not reach them.
 
                 delay_slot_address = insn.address + insn.size
-                split_insn = one(delay_slot_address, None, put_cache=True, linear=linear)
+                split_insn = one(
+                    delay_slot_address,
+                    emu=None,
+                    put_linear_backward_cache=len(insns) >= HEURISTIC_INSTRUCTION_ALIGN_COUNT,
+                    put_cache=True,
+                    linear=linear,
+                )
 
                 # There might not be a valid instruction at the branch delay slot
                 if split_insn is None:
@@ -693,9 +741,11 @@ def near(
 
                 delay_slot_cache[split_insn.address] = insn
 
-                fallback_backward_cache[insn.next] = split_insn.address
-                fallback_backward_cache[split_insn.address + split_insn.size] = split_insn.address
-                fallback_backward_cache[split_insn.address] = insn.address
+                dynamic_backward_address_cache[insn.next] = split_insn.address
+                dynamic_backward_address_cache[split_insn.address + split_insn.size] = (
+                    split_insn.address
+                )
+                dynamic_backward_address_cache[split_insn.address] = insn.address
 
                 instruction_sequence_head = InstructionSequenceNode(
                     instruction_sequence_head, split_insn
@@ -732,7 +782,19 @@ def near(
         next_addresses_cache.add(target)
 
         # The emulator is stepped within this call
-        insn = one(target, emu, put_cache=True, assistant=assistant, linear=linear)
+        # Explanation for the `put_linear_backward_cache` logic:
+        #   We only want to record the sequence of instructions when we are confident that it's the correct sequence.
+        #   It is possible that we are disassembling from the middle of an instruction, if we are doing `nearpc guessed_address`
+        #   If we start caching the instruction sequence immediately, the cached instruction sequence would be incorrect,
+        #   causing later backwards disassembly (which pulls from the cache) to get incorrect addresses.
+        insn = one(
+            target,
+            emu,
+            put_cache=True,
+            put_linear_backward_cache=len(insns) >= HEURISTIC_INSTRUCTION_ALIGN_COUNT,
+            assistant=assistant,
+            linear=linear,
+        )
 
         if insn:
             # Add the instruction to the front of the linked list tracking the dynamic instruction sequence.

--- a/pwndbg/aglib/disasm/disassembly.py
+++ b/pwndbg/aglib/disasm/disassembly.py
@@ -24,6 +24,7 @@ import pwndbg.aglib.disasm.riscv
 import pwndbg.aglib.disasm.sparc
 import pwndbg.aglib.disasm.x86
 import pwndbg.aglib.memory
+import pwndbg.aglib.vmmap
 import pwndbg.emu.emulator
 import pwndbg.lib.cache
 import pwndbg.lib.config
@@ -176,19 +177,15 @@ def get_previous_instruction(
     """
     if linear:
         prev_address = linear_backward_cache[address]
-        result = (
+
+        if prev_address is None:
+            prev_address = get_previous_address_heuristic(address)
+
+        return (
             one(prev_address, from_cache=use_cache, put_backward_cache=False, linear=linear)
             if prev_address
             else None
         )
-        if result is None and pwndbg.aglib.arch.constant_instruction_size:
-            return one(
-                address - pwndbg.aglib.arch.max_instruction_size,
-                from_cache=use_cache,
-                put_backward_cache=False,
-                linear=linear,
-            )
-        return result
 
     sequence_node = get_instruction_sequence_node(address, saveptr)
 
@@ -199,9 +196,92 @@ def get_previous_instruction(
             return prev_node.instruction
 
     prev_address = fallback_backward_cache[address]
+
+    if prev_address is None:
+        prev_address = get_previous_address_heuristic(address)
+
     return (
         one(prev_address, from_cache=use_cache, put_backward_cache=False) if prev_address else None
     )
+
+
+def get_previous_address_heuristic(current_instruction_address: int) -> int:
+    """
+    Return the address at which the previous instruction starts.
+
+    On variable width instructions sets like x86, disassembling backwards requires some hueristics, since instructions are
+    not self-synchronizing.
+
+    However, in practice, long sequences of instructions are self-aligning. If we start disassembling many bytes into the past,
+    we can have confidence that the instruction sequence will align with the true instruction boundaries eventually.
+
+    While doing this, we populate the `linear_backward_cache` to avoid calling this function too many times.
+    """
+
+    if pwndbg.aglib.arch.constant_instruction_size:
+        return current_instruction_address - pwndbg.aglib.arch.max_instruction_size
+
+    max_instruction_size = pwndbg.aglib.arch.max_instruction_size
+
+    # Start disassembling 30 instructions worth of byte behind the PC, assuming the worst case that all instructions are max width.
+    # However, we will have confidence that the last 20 instructions are aligned correctly.
+    # This is highly conservative to give high confidence that instruction boundaries have aligned.
+    HUERISTIC_INSTRUCTION_COUNT = 30
+    CONFIDENCE_INSTRUCTION_COUNT = 20
+
+    START_BYTE_OFFSET = max_instruction_size * HUERISTIC_INSTRUCTION_COUNT
+
+    # At what offset behind the PC do we no longer want to try to start disassembling from?
+    LAST_SAFE_ADDRESS_OFFSET = max_instruction_size * CONFIDENCE_INSTRUCTION_COUNT
+
+    cs_info = pwndbg.aglib.arch.get_capstone_constants(current_instruction_address)
+    if cs_info is None:
+        # This means capstone disassembler is not supported
+        return None
+
+    md = get_disassembler(cs_info)
+
+    for guess_disassembly_address in range(
+        current_instruction_address - START_BYTE_OFFSET,
+        current_instruction_address - LAST_SAFE_ADDRESS_OFFSET,
+    ):
+        # If we encounter errors while disassembling, this loop allows us to move
+        # forward one byte and try again
+
+        # Make sure we are in an executable page
+        page = pwndbg.aglib.vmmap.find(guess_disassembly_address)
+        if page is None or not page.execute:
+            continue
+
+        try:
+            data = pwndbg.aglib.memory.read(
+                guess_disassembly_address, current_instruction_address - guess_disassembly_address
+            )
+
+            capstone_instructions = list(md.disasm(bytes(data), guess_disassembly_address))
+
+            # Capstone returns empty list or truncated list when it fails to disassemble an instruction
+            # In this case, just move up one byte until it doesn't fail
+            if len(capstone_instructions) < CONFIDENCE_INSTRUCTION_COUNT:
+                continue
+
+            instructions = capstone_instructions[-CONFIDENCE_INSTRUCTION_COUNT:]
+
+            if instructions[-1].address + instructions[-1].size != current_instruction_address:
+                # In the unlikely case that these instruction don't lead to the current one, keep trying
+                continue
+
+            # Setup cache values
+            for insn in instructions:
+                linear_backward_cache[insn.address + insn.size] = insn.address
+
+            return instructions[-1].address
+
+        except pwndbg.dbg_mod.Error:
+            # The memory read might fail (reading around address space boundary, for example)
+            continue
+
+    return None
 
 
 @pwndbg.lib.cache.cache_until("objfile")

--- a/pwndbg/aglib/disasm/disassembly.py
+++ b/pwndbg/aglib/disasm/disassembly.py
@@ -174,33 +174,51 @@ def get_instruction_sequence_node(
 
 def get_previous_instruction(
     address: int, use_cache: bool, linear: bool, saveptr: InstructionSequenceSavePointer
-) -> PwndbgInstruction | None:
+) -> tuple[PwndbgInstruction, bool] | None:
     """
     Retrieve the instruction prior to the instruction at `address`.
+
+    Also, indicates whether the instruction was pulled linearly from memory, rather than using emulated flow.
+
+    Returns:
+        Tuple[PwndbgInstruction, is_linear]
     """
     if linear:
-        prev_address = get_previous_address_with_heuristic(address)
+        prev_address = get_previous_linear_address_with_heuristic(address)
 
-        return (
+        insn = (
             one(prev_address, from_cache=use_cache, put_linear_backward_cache=False, linear=linear)
             if prev_address
             else None
         )
 
+        return (insn, True) if insn is not None else None
+
+    # Fetch instruction assuming dynamic flow
     sequence_node = get_instruction_sequence_node(address, saveptr)
 
     if sequence_node is not None:
         prev_node = sequence_node.previous
         saveptr.node = prev_node
         if prev_node is not None:
-            return prev_node.instruction
+            return (prev_node.instruction, False)
 
     prev_address = dynamic_backward_address_cache[address]
 
-    if prev_address is None:
-        prev_address = get_previous_address_with_heuristic(address)
+    if prev_address is not None:
+        insn = one(
+            prev_address,
+            from_cache=use_cache,
+            put_linear_backward_cache=False,
+            put_dynamic_backward_cache=False,
+        )
 
-    return (
+        return (insn, False) if insn is not None else None
+
+    # Finally, fall back to getting linearly from memory
+    prev_address = get_previous_linear_address_with_heuristic(address)
+
+    insn = (
         one(
             prev_address,
             from_cache=use_cache,
@@ -211,6 +229,8 @@ def get_previous_instruction(
         else None
     )
 
+    return (insn, True) if insn is not None else None
+
 
 # If we start disassembling at a given address (which may be in the middle of a instruction),
 # how many instructions will it take for the instruction sequence to align with true instruction boundaries?
@@ -218,7 +238,7 @@ def get_previous_instruction(
 HEURISTIC_INSTRUCTION_ALIGN_COUNT = 10
 
 
-def get_previous_address_with_heuristic(current_address: int) -> int:
+def get_previous_linear_address_with_heuristic(current_address: int) -> int:
     """
     Return the address at which the previous instruction starts.
 
@@ -228,7 +248,7 @@ def get_previous_address_with_heuristic(current_address: int) -> int:
     However, in practice, long sequences of instructions are self-aligning. If we start disassembling many bytes into the past,
     we can have confidence that the instruction sequence will align with the true instruction boundaries eventually.
 
-    While doing this, we populate the `linear_backward_address_cache` to avoid calling this function too many times.
+    While doing this, we populate the `linear_backward_address_cache` to avoid disassembling the same memory again and again.
     """
 
     if (prev_address := linear_backward_address_cache[current_address]) is not None:
@@ -556,7 +576,7 @@ def near(
     show_prev_insns=True,
     use_cache=False,
     linear=False,
-) -> tuple[list[PwndbgInstruction], int]:
+) -> tuple[list[PwndbgInstruction], int, int]:
     """
     Disassembles instructions near given `address`. Passing `emulate` makes use of
     unicorn engine to emulate instructions to predict branches that will be taken.
@@ -574,6 +594,9 @@ def near(
             If this is set, `forward_count` is ignored.
         end_address:
             determines the maximum address (non-inclusive) that can be disassembled.
+
+    Returns:
+        Tuple[list of disassembled instructions, index of instruction at `address`, index of last instruction disassembled linearly]
     """
 
     pc = pwndbg.aglib.regs.pc
@@ -592,7 +615,7 @@ def near(
         except pwndbg.dbg_mod.Error as e:
             match = re.search(r"Memory at address (\w+) unavailable\.", str(e))
             if match:
-                return ([], -1)
+                return ([], -1, -1)
             raise
 
     # By using the same assistant for all the instructions disassembled in this pass, we can track and share information across the instructions
@@ -619,7 +642,7 @@ def near(
             print("Emulator failed at first step")
 
     if current is None:
-        return ([], -1)
+        return ([], -1, -1)
 
     # A linked list that contains the order of instructions that emulation
     # determines will run upon uses of the "nexti" command.
@@ -638,20 +661,29 @@ def near(
     if DEBUG_ENHANCEMENT:
         print(f"CACHE START -------------------, {current.address}")
 
+    # Keep track of which of the previous instructions were disassembly linearly so we can display them as gray while emulating
+    # The assumption is that the instruction list will start with the linear instructions, and then transition to the emulated one
+    index_of_last_linearly_disassembled_instruction = -1
+
     if show_prev_insns:
         saveptr = InstructionSequenceSavePointer(None)
 
-        insn = get_previous_instruction(
+        prev_instruction_fetch = get_previous_instruction(
             current.address, use_cache=use_cache, linear=linear, saveptr=saveptr
         )
-        while insn is not None and len(insns) < backward_count:
+        while prev_instruction_fetch is not None and len(insns) < backward_count:
+            insn, was_linear = prev_instruction_fetch
+
+            if was_linear:
+                index_of_last_linearly_disassembled_instruction += 1
+
             if DEBUG_ENHANCEMENT:
                 print(f"Got instruction from cache, addr={insn.address:#x}")
             if insn.jump_like and insn.split == SplitType.NO_SPLIT and not insn.causes_branch_delay:
                 insn.split = SplitType.BRANCH_NOT_TAKEN
             insns.append(insn)
 
-            insn = get_previous_instruction(
+            prev_instruction_fetch = get_previous_instruction(
                 insn.address, use_cache=use_cache, linear=linear, saveptr=saveptr
             )
         insns.reverse()
@@ -817,7 +849,7 @@ def near(
     while insns and len(insns) > 2 and insns[-3].address == insns[-2].address == insns[-1].address:
         del insns[-1]
 
-    return (insns, index_of_current_instruction)
+    return (insns, index_of_current_instruction, index_of_last_linearly_disassembled_instruction)
 
 
 ALL_DISASSEMBLY_ASSISTANTS: dict[

--- a/pwndbg/aglib/nearpc.py
+++ b/pwndbg/aglib/nearpc.py
@@ -662,7 +662,7 @@ def nearpc(
                 ]
             )
 
-        if i <= index_of_last_linearly_disassembled_instruction:
+        if not linear and i <= index_of_last_linearly_disassembled_instruction:
             line = gray(pwndbg.color.strip(line))
 
         result.append(line)
@@ -682,7 +682,7 @@ def nearpc(
         elif instruction.split == SplitType.BRANCH_NOT_TAKEN:
             if nearpc_branch_marker_contiguous:
                 if empty_line_branch_vis_string:
-                    result.append(empty_line_branch_vis_string)
+                    result.append(gray(pwndbg.color.strip(empty_line_branch_vis_string)))
                 else:
                     result.append(f"{nearpc_branch_marker_contiguous}")
 

--- a/pwndbg/aglib/nearpc.py
+++ b/pwndbg/aglib/nearpc.py
@@ -682,7 +682,10 @@ def nearpc(
         elif instruction.split == SplitType.BRANCH_NOT_TAKEN:
             if nearpc_branch_marker_contiguous:
                 if empty_line_branch_vis_string:
-                    result.append(gray(pwndbg.color.strip(empty_line_branch_vis_string)))
+                    if not linear and i <= index_of_last_linearly_disassembled_instruction:
+                        empty_line_branch_vis_string = gray(pwndbg.color.strip(empty_line_branch_vis_string))
+
+                    result.append(empty_line_branch_vis_string)
                 else:
                     result.append(f"{nearpc_branch_marker_contiguous}")
 

--- a/pwndbg/aglib/nearpc.py
+++ b/pwndbg/aglib/nearpc.py
@@ -21,6 +21,7 @@ from pwndbg.aglib.disasm.instruction import SplitType
 from pwndbg.color import ColorConfig
 from pwndbg.color import ColorParamSpec
 from pwndbg.color import blue
+from pwndbg.color import gray
 from pwndbg.color import green
 from pwndbg.color import light_gray
 from pwndbg.color import light_green
@@ -477,16 +478,18 @@ def nearpc(
     #         for line in symtab.linetable():
     #             pc_to_linenos[line.pc].append(line.line)
 
-    instructions, index_of_pc = pwndbg.aglib.disasm.disassembly.near(
-        pc,
-        forward_count=lines,
-        backward_count=back_lines,
-        total_count=total_lines,
-        emulate=emulate,
-        show_prev_insns=not repeat,
-        use_cache=use_cache,
-        linear=linear,
-        end_address=end_address,
+    instructions, index_of_pc, index_of_last_linearly_disassembled_instruction = (
+        pwndbg.aglib.disasm.disassembly.near(
+            pc,
+            forward_count=lines,
+            backward_count=back_lines,
+            total_count=total_lines,
+            emulate=emulate,
+            show_prev_insns=not repeat,
+            use_cache=use_cache,
+            linear=linear,
+            end_address=end_address,
+        )
     )
 
     # If doing branch visualization, preprocess some datastructures
@@ -658,6 +661,9 @@ def nearpc(
                     hex(instruction.address)
                 ]
             )
+
+        if i <= index_of_last_linearly_disassembled_instruction:
+            line = gray(pwndbg.color.strip(line))
 
         result.append(line)
 

--- a/pwndbg/aglib/nearpc.py
+++ b/pwndbg/aglib/nearpc.py
@@ -425,6 +425,7 @@ def nearpc(
     branch_visualization: bool = False,
     address_to_highlight: int | None = None,
     end_address: int | None = None,
+    max_backwards_linear_count: int | None = None,
 ) -> list[str]:
     """
     Disassemble near a specified address.
@@ -489,6 +490,7 @@ def nearpc(
             use_cache=use_cache,
             linear=linear,
             end_address=end_address,
+            max_backwards_linear_count=max_backwards_linear_count,
         )
     )
 
@@ -683,7 +685,9 @@ def nearpc(
             if nearpc_branch_marker_contiguous:
                 if empty_line_branch_vis_string:
                     if not linear and i <= index_of_last_linearly_disassembled_instruction:
-                        empty_line_branch_vis_string = gray(pwndbg.color.strip(empty_line_branch_vis_string))
+                        empty_line_branch_vis_string = gray(
+                            pwndbg.color.strip(empty_line_branch_vis_string)
+                        )
 
                     result.append(empty_line_branch_vis_string)
                 else:

--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -1335,6 +1335,12 @@ disasm_lines = pwndbg.config.add_param(
     "context-disasm-lines", 10, "number of additional lines to print in the disasm context"
 )
 
+disasm_backwards_linear_lines = pwndbg.config.add_param(
+    "context-disasm-back-linear-lines",
+    "auto",
+    "maximum number of lines to disassemble backwards linearly in memory",
+)
+
 
 def try_emulate_if_bug_disable(handler: Callable[[], T]) -> T:
     try:
@@ -1374,12 +1380,18 @@ def context_disasm(
 
     additional_disasm_lines = max(int(disasm_lines), height or 0)
 
+    if disasm_backwards_linear_lines == "auto":
+        max_backwards_linear_count = min(10, additional_disasm_lines // 3)
+    else:
+        max_backwards_linear_count = int(disasm_backwards_linear_lines)
+
     result = try_emulate_if_bug_disable(
         lambda: pwndbg.aglib.nearpc.nearpc(
             back_lines=additional_disasm_lines // 2,
             total_lines=additional_disasm_lines + 1,
             emulate=pwndbg.config.emulate != "off",
             use_cache=True,
+            max_backwards_linear_count=max_backwards_linear_count,
         )
     )
 

--- a/pwndbg/commands/dev.py
+++ b/pwndbg/commands/dev.py
@@ -66,7 +66,7 @@ def dev_dump_instruction(address=None, force_emulate=False, no_emulate=False) ->
             bool(pwndbg.config.emulate == "on") if override_setting is None else override_setting
         )
 
-        instructions, index_of_pc = pwndbg.aglib.disasm.disassembly.near(
+        instructions, index_of_pc, _ = pwndbg.aglib.disasm.disassembly.near(
             pwndbg.aglib.regs.pc, 1, emulate=use_emulation, show_prev_insns=False, use_cache=False
         )
 

--- a/pwndbg/commands/nearpc.py
+++ b/pwndbg/commands/nearpc.py
@@ -89,6 +89,7 @@ def nearpc(
     linear: bool = True,
     no_branch: bool = False,
     function: int | None = None,
+    max_backwards_linear_count: int | None = None,
 ) -> None:
     """
     Disassemble near a specified address.
@@ -164,6 +165,7 @@ def nearpc(
                 branch_visualization=not no_branch,
                 address_to_highlight=address_to_highlight,
                 end_address=end_address,
+                max_backwards_linear_count=max_backwards_linear_count,
             )
         )
     )
@@ -212,4 +214,5 @@ def emulate(pc=None, lines=None, reverse=None, total=None, emulate_=True) -> Non
         use_cache=True,
         linear=False,
         no_branch=True,
+        max_backwards_linear_count=0,
     )

--- a/tests/binaries/host/stepsyscall.x86-64.asm
+++ b/tests/binaries/host/stepsyscall.x86-64.asm
@@ -54,4 +54,7 @@ section .data
     len2 equ $ - msg2
 
 section .bss
+    ; This prevents the `buf` variable overlapping with `__bss_start`
+    ; When resolving variable names at an address, different version of GDB return one or the other
+    padding resb 100 
     buf resb 16

--- a/tests/host/gdb/pytests_launcher.py
+++ b/tests/host/gdb/pytests_launcher.py
@@ -52,6 +52,8 @@ class _GDBController(host.Controller):
         self._gdb_execute("set exception-verbose on")
         self._gdb_execute("set width 80")
         self._gdb_execute("set context-reserve-lines never")
+        self._gdb_execute("set heuristic-backwards-disasm off")
+        self._gdb_execute("set context-disasm-back-linear-lines 0")
         os.environ["COLUMNS"] = "80"
         for k, v in env.items():
             self._gdb_execute(f"set environment {k}={v}")

--- a/tests/host/lldb/launch_guest.py
+++ b/tests/host/lldb/launch_guest.py
@@ -38,6 +38,8 @@ async def _run(ctrl: Any, outer: Callable[..., Coroutine[Any, Any, None]]) -> No
                 pytest.skip(f"{os.path.basename(binary)} does not exist. Platform not supported.")
 
             await self.pc.execute("set context-reserve-lines never")
+            await self.pc.execute("set heuristic-backwards-disasm off")
+            await self.pc.execute("set context-disasm-back-linear-lines 0")
             # Disable debuginfod globally for LLDB tests: a partial/laggy
             # download triggers `LLVM ERROR: CachedFileStream was not committed`
             # which aborts the whole process and makes CI flaky (commonly seen

--- a/tests/library/dbg/tests/test_emulate.py
+++ b/tests/library/dbg/tests/test_emulate.py
@@ -102,31 +102,35 @@ def compare_output_without_emu(expected_output):
     assert nearpc(back_lines=5, total_lines=11, linear=True) == expected_output
 
 
-SYSCALLS_BINARY = get_binary("syscalls.x86-64.out")
+STEPSYSCALL_X64_BINARY = get_binary("stepsyscall.x86-64.out")
 
 
 @pwndbg_test
 async def test_backwards_backwards_disassemble_heuristic(ctrl: Controller) -> None:
 
-    await ctrl.launch(SYSCALLS_BINARY)
+    await ctrl.launch(STEPSYSCALL_X64_BINARY)
 
     # Enable the heuristic
     await ctrl.execute_and_capture("set heuristic-backwards-disasm on")
 
-    dis = await ctrl.execute_and_capture("nearpc $rip+20 -r 4 -t 11")
+    dis = await ctrl.execute_and_capture("nearpc -n -t 11")
 
     expected = (
-        "   0x400080 <_start>       mov    eax, 0                 EAX => 0\n"
-        "   0x400085 <_start+5>     mov    edi, 0x1337            EDI => 0x1337\n"
-        "   0x40008a <_start+10>    mov    esi, 0xdeadbeef        ESI => 0xdeadbeef\n"
-        "   0x40008f <_start+15>    mov    ecx, 0x10              ECX => 0x10\n"
-        " ► 0x400094 <_start+20>    syscall\n"
-        "   0x400096 <_start+22>    mov    eax, 0xa               EAX => 0xa\n"
-        "   0x40009b <_start+27>    int    0x80 <SYS_unlink>\n"
-        "   0x40009d                add    byte ptr [rax], al\n"
-        "   0x40009f                add    byte ptr [rax], al\n"
-        "   0x4000a1                add    byte ptr [rax], al\n"
-        "   0x4000a3                add    byte ptr [rax], al\n"
+        "   0x4000bd <do_read+5>               mov    edi, 0               EDI => 0\n"
+        "   0x4000c2 <do_read+10>              movabs rsi, __bss_start     RSI => 0x800001c (__bss_start)\n"
+        "   0x4000cc <do_read+20>              mov    edx, 1               EDX => 1\n"
+        "   0x4000d1 <syscall_read_label>      syscall\n"
+        "   0x4000d3 <syscall_read_label+2>    ret   \n"
+        " \n"
+        " ► 0x4000d4 <_start>                  nop   \n"
+        "   0x4000d5 <_start+1>                jmp    label1                      <label1>\n"
+        " \n"
+        "   0x4000d7 <_start+3>                nop   \n"
+        "   0x4000d8 <label1>                  call   write_stdout                <write_stdout>\n"
+        " \n"
+        "   0x4000dd <label1+5>                call   write_stderr                <write_stderr>\n"
+        " \n"
+        "   0x4000e2 <exit>                    mov    eax, 0x3c     EAX => 0x3c\n"
     )
 
     assert dis == expected
@@ -147,30 +151,35 @@ async def test_backwards_linear_cache_populate_when_disassemble_from_pc(ctrl: Co
     This is an edge case, because if the user does `nearpc random_address`, we don't want to add next couple instructions
     to the linear backward cache, because "random_address" may not be aligned to a real address. This would corrupt the cache,
     causing future disassembles at "random_address+offset" to not be able to disassemble backwards correctly (they would use the corrupted cache, and not the heuristic)
+
+    This is NOT testing the backwards disassembly itself. It is rather testing that the method of populating the linear cache works.
     """
 
-    await ctrl.launch(SYSCALLS_BINARY)
+    await ctrl.launch(STEPSYSCALL_X64_BINARY)
 
     # This filling up caches, disassembling from PC
-    dis = await ctrl.execute_and_capture("nearpc -t 11")
+    dis = await ctrl.execute_and_capture("nearpc -n -t 11")
 
     await ctrl.step_instruction()
 
-    dis = await ctrl.execute_and_capture("nearpc -t 11")
+    dis = await ctrl.execute_and_capture("nearpc -n -t 11")
 
     # This should be able to disassemble backwards using the backwards caches!
     expected = (
-        "   0x400080 <_start>       mov    eax, 0                 EAX => 0\n"
-        " ► 0x400085 <_start+5>     mov    edi, 0x1337            EDI => 0x1337\n"
-        "   0x40008a <_start+10>    mov    esi, 0xdeadbeef        ESI => 0xdeadbeef\n"
-        "   0x40008f <_start+15>    mov    ecx, 0x10              ECX => 0x10\n"
-        "   0x400094 <_start+20>    syscall <SYS_read>\n"
-        "   0x400096 <_start+22>    mov    eax, 0xa               EAX => 0xa\n"
-        "   0x40009b <_start+27>    int    0x80 <SYS_unlink>\n"
-        "   0x40009d                add    byte ptr [rax], al\n"
-        "   0x40009f                add    byte ptr [rax], al\n"
-        "   0x4000a1                add    byte ptr [rax], al\n"
-        "   0x4000a3                add    byte ptr [rax], al\n"
+        "   0x4000d4 <_start>                nop   \n"
+        " ► 0x4000d5 <_start+1>              jmp    label1                      <label1>\n"
+        " \n"
+        "   0x4000d7 <_start+3>              nop   \n"
+        "   0x4000d8 <label1>                call   write_stdout                <write_stdout>\n"
+        " \n"
+        "   0x4000dd <label1+5>              call   write_stderr                <write_stderr>\n"
+        " \n"
+        "   0x4000e2 <exit>                  mov    eax, 0x3c              EAX => 0x3c\n"
+        "   0x4000e7 <exit+5>                mov    edi, 0                 EDI => 0\n"
+        "   0x4000ec <syscall_exit_label>    syscall <SYS_exit>\n"
+        "   0x4000ee                         add    byte ptr [rax], al\n"
+        "   0x4000f0                         add    byte ptr [rax], al\n"
+        "   0x4000f2                         add    byte ptr [rax], al\n"
     )
     assert dis == expected
 
@@ -187,52 +196,77 @@ async def test_backwards_linear_cache_misaligned_disasm(ctrl: Controller) -> Non
     # Do not allow the disassembly section to run to populate the caches
     await ctrl.execute_and_capture("set context-sections ''")
 
-    await ctrl.launch(SYSCALLS_BINARY)
+    await ctrl.launch(STEPSYSCALL_X64_BINARY)
 
-    # This filling up caches, disassembling from misaligned address
-    await ctrl.execute_and_capture("nearpc $rip+3 -t 11")
+    # Disassemble from misaligned address
+    dis_0 = await ctrl.execute_and_capture("nearpc $rip-2 -t 11")
+
+    # Misaligned disassembly!
+    expected_0 = (
+        " ► 0x4000d2 <syscall_read_label+1>    add    eax, 0x1eb90c3\n"
+        "   0x4000d7 <_start+3>                nop   \n"
+        "   0x4000d8 <label1>                  call   write_stdout                <write_stdout>\n"
+        " \n"
+        "   0x4000dd <label1+5>                call   write_stderr                <write_stderr>\n"
+        " \n"
+        "   0x4000e2 <exit>                    mov    eax, 0x3c              EAX => 0x3c\n"
+        "   0x4000e7 <exit+5>                  mov    edi, 0                 EDI => 0\n"
+        "   0x4000ec <syscall_exit_label>      syscall <SYS_exit>\n"
+        "   0x4000ee                           add    byte ptr [rax], al\n"
+        "   0x4000f0                           add    byte ptr [rax], al\n"
+        "   0x4000f2                           add    byte ptr [rax], al\n"
+        "   0x4000f4                           add    byte ptr [rax], al\n"
+    )
+
+    assert dis_0 == expected_0
 
     # Disable the heuristic
     await ctrl.execute_and_capture("set heuristic-backwards-disasm off")
     await ctrl.execute_and_capture("set context-disasm-back-linear-lines 0")
 
     # Without the heuristic, we disassemble straightline
-    dis = await ctrl.execute_and_capture("nearpc $rip+10 -t 11")
+    dis = await ctrl.execute_and_capture("nearpc $rip+4 -t 11")
 
     expected = (
-        " ► 0x40008a <_start+10>    mov    esi, 0xdeadbeef        ESI => 0xdeadbeef\n"
-        "   0x40008f <_start+15>    mov    ecx, 0x10              ECX => 0x10\n"
-        "   0x400094 <_start+20>    syscall\n"
-        "   0x400096 <_start+22>    mov    eax, 0xa               EAX => 0xa\n"
-        "   0x40009b <_start+27>    int    0x80 <SYS_unlink>\n"
-        "   0x40009d                add    byte ptr [rax], al\n"
-        "   0x40009f                add    byte ptr [rax], al\n"
-        "   0x4000a1                add    byte ptr [rax], al\n"
-        "   0x4000a3                add    byte ptr [rax], al\n"
-        "   0x4000a5                add    byte ptr [rax], al\n"
-        "   0x4000a7                add    byte ptr [rax], al\n"
+        " ► 0x4000d8 <label1>                call   write_stdout                <write_stdout>\n"
+        " \n"
+        "   0x4000dd <label1+5>              call   write_stderr                <write_stderr>\n"
+        " \n"
+        "   0x4000e2 <exit>                  mov    eax, 0x3c              EAX => 0x3c\n"
+        "   0x4000e7 <exit+5>                mov    edi, 0                 EDI => 0\n"
+        "   0x4000ec <syscall_exit_label>    syscall <SYS_exit>\n"
+        "   0x4000ee                         add    byte ptr [rax], al\n"
+        "   0x4000f0                         add    byte ptr [rax], al\n"
+        "   0x4000f2                         add    byte ptr [rax], al\n"
+        "   0x4000f4                         add    byte ptr [rax], al\n"
+        "   0x4000f6                         add    byte ptr [rax], al\n"
+        "   0x4000f8                         add    byte ptr [rax], al\n"
     )
     assert dis == expected
 
     # Enable the heuristic
     await ctrl.execute_and_capture("set heuristic-backwards-disasm on")
 
-    # Now, nearpc from an address after it. The caches should NOT be filled.
-    # Instead, the heuristic will be used to disassemble backwards, to correctly find "start_"
-    dis_2 = await ctrl.execute_and_capture("nearpc $rip+10 -r 2 -t 11")
+    # The caches should NOT be filled.
+    # Instead, the heuristic will be used to disassemble backwards
+    dis_2 = await ctrl.execute_and_capture("nearpc $rip+4 -n -t 11")
 
     # This should be able to disassemble backwards using the backwards caches!
     expected_2 = (
-        "   0x400080 <_start>       mov    eax, 0                 EAX => 0\n"
-        "   0x400085 <_start+5>     mov    edi, 0x1337            EDI => 0x1337\n"
-        " ► 0x40008a <_start+10>    mov    esi, 0xdeadbeef        ESI => 0xdeadbeef\n"
-        "   0x40008f <_start+15>    mov    ecx, 0x10              ECX => 0x10\n"
-        "   0x400094 <_start+20>    syscall\n"
-        "   0x400096 <_start+22>    mov    eax, 0xa               EAX => 0xa\n"
-        "   0x40009b <_start+27>    int    0x80 <SYS_unlink>\n"
-        "   0x40009d                add    byte ptr [rax], al\n"
-        "   0x40009f                add    byte ptr [rax], al\n"
-        "   0x4000a1                add    byte ptr [rax], al\n"
-        "   0x4000a3                add    byte ptr [rax], al\n"
+        "   0x4000d1 <syscall_read_label>      syscall\n"
+        "   0x4000d3 <syscall_read_label+2>    ret   \n"
+        " \n"
+        "   0x4000d4 <_start>                  nop   \n"
+        "   0x4000d5 <_start+1>                jmp    label1                      <label1>\n"
+        " \n"
+        "   0x4000d7 <_start+3>                nop   \n"
+        " ► 0x4000d8 <label1>                  call   write_stdout                <write_stdout>\n"
+        " \n"
+        "   0x4000dd <label1+5>                call   write_stderr                <write_stderr>\n"
+        " \n"
+        "   0x4000e2 <exit>                    mov    eax, 0x3c              EAX => 0x3c\n"
+        "   0x4000e7 <exit+5>                  mov    edi, 0                 EDI => 0\n"
+        "   0x4000ec <syscall_exit_label>      syscall <SYS_exit>\n"
+        "   0x4000ee                           add    byte ptr [rax], al\n"
     )
     assert dis_2 == expected_2

--- a/tests/library/dbg/tests/test_emulate.py
+++ b/tests/library/dbg/tests/test_emulate.py
@@ -106,8 +106,10 @@ STEPSYSCALL_X64_BINARY = get_binary("stepsyscall.x86-64.out")
 
 
 @pwndbg_test
-async def test_backwards_backwards_disassemble_heuristic(ctrl: Controller) -> None:
-
+async def test_backwards_disassemble_heuristic(ctrl: Controller) -> None:
+    """
+    This tests our capability of disassembling backwards in a variable length instruction set, where instruction alignment is not known ahead of time.
+    """
     await ctrl.launch(STEPSYSCALL_X64_BINARY)
 
     # Enable the heuristic
@@ -116,9 +118,9 @@ async def test_backwards_backwards_disassemble_heuristic(ctrl: Controller) -> No
     dis = await ctrl.execute_and_capture("nearpc -n -t 11")
 
     expected = (
-        "   0x4000bd <do_read+5>               mov    edi, 0               EDI => 0\n"
-        "   0x4000c2 <do_read+10>              movabs rsi, __bss_start     RSI => 0x800001c (__bss_start)\n"
-        "   0x4000cc <do_read+20>              mov    edx, 1               EDX => 1\n"
+        "   0x4000bd <do_read+5>               mov    edi, 0       EDI => 0\n"
+        "   0x4000c2 <do_read+10>              movabs rsi, buf     RSI => 0x800001c (buf)\n"
+        "   0x4000cc <do_read+20>              mov    edx, 1       EDX => 1\n"
         "   0x4000d1 <syscall_read_label>      syscall\n"
         "   0x4000d3 <syscall_read_label+2>    ret   \n"
         " \n"

--- a/tests/library/dbg/tests/test_emulate.py
+++ b/tests/library/dbg/tests/test_emulate.py
@@ -113,10 +113,9 @@ async def test_backwards_backwards_disassemble_heuristic(ctrl: Controller) -> No
     # Enable the heuristic
     await ctrl.execute_and_capture("set heuristic-backwards-disasm on")
 
-    dis = await ctrl.execute_and_capture("nearpc *$pc+20 -t 11")
+    dis = await ctrl.execute_and_capture("nearpc *_start+20 -r 4 -t 11")
 
     expected = (
-        "   0x40007e                add    byte ptr [rax], al\n"
         "   0x400080 <_start>       mov    eax, 0                 EAX => 0\n"
         "   0x400085 <_start+5>     mov    edi, 0x1337            EDI => 0x1337\n"
         "   0x40008a <_start+10>    mov    esi, 0xdeadbeef        ESI => 0xdeadbeef\n"
@@ -127,6 +126,7 @@ async def test_backwards_backwards_disassemble_heuristic(ctrl: Controller) -> No
         "   0x40009d                add    byte ptr [rax], al\n"
         "   0x40009f                add    byte ptr [rax], al\n"
         "   0x4000a1                add    byte ptr [rax], al\n"
+        "   0x4000a3                add    byte ptr [rax], al\n"
     )
 
     assert dis == expected
@@ -190,14 +190,14 @@ async def test_backwards_linear_cache_misaligned_disasm(ctrl: Controller) -> Non
     await ctrl.launch(SYSCALLS_BINARY)
 
     # This filling up caches, disassembling from misaligned address
-    await ctrl.execute_and_capture("nearpc *$pc+3 -t 11")
+    await ctrl.execute_and_capture("nearpc *_start+3 -t 11")
 
     # Disable the heuristic
     await ctrl.execute_and_capture("set heuristic-backwards-disasm off")
     await ctrl.execute_and_capture("set context-disasm-back-linear-lines 0")
 
     # Without the heuristic, we disassemble straightline
-    dis = await ctrl.execute_and_capture("nearpc *$pc+10 -t 11")
+    dis = await ctrl.execute_and_capture("nearpc *_start+10 -t 11")
 
     expected = (
         " ► 0x40008a <_start+10>    mov    esi, 0xdeadbeef        ESI => 0xdeadbeef\n"
@@ -219,13 +219,10 @@ async def test_backwards_linear_cache_misaligned_disasm(ctrl: Controller) -> Non
 
     # Now, nearpc from an address after it. The caches should NOT be filled.
     # Instead, the heuristic will be used to disassemble backwards, to correctly find "start_"
-    dis_2 = await ctrl.execute_and_capture("nearpc *$pc+10 -t 11")
+    dis_2 = await ctrl.execute_and_capture("nearpc *_start+10 -r 2 -t 11")
 
     # This should be able to disassemble backwards using the backwards caches!
     expected_2 = (
-        "   0x40007a                add    byte ptr [rax], al\n"
-        "   0x40007c                add    byte ptr [rax], al\n"
-        "   0x40007e                add    byte ptr [rax], al\n"
         "   0x400080 <_start>       mov    eax, 0                 EAX => 0\n"
         "   0x400085 <_start+5>     mov    edi, 0x1337            EDI => 0x1337\n"
         " ► 0x40008a <_start+10>    mov    esi, 0xdeadbeef        ESI => 0xdeadbeef\n"
@@ -234,5 +231,8 @@ async def test_backwards_linear_cache_misaligned_disasm(ctrl: Controller) -> Non
         "   0x400096 <_start+22>    mov    eax, 0xa               EAX => 0xa\n"
         "   0x40009b <_start+27>    int    0x80 <SYS_unlink>\n"
         "   0x40009d                add    byte ptr [rax], al\n"
+        "   0x40009f                add    byte ptr [rax], al\n"
+        "   0x4000a1                add    byte ptr [rax], al\n"
+        "   0x4000a3                add    byte ptr [rax], al\n"
     )
     assert dis_2 == expected_2

--- a/tests/library/dbg/tests/test_emulate.py
+++ b/tests/library/dbg/tests/test_emulate.py
@@ -119,6 +119,7 @@ async def test_backwards_disassemble_heuristic(ctrl: Controller) -> None:
 
     dis = await ctrl.execute_and_capture("nearpc -n -t 11")
 
+    # Data region location can differ based on the system
     buf_addr = int(pwndbg.aglib.symbol.lookup_symbol_addr("buf"))
 
     expected = (

--- a/tests/library/dbg/tests/test_emulate.py
+++ b/tests/library/dbg/tests/test_emulate.py
@@ -100,3 +100,139 @@ def compare_output_without_emu(expected_output):
     from pwndbg.aglib.nearpc import nearpc
 
     assert nearpc(back_lines=5, total_lines=11, linear=True) == expected_output
+
+
+SYSCALLS_BINARY = get_binary("syscalls.x86-64.out")
+
+
+@pwndbg_test
+async def test_backwards_backwards_disassemble_heuristic(ctrl: Controller) -> None:
+
+    await ctrl.launch(SYSCALLS_BINARY)
+
+    # Enable the heuristic
+    await ctrl.execute_and_capture("set heuristic-backwards-disasm on")
+
+    dis = await ctrl.execute_and_capture("nearpc *pc+20 -t 11")
+
+    expected = (
+        "   0x40007e                add    byte ptr [rax], al\n"
+        "   0x400080 <_start>       mov    eax, 0                 EAX => 0\n"
+        "   0x400085 <_start+5>     mov    edi, 0x1337            EDI => 0x1337\n"
+        "   0x40008a <_start+10>    mov    esi, 0xdeadbeef        ESI => 0xdeadbeef\n"
+        "   0x40008f <_start+15>    mov    ecx, 0x10              ECX => 0x10\n"
+        " ► 0x400094 <_start+20>    syscall\n"
+        "   0x400096 <_start+22>    mov    eax, 0xa               EAX => 0xa\n"
+        "   0x40009b <_start+27>    int    0x80 <SYS_unlink>\n"
+        "   0x40009d                add    byte ptr [rax], al\n"
+        "   0x40009f                add    byte ptr [rax], al\n"
+        "   0x4000a1                add    byte ptr [rax], al\n"
+    )
+
+    assert dis == expected
+
+
+@pwndbg_test
+async def test_backwards_linear_cache_populate_when_disassemble_from_pc(ctrl: Controller) -> None:
+    """
+    When disassembling from an arbitrary point, such as `nearpc random_address`, we don't want to
+    populate the "linear backward cache" immediately. This is because `random_address` may not be at a real instruction boundary,
+    and we don't want corrupted values in the cache. Instead, we disassembling N instructions (N is some heuristic amount), and assume the
+    instruction stream has self-aligned at that point. Only then do we start populating the linear backward cache.
+
+    However, there is an edge case where we populate this cache immediately: when disassembling from the program PC.
+    1. When stepping in the disasm view, we know the PC is aligned to a real instruction as interpreted by the CPU
+    2. In this case, make sure we track the linear flow of instructions ("linear backward cache") in this case
+
+    This is an edge case, because if the user does `nearpc random_address`, we don't want to add next couple instructions
+    to the linear backward cache, because "random_address" may not be aligned to a real address. This would corrupt the cache,
+    causing future disassembles at "random_address+offset" to not be able to disassemble backwards correctly (they would use the corrupted cache, and not the heuristic)
+    """
+
+    await ctrl.launch(SYSCALLS_BINARY)
+
+    # This filling up caches, disassembling from PC
+    dis = await ctrl.execute_and_capture("nearpc -t 11")
+
+    await ctrl.step_instruction()
+
+    dis = await ctrl.execute_and_capture("nearpc -t 11")
+
+    # This should be able to disassemble backwards using the backwards caches!
+    expected = (
+        "   0x400080 <_start>       mov    eax, 0                 EAX => 0\n"
+        " ► 0x400085 <_start+5>     mov    edi, 0x1337            EDI => 0x1337\n"
+        "   0x40008a <_start+10>    mov    esi, 0xdeadbeef        ESI => 0xdeadbeef\n"
+        "   0x40008f <_start+15>    mov    ecx, 0x10              ECX => 0x10\n"
+        "   0x400094 <_start+20>    syscall <SYS_read>\n"
+        "   0x400096 <_start+22>    mov    eax, 0xa               EAX => 0xa\n"
+        "   0x40009b <_start+27>    int    0x80 <SYS_unlink>\n"
+        "   0x40009d                add    byte ptr [rax], al\n"
+        "   0x40009f                add    byte ptr [rax], al\n"
+        "   0x4000a1                add    byte ptr [rax], al\n"
+        "   0x4000a3                add    byte ptr [rax], al\n"
+    )
+    assert dis == expected
+
+
+@pwndbg_test
+async def test_backwards_linear_cache_misaligned_disasm(ctrl: Controller) -> None:
+    """
+    Testing same mechanism as previous test, but not disassembling from PC.
+
+    Do not let the "linear backward cache" be corrupted if disassemble at a misaligned address.
+    Doing this is very common when "guessing" address to "nearpc" from.
+    """
+
+    # Do not allow the disassembly section to run to populate the caches
+    await ctrl.execute_and_capture("set context-sections ''")
+
+    await ctrl.launch(SYSCALLS_BINARY)
+
+    # This filling up caches, disassembling from misaligned address
+    await ctrl.execute_and_capture("nearpc *pc+3 -t 11")
+
+    # Disable the heuristic
+    await ctrl.execute_and_capture("set heuristic-backwards-disasm off")
+    await ctrl.execute_and_capture("set context-disasm-back-linear-lines 0")
+
+    # Without the heuristic, we disassemble straightline
+    dis = await ctrl.execute_and_capture("nearpc *pc+10 -t 11")
+
+    expected = (
+        " ► 0x40008a <_start+10>    mov    esi, 0xdeadbeef        ESI => 0xdeadbeef\n"
+        "   0x40008f <_start+15>    mov    ecx, 0x10              ECX => 0x10\n"
+        "   0x400094 <_start+20>    syscall\n"
+        "   0x400096 <_start+22>    mov    eax, 0xa               EAX => 0xa\n"
+        "   0x40009b <_start+27>    int    0x80 <SYS_unlink>\n"
+        "   0x40009d                add    byte ptr [rax], al\n"
+        "   0x40009f                add    byte ptr [rax], al\n"
+        "   0x4000a1                add    byte ptr [rax], al\n"
+        "   0x4000a3                add    byte ptr [rax], al\n"
+        "   0x4000a5                add    byte ptr [rax], al\n"
+        "   0x4000a7                add    byte ptr [rax], al\n"
+    )
+    assert dis == expected
+
+    # Enable the heuristic
+    await ctrl.execute_and_capture("set heuristic-backwards-disasm on")
+
+    # Now, nearpc from an address after it. The caches should NOT be filled.
+    # Instead, the heuristic will be used to disassemble backwards, to correctly find "start_"
+    dis_2 = await ctrl.execute_and_capture("nearpc *pc+10 -t 11")
+
+    # This should be able to disassemble backwards using the backwards caches!
+    expected_2 = (
+        "   0x40007a                add    byte ptr [rax], al\n"
+        "   0x40007c                add    byte ptr [rax], al\n"
+        "   0x40007e                add    byte ptr [rax], al\n"
+        "   0x400080 <_start>       mov    eax, 0                 EAX => 0\n"
+        "   0x400085 <_start+5>     mov    edi, 0x1337            EDI => 0x1337\n"
+        " ► 0x40008a <_start+10>    mov    esi, 0xdeadbeef        ESI => 0xdeadbeef\n"
+        "   0x40008f <_start+15>    mov    ecx, 0x10              ECX => 0x10\n"
+        "   0x400094 <_start+20>    syscall\n"
+        "   0x400096 <_start+22>    mov    eax, 0xa               EAX => 0xa\n"
+        "   0x40009b <_start+27>    int    0x80 <SYS_unlink>\n"
+        "   0x40009d                add    byte ptr [rax], al\n"
+    )
+    assert dis_2 == expected_2

--- a/tests/library/dbg/tests/test_emulate.py
+++ b/tests/library/dbg/tests/test_emulate.py
@@ -119,7 +119,7 @@ async def test_backwards_disassemble_heuristic(ctrl: Controller) -> None:
 
     expected = (
         "   0x4000bd <do_read+5>               mov    edi, 0       EDI => 0\n"
-        "   0x4000c2 <do_read+10>              movabs rsi, buf     RSI => 0x800001c (buf)\n"
+        "   0x4000c2 <do_read+10>              movabs rsi, buf     RSI => 0x8000080 (buf)\n"
         "   0x4000cc <do_read+20>              mov    edx, 1       EDX => 1\n"
         "   0x4000d1 <syscall_read_label>      syscall\n"
         "   0x4000d3 <syscall_read_label+2>    ret   \n"

--- a/tests/library/dbg/tests/test_emulate.py
+++ b/tests/library/dbg/tests/test_emulate.py
@@ -110,6 +110,8 @@ async def test_backwards_disassemble_heuristic(ctrl: Controller) -> None:
     """
     This tests our capability of disassembling backwards in a variable length instruction set, where instruction alignment is not known ahead of time.
     """
+    import pwndbg.aglib
+
     await ctrl.launch(STEPSYSCALL_X64_BINARY)
 
     # Enable the heuristic
@@ -117,9 +119,11 @@ async def test_backwards_disassemble_heuristic(ctrl: Controller) -> None:
 
     dis = await ctrl.execute_and_capture("nearpc -n -t 11")
 
+    buf_addr = int(pwndbg.aglib.symbol.lookup_symbol_addr("buf"))
+
     expected = (
         "   0x4000bd <do_read+5>               mov    edi, 0       EDI => 0\n"
-        "   0x4000c2 <do_read+10>              movabs rsi, buf     RSI => 0x8000080 (buf)\n"
+        f"   0x4000c2 <do_read+10>              movabs rsi, buf     RSI => 0x{buf_addr:x} (buf)\n"
         "   0x4000cc <do_read+20>              mov    edx, 1       EDX => 1\n"
         "   0x4000d1 <syscall_read_label>      syscall\n"
         "   0x4000d3 <syscall_read_label+2>    ret   \n"

--- a/tests/library/dbg/tests/test_emulate.py
+++ b/tests/library/dbg/tests/test_emulate.py
@@ -113,7 +113,7 @@ async def test_backwards_backwards_disassemble_heuristic(ctrl: Controller) -> No
     # Enable the heuristic
     await ctrl.execute_and_capture("set heuristic-backwards-disasm on")
 
-    dis = await ctrl.execute_and_capture("nearpc *_start+20 -r 4 -t 11")
+    dis = await ctrl.execute_and_capture("nearpc $rip+20 -r 4 -t 11")
 
     expected = (
         "   0x400080 <_start>       mov    eax, 0                 EAX => 0\n"
@@ -190,14 +190,14 @@ async def test_backwards_linear_cache_misaligned_disasm(ctrl: Controller) -> Non
     await ctrl.launch(SYSCALLS_BINARY)
 
     # This filling up caches, disassembling from misaligned address
-    await ctrl.execute_and_capture("nearpc *_start+3 -t 11")
+    await ctrl.execute_and_capture("nearpc $rip+3 -t 11")
 
     # Disable the heuristic
     await ctrl.execute_and_capture("set heuristic-backwards-disasm off")
     await ctrl.execute_and_capture("set context-disasm-back-linear-lines 0")
 
     # Without the heuristic, we disassemble straightline
-    dis = await ctrl.execute_and_capture("nearpc *_start+10 -t 11")
+    dis = await ctrl.execute_and_capture("nearpc $rip+10 -t 11")
 
     expected = (
         " ► 0x40008a <_start+10>    mov    esi, 0xdeadbeef        ESI => 0xdeadbeef\n"
@@ -219,7 +219,7 @@ async def test_backwards_linear_cache_misaligned_disasm(ctrl: Controller) -> Non
 
     # Now, nearpc from an address after it. The caches should NOT be filled.
     # Instead, the heuristic will be used to disassemble backwards, to correctly find "start_"
-    dis_2 = await ctrl.execute_and_capture("nearpc *_start+10 -r 2 -t 11")
+    dis_2 = await ctrl.execute_and_capture("nearpc $rip+10 -r 2 -t 11")
 
     # This should be able to disassemble backwards using the backwards caches!
     expected_2 = (

--- a/tests/library/dbg/tests/test_emulate.py
+++ b/tests/library/dbg/tests/test_emulate.py
@@ -113,7 +113,7 @@ async def test_backwards_backwards_disassemble_heuristic(ctrl: Controller) -> No
     # Enable the heuristic
     await ctrl.execute_and_capture("set heuristic-backwards-disasm on")
 
-    dis = await ctrl.execute_and_capture("nearpc *pc+20 -t 11")
+    dis = await ctrl.execute_and_capture("nearpc *$pc+20 -t 11")
 
     expected = (
         "   0x40007e                add    byte ptr [rax], al\n"
@@ -190,14 +190,14 @@ async def test_backwards_linear_cache_misaligned_disasm(ctrl: Controller) -> Non
     await ctrl.launch(SYSCALLS_BINARY)
 
     # This filling up caches, disassembling from misaligned address
-    await ctrl.execute_and_capture("nearpc *pc+3 -t 11")
+    await ctrl.execute_and_capture("nearpc *$pc+3 -t 11")
 
     # Disable the heuristic
     await ctrl.execute_and_capture("set heuristic-backwards-disasm off")
     await ctrl.execute_and_capture("set context-disasm-back-linear-lines 0")
 
     # Without the heuristic, we disassemble straightline
-    dis = await ctrl.execute_and_capture("nearpc *pc+10 -t 11")
+    dis = await ctrl.execute_and_capture("nearpc *$pc+10 -t 11")
 
     expected = (
         " ► 0x40008a <_start+10>    mov    esi, 0xdeadbeef        ESI => 0xdeadbeef\n"
@@ -219,7 +219,7 @@ async def test_backwards_linear_cache_misaligned_disasm(ctrl: Controller) -> Non
 
     # Now, nearpc from an address after it. The caches should NOT be filled.
     # Instead, the heuristic will be used to disassemble backwards, to correctly find "start_"
-    dis_2 = await ctrl.execute_and_capture("nearpc *pc+10 -t 11")
+    dis_2 = await ctrl.execute_and_capture("nearpc *$pc+10 -t 11")
 
     # This should be able to disassemble backwards using the backwards caches!
     expected_2 = (

--- a/tests/library/gdb/conftest.py
+++ b/tests/library/gdb/conftest.py
@@ -24,6 +24,7 @@ def start_binary():
         gdb.execute("set exception-verbose on")
         gdb.execute("set width 80")
         gdb.execute("set context-reserve-lines never")
+        gdb.execute("set heuristic-backwards-disasm off")
         gdb.execute("set context-disasm-back-linear-lines 0")
         os.environ["COLUMNS"] = "80"
         gdb.execute("starti " + " ".join(args))

--- a/tests/library/gdb/conftest.py
+++ b/tests/library/gdb/conftest.py
@@ -24,6 +24,7 @@ def start_binary():
         gdb.execute("set exception-verbose on")
         gdb.execute("set width 80")
         gdb.execute("set context-reserve-lines never")
+        gdb.execute("set context-disasm-back-linear-lines 0")
         os.environ["COLUMNS"] = "80"
         gdb.execute("starti " + " ".join(args))
 

--- a/tests/library/qemu_user/conftest.py
+++ b/tests/library/qemu_user/conftest.py
@@ -184,6 +184,7 @@ def qemu_assembly_run():
         gdb.execute("set exception-verbose on")
         gdb.execute("set context-reserve-lines never")
         gdb.execute("set width 80")
+        gdb.execute("set context-disasm-back-linear-lines 0")
         gdb.execute(f"target remote :{QEMU_PORT}")
 
         global _start_binary_called

--- a/tests/library/qemu_user/conftest.py
+++ b/tests/library/qemu_user/conftest.py
@@ -184,6 +184,7 @@ def qemu_assembly_run():
         gdb.execute("set exception-verbose on")
         gdb.execute("set context-reserve-lines never")
         gdb.execute("set width 80")
+        gdb.execute("set heuristic-backwards-disasm off")
         gdb.execute("set context-disasm-back-linear-lines 0")
         gdb.execute(f"target remote :{QEMU_PORT}")
 


### PR DESCRIPTION
This implements disassembling backwards in variable width instruction architectures to implement #3784.

Prior to this PR, if you hit a breakpoint or did `nearpc random_address`, and if the disassembly system had not already encountered the surrounding sequence of instructions before, then we were unable to display the "previous" instructions behind the instruction pointer. 

This implements a method to  "guess" the valid sequence of instructions that lead to the current instruction, allowing disassembling backwards. Since ISA's like x86 are not self-synchronizing, we do a best-effort guess at determining the true instruction boundaries.

The method is simple: start a certain amount of bytes in the past, and start disassembling towards the current instruction. We will assume that after a certain number of disassembled instructions, that the sequence will "self-align" to the real sequence (which works in practice).



There is one case where this might not be desirable (i.e. changes longstanding pwndbg behavior), which is stepping into a function call. Previously, when you stepped into a call, the first instruction would be the first one displayed. Now, because we can disassemble backwards, it displays the instructions linearly behind the instruction.

This can get confusing, giving we are now mixing emulation (displaying the true sequence of instruction) with sometimes displaying instructions linearly behind the address.

<img width="1569" height="311" alt="image" src="https://github.com/user-attachments/assets/3db12f6e-ad24-4e6d-8d98-5f28c356ceab" />

<img width="1626" height="360" alt="image" src="https://github.com/user-attachments/assets/75ec88a3-1999-4107-8c21-94106ebe068d" />


