### PR TITLE
Loading kernel common structs only when necessary

### DIFF
--- a/pwndbg/aglib/kernel/__init__.py
+++ b/pwndbg/aglib/kernel/__init__.py
@@ -107,11 +107,6 @@ def requires_debug_info(default: D = None) -> Callable[[Callable[P, T]], Callabl
     return decorator
 
 
-# Set by pwndbg.aglib.kernel.symbol.load_common_structs_on_load_linux() when page typeinfo
-# recovery fails.
-page_typeinfo_recovery_failure: None | TypeNotRecoveredError = None
-
-
 def typeinfo_recovery(
     name: str, requires_kversion: bool = False, requires_kbase: bool = False
 ) -> Callable[[Callable[P, str]], Callable[P, None]]:
@@ -126,6 +121,9 @@ def typeinfo_recovery(
                 return
             if pwndbg.aglib.typeinfo.lookup_types(name) is not None:
                 return
+            recover_common_types_func = pwndbg.aglib.kernel.symbol.recover_page_typeinfo
+            if f.__name__ != recover_common_types_func.__name__:
+                recover_common_types_func()
             if requires_kversion and kversion() is None:
                 raise TypeNotRecoveredError(name, "kernel version is unavailable")
             if requires_kbase and kbase() is None:
@@ -134,13 +132,6 @@ def typeinfo_recovery(
             try:
                 result = f(*args, **kwargs)
             except TypeNotFoundError as e:
-                # typeinfo_recovery functions depend on
-                # pwndbg.aglib.kernel.symbol.load_common_structs_on_load_linux()
-                # succeeding and will try to directly read those types from the debbuger
-                # like e.g. `pwndbg.aglib.memory.get_typed_pointer("struct list_head", db_list)`
-                # This will raise a TypeNotFoundError exception.
-                if page_typeinfo_recovery_failure is not None:
-                    raise page_typeinfo_recovery_failure
                 raise TypeNotRecoveredError(name, str(e))
             except AssertionError as e:
                 # FIXME: Some type recovery functions `assert` under the assumption that the assert

--- a/pwndbg/aglib/kernel/__init__.py
+++ b/pwndbg/aglib/kernel/__init__.py
@@ -110,6 +110,12 @@ def requires_debug_info(default: D = None) -> Callable[[Callable[P, T]], Callabl
 def typeinfo_recovery(
     name: str, requires_kversion: bool = False, requires_kbase: bool = False
 ) -> Callable[[Callable[P, str]], Callable[P, None]]:
+    """
+    Attached to functions which return the C source-code of the `name` type (usually struct).
+    
+    Compiles and adds the debug info for the struct into the debugger, from then on accessible via APIs
+    like `pwndbg.aglib.memory.get_typed_pointer("struct list_head", db_list)`.
+    """
     def decorator(f: Callable[P, str]) -> Callable[P, None]:
         # returns true if the type exists or has been successfully recovered
         @functools.wraps(f)

--- a/pwndbg/aglib/kernel/__init__.py
+++ b/pwndbg/aglib/kernel/__init__.py
@@ -112,10 +112,11 @@ def typeinfo_recovery(
 ) -> Callable[[Callable[P, str]], Callable[P, None]]:
     """
     Attached to functions which return the C source-code of the `name` type (usually struct).
-    
+
     Compiles and adds the debug info for the struct into the debugger, from then on accessible via APIs
     like `pwndbg.aglib.memory.get_typed_pointer("struct list_head", db_list)`.
     """
+
     def decorator(f: Callable[P, str]) -> Callable[P, None]:
         # returns true if the type exists or has been successfully recovered
         @functools.wraps(f)

--- a/pwndbg/aglib/kernel/symbol.py
+++ b/pwndbg/aglib/kernel/symbol.py
@@ -290,20 +290,6 @@ def recover_page_typeinfo() -> str:
     return result
 
 
-@pwndbg.dbg.event_handler(EventType.NEW_MODULE)
-def load_common_structs_on_load_linux() -> None:
-    if pwndbg.aglib.qemu.is_qemu_kernel() and pwndbg.dbg.selected_inferior().is_linux():
-        try:
-            recover_page_typeinfo()
-        except (TypeNotRecoveredError, NotImplementedError) as e:
-            # We are not going to print anything here, because the user may not
-            # even end up using the type-dependant commands.
-            # Other commands and typeinfo recoveries depend on this succeeding,
-            # so we save the actual failure reason to have something meaningful to
-            # FIXME: NotImplementedError: Currently raised for non-linux OSes by stuff like `_paginginfo`. See #3911 .
-            pwndbg.aglib.kernel.page_typeinfo_recovery_failure = e
-
-
 P = ParamSpec("P")
 
 

--- a/pwndbg/aglib/kernel/symbol.py
+++ b/pwndbg/aglib/kernel/symbol.py
@@ -16,8 +16,6 @@ import pwndbg.aglib.symbol
 import pwndbg.aglib.typeinfo
 import pwndbg.dbg_mod
 import pwndbg.lib.cache
-from pwndbg.dbg_mod import EventType
-from pwndbg.lib import TypeNotRecoveredError
 
 #########################################
 # helpers

--- a/tests/library/qemu_system/tests/test_commands_kernel.py
+++ b/tests/library/qemu_system/tests/test_commands_kernel.py
@@ -28,7 +28,6 @@ def KernelTest(func: Callable[P, T]) -> Callable[P, T | None]:
     def wrapper(*a: P.args, **kw: P.kwargs) -> T | None:
         pwndbg.color._disable_colors_trigger()
         # TODO: trigger NEW_OBJFILE event instead
-        pwndbg.aglib.kernel.symbol.load_common_structs_on_load_linux()
         return func(*a, **kw)
 
     return wrapper


### PR DESCRIPTION
Should partially mitigate #3911
Might fix #3820 