### PR TITLE
slab: update field name of struct kmem_cache

### DIFF
--- a/pwndbg/aglib/kernel/slab.py
+++ b/pwndbg/aglib/kernel/slab.py
@@ -207,7 +207,10 @@ class SlabCache:
     def node_caches(self) -> Generator[NodeCache, None, None]:
         """returns node caches for all NUMA nodes"""
         for node in range(kernel.num_numa_nodes()):
-            yield NodeCache(self._slab_cache["node"][node], self, node)
+            if self._slab_cache.dereference().type.has_field("node"):
+                yield NodeCache(self._slab_cache["node"][node], self, node)
+            else:
+                yield NodeCache(self._slab_cache["per_node"][node]["node"], self, node)
 
     @property
     def cpu_partial(self) -> int | None:

--- a/pwndbg/aglib/kernel/slab.py
+++ b/pwndbg/aglib/kernel/slab.py
@@ -206,11 +206,12 @@ class SlabCache:
     @property
     def node_caches(self) -> Generator[NodeCache, None, None]:
         """returns node caches for all NUMA nodes"""
-        for node in range(kernel.num_numa_nodes()):
-            if self._slab_cache.dereference().type.has_field("node"):
-                yield NodeCache(self._slab_cache["node"][node], self, node)
-            else:
+        if kernel.krelease() >= (7, 1):
+            for node in range(kernel.num_numa_nodes()):
                 yield NodeCache(self._slab_cache["per_node"][node]["node"], self, node)
+        else:
+            for node in range(kernel.num_numa_nodes()):
+                yield NodeCache(self._slab_cache["node"][node], self, node)
 
     @property
     def cpu_partial(self) -> int | None:


### PR DESCRIPTION
Add a new lookup path of `struct kmem_cache` due to the update of field name and its data structure.
Due to this kernel patch[1], slab commands failed like below image.

Reference
[1] https://lore.kernel.org/all/20260311-b4-slab-memoryless-barns-v1-1-70ab850be4ce@kernel.org/

<img width="666" height="185" alt="Screenshot 2026-06-03 at 1 05 17 AM" src="https://github.com/user-attachments/assets/616c0a54-3304-4dc0-b17a-04ea12172b3e" />
