### PR TITLE
Fix large frame offset

### DIFF
--- a/pwndbg/commands/telescope.py
+++ b/pwndbg/commands/telescope.py
@@ -270,12 +270,15 @@ def telescope(
 
 def regs_or_frame_offset(addr: int, bp: int | None, regs: dict[int, str], longest_regs: int) -> str:
     # bp only set if print_framepointer_offset=True
-    if bp is None or regs[addr]:
+    if bp is None or regs[addr] or not -0xFFFF <= addr - bp <= 0xFFFF:
         # We do .rjust(3) because some arches have two-letter registers.
         return " " + T.register(regs[addr].ljust(longest_regs).rjust(3))
     # Print offset to frame pointer
-    offset = addr -bp
-    offset_str = f"{offset:+05x}" if abs(offset) <= 0xFFFF else f"{offset:+09x}"
+    offset = addr - bp
+    if abs(offset) < 0x1000:
+        offset_str = f"{offset:+04x}"
+    else:
+        offset_str = f"{offset:+05x}"
     return offset_str.ljust(longest_regs + 1)
 
 

--- a/pwndbg/commands/telescope.py
+++ b/pwndbg/commands/telescope.py
@@ -270,11 +270,13 @@ def telescope(
 
 def regs_or_frame_offset(addr: int, bp: int | None, regs: dict[int, str], longest_regs: int) -> str:
     # bp only set if print_framepointer_offset=True
-    if bp is None or regs[addr] or not -0xFFF <= addr - bp <= 0xFFF:
+    if bp is None or regs[addr]:
         # We do .rjust(3) because some arches have two-letter registers.
         return " " + T.register(regs[addr].ljust(longest_regs).rjust(3))
-    # If offset to frame pointer as hex fits in hex 3 digits, print it
-    return ("%+04x" % (addr - bp)).ljust(longest_regs + 1)
+    # Print offset to frame pointer
+    offset = addr -bp
+    offset_str = f"{offset:+05x}" if abs(offset) <= 0xFFFF else f"{offset:+09x}"
+    return offset_str.ljust(longest_regs + 1)
 
 
 parser = argparse.ArgumentParser(


### PR DESCRIPTION
<!--
    Please make sure to read the linting and testing instructions at
    https://pwndbg.re/dev/contributing/ before creating a PR.
-->

+ [ ] I read the contributing documentation.
+ [ ] I am providing a screenshot of the (new feature) / (fixed bug).

Closes #3802

Previously, the offset was only displayed correctly when it fit within the ±0xFFF range. 
With this change, offsets up to ±0xFFFF are shown correctly, and the offset column has a fixed width so all rows stay aligned. 
Is a fixed width of ±0xFFFF sufficient, or would it be better to calculate the column width dynamically based on the actual largest offset in the current output?