### PR TITLE
Fix --nx still loading ~/.gdbinit when pwndbg is sourced from a .gdbinit

### DIFF
--- a/pwndbg/dbg_mod/gdb/__init__.py
+++ b/pwndbg/dbg_mod/gdb/__init__.py
@@ -1633,23 +1633,15 @@ class GDB(pwndbg.dbg_mod.Debugger):
 
         import psutil
 
-        disable_home_gdbinit = 0
-        disable_any_gdbinit = 0
+        import pwndbg
+        import pwndbg.lib.gdbinit
+
+        # _is_loaded_from_pwndbg only gets set when we came in through the portable
+        # binary, which is the thing that injects an extra -nx.
+        loaded_from_portable = hasattr(pwndbg, "_is_loaded_from_pwndbg")
+
         proc = psutil.Process(os.getpid())
-        for arg in proc.cmdline():
-            if arg in ("-args", "--args"):
-                break
-            if arg in ("-nh", "--nh"):
-                disable_home_gdbinit += 1
-            elif arg in ("-nx", "--nx", "-n", "--n"):
-                disable_any_gdbinit += 1
-
-        if disable_any_gdbinit == 0:
-            # The `--nx` option is added only in pwndbg-portable mode.
-            # This check allows using OLD syntax, eg: `source /path/to/pwndbg/gdbinit.py`, from ~/.gdbinit
-            return True, True
-
-        return disable_any_gdbinit >= 2, disable_home_gdbinit >= 1
+        return pwndbg.lib.gdbinit.disable_gdbinit_loading(proc.cmdline(), loaded_from_portable)
 
     def _load_gdbinit(self):
         # Emulate how `gdb` loads `.gdbinit` files (home and local)

--- a/pwndbg/lib/gdbinit.py
+++ b/pwndbg/lib/gdbinit.py
@@ -1,0 +1,37 @@
+"""Small helpers for figuring out whether we should skip loading gdbinit files.
+
+Kept dependency-free so it can be unit tested without dragging in the real gdb
+module.
+"""
+
+from __future__ import annotations
+
+
+def disable_gdbinit_loading(cmdline: list[str], loaded_from_portable: bool) -> tuple[bool, bool]:
+    """Mirror gdb's --nx/--nh handling, accounting for the portable launcher.
+
+    Returns (disable_any, disable_home). cmdline is the process argv, and
+    loaded_from_portable says whether we got here through the portable `pwndbg`
+    binary (which injects its own -nx) instead of being sourced from a user's
+    own .gdbinit.
+    """
+    disable_home_gdbinit = 0
+    disable_any_gdbinit = 0
+    for arg in cmdline:
+        if arg in ("-args", "--args"):
+            break
+        if arg in ("-nh", "--nh"):
+            disable_home_gdbinit += 1
+        elif arg in ("-nx", "--nx", "-n", "--n"):
+            disable_any_gdbinit += 1
+
+    if disable_any_gdbinit == 0:
+        # The `--nx` option is added only in pwndbg-portable mode.
+        # This keeps the OLD syntax working, eg: `source /path/to/pwndbg/gdbinit.py` from ~/.gdbinit
+        return True, True
+
+    # The portable binary injects one -nx of its own, so the user's real --nx only
+    # starts counting from the second one. When we were sourced from a user's
+    # .gdbinit there's no injected -nx, so a single --nx is enough, same as vanilla gdb.
+    nx_threshold = 2 if loaded_from_portable else 1
+    return disable_any_gdbinit >= nx_threshold, disable_home_gdbinit >= 1

--- a/pwndbginit/gdbinit.py
+++ b/pwndbginit/gdbinit.py
@@ -61,8 +61,13 @@ def main() -> None:
     import pwndbg  # noqa: F811
     import pwndbg.dbg_mod.gdb
 
-    # Mark that pwndbg was loaded from `pwndbg` binary (for double-load detection)
-    setattr(pwndbg, "_is_loaded_from_pwndbg", True)
+    # Only mark this when we actually came in through the portable `pwndbg` binary.
+    # The portable launcher injects an extra -nx, so the gdbinit loader needs to
+    # know about it to count --nx flags correctly. When pwndbg is sourced from a
+    # user's own .gdbinit there's no injected -nx, so leaving this unset lets a
+    # single user --nx behave like vanilla gdb. Also used for double-load detection.
+    if os.environ.get("PWNDBG_LOADED_FROM_PORTABLE") == "1":
+        setattr(pwndbg, "_is_loaded_from_pwndbg", True)
 
     pwndbg.dbg = pwndbg.dbg_mod.gdb.GDB()
     pwndbg.dbg.setup()

--- a/pwndbginit/pwndbg_gdb.py
+++ b/pwndbginit/pwndbg_gdb.py
@@ -47,6 +47,12 @@ def prepend_venv_bin_to_path():
 def main():
     prepend_venv_bin_to_path()
 
+    # Let the rest of the loader know we got here through the portable binary and
+    # not from someone sourcing gdbinit.py out of their own .gdbinit. We inject a
+    # -nx below, and that extra -nx changes how many --nx the user needs to pass
+    # to actually skip ~/.gdbinit. See _disable_gdbinit_loading.
+    os.environ["PWNDBG_LOADED_FROM_PORTABLE"] = "1"
+
     gdb_argv = [
         sys.argv[0],
         "-q",

--- a/tests/unit_tests/test_disable_gdbinit.py
+++ b/tests/unit_tests/test_disable_gdbinit.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from pwndbg.lib.gdbinit import disable_gdbinit_loading
+
+
+def test_portable_needs_two_nx_to_disable():
+    # one user --nx is not enough under the portable binary because the launcher
+    # already injected its own -nx.
+    disable_any, _ = disable_gdbinit_loading(["gdb", "-q", "-nx"], loaded_from_portable=True)
+    assert disable_any is False
+
+    disable_any, _ = disable_gdbinit_loading(["gdb", "-q", "-nx", "-nx"], loaded_from_portable=True)
+    assert disable_any is True
+
+
+def test_sourced_needs_one_nx_to_disable():
+    # when sourced from a user's own .gdbinit a single --nx should disable loading,
+    # matching vanilla gdb. this is the actual bug from #3896.
+    disable_any, _ = disable_gdbinit_loading(
+        ["gdb", "-nx", "-x", "~/.gdbinit.local"], loaded_from_portable=False
+    )
+    assert disable_any is True
+
+
+def test_no_nx_keeps_old_source_syntax_working():
+    # no --nx at all still disables everything, so the old `source gdbinit.py` style
+    # from ~/.gdbinit keeps working.
+    disable_any, disable_home = disable_gdbinit_loading(["gdb"], loaded_from_portable=False)
+    assert disable_any is True
+    assert disable_home is True
+
+
+def test_nh_disables_home():
+    _, disable_home = disable_gdbinit_loading(["gdb", "-nx", "-nh"], loaded_from_portable=False)
+    assert disable_home is True
+
+
+def test_args_stops_counting():
+    # flags after --args belong to the debugged program, so they don't count as
+    # user --nx. with none counted we fall back to disabling (old source syntax).
+    disable_any, disable_home = disable_gdbinit_loading(
+        ["gdb", "--args", "./prog", "-nx", "-nx"], loaded_from_portable=True
+    )
+    assert disable_any is True
+    assert disable_home is True


### PR DESCRIPTION
when pwndbg is sourced from a user's own .gdbinit (not the portable binary), a single --nx wasn't enough to skip ~/.gdbinit because the loader always assumed an extra -nx had been injected and so wanted two of them. that injected -nx only actually happens in portable mode, so i made the distinction explicit. the portable launcher now sets PWNDBG_LOADED_FROM_PORTABLE and we only mark _is_loaded_from_pwndbg in that case, then _disable_gdbinit_loading needs two --nx for portable and one when sourced, which matches vanilla gdb. went with the _is_loaded_from_pwndbg approach k4lizen mentioned in the thread.

pulled the flag counting out into pwndbg/lib/gdbinit.py so it's testable without dragging in real gdb. added unit tests for the portable/sourced/--nh/--args cases and they pass.

closes #3896
