### PR TITLE
Enable Riscv B extension for disassembly

### DIFF
--- a/pwndbg/aglib/arch_mod.py
+++ b/pwndbg/aglib/arch_mod.py
@@ -27,6 +27,9 @@ from capstone6pwndbg import CS_MODE_MIPS64
 from capstone6pwndbg import CS_MODE_RISCV32
 from capstone6pwndbg import CS_MODE_RISCV64
 from capstone6pwndbg import CS_MODE_RISCV_C
+from capstone6pwndbg import CS_MODE_RISCV_ZBA
+from capstone6pwndbg import CS_MODE_RISCV_ZBB
+from capstone6pwndbg import CS_MODE_RISCV_ZBS
 from capstone6pwndbg import CS_MODE_THUMB
 from capstone6pwndbg import CS_MODE_V9
 from typing_extensions import override
@@ -326,7 +329,14 @@ class RISCV32Arch(PwndbgArchitecture):
 
     @override
     def get_capstone_constants(self, address: int) -> tuple[int, int]:
-        return (CS_ARCH_RISCV, CS_MODE_RISCV32 | CS_MODE_RISCV_C)
+        return (
+            CS_ARCH_RISCV,
+            CS_MODE_RISCV32
+            | CS_MODE_RISCV_C
+            | CS_MODE_RISCV_ZBA
+            | CS_MODE_RISCV_ZBB
+            | CS_MODE_RISCV_ZBS,
+        )
 
 
 class RISCV64Arch(PwndbgArchitecture):
@@ -338,7 +348,14 @@ class RISCV64Arch(PwndbgArchitecture):
 
     @override
     def get_capstone_constants(self, address: int) -> tuple[int, int]:
-        return (CS_ARCH_RISCV, CS_MODE_RISCV64 | CS_MODE_RISCV_C)
+        return (
+            CS_ARCH_RISCV,
+            CS_MODE_RISCV64
+            | CS_MODE_RISCV_C
+            | CS_MODE_RISCV_ZBA
+            | CS_MODE_RISCV_ZBB
+            | CS_MODE_RISCV_ZBS,
+        )
 
 
 class MipsArch(PwndbgArchitecture):


### PR DESCRIPTION
The latest capstone version upgraded RISC-V, and enabled a way to allow disassembling certain RISCV ISA extensions. The riscv B extension instructions (https://github.com/riscv/riscv-b) are pretty common, and this enables it by default.

See other extensions in this guide: https://github.com/capstone-engine/capstone/blob/next/docs/cs_v6_release_guide.md

(search for `CS_MODE_RISCV_ZBA`)

This fixes #2706