### PR TITLE
Make the heap decorators happen in the correct order

### DIFF
--- a/pwndbg/commands/ptmalloc2.py
+++ b/pwndbg/commands/ptmalloc2.py
@@ -198,11 +198,16 @@ parser.add_argument(
     "-s", "--simple", action="store_true", help="Simply print malloc_chunk struct's contents."
 )
 
+# NOTE: Order is important. @Command has to be at the top so everything below gets
+# properly run. Decorators do the decoration bottom to top at decoration time; when the function
+# is called the checks happen from top to bottom. I.e. it's important that @OnlyWhenHeapIsInitialized
+# is above @OnlyWithResolvedHeapSyms otherwise we get assertion failure if the process is not alive.
+
 
 @pwndbg.commands.Command(parser, category=CommandCategory.PTMALLOC2)
-@pwndbg.commands.OnlyWithResolvedHeapSyms
-@pwndbg.commands.OnlyWhenHeapIsInitialized
 @pwndbg.commands.OnlyWhenUserspace
+@pwndbg.commands.OnlyWhenHeapIsInitialized
+@pwndbg.commands.OnlyWithResolvedHeapSyms
 def heap(
     addr_start: int | None = None,
     addr_end: int | None = None,
@@ -281,9 +286,8 @@ parser.add_argument(
 
 
 @pwndbg.commands.Command(parser, category=CommandCategory.PTMALLOC2)
-@pwndbg.commands.OnlyWhenRunning
-@pwndbg.commands.OnlyWithResolvedHeapSyms
 @pwndbg.commands.OnlyWhenHeapIsInitialized
+@pwndbg.commands.OnlyWithResolvedHeapSyms
 def hi(addr: int, verbose: bool = False, simple: bool = False, fake: bool = False) -> None:
     try:
         heap = Heap(addr)
@@ -320,9 +324,9 @@ parser.add_argument("addr", nargs="?", type=int, default=None, help="Address of 
 
 
 @pwndbg.commands.Command(parser, category=CommandCategory.PTMALLOC2)
-@pwndbg.commands.OnlyWithResolvedHeapSyms
-@pwndbg.commands.OnlyWhenHeapIsInitialized
 @pwndbg.commands.OnlyWhenUserspace
+@pwndbg.commands.OnlyWhenHeapIsInitialized
+@pwndbg.commands.OnlyWithResolvedHeapSyms
 def arena(addr: int | None = None) -> None:
     """Print the contents of an arena, default to the current thread's arena."""
     allocator = pwndbg.aglib.heap.current
@@ -350,9 +354,9 @@ parser = argparse.ArgumentParser(description="List this process's arenas.")
 
 
 @pwndbg.commands.Command(parser, category=CommandCategory.PTMALLOC2)
-@pwndbg.commands.OnlyWithResolvedHeapSyms
-@pwndbg.commands.OnlyWhenHeapIsInitialized
 @pwndbg.commands.OnlyWhenUserspace
+@pwndbg.commands.OnlyWhenHeapIsInitialized
+@pwndbg.commands.OnlyWithResolvedHeapSyms
 def arenas() -> None:
     """Lists this process's arenas."""
     allocator = pwndbg.aglib.heap.current
@@ -416,10 +420,10 @@ parser.add_argument("addr", nargs="?", type=int, default=None, help="Address of 
 
 
 @pwndbg.commands.Command(parser, category=CommandCategory.PTMALLOC2)
-@pwndbg.commands.OnlyWithResolvedHeapSyms
-@pwndbg.commands.OnlyWhenHeapIsInitialized
-@pwndbg.commands.OnlyWithTcache
 @pwndbg.commands.OnlyWhenUserspace
+@pwndbg.commands.OnlyWhenHeapIsInitialized
+@pwndbg.commands.OnlyWithResolvedHeapSyms
+@pwndbg.commands.OnlyWithTcache
 def tcache(addr: int | None = None) -> None:
     """Print a thread's tcache contents, default to the current thread's
     tcache.
@@ -446,9 +450,9 @@ parser = argparse.ArgumentParser(description="Print the mp_ struct's contents.")
 
 
 @pwndbg.commands.Command(parser, category=CommandCategory.PTMALLOC2)
-@pwndbg.commands.OnlyWithResolvedHeapSyms
-@pwndbg.commands.OnlyWhenHeapIsInitialized
 @pwndbg.commands.OnlyWhenUserspace
+@pwndbg.commands.OnlyWhenHeapIsInitialized
+@pwndbg.commands.OnlyWithResolvedHeapSyms
 def mp() -> None:
     """Print the mp_ struct's contents."""
     allocator = pwndbg.aglib.heap.current
@@ -467,9 +471,9 @@ parser.add_argument("addr", nargs="?", type=int, default=None, help="Address of 
 
 
 @pwndbg.commands.Command(parser, category=CommandCategory.PTMALLOC2)
-@pwndbg.commands.OnlyWithResolvedHeapSyms
-@pwndbg.commands.OnlyWhenHeapIsInitialized
 @pwndbg.commands.OnlyWhenUserspace
+@pwndbg.commands.OnlyWhenHeapIsInitialized
+@pwndbg.commands.OnlyWithResolvedHeapSyms
 def top_chunk(addr: int | None = None) -> None:
     """Print relevant information about an arena's top chunk, default to the
     current thread's arena.
@@ -508,9 +512,9 @@ parser.add_argument(
 
 
 @pwndbg.commands.Command(parser, category=CommandCategory.PTMALLOC2)
-@pwndbg.commands.OnlyWithResolvedHeapSyms
-@pwndbg.commands.OnlyWhenHeapIsInitialized
 @pwndbg.commands.OnlyWhenUserspace
+@pwndbg.commands.OnlyWhenHeapIsInitialized
+@pwndbg.commands.OnlyWithResolvedHeapSyms
 def malloc_chunk(
     addr: int,
     fake: bool = False,
@@ -624,9 +628,9 @@ parser.add_argument("tcache_addr", nargs="?", type=int, default=None, help="Addr
 
 
 @pwndbg.commands.Command(parser, category=CommandCategory.PTMALLOC2)
-@pwndbg.commands.OnlyWithResolvedHeapSyms
-@pwndbg.commands.OnlyWhenHeapIsInitialized
 @pwndbg.commands.OnlyWhenUserspace
+@pwndbg.commands.OnlyWhenHeapIsInitialized
+@pwndbg.commands.OnlyWithResolvedHeapSyms
 def bins(addr: int | None = None, tcache_addr: int | None = None) -> None:
     """Print the contents of all an arena's bins and a thread's tcache,
     default to the current thread's arena and tcache.
@@ -661,9 +665,9 @@ parser.add_argument(
 
 
 @pwndbg.commands.Command(parser, category=CommandCategory.PTMALLOC2)
-@pwndbg.commands.OnlyWithResolvedHeapSyms
-@pwndbg.commands.OnlyWhenHeapIsInitialized
 @pwndbg.commands.OnlyWhenUserspace
+@pwndbg.commands.OnlyWhenHeapIsInitialized
+@pwndbg.commands.OnlyWithResolvedHeapSyms
 def fastbins(addr: int | None = None, verbose: bool = False) -> None:
     """Print the contents of an arena's fastbins, default to the current
     thread's arena.
@@ -700,9 +704,9 @@ parser.add_argument(
 
 
 @pwndbg.commands.Command(parser, category=CommandCategory.PTMALLOC2)
-@pwndbg.commands.OnlyWithResolvedHeapSyms
-@pwndbg.commands.OnlyWhenHeapIsInitialized
 @pwndbg.commands.OnlyWhenUserspace
+@pwndbg.commands.OnlyWhenHeapIsInitialized
+@pwndbg.commands.OnlyWithResolvedHeapSyms
 def unsortedbin(addr: int | None = None, verbose: bool = False) -> None:
     """Print the contents of an arena's unsortedbin, default to the current
     thread's arena.
@@ -735,9 +739,9 @@ parser.add_argument(
 
 
 @pwndbg.commands.Command(parser, category=CommandCategory.PTMALLOC2)
-@pwndbg.commands.OnlyWithResolvedHeapSyms
-@pwndbg.commands.OnlyWhenHeapIsInitialized
 @pwndbg.commands.OnlyWhenUserspace
+@pwndbg.commands.OnlyWhenHeapIsInitialized
+@pwndbg.commands.OnlyWithResolvedHeapSyms
 def smallbins(addr: int | None = None, verbose: bool = False) -> None:
     """Print the contents of an arena's smallbins, default to the current
     thread's arena.
@@ -770,9 +774,9 @@ parser.add_argument(
 
 
 @pwndbg.commands.Command(parser, category=CommandCategory.PTMALLOC2)
-@pwndbg.commands.OnlyWithResolvedHeapSyms
-@pwndbg.commands.OnlyWhenHeapIsInitialized
 @pwndbg.commands.OnlyWhenUserspace
+@pwndbg.commands.OnlyWhenHeapIsInitialized
+@pwndbg.commands.OnlyWithResolvedHeapSyms
 def largebins(addr: int | None = None, verbose: bool = False) -> None:
     """Print the contents of an arena's largebins, default to the current
     thread's arena.
@@ -804,10 +808,10 @@ parser.add_argument(
 
 
 @pwndbg.commands.Command(parser, category=CommandCategory.PTMALLOC2)
-@pwndbg.commands.OnlyWithResolvedHeapSyms
-@pwndbg.commands.OnlyWhenHeapIsInitialized
-@pwndbg.commands.OnlyWithTcache
 @pwndbg.commands.OnlyWhenUserspace
+@pwndbg.commands.OnlyWhenHeapIsInitialized
+@pwndbg.commands.OnlyWithResolvedHeapSyms
+@pwndbg.commands.OnlyWithTcache
 def tcachebins(addr: int | None = None, verbose: bool = False) -> None:
     """Print the contents of a tcache, default to the current thread's tcache."""
     allocator = pwndbg.aglib.heap.current
@@ -863,9 +867,9 @@ parser.add_argument(
 
 
 @pwndbg.commands.Command(parser, category=CommandCategory.PTMALLOC2)
-@pwndbg.commands.OnlyWithResolvedHeapSyms
-@pwndbg.commands.OnlyWhenHeapIsInitialized
 @pwndbg.commands.OnlyWhenUserspace
+@pwndbg.commands.OnlyWhenHeapIsInitialized
+@pwndbg.commands.OnlyWithResolvedHeapSyms
 def find_fake_fast(
     target_address: int,
     max_candidate_size: int | None = None,
@@ -1060,9 +1064,9 @@ group.add_argument(
 
 
 @pwndbg.commands.Command(parser, aliases=["vis"], category=CommandCategory.PTMALLOC2)
-@pwndbg.commands.OnlyWithResolvedHeapSyms
-@pwndbg.commands.OnlyWhenHeapIsInitialized
 @pwndbg.commands.OnlyWhenUserspace
+@pwndbg.commands.OnlyWhenHeapIsInitialized
+@pwndbg.commands.OnlyWithResolvedHeapSyms
 def vis_heap_chunks(
     addr: int | None = None,
     count: int | None = None,
@@ -1375,9 +1379,9 @@ try_free_parser.add_argument("addr", type=int, help="Address passed to free")
 
 
 @pwndbg.commands.Command(try_free_parser, category=CommandCategory.PTMALLOC2)
+@pwndbg.commands.OnlyWhenUserspace
 @pwndbg.commands.OnlyWhenHeapIsInitialized
 @pwndbg.commands.OnlyWithResolvedHeapSyms
-@pwndbg.commands.OnlyWhenUserspace
 def try_free(addr: str | int) -> None:
     addr = int(addr)
 


### PR DESCRIPTION
Issue repro:

`gdb /bin/sh`
`heap`

you get:

<img width="648" height="245" alt="image" src="https://github.com/user-attachments/assets/dab6b597-7537-4f0e-9d05-03c2a0b6d331" />
