### PR TITLE
Fix enhance errors in environment lacking paging information

### DIFF
--- a/pwndbg/chain.py
+++ b/pwndbg/chain.py
@@ -184,8 +184,8 @@ def format(
 
         page = pwndbg.aglib.vmmap.find(pointer_to_enhance)
 
-        # Check if we dereferenced the last pointer, but it is not in the vmmap mappings
-        # If so, we have to create the page permissions
+        # If the pointer is not in the vmmap mappings, we create page permissions for it.
+        # We know it's a valid pointer, because we dereferenced it.
         if not page:
             mem_flags = pwndbg.aglib.vmmap_custom.get_memory_flags(pointer_to_enhance)
             if mem_flags is not None:

--- a/pwndbg/chain.py
+++ b/pwndbg/chain.py
@@ -4,6 +4,8 @@ Dereference and format pointer chains.
 
 from __future__ import annotations
 
+import os
+
 import pwndbg.aglib
 import pwndbg.aglib.memory
 import pwndbg.aglib.vmmap
@@ -189,12 +191,13 @@ def format(
         if not page:
             mem_flags = pwndbg.aglib.vmmap_custom.get_memory_flags(pointer_to_enhance)
             if mem_flags is not None:
-                # The page start/end are set because they are used in some edge case checks in the enhance function
-                start = pwndbg.lib.memory.page_align(pointer_to_enhance)
-                end = 1 << pwndbg.aglib.arch.ptrbits
-                page = Page(
-                    start, end, mem_flags, pointer_to_enhance - start, pwndbg.aglib.arch.ptrsize
-                )
+                mem_flags = os.R_OK
+            # The page start/end are set because they are used in some edge case checks in the enhance function
+            start = pwndbg.lib.memory.page_align(pointer_to_enhance)
+            end = 1 << pwndbg.aglib.arch.ptrbits
+            page = Page(
+                start, end, mem_flags, pointer_to_enhance - start, pwndbg.aglib.arch.ptrsize
+            )
 
         enhanced = pwndbg.enhance.enhance(
             pointer_to_enhance,

--- a/pwndbg/chain.py
+++ b/pwndbg/chain.py
@@ -190,7 +190,7 @@ def format(
         # We know it's a valid pointer, because we dereferenced it.
         if not page:
             mem_flags = pwndbg.aglib.vmmap_custom.get_memory_flags(pointer_to_enhance)
-            if mem_flags is not None:
+            if mem_flags is None:
                 mem_flags = os.R_OK
             # The page start/end are set because they are used in some edge case checks in the enhance function
             start = pwndbg.lib.memory.page_align(pointer_to_enhance)

--- a/pwndbg/chain.py
+++ b/pwndbg/chain.py
@@ -14,6 +14,7 @@ import pwndbg.enhance
 from pwndbg.color import ColorConfig
 from pwndbg.color import ColorParamSpec
 from pwndbg.color import theme
+from pwndbg.lib.memory import Page
 
 LIMIT = pwndbg.config.add_param(
     "dereference-limit", 5, "max number of pointers to dereference in a chain"
@@ -179,12 +180,29 @@ def format(
     # We want to enhance the last pointer value. If an offset was used
     # chain failed at that offset, so display that offset.
     elif len(chain) < limit + 1:
+        pointer_to_enhance = chain[-2] + offset
+
+        page = pwndbg.aglib.vmmap.find(pointer_to_enhance)
+
+        # Check if we dereferenced the last pointer, but it is not in the vmmap mappings
+        # If so, we have to create the page permissions
+        if not page:
+            mem_flags = pwndbg.aglib.vmmap_custom.get_memory_flags(pointer_to_enhance)
+            if mem_flags is not None:
+                # The page start/end are set because they are used in some edge case checks in the enhance function
+                start = pwndbg.lib.memory.page_align(pointer_to_enhance)
+                end = 1 << pwndbg.aglib.arch.ptrbits
+                page = Page(
+                    start, end, mem_flags, pointer_to_enhance - start, pwndbg.aglib.arch.ptrsize
+                )
+
         enhanced = pwndbg.enhance.enhance(
-            chain[-2] + offset,
+            pointer_to_enhance,
             code=code,
             safe_linking=safe_linking,
             enhance_string_len=enhance_string_len,
             respect_ptrwidth=bool(respect_ptrwidth),
+            page=page,
         )
 
     else:

--- a/pwndbg/enhance.py
+++ b/pwndbg/enhance.py
@@ -24,6 +24,7 @@ import pwndbg.color.memory
 import pwndbg.dintegration
 import pwndbg.lib.pretty_print
 from pwndbg import color
+from pwndbg.lib.memory import Page
 
 
 def int_str(value: int, respect_ptrwidth: bool = False) -> str:
@@ -47,6 +48,7 @@ def enhance(
     attempt_dereference=True,
     enhance_string_len: int = None,
     respect_ptrwidth: bool = False,
+    page: Page = None,
 ) -> str:
     """
     Given the last pointer in a chain, attempt to characterize
@@ -66,10 +68,10 @@ def enhance(
     """
     value = int(value)
 
-    page = pwndbg.aglib.vmmap.find(value)
+    if not page:
+        page = pwndbg.aglib.vmmap.find(value)
 
-    # If it's not in a page we know about, try to dereference
-    # it anyway just to test.
+    # If it's not in a page we know about, see if we can try to dereference it anyways.
     can_read = True
     if not attempt_dereference or not page or None is pwndbg.aglib.memory.peek(value):
         can_read = False


### PR DESCRIPTION
Provides a fix for #2806 - see that issue for details on the bug.

The issue occurs when a memory address is dereferenced, but it does not exist in page in the vmmap list.

This basically implements the idea here: https://github.com/pwndbg/pwndbg/issues/2806#issuecomment-4051963537. While calling `enhance`, we pass it info indicating that we know this pointer can be dereferenced.

This fixes issue of telescoping printing pointers to point to themselves, instead of the memory they point to.