### PR TITLE
Listen for 'set architecture' command to reset caches

### DIFF
--- a/pwndbg/aglib/arch_mod.py
+++ b/pwndbg/aglib/arch_mod.py
@@ -38,6 +38,7 @@ import pwndbg
 import pwndbg.aglib
 import pwndbg.aglib.disasm
 import pwndbg.dbg_mod
+import pwndbg.lib.cache
 from pwndbg.aglib import typeinfo
 from pwndbg.lib.abi import ABI
 from pwndbg.lib.abi import DEFAULT_ABIS
@@ -463,3 +464,15 @@ def update() -> None:
         pwndbg.aglib.set_arch(pwndbg_arch)
 
     pwndbg.aglib.arch.update(a)
+
+
+def force_reload_architecture() -> None:
+    """
+    Call this function to force an architecture change
+    in the underlying debugger to be observed by pwndbg.
+
+    For example, in GDB, there is not a "new architecture" event we can hook, but we add
+    a hook for the `set architecture` command, and run this function to reset pwndbg's view
+    """
+    pwndbg.lib.cache.clear_caches()
+    update()

--- a/pwndbg/dbg_mod/gdb/__init__.py
+++ b/pwndbg/dbg_mod/gdb/__init__.py
@@ -1719,25 +1719,30 @@ class GDB(pwndbg.dbg_mod.Debugger):
 
         prompt.set_prompt()
 
-        pre_commands = """
-        set auto-load safe-path /
-        set confirm off
-        set verbose off
-        set pagination off
-        set history save on
-        set follow-fork-mode child
-        set backtrace past-main on
-        set step-mode on
-        set print pretty on
-        set output-radix 16
-        handle SIGALRM nostop print nopass
-        handle SIGBUS  stop   print nopass
-        handle SIGPIPE nostop print nopass
-        handle SIGSEGV stop   print nopass
-        """
+        pre_commands: list[str] = [
+            "set auto-load safe-path /",
+            "set confirm off",
+            "set verbose off",
+            "set pagination off",
+            "set history save on",
+            "set follow-fork-mode child",
+            "set backtrace past-main on",
+            "set step-mode on",
+            "set print pretty on",
+            "set output-radix 16",
+            "handle SIGALRM nostop print nopass",
+            "handle SIGBUS  stop   print nopass",
+            "handle SIGPIPE nostop print nopass",
+            "handle SIGSEGV stop   print nopass",
+            """\
+define set hookpost-architecture
+pi pwndbg.aglib.arch_mod.force_reload_architecture()
+end\
+""",
+        ]
 
-        for line in pre_commands.strip().splitlines():
-            gdb.execute(line)
+        for line in pre_commands:
+            gdb.execute(line.strip())
 
         # debuginfod may not be compiled in (e.g. bare-metal cross GDB)
         with suppress(gdb.error):

--- a/pwndbg/dbg_mod/gdb/__init__.py
+++ b/pwndbg/dbg_mod/gdb/__init__.py
@@ -1736,7 +1736,7 @@ class GDB(pwndbg.dbg_mod.Debugger):
             "handle SIGSEGV stop   print nopass",
             """\
 define set hookpost-architecture
-pi pwndbg.aglib.arch_mod.force_reload_architecture()
+python pwndbg.aglib.arch_mod.force_reload_architecture()
 end\
 """,
         ]


### PR DESCRIPTION
Listens for the "set architecture" command, and resets pwndbg caches and polls for the debugger for the architecture to immediately align with GDB, instead of having to "step" once.

This uses a GDB hook  `define set hookpost-architecture` which runs the command AFTER `set architecture` is run. There is no equivalent in the Python API.

Original bug described here: #2713

This bug came up again due to work in #3911, where user has to manually do `set architecture` to tell GDB it was is i8086, not i386, which causes the cache bug 