### PR TITLE
Align backtrace symbols after wide addresses

### DIFF
--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -1568,24 +1568,26 @@ def context_backtrace(
             break
         newest_frame = candidate
 
-    frame = newest_frame
-    i = 0
     bt_prefix = f"{pwndbg.config.backtrace_prefix}"
     # Use visual width of the prefix (strip color codes) so Unicode chars like ► are measured correctly
     bt_prefix_visual_len = len(pwndbg.color.strip(bt_prefix))
 
-    # Pre-compute total number of frames to pad the frame label width consistently
-    total_frames = i
-    tmp = newest_frame
-    while tmp != oldest_frame:
-        total_frames += 1
-        tmp = tmp.parent()
-    frame_label_width = len(f"{backtrace_frame_label}{total_frames}")
-
+    frames = []
+    frame = newest_frame
     while True:
+        frames.append(frame)
+        if frame == oldest_frame:
+            break
+        frame = frame.parent()
+
+    frame_label_width = len(f"{backtrace_frame_label}{len(frames) - 1}")
+    frame_address_texts = [pwndbg.ui.addrsz(frame.pc()) for frame in frames]
+    frame_address_width = max(len(pwndbg.color.strip(text)) for text in frame_address_texts)
+
+    for i, (frame, address_text) in enumerate(zip(frames, frame_address_texts)):
         prefix = bt_prefix if frame == this_frame else " " * bt_prefix_visual_len
         prefix = f" {c.prefix(prefix)}"
-        addrsz = c.address(pwndbg.ui.addrsz(frame.pc()))
+        addrsz = c.address(address_text.rjust(frame_address_width))
         symbol = c.symbol(pwndbg.aglib.symbol.resolve_addr(int(frame.pc())))
         if symbol:
             if bool(config_backtrace_format):
@@ -1596,12 +1598,6 @@ def context_backtrace(
             addrsz = f"{addrsz} {symbol}"
         frame_label = f"{backtrace_frame_label}{i}".rjust(frame_label_width)
         result.append(f"{prefix} {c.frame_label(frame_label)} {addrsz}")
-
-        if frame == oldest_frame:
-            break
-
-        frame = frame.parent()
-        i += 1
     return result
 
 

--- a/tests/library/dbg/tests/test_context_commands.py
+++ b/tests/library/dbg/tests/test_context_commands.py
@@ -296,6 +296,74 @@ async def test_context_backtrace_show_proper_symbol_names(ctrl: Controller) -> N
 
 
 @pwndbg_test
+async def test_context_backtrace_aligns_symbols_after_wide_addresses(ctrl: Controller) -> None:
+    import pwndbg
+    import pwndbg.aglib.symbol
+    import pwndbg.commands.context
+    import pwndbg.ui
+
+    class FakeFrame:
+        def __init__(self, pc: int) -> None:
+            self._pc = pc
+            self._parent: FakeFrame | None = None
+            self._child: FakeFrame | None = None
+
+        def pc(self) -> int:
+            return self._pc
+
+        def parent(self) -> FakeFrame | None:
+            return self._parent
+
+        def child(self) -> FakeFrame | None:
+            return self._child
+
+    current = FakeFrame(0xFFFFFFFF81723AD0)
+    caller = FakeFrame(0)
+    current._parent = caller
+    caller._child = current
+
+    addresses = {
+        current.pc(): "0xffffffff81723ad0",
+        caller.pc(): "             0x0",
+    }
+    symbols = {
+        current.pc(): "newque",
+        caller.pc(): "__pfx_init_module",
+    }
+
+    await ctrl.launch(MANGLING_BINARY)
+
+    original_selected_frame = pwndbg.dbg.selected_frame
+    original_addrsz = pwndbg.ui.addrsz
+    original_resolve_addr = pwndbg.aglib.symbol.resolve_addr
+
+    def fake_selected_frame() -> FakeFrame:
+        return current
+
+    def fake_addrsz(address: int) -> str:
+        return addresses[address]
+
+    def fake_resolve_addr(address: int) -> str:
+        return symbols[address]
+
+    try:
+        setattr(pwndbg.dbg, "selected_frame", fake_selected_frame)
+        setattr(pwndbg.ui, "addrsz", fake_addrsz)
+        setattr(pwndbg.aglib.symbol, "resolve_addr", fake_resolve_addr)
+
+        backtrace = [
+            pwndbg.color.strip(line)
+            for line in pwndbg.commands.context.context_backtrace(with_banner=False)
+        ]
+    finally:
+        setattr(pwndbg.dbg, "selected_frame", original_selected_frame)
+        setattr(pwndbg.ui, "addrsz", original_addrsz)
+        setattr(pwndbg.aglib.symbol, "resolve_addr", original_resolve_addr)
+
+    assert backtrace[0].index("newque") == backtrace[1].index("__pfx_init_module")
+
+
+@pwndbg_test
 async def test_context_disasm_works_properly_with_disasm_flavor_switch(ctrl: Controller) -> None:
     await ctrl.launch(SYSCALLS_BINARY)
 


### PR DESCRIPTION
+ [x] I read the contributing documentation.
+ [ ] I am providing a screenshot of the (new feature) / (fixed bug).

## Summary

Fixes #3770.

This updates `context backtrace` to right-align every rendered frame address to the widest visible address in the current backtrace before appending the symbol name. That keeps symbols aligned when the backtrace mixes full kernel addresses with short values like `0x0`.

I also added a regression test with fake frames matching the reported shape: one full kernel address and one short padded `0x0` address.

## Tests

- `UV_CACHE_DIR=/tmp/pwndbg-3770-uv-cache uv run --group lint ruff check pwndbg/commands/context.py tests/library/dbg/tests/test_context_commands.py`
- `UV_CACHE_DIR=/tmp/pwndbg-3770-uv-cache uv run --group lint ruff format --check pwndbg/commands/context.py tests/library/dbg/tests/test_context_commands.py`
- `git diff --check`
- `UV_CACHE_DIR=/tmp/pwndbg-3770-uv-cache uv run --group tests pytest tests/unit_tests/test_arch.py -q`

I also tried to run `UV_CACHE_DIR=/tmp/pwndbg-3770-uv-cache ./tests.sh -g dbg -d gdb -s test_context_backtrace_aligns_symbols_after_wide_addresses`, but this macOS host could not build the Linux-oriented host test binaries (`ldd` unavailable, missing `<malloc.h>`, and an `_main` link error).
