### PR TITLE
Add  GDB convenience variable to detect presence of pwndbg in .gdbinit

### DIFF
--- a/pwndbg/dbg_mod/gdb/__init__.py
+++ b/pwndbg/dbg_mod/gdb/__init__.py
@@ -1765,12 +1765,12 @@ class GDB(pwndbg.dbg_mod.Debugger):
 
         from pwndbg.dbg_mod.gdb import debug_sym as debug_sym
 
-        self._load_gdbinit()
-
         # Set a variable, "$pwndbg_plugin_enabled", that a .gdbinit config can use to detect
         # that pwndbg is enabled with `if ! $_isvoid($pwndbg_plugin_enabled)`
         # This allows the .gdbinit to conditionally configure pwndbg settings
         gdb.set_convenience_variable("pwndbg_plugin_enabled", True)
+
+        self._load_gdbinit()
 
         # show_hint must be called after loading ~/.gdbinit, this order allow disabling show_hint
         prompt.show_hint()

--- a/pwndbg/dbg_mod/gdb/__init__.py
+++ b/pwndbg/dbg_mod/gdb/__init__.py
@@ -1767,6 +1767,11 @@ class GDB(pwndbg.dbg_mod.Debugger):
 
         self._load_gdbinit()
 
+        # Set a variable, "$pwndbg_plugin_enabled", that a .gdbinit config can use to detect
+        # that pwndbg is enabled with `if ! $_isvoid($pwndbg_plugin_enabled)`
+        # This allows the .gdbinit to conditionally configure pwndbg settings
+        gdb.set_convenience_variable("pwndbg_plugin_enabled", True)
+
         # show_hint must be called after loading ~/.gdbinit, this order allow disabling show_hint
         prompt.show_hint()
 


### PR DESCRIPTION
This creates a variable, `$pwndbg_plugin_enabled`, when Pwndbg starts up in GDB.

This allows `.gdbinit` files to detect the presence of pwndbg and conditionally set pwndbg-specific settings

Example `.gdbinit`:
```
source /path/to/pwndbg/gdbinit.py

if ! $_isvoid($pwndbg_plugin_enabled)

    set context-code-lines 40

end
```

This makes it easier to quickly edit the `.gdbinit` and commenting/uncommenting the one `source /path/to/gdbinit.py` file to toggle it, and not have to change the rest of the pwndbg-specific lines in the file.