### PR TITLE
lint: enable all of flake8 return && ignore a subset of rules (instead of whitelisting some rules) 

### DIFF
--- a/pwndbg/aglib/argv.py
+++ b/pwndbg/aglib/argv.py
@@ -26,7 +26,7 @@ _was_updated = False
 @pwndbg.dbg.event_handler(pwndbg.dbg_mod.EventType.START)
 def update() -> None:
     if not pwndbg.dbg.selected_inferior().is_linux():
-        return None
+        return
 
     global _stack_ptr
     global _was_updated
@@ -47,7 +47,7 @@ def update_state() -> None:
     global _envc_numbers
 
     if _was_updated:
-        return None
+        return
     _was_updated = True
 
     sp = _stack_ptr
@@ -57,7 +57,7 @@ def update_state() -> None:
     try:
         _argc_numbers = pwndbg.aglib.memory.u(sp, ptrbits)
     except pwndbg.dbg_mod.Error:
-        return None
+        return
 
     sp += ptrsize
     _argv_ptr = sp

--- a/pwndbg/aglib/disasm/assistant.py
+++ b/pwndbg/aglib/disasm/assistant.py
@@ -301,7 +301,7 @@ class DisassemblyAssistant:
         The goal of this function is to set the `annotation` field of the instruction,
         which is the string to be printed in a disasm view.
         """
-        return None
+        return
 
     def _enhance_operands(
         self, instruction: PwndbgInstruction, emu: Emulator, jump_emu: Emulator
@@ -622,12 +622,12 @@ class DisassemblyAssistant:
 
     def _enhance_syscall(self, instruction: PwndbgInstruction, emu: Emulator) -> None:
         if CS_GRP_INT not in instruction.groups:
-            return None
+            return
 
         syscall_arch, syscall_register = self._get_syscall_arch_info(instruction)
 
         if syscall_arch is None:
-            return None
+            return
 
         instruction.syscall = self._read_register_name(instruction, syscall_register, emu)
         if instruction.syscall is not None:

--- a/pwndbg/aglib/file.py
+++ b/pwndbg/aglib/file.py
@@ -302,4 +302,4 @@ def vfile_close(fd):
     packet = f"vFile:close:{fd:X}"
     response = pwndbg.dbg.selected_inferior().send_remote(packet)
     _vfile_check_response(response)
-    return None
+    return

--- a/pwndbg/aglib/next.py
+++ b/pwndbg/aglib/next.py
@@ -187,7 +187,7 @@ async def break_next_call(ec: pwndbg.dbg_mod.ExecutionController, symbol_regex=N
     while pwndbg.aglib.proc.alive():
         # Break on signal as it may be a segfault
         if pwndbg.aglib.proc.stopped_with_signal():
-            return
+            return None
 
         ins = await break_next_branch(ec)
 
@@ -214,7 +214,7 @@ async def break_next_ret(ec: pwndbg.dbg_mod.ExecutionController, address=None):
     while pwndbg.aglib.proc.alive():
         # Break on signal as it may be a segfault
         if pwndbg.aglib.proc.stopped_with_signal():
-            return
+            return None
 
         ins = await break_next_branch(ec, address)
 

--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -743,7 +743,7 @@ def context(
     # Allow to view history after the program has exited
     if not pwndbg.aglib.proc.alive() and (context_history_size <= 0 or not context_history):
         log.error("context: The program is not being run.")
-        return None
+        return
 
     if subcontext is None:
         subcontext = []

--- a/pwndbg/commands/pie.py
+++ b/pwndbg/commands/pie.py
@@ -21,7 +21,7 @@ def translate_addr(offset, module):
             "There are no memory pages in `vmmap` "
             f"for specified address=0x{offset:x} and module={module}"
         )
-        return
+        return None
 
     first_page = min(pages, key=lambda page: page.vaddr)
 
@@ -34,7 +34,7 @@ def translate_addr(offset, module):
         )
         for p in pages:
             print(p)
-        return
+        return None
 
     return addr
 

--- a/pwndbg/commands/ptmalloc2.py
+++ b/pwndbg/commands/ptmalloc2.py
@@ -942,7 +942,7 @@ def find_fake_fast(
                     "No fake fast chunk candidates found; memory preceding target address is not readable"
                 )
             )
-            return None
+            return
 
     if align:
         search_start = pwndbg.lib.memory.align_up(search_start, size_sz)
@@ -954,7 +954,7 @@ def find_fake_fast(
                     "No fake fast chunk candidates found; alignment didn't leave enough space for a size field"
                 )
             )
-            return None
+            return
 
     print(
         message.notice(

--- a/pwndbg/commands/telescope.py
+++ b/pwndbg/commands/telescope.py
@@ -133,7 +133,7 @@ def telescope(
     address = address if address else pwndbg.aglib.regs.sp
     if address is None:
         print("Cannot display stack frame because stack pointer is unavailable")
-        return
+        return None
 
     address = int(address) & pwndbg.aglib.arch.ptrmask
     input_address = address
@@ -154,19 +154,19 @@ def telescope(
     if frame:
         if not pwndbg.aglib.regs.frame:
             print("The frame register is not defined for this architecture.")
-            return
+            return None
         sp = pwndbg.aglib.regs.sp
         bp = pwndbg.aglib.regs.read_reg(pwndbg.aglib.regs.frame)
         if sp > bp:
             print("Cannot display stack frame because base pointer is below stack pointer")
-            return
+            return None
 
         for page in pwndbg.aglib.vmmap.get():
             if sp in page and bp not in page:
                 print(
                     "Cannot display stack frame because base pointer is not on the same page with stack pointer"
                 )
-                return
+                return None
 
         address = sp
         count = int((bp - sp) / ptrsize) + 1

--- a/pwndbg/gdblib/events.py
+++ b/pwndbg/gdblib/events.py
@@ -334,13 +334,13 @@ def event_handler_factory(
 
 def log_objfiles(ofile: gdb.NewObjFileEvent | None = None) -> None:
     if not (pwndbg.config.dev_debug_events and ofile):
-        return None
+        return
 
     name = ofile.new_objfile.filename
 
     print(f"objfile: {name!r}")
     gdb.execute("info sharedlibrary")
-    return None
+    return
 
 
 gdb.events.new_objfile.connect(log_objfiles)

--- a/pwndbg/lib/regs.py
+++ b/pwndbg/lib/regs.py
@@ -394,7 +394,7 @@ class PseudoEmulatedRegisterFile:
         # Definition of the register we are writing
         write_reg_def = self.register_set.reg_definitions.get(reg)
         if write_reg_def is None:
-            return None
+            return
 
         register_bit_offset = write_reg_def.offset * 8
         written_register_size = (
@@ -475,7 +475,7 @@ class PseudoEmulatedRegisterFile:
         # Definition of the register we are invalidating
         written_reg_def = self.register_set.reg_definitions.get(reg)
         if written_reg_def is None:
-            return None
+            return
 
         register_bit_offset = written_reg_def.offset * 8
         written_register_size = (

--- a/pwndbginit/gdbpatches.py
+++ b/pwndbginit/gdbpatches.py
@@ -42,7 +42,7 @@ def fix_readline():
         def find_spec(self, fullname, path=None, target=None):
             if fullname == "readline":
                 raise ImportError("readline module disabled under GDB")
-            return None
+            return
 
     sys.meta_path.insert(0, GdbRemoveReadlineFinder())
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,17 @@ explicit = true
 line-length = 100
 
 [tool.ruff.lint]
-ignore = ["A003", "E402", "E501", "E731", "F405", "F821", "W505"]
+ignore = [
+    "A003",
+    "E402",
+    "E501",
+    "E731",
+    "F405",
+    "F821",
+    "W505",
+    "RET503", # flake8-return implicit-return
+    "RET504", # flake8-return unnecessary-assign
+]
 
 select = [
     "A",      # flake8-builtins
@@ -123,11 +133,8 @@ select = [
     "SLOT",   # flake8-slots
     "FLY",    # flynt
     "PGH",    # pygrep-hooks
-    "RET505", # flake8-return: superfluous-else-return
-    "RET506", # flake8-return: superfluous-else-raise
-    "RET507", # flake8-return: superfluous-else-continue
-    "RET508", # flake8-return: superfluous-else-break
-    "UP",      # pyugprade
+    "RET",    # flake8-return
+    "UP",     # pyugprade
     # We want to enable the below lints, but they currently return too many errors
     # "SLF" # flake8-self
     # "SIM", # flake8-simplify


### PR DESCRIPTION
#[]()1 out of X PRs regarding ruff config :innocent: 

From the [`RET` ruleset](https://docs.astral.sh/ruff/rules/#flake8-return-ret), the following two can't be "trivially"* applied/fixed:
- [`RET503`](https://docs.astral.sh/ruff/rules/implicit-return/)
- [`RET504`](https://docs.astral.sh/ruff/rules/unnecessary-assign/) 

instead of selecting a subset of `RET`, ignore only these 2

_*trivially as in "automated" without potentially degrading code quality/losing information_