### PR TITLE
telescope-pad-leading-zeroes config to print pointer-aligned integers with tele

### DIFF
--- a/docs/configuration/config.md
+++ b/docs/configuration/config.md
@@ -993,6 +993,17 @@ Number of lines to printed by the telescope command.
 
 ----------
 
+## **telescope-pad-leading-zeroes**
+
+
+Align all integers to pointer-width by front-padding them with zeroes.
+
+
+
+**Default:** off  
+
+----------
+
 ## **telescope-skip-repeating-val**
 
 

--- a/pwndbg/chain.py
+++ b/pwndbg/chain.py
@@ -98,10 +98,6 @@ config_contiguous = theme.add_param(
     "chain-contiguous-marker", "...", "contiguous marker of chain formatting"
 )
 
-config_full_values = pwndbg.config.add_param(
-    "chain-full-values", False, "show the full word instead of trimming the leading zeroes"
-)
-
 
 def format(
     value: int | list[int] | None,
@@ -112,6 +108,7 @@ def format(
     hard_end: int = 0,
     safe_linking: bool = False,
     enhance_string_len: int | None = None,
+    respect_ptrwidth: bool = False,
 ) -> str:
     """
     Recursively dereferences an address into string representation, or convert the list representation
@@ -149,9 +146,7 @@ def format(
 
     # Colorize the chain
     rest = [
-        mem_color.get_address_and_symbol(
-            addr, stack_vars, respect_ptrwidth=bool(config_full_values)
-        )
+        mem_color.get_address_and_symbol(addr, stack_vars, respect_ptrwidth=bool(respect_ptrwidth))
         if addr >= 0
         else ""
         for addr in chain
@@ -179,7 +174,7 @@ def format(
             code=code,
             attempt_dereference=False,
             enhance_string_len=enhance_string_len,
-            respect_ptrwidth=bool(config_full_values),
+            respect_ptrwidth=bool(respect_ptrwidth),
         )
     # We want to enhance the last pointer value. If an offset was used
     # chain failed at that offset, so display that offset.
@@ -189,7 +184,7 @@ def format(
             code=code,
             safe_linking=safe_linking,
             enhance_string_len=enhance_string_len,
-            respect_ptrwidth=bool(config_full_values),
+            respect_ptrwidth=bool(respect_ptrwidth),
         )
 
     else:

--- a/pwndbg/chain.py
+++ b/pwndbg/chain.py
@@ -98,10 +98,14 @@ config_contiguous = theme.add_param(
     "chain-contiguous-marker", "...", "contiguous marker of chain formatting"
 )
 
+config_full_values = pwndbg.config.add_param(
+    "chain-full-values", False, "show the full word instead of trimming the leading zeroes"
+)
+
 
 def format(
     value: int | list[int] | None,
-    limit: int = LIMIT,
+    limit: int = int(LIMIT),
     code: bool = True,
     offset: int = 0,
     hard_stop: int | None = None,
@@ -145,7 +149,12 @@ def format(
 
     # Colorize the chain
     rest = [
-        mem_color.get_address_and_symbol(addr, stack_vars) if addr >= 0 else "" for addr in chain
+        mem_color.get_address_and_symbol(
+            addr, stack_vars, respect_ptrwidth=bool(config_full_values)
+        )
+        if addr >= 0
+        else ""
+        for addr in chain
     ]
 
     # If the dereference limit is zero, skip any enhancements.
@@ -170,6 +179,7 @@ def format(
             code=code,
             attempt_dereference=False,
             enhance_string_len=enhance_string_len,
+            respect_ptrwidth=bool(config_full_values),
         )
     # We want to enhance the last pointer value. If an offset was used
     # chain failed at that offset, so display that offset.
@@ -179,6 +189,7 @@ def format(
             code=code,
             safe_linking=safe_linking,
             enhance_string_len=enhance_string_len,
+            respect_ptrwidth=bool(config_full_values),
         )
 
     else:

--- a/pwndbg/color/memory.py
+++ b/pwndbg/color/memory.py
@@ -30,21 +30,28 @@ c = ColorConfig(
 )
 
 
-def get_address_and_symbol(address: int, decompiler_stack_variables: dict[int, str]) -> str:
+def get_address_and_symbol(
+    address: int, decompiler_stack_variables: dict[int, str], respect_ptrwidth: bool = False
+) -> str:
     """
     Convert and colorize address 0x7ffff7fcecd0 to string `0x7ffff7fcecd0 (_dl_fini)`
-    If no symbol exists for the address, return colorized address
+    If no symbol exists for the address, return colorized address.
+
+    Args:
+        respect_ptrwidth: Align value to pointer width, i.e. would output
+            `0x00007ffff7fcecd0 (_dl_fini)`.
     """
     symbol = pwndbg.aglib.symbol.resolve_addr(address)
+    ptralignment: int = pwndbg.aglib.arch.ptrbits if respect_ptrwidth else -1
     if symbol:
-        symbol = f"{address:#x} ({symbol})"
+        symbol = pwndbg.lib.pretty_print.int_to_string(address, ptralignment) + f" ({symbol})"
     else:
         var: str | None = pwndbg.aglib.stack.get_stack_var_name(address)
         if var is None:
             var = decompiler_stack_variables.get(address)
         if var is not None:
-            symbol = f"{address:#x} {{{var}}}"
-    return get(address, symbol)
+            symbol = pwndbg.lib.pretty_print.int_to_string(address, ptralignment) + f" {{{var}}}"
+    return get(address, symbol, respect_ptrwidth=respect_ptrwidth)
 
 
 def get_address_or_symbol(address: int, decompiler_stack_variables: dict[int, str]) -> str:
@@ -80,6 +87,7 @@ def get(
     text: str | None = None,
     prefix: str | None = None,
     page: pwndbg.lib.memory.Page | None = None,
+    respect_ptrwidth: bool = False,
 ) -> str:
     """
     Returns a colorized string representing the provided address.
@@ -88,6 +96,7 @@ def get(
         address: Address to look up
         text: Optional text to use in place of the address in the return value string.
         prefix: Optional text to set at beginning in the return value string, followed by a space, without modifiying the original text.
+        respect_ptrwidth: Pad value with leading zeroes so that it is pointer-sized.
     """
     address = int(address)
     if page is None:  # if we know the containing page, don't bother to find it as an optimization
@@ -120,7 +129,8 @@ def get(
         color = lambda x: c.wx(old_color(x))
 
     if text is None:
-        text = pwndbg.lib.pretty_print.int_to_string(address)
+        ptralignment: int = pwndbg.aglib.arch.ptrbits if respect_ptrwidth else -1
+        text = pwndbg.lib.pretty_print.int_to_string(address, adhere_to_ptrwidth=ptralignment)
 
     if prefix is not None:
         # Prepend the prefix and a space before the existing text

--- a/pwndbg/commands/telescope.py
+++ b/pwndbg/commands/telescope.py
@@ -34,6 +34,11 @@ skip_repeating_values_minimum = pwndbg.config.add_param(
     3,
     "minimum amount of repeated values before skipping lines",
 )
+pad_leading_zeroes = pwndbg.config.add_param(
+    "telescope-pad-leading-zeroes",
+    False,
+    "align all integers to pointer-width by front-padding them with zeroes",
+)
 print_framepointer_offset = pwndbg.config.add_param(
     "telescope-framepointer-offset",
     True,
@@ -251,7 +256,7 @@ def telescope(
         line = T.offset(f"{idx_offset:02x}{delimiter}{line_offset:04x}{separator}") + " ".join(
             (
                 regs_or_frame_offset(addr, bp, regs, longest_regs),
-                pwndbg.chain.format(addr),
+                pwndbg.chain.format(addr, respect_ptrwidth=bool(pad_leading_zeroes)),
             )
         )
 

--- a/pwndbg/enhance.py
+++ b/pwndbg/enhance.py
@@ -76,7 +76,7 @@ def enhance(
     # If it's a pointer that we told we cannot deference, then color it accordingly and add symbol if can
     if page and not attempt_dereference:
         return pwndbg.color.memory.get_address_and_symbol(
-            value, pwndbg.dintegration.manager.get_stack_var_dict_all()
+            value, pwndbg.dintegration.manager.get_stack_var_dict_all(), respect_ptrwidth
         )
 
     if not can_read:
@@ -114,7 +114,12 @@ def enhance(
     if safe_linking:
         intval ^= value >> 12
     intval0 = intval
-    intval = E.integer(pwndbg.lib.pretty_print.int_to_string(intval & pwndbg.aglib.arch.ptrmask))
+    intval = E.integer(
+        pwndbg.lib.pretty_print.int_to_string(
+            intval & pwndbg.aglib.arch.ptrmask,
+            pwndbg.aglib.arch.ptrbits if respect_ptrwidth else -1,
+        )
+    )
 
     retval = []
 
@@ -153,7 +158,7 @@ def enhance(
         new_page = pwndbg.aglib.vmmap.find(intval0)
         if new_page:
             return pwndbg.color.memory.get_address_and_symbol(
-                intval0, pwndbg.dintegration.manager.get_stack_var_dict_all()
+                intval0, pwndbg.dintegration.manager.get_stack_var_dict_all(), respect_ptrwidth
             )
         return E.integer(int_str(intval0, respect_ptrwidth))
 

--- a/pwndbg/enhance.py
+++ b/pwndbg/enhance.py
@@ -25,8 +25,9 @@ import pwndbg.lib.pretty_print
 from pwndbg import color
 
 
-def int_str(value: int) -> str:
-    retval = pwndbg.lib.pretty_print.int_to_string(value)
+def int_str(value: int, respect_ptrwidth: bool = False) -> str:
+    ptralignment: int = pwndbg.aglib.arch.ptrbits if respect_ptrwidth else -1
+    retval = pwndbg.lib.pretty_print.int_to_string(value, adhere_to_ptrwidth=ptralignment)
 
     # Try to unpack the value as a string
     packed = pwndbg.aglib.arch.pack(value)
@@ -44,6 +45,7 @@ def enhance(
     safe_linking: bool = False,
     attempt_dereference=True,
     enhance_string_len: int = None,
+    respect_ptrwidth: bool = False,
 ) -> str:
     """
     Given the last pointer in a chain, attempt to characterize
@@ -78,7 +80,7 @@ def enhance(
         )
 
     if not can_read:
-        return E.integer(int_str(value))
+        return E.integer(int_str(value, respect_ptrwidth))
 
     # It's mapped memory, or we can at least read it.
     # Try to find out if it's a string.
@@ -106,7 +108,7 @@ def enhance(
 
     # Fix for case when we can't read the end address anyway (#946)
     if value + pwndbg.aglib.arch.ptrsize > page.end:
-        return E.integer(int_str(value))
+        return E.integer(int_str(value, respect_ptrwidth))
 
     intval = pwndbg.aglib.memory.read_pointer_width(value)
     if safe_linking:
@@ -153,7 +155,7 @@ def enhance(
             return pwndbg.color.memory.get_address_and_symbol(
                 intval0, pwndbg.dintegration.manager.get_stack_var_dict_all()
             )
-        return E.integer(int_str(intval0))
+        return E.integer(int_str(intval0, respect_ptrwidth))
 
     retval = tuple(filter(lambda x: x is not None, retval))
 

--- a/pwndbg/lib/pretty_print.py
+++ b/pwndbg/lib/pretty_print.py
@@ -31,13 +31,23 @@ this setting at 9 (the default).
 )
 
 
-def int_to_string(num: int) -> str:
+def int_to_string(num: int, adhere_to_ptrwidth: int = -1) -> str:
     """
     Converts an integer value to string.
 
     Decides whether to format it in decimal or
     hex depending on the max-decimal-number config.
+
+    If adhere_to_ptrwidth is not `-1`, it should be the size of a pointer
+    of the current CPU architecture in bits. Will cause the output string
+    to be aligned to the pointer size. E.g. `0x00007ffff7fe36c6` instead
+    of `0x7ffff7fe36c6`. If this is not -1, the int will always be hexified
+    regardless of `max-decimal-number`. See also `chain-full-values`.
     """
+    if adhere_to_ptrwidth != -1:
+        nibble_num = adhere_to_ptrwidth * 2 // 8
+        # assert (adhere_to_ptrwidth * 2) % 8 == 0
+        return f"{num:#0{nibble_num+2}x}"
     if max_decimal_number == -1:
         return f"{num}"
     if max_decimal_number == 0:


### PR DESCRIPTION
Some people prefer this type of output because it aligns better.

<img width="1057" height="427" alt="image" src="https://github.com/user-attachments/assets/cb8d7775-6838-444f-b3e6-213b3979a458" />
