### PR TITLE
fix(color): validate colour names

### DIFF
--- a/pwndbg/color/__init__.py
+++ b/pwndbg/color/__init__.py
@@ -197,7 +197,7 @@ class ColorConfig:
 
 
 def generate_color_function(
-    config: str | Parameter, _globals: dict[str, Callable[[str], str]] = globals()
+    config: str | Parameter, _locals: dict[str, Callable[[str], str]] = locals()
 ) -> Callable[[object], str]:
     # the `config` here may be a config Parameter object
     # and if we run with disable_colors or if the config value
@@ -211,7 +211,10 @@ def generate_color_function(
 
     for color in config.split(","):
         func_name = color.lower().replace("-", "_")
-        function = generate_color_function_inner(function, _globals[func_name])
+        fn = _locals.get(func_name)
+        assert fn is not None, f"Invalid colour {color}"
+        assert callable(fn), f"Invalid colour {color}"
+        function = generate_color_function_inner(function, fn)
     return function
 
 


### PR DESCRIPTION
fixes #2874

<!--
    Please make sure to read the linting and testing instructions at
    https://pwndbg.re/dev/contributing/ before creating a PR.
-->

+ [x] I read the contributing documentation.
+ [x] I am providing a screenshot of the (new feature) / (fixed bug).

---
## before

<img width="1426" height="475" alt="image" src="https://github.com/user-attachments/assets/c3751ba5-e992-4938-b509-235b1bc70197" />

## after

<img width="770" height="215" alt="image" src="https://github.com/user-attachments/assets/21798752-3a7c-49f4-83eb-b7dcd4050def" />


---

- use `locals` instead of `globals`  (these are equivalent when used like this)
- assert that the provided `color` is in these locals
- assert that `locals()[key]` is callable

in theory, you could also add checks for function arity (using `inspect`, or something more deranged line `fn.__code__`) but that would probably have an impact on performance? 