### PR TITLE
Fix crash on load_common_structs_on_load_linux

### DIFF
--- a/pwndbg/aglib/kernel/symbol.py
+++ b/pwndbg/aglib/kernel/symbol.py
@@ -299,7 +299,7 @@ def load_common_structs_on_load_linux() -> None:
             # even end up using the type-dependant commands.
             # Other commands and typeinfo recoveries depend on this succeeding,
             # so we save the actual failure reason to have something meaningful to
-            # show to the user.
+            # FIXME: NotImplementedError: Currently raised for non-linux OSes by stuff like `_paginginfo`. See #3911 .
             pwndbg.aglib.kernel.page_typeinfo_recovery_failure = e
 
 

--- a/pwndbg/aglib/kernel/symbol.py
+++ b/pwndbg/aglib/kernel/symbol.py
@@ -294,7 +294,7 @@ def load_common_structs_on_load_linux() -> None:
     if pwndbg.aglib.qemu.is_qemu_kernel() and pwndbg.dbg.selected_inferior().is_linux():
         try:
             recover_page_typeinfo()
-        except TypeNotRecoveredError as e:
+        except (TypeNotRecoveredError, NotImplementedError) as e:
             # We are not going to print anything here, because the user may not
             # even end up using the type-dependant commands.
             # Other commands and typeinfo recoveries depend on this succeeding,


### PR DESCRIPTION
Fixes the crash detailed in #3911 (the event listener would cause pwndbg to crash when debugging a program run by qemu-system that invoked a crash deeper in the call stack) 