### PR TITLE
kernel: add function percpu

### DIFF
--- a/docs/functions/index.md
+++ b/docs/functions/index.md
@@ -349,3 +349,19 @@ $33 = (struct kmem_cache *) 0xffff888006552e00
 ```
 
 ----------
+
+### **percpu**
+
+``` {.python .no-copy}
+percpu(addr: gdb.Value, cpu: gdb.Value = gdb.Value(-1)) -> gdb.Value
+```
+
+Resolve a per-cpu pointer to its address for the given CPU.
+
+#### Example
+```
+pwndbg> p $percpu(&percpu_addr)
+pwndbg> p $percpu(&percpu_addr, 2)
+```
+
+----------

--- a/docs/functions/index.md
+++ b/docs/functions/index.md
@@ -298,6 +298,45 @@ pwndbg> vmmap $11
 
 ----------
 
+### **percpu**
+
+
+``` {.python .no-copy}
+percpu(addr: gdb.Value, cpu: gdb.Value = gdb.Value(-1)) -> gdb.Value
+```
+
+
+Resolve a Linux kernel per-cpu pointer to its absolute virtual address.
+
+The kernel keeps per-cpu data (`DEFINE_PER_CPU` / `alloc_percpu`) so that
+each CPU has its own private copy of a variable, which avoids locking and
+cache-line bouncing. A `__percpu` pointer is therefore not directly
+dereferenceable: it is a base/offset that must be combined with a given
+CPU's per-cpu offset (`__per_cpu_offset[cpu]`) to obtain the real address.
+That is exactly what the kernel's `per_cpu_ptr(ptr, cpu)` / `this_cpu_ptr(ptr)`
+macros do, and what this function reproduces:
+
+    result = addr + __per_cpu_offset[cpu]
+
+If `cpu` is omitted (or -1), the currently running CPU is used.
+
+References (Linux kernel):
+- https://docs.kernel.org/core-api/this_cpu_ops.html
+- include/linux/percpu-defs.h  (per_cpu_ptr, this_cpu_ptr)
+- mm/percpu.c                  (the per-cpu allocator)
+
+Only valid when kernel debugging; requires the `__per_cpu_offset` symbol.
+Tested on x86-64 Linux 7.1.
+
+#### Example
+```
+pwndbg> p $percpu(&some_percpu_var)
+pwndbg> p $percpu(&some_percpu_var, 2)
+pwndbg> p *$percpu(cache->cpu_slab)
+```
+
+----------
+
 ### **rebase**
 
 
@@ -346,43 +385,6 @@ Get the kmem_cache of a random heap object (`0xffff88800555c000` here) manually 
 ```
 pwndbg> p ((struct slab*)({$obj=0xffff88800555c000,$tpage=((struct page*)vmemmap_base+($v2p($obj)>>12)),$tpage->compound_head&1?$tpage->compound_head^1:$tpage}[2]))->slab_cache
 $33 = (struct kmem_cache *) 0xffff888006552e00
-```
-
-----------
-
-### **percpu**
-
-``` {.python .no-copy}
-percpu(addr: gdb.Value, cpu: gdb.Value = gdb.Value(-1)) -> gdb.Value
-```
-
-Resolve a Linux kernel per-cpu pointer to its absolute address.
-
-The kernel keeps per-cpu data (`DEFINE_PER_CPU` / `alloc_percpu`) so that
-each CPU has its own private copy of a variable, which avoids locking and
-cache-line bouncing. A `__percpu` pointer is therefore not directly
-dereferenceable: it is a base/offset that must be combined with a given
-CPU's per-cpu offset (`__per_cpu_offset[cpu]`) to obtain the real address.
-That is exactly what the kernel's `per_cpu_ptr(ptr, cpu)` / `this_cpu_ptr(ptr)`
-macros do, and what this function reproduces:
-
-    result = addr + __per_cpu_offset[cpu]
-
-If `cpu` is omitted (or -1), the currently running CPU is used.
-Tested on x86-64 Linux 7.1.
-
-References (Linux kernel):
-- https://docs.kernel.org/core-api/this_cpu_ops.html
-- include/linux/percpu-defs.h  (per_cpu_ptr, this_cpu_ptr)
-- mm/percpu.c                  (the per-cpu allocator)
-
-Only valid when kernel debugging; requires the `__per_cpu_offset` symbol.
-
-#### Example
-```
-pwndbg> p $percpu(&some_percpu_var)
-pwndbg> p $percpu(&some_percpu_var, 2)
-pwndbg> p *$percpu(cache->cpu_slab)
 ```
 
 ----------

--- a/docs/functions/index.md
+++ b/docs/functions/index.md
@@ -356,12 +356,33 @@ $33 = (struct kmem_cache *) 0xffff888006552e00
 percpu(addr: gdb.Value, cpu: gdb.Value = gdb.Value(-1)) -> gdb.Value
 ```
 
-Resolve a per-cpu pointer to its address for the given CPU.
+Resolve a Linux kernel per-cpu pointer to its absolute address.
+
+The kernel keeps per-cpu data (`DEFINE_PER_CPU` / `alloc_percpu`) so that
+each CPU has its own private copy of a variable, which avoids locking and
+cache-line bouncing. A `__percpu` pointer is therefore not directly
+dereferenceable: it is a base/offset that must be combined with a given
+CPU's per-cpu offset (`__per_cpu_offset[cpu]`) to obtain the real address.
+That is exactly what the kernel's `per_cpu_ptr(ptr, cpu)` / `this_cpu_ptr(ptr)`
+macros do, and what this function reproduces:
+
+    result = addr + __per_cpu_offset[cpu]
+
+If `cpu` is omitted (or -1), the currently running CPU is used.
+Tested on x86-64 Linux 7.1.
+
+References (Linux kernel):
+- https://docs.kernel.org/core-api/this_cpu_ops.html
+- include/linux/percpu-defs.h  (per_cpu_ptr, this_cpu_ptr)
+- mm/percpu.c                  (the per-cpu allocator)
+
+Only valid when kernel debugging; requires the `__per_cpu_offset` symbol.
 
 #### Example
 ```
-pwndbg> p $percpu(&percpu_addr)
-pwndbg> p $percpu(&percpu_addr, 2)
+pwndbg> p $percpu(&some_percpu_var)
+pwndbg> p $percpu(&some_percpu_var, 2)
+pwndbg> p *$percpu(cache->cpu_slab)
 ```
 
 ----------

--- a/pwndbg/gdblib/functions.py
+++ b/pwndbg/gdblib/functions.py
@@ -406,6 +406,7 @@ def p2v(paddr: gdb.Value) -> int:
 
     return vaddr
 
+
 @GdbFunction(only_when_running=True)
 def percpu(addr: gdb.Value, cpu: gdb.Value = gdb.Value(-1)) -> gdb.Value:
     """

--- a/pwndbg/gdblib/functions.py
+++ b/pwndbg/gdblib/functions.py
@@ -410,7 +410,7 @@ def p2v(paddr: gdb.Value) -> int:
 @GdbFunction(only_when_running=True)
 def percpu(addr: gdb.Value, cpu: gdb.Value = gdb.Value(-1)) -> gdb.Value:
     """
-    Resolve a Linux kernel per-cpu pointer to its absolute address.
+    Resolve a Linux kernel per-cpu pointer to its absolute virtual address.
 
     The kernel keeps per-cpu data (`DEFINE_PER_CPU` / `alloc_percpu`) so that
     each CPU has its own private copy of a variable, which avoids locking and

--- a/pwndbg/gdblib/functions.py
+++ b/pwndbg/gdblib/functions.py
@@ -410,12 +410,33 @@ def p2v(paddr: gdb.Value) -> int:
 @GdbFunction(only_when_running=True)
 def percpu(addr: gdb.Value, cpu: gdb.Value = gdb.Value(-1)) -> gdb.Value:
     """
-    Resolve a per-cpu pointer to its address for the given CPU.
+    Resolve a Linux kernel per-cpu pointer to its absolute address.
+
+    The kernel keeps per-cpu data (`DEFINE_PER_CPU` / `alloc_percpu`) so that
+    each CPU has its own private copy of a variable, which avoids locking and
+    cache-line bouncing. A `__percpu` pointer is therefore not directly
+    dereferenceable: it is a base/offset that must be combined with a given
+    CPU's per-cpu offset (`__per_cpu_offset[cpu]`) to obtain the real address.
+    That is exactly what the kernel's `per_cpu_ptr(ptr, cpu)` / `this_cpu_ptr(ptr)`
+    macros do, and what this function reproduces:
+
+        result = addr + __per_cpu_offset[cpu]
+
+    If `cpu` is omitted (or -1), the currently running CPU is used.
+
+    References (Linux kernel):
+    - https://docs.kernel.org/core-api/this_cpu_ops.html
+    - include/linux/percpu-defs.h  (per_cpu_ptr, this_cpu_ptr)
+    - mm/percpu.c                  (the per-cpu allocator)
+
+    Only valid when kernel debugging; requires the `__per_cpu_offset` symbol.
+    Tested on x86-64 Linux 7.1.
 
     Example:
     ```
-    pwndbg> p $percpu(&percpu_addr)
-    pwndbg> p $percpu(&percpu_addr, 2)
+    pwndbg> p $percpu(&some_percpu_var)
+    pwndbg> p $percpu(&some_percpu_var, 2)
+    pwndbg> p *$percpu(cache->cpu_slab)
     ```
     """
     from pwndbg.dbg_mod.gdb import GDBValue

--- a/pwndbg/gdblib/functions.py
+++ b/pwndbg/gdblib/functions.py
@@ -405,3 +405,22 @@ def p2v(paddr: gdb.Value) -> int:
         raise gdb.GdbError("Physical to virtual address failed, invalid physical address?")
 
     return vaddr
+
+@GdbFunction(only_when_running=True)
+def percpu(addr: gdb.Value, cpu: gdb.Value = gdb.Value(-1)) -> gdb.Value:
+    """
+    Resolve a per-cpu pointer to its address for the given CPU.
+
+    Example:
+    ```
+    pwndbg> p $percpu(&percpu_addr)
+    pwndbg> p $percpu(&percpu_addr, 2)
+    ```
+    """
+    from pwndbg.dbg_mod.gdb import GDBValue
+
+    cpu = int(cpu)
+    result = pwndbg.aglib.kernel.per_cpu(GDBValue(addr), cpu if cpu >= 0 else None)
+    if result is None:
+        raise gdb.GdbError("__per_cpu_offset not found")
+    return dbg_value_to_gdb(result)

--- a/scripts/_docs/extract_function_docs.py
+++ b/scripts/_docs/extract_function_docs.py
@@ -46,6 +46,7 @@ def sanitize_signature(func_name: str, sig: str) -> str:
         "stack": 0,
         "bss": 0,
         "got": 0,
+        "percpu": -1,
     }
     if func_name in gdb_value_fixups:
         sig = re.sub(


### PR DESCRIPTION
Add `$percpu(addr, cpu)` function for better kernel debugging.

It performs exactly the same as `pwndbg.aglib.kernel.per_cpu(addr, cpu)`. It allows user to convert `__per_cpu` variables to real virtual address, which makes it possible to dereference the per-cpu pointers.

<img width="397" height="282" alt="Screenshot 2026-06-05 at 4 47 06 PM" src="https://github.com/user-attachments/assets/1b6e9fd6-1929-4c3e-b992-1b9fee2eeb45" />
