### PR TITLE
Handle ljmp instruction target resolution for i8086

### DIFF
--- a/pwndbg/aglib/disasm/disassembly.py
+++ b/pwndbg/aglib/disasm/disassembly.py
@@ -682,6 +682,7 @@ ALL_DISASSEMBLY_ASSISTANTS: dict[
     PWNDBG_SUPPORTED_ARCHITECTURES_TYPE, Callable[[], DisassemblyAssistant]
 ] = {
     "aarch64": lambda: pwndbg.aglib.disasm.aarch64.AArch64DisassemblyAssistant("aarch64"),
+    "i8086": lambda: pwndbg.aglib.disasm.x86.X86DisassemblyAssistant("i8086"),
     "i386": lambda: pwndbg.aglib.disasm.x86.X86DisassemblyAssistant("i386"),
     "x86-64": lambda: pwndbg.aglib.disasm.x86.X86DisassemblyAssistant("x86-64"),
     "arm": lambda: pwndbg.aglib.disasm.arm.ArmDisassemblyAssistant("arm", "cpsr"),

--- a/pwndbg/aglib/disasm/instruction.py
+++ b/pwndbg/aglib/disasm/instruction.py
@@ -61,6 +61,7 @@ from capstone6pwndbg.systemz import SYSTEMZ_INS_J
 from capstone6pwndbg.systemz import SYSTEMZ_INS_JL
 from capstone6pwndbg.x86 import X86_INS_CALL
 from capstone6pwndbg.x86 import X86_INS_JMP
+from capstone6pwndbg.x86 import X86_INS_LJMP
 from capstone6pwndbg.x86 import X86_INS_RET
 from capstone6pwndbg.x86 import X86Op
 from typing_extensions import override
@@ -70,7 +71,7 @@ from pwndbg.dbg_mod import DisassembledInstruction
 
 # Architecture specific instructions that mutate the instruction pointer unconditionally
 UNCONDITIONAL_JUMP_INSTRUCTIONS: dict[int, set[int]] = {
-    CS_ARCH_X86: {X86_INS_CALL, X86_INS_RET, X86_INS_JMP},
+    CS_ARCH_X86: {X86_INS_CALL, X86_INS_RET, X86_INS_JMP, X86_INS_LJMP},
     CS_ARCH_MIPS: {
         MIPS_INS_J,
         MIPS_INS_JR,

--- a/pwndbg/aglib/disasm/x86.py
+++ b/pwndbg/aglib/disasm/x86.py
@@ -374,6 +374,16 @@ class X86DisassemblyAssistant(pwndbg.aglib.disasm.assistant.DisassemblyAssistant
 
     @override
     def _resolve_target(self, instruction: PwndbgInstruction, emu: Emulator | None):
+
+        if X86_INS_LJMP == instruction.id:
+            target_cs = instruction.operands[0].before_value
+            target_eip = instruction.operands[1].before_value
+
+            if target_cs is None or target_eip is None:
+                return super()._resolve_target(instruction, emu)
+
+            return target_cs * 0x10 + target_eip
+
         # Only handle 'ret', otherwise fallback to default implementation
         if X86_INS_RET != instruction.id or len(instruction.operands) > 1:
             return super()._resolve_target(instruction, emu)


### PR DESCRIPTION
Handle target resolution of `ljmp` instruction, which uses segment selector to augment the target PC. This is relevant for 16-bit real mode. This will now correctly work for ljmps that are within 16-bit real mode. More complex changes would be necessary to capture an `ljmp` that changes from 16-real mode to 32-bit protected mode that will go in a different PR.

Before:
<img width="1292" height="278" alt="image" src="https://github.com/user-attachments/assets/e25f8169-582a-4c1d-8441-44bee8d60e74" />


After:
<img width="1460" height="365" alt="image" src="https://github.com/user-attachments/assets/dfd12267-dbe3-4f39-b380-39de41421d7f" />
