### PR TITLE
Reading `/proc/pid/mem` by default when scanning pagetables

### DIFF
--- a/profiling/benchmark.py
+++ b/profiling/benchmark.py
@@ -29,7 +29,6 @@ def run_benchmark(name: str, prefix: str, callback: Callable, count=COUNT) -> fl
     profiler.enable()
 
     for _ in range(count):
-        pwndbg.lib.cache.clear_caches()
         callback()
 
     profiler.disable()

--- a/profiling/benchmark.py
+++ b/profiling/benchmark.py
@@ -19,7 +19,9 @@ import pwndbg.lib.cache
 COUNT = 100
 
 
-def run_benchmark(name: str, prefix: str, callback: Callable, count=COUNT) -> float:
+def run_benchmark(
+    name: str, prefix: str, callback: Callable, count: int = COUNT, with_cache: bool = True
+) -> float:
     """
     Return:
         Average time to execute callback in seconds
@@ -29,6 +31,8 @@ def run_benchmark(name: str, prefix: str, callback: Callable, count=COUNT) -> fl
     profiler.enable()
 
     for _ in range(count):
+        if not with_cache:
+            pwndbg.lib.cache.clear_caches()
         callback()
 
     profiler.disable()

--- a/profiling/benchmark.py
+++ b/profiling/benchmark.py
@@ -18,6 +18,7 @@ import pwndbg.lib.cache
 
 COUNT = 100
 
+
 def run_benchmark(name: str, prefix: str, callback: Callable, count=COUNT) -> float:
     """
     Return:
@@ -28,6 +29,7 @@ def run_benchmark(name: str, prefix: str, callback: Callable, count=COUNT) -> fl
     profiler.enable()
 
     for _ in range(count):
+        pwndbg.lib.cache.clear_caches()
         callback()
 
     profiler.disable()
@@ -43,6 +45,7 @@ def run_benchmark(name: str, prefix: str, callback: Callable, count=COUNT) -> fl
 
     return full_time / count
 
+
 parser = argparse.ArgumentParser(
     description="""
 Benchmark contexts.
@@ -56,9 +59,9 @@ However, you can use it to find relative performance before/after changes, and f
 
 parser.add_argument("name", type=str, help="Name placed into output pstats filename")
 
+
 @pwndbg.commands.Command(parser, category=pwndbg.commands.CommandCategory.DEV)
 def benchmark_context(name: str):
-
     # Context - clear cache
     ## Benchmark the `context` command, no caching
 
@@ -66,14 +69,9 @@ def benchmark_context(name: str):
         pwndbg.lib.cache.clear_caches()
         pwndbg.commands.context.context.function()
 
-    run_benchmark(
-        name,
-        "context-without-cache",
-        run_with_clear
-    )
+    run_benchmark(name, "context-without-cache", run_with_clear)
 
     pwndbg.lib.cache.clear_caches()
-
 
     # Context - with cache
     ## Benchmark the `context` command with cache
@@ -81,7 +79,7 @@ def benchmark_context(name: str):
         name,
         "context-with-cache",
         # Bypass the decorator so cProfile/snakeviz sees things correctly
-        lambda: pwndbg.commands.context.context.function()
+        lambda: pwndbg.commands.context.context.function(),
     )
 
     pwndbg.lib.cache.clear_caches()
@@ -93,11 +91,7 @@ def benchmark_context(name: str):
         # Bypass the decorator so cProfile can see function stack correctly
         pwndbg.commands.context.context.function()
 
-    run_benchmark(
-        name,
-        "step",
-        run_with_step
-    )
+    run_benchmark(name, "step", run_with_step)
 
     # Regs
 
@@ -105,11 +99,7 @@ def benchmark_context(name: str):
         gdb.execute("stepi")
         pwndbg.commands.context.context_regs()
 
-    run_benchmark(
-        name,
-        "regs",
-        regs
-    )
+    run_benchmark(name, "regs", regs)
 
     # Disasm
 
@@ -117,11 +107,7 @@ def benchmark_context(name: str):
         gdb.execute("stepi")
         pwndbg.commands.context.context_disasm()
 
-    run_benchmark(
-        name,
-        "disasm",
-        disasm
-    )
+    run_benchmark(name, "disasm", disasm)
 
     # Stack
 
@@ -129,12 +115,7 @@ def benchmark_context(name: str):
         gdb.execute("stepi")
         pwndbg.commands.context.context_stack()
 
-    run_benchmark(
-        name,
-        "stack",
-        stack
-    )
-
+    run_benchmark(name, "stack", stack)
 
 
 parser = argparse.ArgumentParser(
@@ -155,10 +136,4 @@ def benchmark_large_telescope(name: str):
     def print_all_stack():
         pwndbg.commands.telescope.telescope(start, len // pwndbg.aglib.arch.ptrsize)
 
-    run_benchmark(
-        name,
-        "all-stack",
-        print_all_stack,
-        4
-    )
-
+    run_benchmark(name, "all-stack", print_all_stack, 4)

--- a/pwndbg/aglib/kernel/__init__.py
+++ b/pwndbg/aglib/kernel/__init__.py
@@ -386,8 +386,8 @@ class ArchOps(ABC):
         return self._paginginfo().physmap
 
     @property
-    def phys_offset(self) -> int:
-        return self._paginginfo().phys_offset
+    def ram_phys_start(self) -> int:
+        return self._paginginfo().ram_phys_start
 
     @property
     def page_shift(self) -> int:
@@ -525,11 +525,11 @@ class Aarch64Ops(ArchOps):
             _virt = pagewalk(virt).virt
         if _virt is None:
             _virt = virt
-        return _virt - self.page_offset + self.phys_offset
+        return _virt - self.page_offset + self.ram_phys_start
 
     def phys_to_virt(self, phys: int) -> int:
         # https://elixir.bootlin.com/linux/v6.16.4/source/arch/arm64/include/asm/memory.h#L356
-        return phys - self.phys_offset + self.page_offset
+        return phys - self.ram_phys_start + self.page_offset
 
     def phys_to_pfn(self, phys: int) -> int:
         return phys >> self.page_shift

--- a/pwndbg/aglib/kernel/paging.py
+++ b/pwndbg/aglib/kernel/paging.py
@@ -359,10 +359,10 @@ class ArchPagingInfo:
             for level in levels:
                 if level.phys is None or level.level is None:
                     continue
-                level.virt = level.phys + self.physmap - self.phys_offset
+                level.virt = level.phys + self.physmap - self.ram_phys_start
                 level.name = self.pagetable_level_names[level.level]
             if result.phys is not None:
-                result.virt = result.phys + self.physmap - self.phys_offset
+                result.virt = result.phys + self.physmap - self.ram_phys_start
         except Exception:
             pass
         finally:  # so that the PhyMemMode value is always restored
@@ -390,7 +390,7 @@ class ArchPagingInfo:
         raise NotImplementedError()
 
     @property
-    def phys_offset(self) -> int:
+    def ram_phys_start(self) -> int:
         return 0
 
     @property
@@ -724,7 +724,7 @@ class Aarch64PagingInfo(ArchPagingInfo):
             self.VMEMMAP_START = pwndbg.aglib.arch.unsigned(-0x40000000 - self.VMEMMAP_SIZE)
 
         # obtained through debugging -- kaslr offset of physmap determines the offset of vmemmap
-        vmemmap_kaslr = (self.physmap - self.PAGE_OFFSET - self.phys_offset) >> vmemmap_shift
+        vmemmap_kaslr = (self.physmap - self.PAGE_OFFSET - self.ram_phys_start) >> vmemmap_shift
         return self.VMEMMAP_START + vmemmap_kaslr
 
     @property
@@ -904,7 +904,7 @@ class Aarch64PagingInfo(ArchPagingInfo):
 
     @property
     @pwndbg.lib.cache.cache_until("start")
-    def phys_offset(self) -> int:
+    def ram_phys_start(self) -> int:
         found_system = False
         try:
             for line in pwndbg.dbg.selected_inferior().send_monitor("info mtree -f").splitlines():

--- a/pwndbg/aglib/kernel/paging.py
+++ b/pwndbg/aglib/kernel/paging.py
@@ -78,10 +78,10 @@ class PageTableScan:
         this needs to be EXTREMELY optimized as it is used to display context
         making as few functions calls or memory reads as possible
         avoid unnecessary python pointer deferences or repetative computations whenever possible
-        when benchmarked on the same linux kernels, on average:
-        - gdb-pt-dump takes ~0.123 for x64 and 5.572 seconds for aarch64
-        - this implementation takes less than 0.0262 seconds to complete for x64 and 0.491 seconds for aarch64
-        --> 2.35x speed up for x64 and more than 10x speed up for aarch64
+        when benchmarked on the same linux kernels with the same read method, on average:
+        - gdb-pt-dump takes ~0.122 for x64 and 0.562 seconds for aarch64
+        - this implementation takes less than 0.0297 seconds to complete for x64 and 0.0492 seconds for aarch64
+        --> 4x faster for x64 and 10x faster for aarch64
         """
         entry &= self.PAGE_ENTRY_MASK
         if (entry, self.paging_level) not in self.cache:

--- a/pwndbg/aglib/kernel/paging.py
+++ b/pwndbg/aglib/kernel/paging.py
@@ -69,8 +69,9 @@ class PageTableScan:
         self.cache: dict[tuple[int, int], list[tuple[int, int, int]]] = {}
         self.entry_cache: dict[int, tuple[int]] = {}
         self.arch = pwndbg.aglib.arch.name
+        # the default is slightly slower but does not require setting yama.ptrace_scope
         self.read: Callable[[int, int], bytearray] = pwndbg.dbg.selected_inferior().read_memory
-        if qm := pwndbg.aglib.qemu.get_qemu_machine():
+        if qm := pwndbg.aglib.qemu.get_qemu_machine():  # note this would fail silently
             self.read = qm.read_physical_memory
 
     def scan(self, entry: int, is_kernel: bool = False) -> list[Page]:

--- a/pwndbg/aglib/kernel/paging.py
+++ b/pwndbg/aglib/kernel/paging.py
@@ -79,10 +79,8 @@ class PageTableScan:
         making as few functions calls or memory reads as possible
         avoid unnecessary python pointer deferences or repetative computations whenever possible
         when benchmarked on the same linux kernels, on average:
-        - gdb-pt-dump takes ~0.153 for x64 and 5.572 seconds for aarch64
-        - this implementation takes less than 0.065 seconds to complete for x64 and 0.491 seconds for aarch64
-        --> around 45-65% of the time is used to read qemu system memory depending on arch and kernel
-            (the theoratical limit would be that all time consumed is used for reading memory)
+        - gdb-pt-dump takes ~0.123 for x64 and 5.572 seconds for aarch64
+        - this implementation takes less than 0.0262 seconds to complete for x64 and 0.491 seconds for aarch64
         --> 2.35x speed up for x64 and more than 10x speed up for aarch64
         """
         entry &= self.PAGE_ENTRY_MASK

--- a/pwndbg/aglib/kernel/paging.py
+++ b/pwndbg/aglib/kernel/paging.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import math
 import re
 import struct
+from collections.abc import Callable
 from dataclasses import dataclass
 
 import pwndbg
@@ -64,11 +65,13 @@ class PageTableScan:
         # for scanning
         self.pagesz = pi.page_size
         self.ptrsize = pwndbg.aglib.arch.ptrsize
-        self.inf = pwndbg.dbg.selected_inferior()
         self.fmt = "<" + ("Q" if self.ptrsize == 8 else "I") * (self.pagesz // self.ptrsize)
         self.cache: dict[tuple[int, int], list[tuple[int, int, int]]] = {}
         self.entry_cache: dict[int, tuple[int]] = {}
         self.arch = pwndbg.aglib.arch.name
+        self.read: Callable[[int, int], bytearray] = pwndbg.dbg.selected_inferior().read_memory
+        if qm := pwndbg.aglib.qemu.get_qemu_machine():
+            self.read = qm.read_physical_memory
 
     def scan(self, entry: int, is_kernel: bool = False) -> list[Page]:
         """
@@ -109,7 +112,7 @@ class PageTableScan:
     def _scan(self, addr: int, level: int) -> None:
         pagesz = self.pagesz
         orig = addr
-        self.entry_cache[addr] = struct.unpack(self.fmt, self.inf.read_memory(addr, self.pagesz))
+        self.entry_cache[addr] = struct.unpack(self.fmt, self.read(addr, self.pagesz))
         entries = self.entry_cache[addr]
         ranges: list[tuple[int, int, int]] = []
         append = ranges.append
@@ -202,9 +205,7 @@ class PageTableScan:
             idx = (target >> shift) & self.PAGE_INDEX_MASK
             addr = entry & self.PAGE_ENTRY_MASK
             if addr not in self.entry_cache:
-                self.entry_cache[addr] = struct.unpack(
-                    self.fmt, self.inf.read_memory(addr, self.pagesz)
-                )
+                self.entry_cache[addr] = struct.unpack(self.fmt, self.read(addr, self.pagesz))
             entry = self.entry_cache[addr][idx]
             if not entry:
                 break
@@ -495,7 +496,7 @@ class x86_64PagingInfo(ArchPagingInfo):
         return pwndbg.aglib.arch.unsigned(-3, self.P4D_SHIFT)
 
     @property
-    def SLAB_DATA_BASE_ADDR(self):
+    def SLAB_DATA_BASE_ADDR(self) -> int:
         STRUCT_SLAB_SIZE = 32 * pwndbg.aglib.arch.ptrsize
         SLAB_VPAGES = (1 << self.P4D_SHIFT) // self.page_size
         SLAB_META_SIZE = pwndbg.lib.memory.round_up(STRUCT_SLAB_SIZE * SLAB_VPAGES, self.page_size)

--- a/pwndbg/aglib/kernel/vmmap.py
+++ b/pwndbg/aglib/kernel/vmmap.py
@@ -119,7 +119,7 @@ def kernel_vmmap_via_page_tables() -> tuple[Page, ...]:
         # QemuMachine requires access to /proc/{qemu-pid}/mem, which is only available on Linux
         return ()
 
-    machine_backend = pwndbg.aglib.qemu.get_qemu_machine()
+    machine_backend = pwndbg.aglib.qemu.get_qemu_machine(True)
     if machine_backend is None:
         return ()
 

--- a/pwndbg/aglib/kernel/vmmap.py
+++ b/pwndbg/aglib/kernel/vmmap.py
@@ -1,13 +1,7 @@
 from __future__ import annotations
 
-import os
-import random
-import string
-import subprocess
 import sys
-import tempfile
 
-from pt.machine import Machine
 from pt.pt import PageTableDump
 from pt.pt_aarch64_parse import PT_Aarch64_Backend
 from pt.pt_riscv64_parse import PT_RiscV64_Backend
@@ -116,91 +110,6 @@ def annotate(pages: pwndbg.dbg_mod.MemoryMap) -> None:
                 break
 
 
-# Most of QemuMachine code was inherited from gdb-pt-dump thanks to Martin Radev (@martinradev)
-# on the MIT license, see:
-# https://github.com/martinradev/gdb-pt-dump/blob/21158ac3f9b36d0e5e0c86193e0ef018fc628e74/pt_gdb/pt_gdb.py#L11-L80
-class QemuMachine(Machine):
-    def __init__(self):
-        super().__init__()
-        self.file = None
-        self.pid = QemuMachine.get_qemu_pid()
-        self.file = os.open(f"/proc/{self.pid}/mem", os.O_RDONLY)
-
-    def __del__(self):
-        if self.file:
-            os.close(self.file)
-
-    @staticmethod
-    def search_pids_for_file(pids: list[str], filename: str) -> str | None:
-        for pid in pids:
-            fd_dir = f"/proc/{pid}/fd"
-            try:
-                for fd in os.listdir(fd_dir):
-                    if os.readlink(f"{fd_dir}/{fd}") == filename:
-                        return pid
-            except FileNotFoundError:
-                # Either the process has gone or fds are changing, not our pid
-                pass
-            except PermissionError:
-                # Evade processes owned by other users
-                pass
-
-        return None
-
-    @staticmethod
-    def get_qemu_pid():
-        try:
-            out = subprocess.check_output(["pgrep", "qemu-system"], encoding="utf8")
-            pids = out.strip().split("\n")
-
-            if len(pids) == 1:
-                return int(pids[0], 10)
-        except subprocess.CalledProcessError:
-            # If no process with the name `qemu-system` is found, fallback to alternative methods,
-            # as the binary name may vary (e.g., `qemu_system`).
-            pass
-
-        # We add a chardev file backend (we dont add a fronted, so it doesn't affect
-        # the guest). We can then look through proc to find which process has the file
-        # open. This approach is agnostic to namespaces (pid, network and mount).
-        chardev_id = "gdb-pt-dump" + "-" + "".join(random.choices(string.ascii_letters, k=16))
-        with tempfile.NamedTemporaryFile() as tmpf:
-            pwndbg.dbg.selected_inferior().send_monitor(
-                f"chardev-add file,id={chardev_id},path={tmpf.name}"
-            )
-            pid_found = QemuMachine.search_pids_for_file(pids, tmpf.name)
-            pwndbg.dbg.selected_inferior().send_monitor(f"chardev-remove {chardev_id}")
-
-        if not pid_found:
-            raise ProcessLookupError("Could not find qemu-system pid")
-
-        return int(pid_found, 10)
-
-    def read_physical_memory(self, physical_address: int, length: int) -> bytes:
-        res = pwndbg.dbg.selected_inferior().send_monitor(f"gpa2hva {hex(physical_address)}")
-
-        # It's not possible to pread large sizes, so let's break the request
-        # into a few smaller ones.
-        max_block_size = 1024 * 1024 * 256
-        try:
-            hva = int(res.split(" ")[-1], 16)
-            data = b""
-            for offset in range(0, length, max_block_size):
-                length_to_read = min(length - offset, max_block_size)
-                block = os.pread(self.file, length_to_read, hva + offset)
-                data += block
-            return data
-        except Exception as e:
-            msg = f"Physical address ({hex(physical_address)}, +{hex(length)}) is not accessible. Reason: {e}. gpa2hva result: {res}"
-            raise OSError(msg)
-
-    def read_register(self, register_name: str) -> int:
-        if register_name.startswith("$"):
-            register_name = register_name[1:]
-
-        return int(pwndbg.aglib.regs.read_reg(register_name))
-
-
 @pwndbg.lib.cache.cache_until("stop")
 def kernel_vmmap_via_page_tables() -> tuple[Page, ...]:
     if not pwndbg.aglib.qemu.is_qemu_kernel():
@@ -210,25 +119,8 @@ def kernel_vmmap_via_page_tables() -> tuple[Page, ...]:
         # QemuMachine requires access to /proc/{qemu-pid}/mem, which is only available on Linux
         return ()
 
-    try:
-        machine_backend = QemuMachine()
-    except PermissionError:
-        print(
-            message.error(
-                "Permission error when attempting to parse page tables with gdb-pt-dump.\n"
-                "Either change the kernel-vmmap setting, re-run GDB as root, or disable "
-                "`ptrace_scope` (`echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope`)"
-            )
-        )
-        return ()
-    except ProcessLookupError:
-        print(
-            message.error(
-                "Could not find the PID for process named `qemu-system`.\n"
-                "This might happen if pwndbg is running on a different machine than `qemu-system`,\n"
-                "or if the `qemu-system` binary has a different name."
-            )
-        )
+    machine_backend = pwndbg.aglib.qemu.get_qemu_machine()
+    if machine_backend is None:
         return ()
 
     arch: str = pwndbg.aglib.arch.name

--- a/pwndbg/aglib/memory.py
+++ b/pwndbg/aglib/memory.py
@@ -34,7 +34,17 @@ def read(addr: int, count: int, partial: bool = False) -> bytearray:
         `bytearray` The memory at the specified address,
         or ``None``.
     """
-    return pwndbg.dbg.selected_inferior().read_memory(address=addr, size=count, partial=partial)
+    try:
+        return pwndbg.dbg.selected_inferior().read_memory(address=addr, size=count, partial=partial)
+    except pwndbg.dbg_mod.Error as e:
+        if pwndbg.aglib.qemu.is_qemu_kernel():
+            qm = pwndbg.aglib.qemu.get_qemu_machine()
+            if qm is not None:
+                try:
+                    return qm.read_memory(addr, count)
+                except (OSError, BlockingIOError):
+                    pass
+        raise e
 
 
 def readtype(type: pwndbg.dbg_mod.Type, addr: int) -> int:
@@ -63,7 +73,7 @@ def write(addr: int, data: str | bytes | bytearray) -> None:
 
     Arguments:
         addr: Address to write
-        data: Data to write
+        data: Data to writebtw is there a wa
     """
     if isinstance(data, str):
         data = bytes(data, "utf8")

--- a/pwndbg/aglib/memory.py
+++ b/pwndbg/aglib/memory.py
@@ -34,17 +34,7 @@ def read(addr: int, count: int, partial: bool = False) -> bytearray:
         `bytearray` The memory at the specified address,
         or ``None``.
     """
-    try:
-        return pwndbg.dbg.selected_inferior().read_memory(address=addr, size=count, partial=partial)
-    except pwndbg.dbg_mod.Error as e:
-        if pwndbg.aglib.qemu.is_qemu_kernel():
-            qm = pwndbg.aglib.qemu.get_qemu_machine()
-            if qm is not None:
-                try:
-                    return qm.read_memory(addr, count)
-                except (OSError, BlockingIOError):
-                    pass
-        raise e
+    return pwndbg.dbg.selected_inferior().read_memory(address=addr, size=count, partial=partial)
 
 
 def readtype(type: pwndbg.dbg_mod.Type, addr: int) -> int:

--- a/pwndbg/aglib/memory.py
+++ b/pwndbg/aglib/memory.py
@@ -4,6 +4,7 @@ from typing import TypeGuard
 from typing import Union
 
 import pwndbg.aglib
+import pwndbg.aglib.qemu
 import pwndbg.aglib.typeinfo
 import pwndbg.dbg_mod
 import pwndbg.lib.cache
@@ -33,7 +34,17 @@ def read(addr: int, count: int, partial: bool = False) -> bytearray:
         `bytearray` The memory at the specified address,
         or ``None``.
     """
-    return pwndbg.dbg.selected_inferior().read_memory(address=addr, size=count, partial=partial)
+    try:
+        return pwndbg.dbg.selected_inferior().read_memory(address=addr, size=count, partial=partial)
+    except pwndbg.dbg_mod.Error as e:
+        if pwndbg.aglib.qemu.is_qemu_kernel():
+            qm = pwndbg.aglib.qemu.get_qemu_machine()
+            if qm is not None:
+                try:
+                    return qm.read_memory(addr, count)
+                except (OSError, BlockingIOError):
+                    pass
+        raise e
 
 
 def readtype(type: pwndbg.dbg_mod.Type, addr: int) -> int:

--- a/pwndbg/aglib/memory.py
+++ b/pwndbg/aglib/memory.py
@@ -4,7 +4,6 @@ from typing import TypeGuard
 from typing import Union
 
 import pwndbg.aglib
-import pwndbg.aglib.qemu
 import pwndbg.aglib.typeinfo
 import pwndbg.dbg_mod
 import pwndbg.lib.cache
@@ -34,17 +33,7 @@ def read(addr: int, count: int, partial: bool = False) -> bytearray:
         `bytearray` The memory at the specified address,
         or ``None``.
     """
-    try:
-        return pwndbg.dbg.selected_inferior().read_memory(address=addr, size=count, partial=partial)
-    except pwndbg.dbg_mod.Error as e:
-        if pwndbg.aglib.qemu.is_qemu_kernel():
-            qm = pwndbg.aglib.qemu.get_qemu_machine()
-            if qm is not None:
-                try:
-                    return qm.read_memory(addr, count)
-                except (OSError, BlockingIOError):
-                    pass
-        raise e
+    return pwndbg.dbg.selected_inferior().read_memory(address=addr, size=count, partial=partial)
 
 
 def readtype(type: pwndbg.dbg_mod.Type, addr: int) -> int:
@@ -73,7 +62,7 @@ def write(addr: int, data: str | bytes | bytearray) -> None:
 
     Arguments:
         addr: Address to write
-        data: Data to writebtw is there a wa
+        data: Data to write
     """
     if isinstance(data, str):
         data = bytes(data, "utf8")

--- a/pwndbg/aglib/qemu.py
+++ b/pwndbg/aglib/qemu.py
@@ -103,11 +103,6 @@ def exec_file_supported() -> bool:
 
 
 class QemuPhysAddressNotResolvedError(Exception):
-    """
-    We tried to recover (i.e. look up in the debugger and find through heuristics) the
-    symbol `name` but failed because of `msg`.
-    """
-
     def __init__(self, address: int) -> None:
         super().__init__(
             f"Qemu physical address {hex(address)} cannot be resolved to a host virtual address"
@@ -259,6 +254,7 @@ class QemuMachine(Machine):
     def read_physical_memory(self, physical_address: int, length: int) -> bytearray:
         """
         Assumes each RAM chunk (defined by each line of the mtree output) is virtually contiguous on the host side
+        Assumes any changes to the mtree output does not change the gpa2hva computed earlier
         """
         # It's not possible to pread large sizes, so let's break the request
         # into a few smaller ones.

--- a/pwndbg/aglib/qemu.py
+++ b/pwndbg/aglib/qemu.py
@@ -110,8 +110,8 @@ class QemuMachine(Machine):
         self.pid = QemuMachine.get_qemu_pid()
         self.file = os.open(f"/proc/{self.pid}/mem", os.O_RDONLY)
         arch_ops = pwndbg.aglib.kernel.arch_ops()
-        self.phys_offset = arch_ops.phys_offset if arch_ops else 0
-        res = pwndbg.dbg.selected_inferior().send_monitor(f"gpa2hva {self.phys_offset}")
+        self.ram_phys_start = arch_ops.ram_phys_start if arch_ops else 0
+        res = pwndbg.dbg.selected_inferior().send_monitor(f"gpa2hva {self.ram_phys_start}")
         try:
             self.base_hva = int(res.split(" ")[-1], 16)
         except Exception as e:
@@ -191,7 +191,7 @@ class QemuMachine(Machine):
             block = os.pread(
                 self.file,
                 length_to_read,
-                self.base_hva + physical_address - self.phys_offset + offset,
+                self.base_hva + physical_address - self.ram_phys_start + offset,
             )
             data += block
         return data

--- a/pwndbg/aglib/qemu.py
+++ b/pwndbg/aglib/qemu.py
@@ -102,26 +102,100 @@ def exec_file_supported() -> bool:
     return b"qXfer:exec-file:read" in response
 
 
+class QemuPhysAddressNotResolvedError(Exception):
+    """
+    We tried to recover (i.e. look up in the debugger and find through heuristics) the
+    symbol `name` but failed because of `msg`.
+    """
+
+    def __init__(self, address: int) -> None:
+        super().__init__(
+            f"Qemu physical address {hex(address)} cannot be resolved to a host virtual address"
+        )
+
+
+class QemuMtree:
+    def __init__(self) -> None:
+        self.mtree = []
+        found_system = False
+        """
+        example monitor output:
+
+        FlatView #2
+        AS "memory", root: system
+        AS "cpu-memory-0", root: system
+        AS "cpu-memory-1", root: system
+        AS "piix3-ide", root: bus master container
+        AS "e1000", root: bus master container
+        Root memory region: system
+        0000000000000000-000000000009ffff (prio 0, ram): m0
+        00000000000a0000-00000000000bffff (prio 1, i/o): vga-lowmem
+        00000000000c0000-00000000000cafff (prio 0, rom): m0 @00000000000c0000
+        00000000000cb000-00000000000cdfff (prio 0, ram): m0 @00000000000cb000
+        00000000000ce000-00000000000e3fff (prio 0, rom): m0 @00000000000ce000
+        00000000000e4000-00000000000effff (prio 0, ram): m0 @00000000000e4000
+        00000000000f0000-00000000000fffff (prio 0, rom): m0 @00000000000f0000
+        0000000000100000-000000007fffffff (prio 0, ram): m0 @0000000000100000
+        0000000080000000-00000000bfffffff (prio 0, ram): m1
+        00000000fd000000-00000000fdffffff (prio 1, ram): vga.vram
+        00000000feb80000-00000000feb9ffff (prio 1, i/o): e1000-mmio
+        00000000febb0000-00000000febb017f (prio 0, i/o): edid
+        00000000febb0180-00000000febb03ff (prio 1, i/o): vga.mmio @0000000000000180
+        00000000febb0400-00000000febb041f (prio 0, i/o): vga ioports remapped
+        00000000febb0420-00000000febb04ff (prio 1, i/o): vga.mmio @0000000000000420
+        00000000febb0500-00000000febb0515 (prio 0, i/o): bochs dispi interface
+        00000000febb0516-00000000febb05ff (prio 1, i/o): vga.mmio @0000000000000516
+        00000000febb0600-00000000febb0607 (prio 0, i/o): qemu extended regs
+        00000000febb0608-00000000febb0fff (prio 1, i/o): vga.mmio @0000000000000608
+        00000000fec00000-00000000fec00fff (prio 0, i/o): ioapic
+        00000000fed00000-00000000fed003ff (prio 0, i/o): hpet
+        00000000fee00000-00000000feefffff (prio 4096, i/o): apic-msi
+        00000000fffc0000-00000000ffffffff (prio 0, rom): pc.bios
+        0000000100000000-000000013fffffff (prio 0, ram): m1 @0000000040000000
+        """
+        for line in pwndbg.dbg.selected_inferior().send_monitor("info mtree -f").splitlines():
+            line = line.strip()
+            if "Root memory region: system" in line:
+                found_system = True
+                continue
+            if found_system:
+                if len(line) == 0:
+                    break
+                if ", ram):" not in line and ", rom):" not in line:
+                    # gpa2hva would return: Memory at address 0xfeb80000is not RAM
+                    continue
+                phys_range = list(filter(None, line.split(" ")))[0]
+                start, end = phys_range.split("-")
+                start = int(start, 16)
+                end = int(end, 16)
+                res = pwndbg.dbg.selected_inferior().send_monitor(f"gpa2hva {hex(start)}")
+                try:
+                    hva = int(res.split(" ")[-1], 16)
+                    self.mtree.append((start, end, hva))
+                except Exception as e:
+                    raise OSError(
+                        f"Physical address {hex(start)} is not accessible. Reason: {e}. gpa2hva result: {res}"
+                    )
+
+    def find(self, physical_address: int) -> tuple[int, int]:
+        for start, end, hva in self.mtree:
+            if start <= physical_address <= end:
+                return start, hva
+        raise QemuPhysAddressNotResolvedError(physical_address)
+
+
 # Most of QemuMachine code was inherited from gdb-pt-dump thanks to Martin Radev (@martinradev)
 # on the MIT license, see:
 # https://github.com/martinradev/gdb-pt-dump/blob/21158ac3f9b36d0e5e0c86193e0ef018fc628e74/pt_gdb/pt_gdb.py#L11-L80
 class QemuMachine(Machine):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.file = None
         self.pid = QemuMachine.get_qemu_pid()
         self.file = os.open(f"/proc/{self.pid}/mem", os.O_RDONLY)
-        arch_ops = pwndbg.aglib.kernel.arch_ops()
-        self.ram_phys_start = arch_ops.ram_phys_start if arch_ops else 0
-        res = pwndbg.dbg.selected_inferior().send_monitor(f"gpa2hva {hex(self.ram_phys_start)}")
-        try:
-            self.base_hva = int(res.split(" ")[-1], 16)
-        except Exception as e:
-            raise OSError(
-                f"Physical address {hex(self.ram_phys_start)} is not accessible. Reason: {e}. gpa2hva result: {res}"
-            )
+        self.mtree = QemuMtree()
 
-    def __del__(self):
+    def __del__(self) -> None:
         if self.file is not None:
             with contextlib.suppress(OSError):
                 os.close(self.file)
@@ -183,8 +257,12 @@ class QemuMachine(Machine):
         return bytearray(self.read_physical_memory(phys, length))
 
     def read_physical_memory(self, physical_address: int, length: int) -> bytearray:
+        """
+        Assumes each RAM chunk (defined by each line of the mtree output) is virtually contiguous on the host side
+        """
         # It's not possible to pread large sizes, so let's break the request
         # into a few smaller ones.
+        region_start, hva = self.mtree.find(physical_address)
         max_block_size = 1024 * 1024 * 256
         data = bytearray()
         assert self.file
@@ -193,7 +271,7 @@ class QemuMachine(Machine):
             block = os.pread(
                 self.file,
                 length_to_read,
-                self.base_hva + physical_address - self.ram_phys_start + offset,
+                hva + physical_address - region_start + offset,
             )
             data.extend(block)
         return data

--- a/pwndbg/aglib/qemu.py
+++ b/pwndbg/aglib/qemu.py
@@ -4,9 +4,23 @@ Determine whether the target is being run under QEMU.
 
 from __future__ import annotations
 
+import os
+import random
+import string
+import subprocess
+import tempfile
+from typing import TYPE_CHECKING
+
+from pt.machine import Machine
+
 import pwndbg
+import pwndbg.aglib
+import pwndbg.color.message as message
 import pwndbg.lib.cache
 import pwndbg.lib.qemu
+
+if TYPE_CHECKING:
+    import pwndbg.aglib.kernel
 
 
 @pwndbg.lib.cache.cache_until("stop")
@@ -85,3 +99,128 @@ def exec_file_supported() -> bool:
     response = pwndbg.dbg.selected_inferior().send_remote("qSupported")
 
     return b"qXfer:exec-file:read" in response
+
+
+# Most of QemuMachine code was inherited from gdb-pt-dump thanks to Martin Radev (@martinradev)
+# on the MIT license, see:
+# https://github.com/martinradev/gdb-pt-dump/blob/21158ac3f9b36d0e5e0c86193e0ef018fc628e74/pt_gdb/pt_gdb.py#L11-L80
+class QemuMachine(Machine):
+    def __init__(self):
+        super().__init__()
+        self.pid = QemuMachine.get_qemu_pid()
+        self.file = os.open(f"/proc/{self.pid}/mem", os.O_RDONLY)
+        res = pwndbg.dbg.selected_inferior().send_monitor("gpa2hva 0")
+        try:
+            self.base_hva = int(res.split(" ")[-1], 16)
+        except Exception as e:
+            raise OSError(
+                f"Physical address 0 is not accessible. Reason: {e}. gpa2hva result: {res}"
+            )
+
+    def __del__(self):
+        if self.file:
+            os.close(self.file)
+
+    @staticmethod
+    def search_pids_for_file(pids: list[str], filename: str) -> str | None:
+        for pid in pids:
+            fd_dir = f"/proc/{pid}/fd"
+            try:
+                for fd in os.listdir(fd_dir):
+                    if os.readlink(f"{fd_dir}/{fd}") == filename:
+                        return pid
+            except FileNotFoundError:
+                # Either the process has gone or fds are changing, not our pid
+                pass
+            except PermissionError:
+                # Evade processes owned by other users
+                pass
+
+        return None
+
+    @staticmethod
+    def get_qemu_pid() -> int:
+        try:
+            out = subprocess.check_output(["pgrep", "qemu-system"], encoding="utf8")
+            pids = out.strip().split("\n")
+
+            if len(pids) == 1:
+                return int(pids[0], 10)
+            # We add a chardev file backend (we dont add a fronted, so it doesn't affect
+            # the guest). We can then look through proc to find which process has the file
+            # open. This approach is agnostic to namespaces (pid, network and mount).
+            chardev_id = (
+                "pwndbg-pt-dump" + "-" + "".join(random.choices(string.ascii_letters, k=16))
+            )
+            with tempfile.NamedTemporaryFile() as tmpf:
+                pwndbg.dbg.selected_inferior().send_monitor(
+                    f"chardev-add file,id={chardev_id},path={tmpf.name}"
+                )
+                pid_found = QemuMachine.search_pids_for_file(pids, tmpf.name)
+                pwndbg.dbg.selected_inferior().send_monitor(f"chardev-remove {chardev_id}")
+            if pid_found:
+                return int(pid_found, 10)
+        except subprocess.CalledProcessError:
+            # If no process with the name `qemu-system` is found, fallback to alternative methods,
+            # as the binary name may vary (e.g., `qemu_system`).
+            pass
+        raise ProcessLookupError("Could not find qemu-system pid")
+
+    def read_memory(self, address: int, length: int) -> bytearray:
+        phys = None
+        res = pwndbg.dbg.selected_inferior().send_monitor(f"gva2gpa {address}")
+        try:
+            phys = int(res.split(" ")[-1], 16)
+        except Exception:
+            pass
+        if phys is None:
+            phys = pwndbg.aglib.kernel.pagewalk(address).phys
+        if phys is None:
+            raise OSError(f"Virtual address {address} cannot be resolved")
+        return bytearray(self.read_physical_memory(phys, length))
+
+    def read_physical_memory(self, physical_address: int, length: int) -> bytes:
+        # It's not possible to pread large sizes, so let's break the request
+        # into a few smaller ones.
+        max_block_size = 1024 * 1024 * 256
+        data = b""
+        for offset in range(0, length, max_block_size):
+            length_to_read = min(length - offset, max_block_size)
+            block = os.pread(self.file, length_to_read, self.base_hva + physical_address + offset)
+            data += block
+        return data
+
+    def read_register(self, _: str) -> int:
+        # we are not using this but the pt dump Machine class requires it - will be removed later
+        raise NotImplementedError()
+
+
+@pwndbg.lib.cache.cache_until("forever")
+def get_qemu_machine(verbose: bool = False) -> QemuMachine | None:
+    try:
+        machine_backend = QemuMachine()
+    except PermissionError:
+        if verbose:
+            print(
+                message.error(
+                    "Permission error when attempting to parse page tables with gdb-pt-dump.\n"
+                    "Either change the kernel-vmmap setting, re-run GDB as root, or disable "
+                    "`ptrace_scope` (`echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope`)"
+                )
+            )
+        return None
+    except ProcessLookupError:
+        if verbose:
+            print(
+                message.error(
+                    "Could not find the PID for process named `qemu-system`.\n"
+                    "This might happen if pwndbg is running on a different machine than `qemu-system`,\n"
+                    "or if the `qemu-system` binary has a different name."
+                )
+            )
+        return None
+    except OSError as e:
+        if verbose:
+            print(e)
+        return None
+    return machine_backend

--- a/pwndbg/aglib/qemu.py
+++ b/pwndbg/aglib/qemu.py
@@ -109,7 +109,9 @@ class QemuMachine(Machine):
         super().__init__()
         self.pid = QemuMachine.get_qemu_pid()
         self.file = os.open(f"/proc/{self.pid}/mem", os.O_RDONLY)
-        res = pwndbg.dbg.selected_inferior().send_monitor("gpa2hva 0")
+        arch_ops = pwndbg.aglib.kernel.arch_ops()
+        self.phys_offset = arch_ops.phys_offset if arch_ops else 0
+        res = pwndbg.dbg.selected_inferior().send_monitor(f"gpa2hva {self.phys_offset}")
         try:
             self.base_hva = int(res.split(" ")[-1], 16)
         except Exception as e:
@@ -186,7 +188,11 @@ class QemuMachine(Machine):
         data = b""
         for offset in range(0, length, max_block_size):
             length_to_read = min(length - offset, max_block_size)
-            block = os.pread(self.file, length_to_read, self.base_hva + physical_address + offset)
+            block = os.pread(
+                self.file,
+                length_to_read,
+                self.base_hva + physical_address - self.phys_offset + offset,
+            )
             data += block
         return data
 

--- a/pwndbg/aglib/qemu.py
+++ b/pwndbg/aglib/qemu.py
@@ -107,21 +107,25 @@ def exec_file_supported() -> bool:
 class QemuMachine(Machine):
     def __init__(self):
         super().__init__()
+        self.file = None
         self.pid = QemuMachine.get_qemu_pid()
         self.file = os.open(f"/proc/{self.pid}/mem", os.O_RDONLY)
         arch_ops = pwndbg.aglib.kernel.arch_ops()
         self.ram_phys_start = arch_ops.ram_phys_start if arch_ops else 0
-        res = pwndbg.dbg.selected_inferior().send_monitor(f"gpa2hva {self.ram_phys_start}")
+        res = pwndbg.dbg.selected_inferior().send_monitor(f"gpa2hva {hex(self.ram_phys_start)}")
         try:
             self.base_hva = int(res.split(" ")[-1], 16)
         except Exception as e:
             raise OSError(
-                f"Physical address 0 is not accessible. Reason: {e}. gpa2hva result: {res}"
+                f"Physical address {hex(self.ram_phys_start)} is not accessible. Reason: {e}. gpa2hva result: {res}"
             )
 
     def __del__(self):
-        if self.file:
-            os.close(self.file)
+        if self.file is not None:
+            try:
+                os.close(self.file)
+            except OSError:
+                pass
 
     @staticmethod
     def search_pids_for_file(pids: list[str], filename: str) -> str | None:
@@ -181,11 +185,12 @@ class QemuMachine(Machine):
             raise OSError(f"Virtual address {address} cannot be resolved")
         return bytearray(self.read_physical_memory(phys, length))
 
-    def read_physical_memory(self, physical_address: int, length: int) -> bytes:
+    def read_physical_memory(self, physical_address: int, length: int) -> bytearray:
         # It's not possible to pread large sizes, so let's break the request
         # into a few smaller ones.
         max_block_size = 1024 * 1024 * 256
-        data = b""
+        data = bytearray()
+        assert self.file
         for offset in range(0, length, max_block_size):
             length_to_read = min(length - offset, max_block_size)
             block = os.pread(
@@ -193,7 +198,7 @@ class QemuMachine(Machine):
                 length_to_read,
                 self.base_hva + physical_address - self.ram_phys_start + offset,
             )
-            data += block
+            data.extend(block)
         return data
 
     def read_register(self, register_name: str) -> int:

--- a/pwndbg/aglib/qemu.py
+++ b/pwndbg/aglib/qemu.py
@@ -190,9 +190,11 @@ class QemuMachine(Machine):
             data += block
         return data
 
-    def read_register(self, _: str) -> int:
-        # we are not using this but the pt dump Machine class requires it - will be removed later
-        raise NotImplementedError()
+    def read_register(self, register_name: str) -> int:
+        if register_name.startswith("$"):
+            register_name = register_name[1:]
+
+        return int(pwndbg.aglib.regs.read_reg(register_name))
 
 
 @pwndbg.lib.cache.cache_until("forever")

--- a/pwndbg/aglib/qemu.py
+++ b/pwndbg/aglib/qemu.py
@@ -4,6 +4,7 @@ Determine whether the target is being run under QEMU.
 
 from __future__ import annotations
 
+import contextlib
 import os
 import random
 import string
@@ -122,10 +123,8 @@ class QemuMachine(Machine):
 
     def __del__(self):
         if self.file is not None:
-            try:
+            with contextlib.suppress(OSError):
                 os.close(self.file)
-            except OSError:
-                pass
 
     @staticmethod
     def search_pids_for_file(pids: list[str], filename: str) -> str | None:
@@ -175,10 +174,8 @@ class QemuMachine(Machine):
     def read_memory(self, address: int, length: int) -> bytearray:
         phys = None
         res = pwndbg.dbg.selected_inferior().send_monitor(f"gva2gpa {address}")
-        try:
+        with contextlib.suppress(Exception):
             phys = int(res.split(" ")[-1], 16)
-        except Exception:
-            pass
         if phys is None:
             phys = pwndbg.aglib.kernel.pagewalk(address).phys
         if phys is None:

--- a/pwndbg/aglib/qemu.py
+++ b/pwndbg/aglib/qemu.py
@@ -114,7 +114,7 @@ class QemuMtree:
         self.mtree = []
         found_system = False
         """
-        example monitor output:
+        example `monitor info mtree -f` output:
 
         FlatView #2
         AS "memory", root: system
@@ -254,7 +254,8 @@ class QemuMachine(Machine):
     def read_physical_memory(self, physical_address: int, length: int) -> bytearray:
         """
         Assumes each RAM chunk (defined by each line of the mtree output) is virtually contiguous on the host side
-        Assumes any changes to the mtree output does not change the gpa2hva computed earlier
+        Assumes any changes to the mtree output does not change the gpa2hva computed earlier, verified as follows:
+            used -S to compare the mtree output during bootloading and when kernel has finished initialization
         """
         # It's not possible to pread large sizes, so let's break the request
         # into a few smaller ones.

--- a/tests/library/qemu_system/tests/test_commands_kernel.py
+++ b/tests/library/qemu_system/tests/test_commands_kernel.py
@@ -371,7 +371,7 @@ def test_command_paging() -> None:
     test_command_paging_helper("initialized", kbase)
     vmemmap = pi.vmemmap
     if pwndbg.aglib.arch.name == "aarch64":
-        vmemmap += pi.phys_offset >> (pi.page_shift - pi.STRUCT_PAGE_SHIFT)
+        vmemmap += pi.ram_phys_start >> (pi.page_shift - pi.STRUCT_PAGE_SHIFT)
     test_command_paging_helper("initialized", vmemmap)
     res = gdb.execute("buddydump", to_string=True)
     matches = get_buddy_freelist_elements(res)


### PR DESCRIPTION
As discussed, reading `/proc/pid/mem` is faster. When benchmarked against `gdb-pt-dump` with optimized (compared to the one provided in the `gdb-pt-dump` repo`) reads, the current implementation is still up to 10x faster. 