### PR TITLE
feat(windbg): add optional count/length parameter to dds/dps/dqs/kd

### DIFF
--- a/docs/commands/windbg/dds.md
+++ b/docs/commands/windbg/dds.md
@@ -2,7 +2,7 @@
 # dds
 
 ```text
-usage: dds [-h] addr
+usage: dds [-h] addr [count]
 
 ```
 
@@ -14,6 +14,7 @@ Dump pointers and symbols at the specified address.
 |Positional Argument|Help|
 | :--- | :--- |
 |addr|The address to dump from.|
+|count|The number of pointers to dump.|
 
 ### Optional arguments
 

--- a/pwndbg/commands/windbg.py
+++ b/pwndbg/commands/windbg.py
@@ -303,19 +303,30 @@ def eX(size, address, data, hex=True) -> None:
             return
 
 
-parser = argparse.ArgumentParser(description="Dump pointers and symbols at the specified address.")
-parser.add_argument("addr", type=pwndbg.commands.HexOrAddressExpr, help="The address to dump from.")
+dds_parser = argparse.ArgumentParser(
+    description="Dump pointers and symbols at the specified address."
+)
+dds_parser.add_argument(
+    "addr", type=pwndbg.commands.HexOrAddressExpr, help="The address to dump from."
+)
+dds_parser.add_argument(
+    "count",
+    type=pwndbg.commands.AddressExpr,
+    default=None,
+    nargs="?",
+    help="The number of pointers to dump.",
+)
 
 
-@pwndbg.commands.Command(
-    parser, aliases=["kd", "dps", "dqs"], category=CommandCategory.WINDBG
-)  # TODO are these really all the same? They had identical implementation...
+@pwndbg.commands.Command(dds_parser, aliases=["kd", "dps", "dqs"], category=CommandCategory.WINDBG)
 @pwndbg.commands.OnlyWhenRunning
-def dds(addr):
+def dds(addr, count=None):
     """
     Dump pointers and symbols at the specified address.
     """
-    return pwndbg.commands.telescope.telescope(addr)
+    if count is None:
+        return pwndbg.commands.telescope.telescope(addr, repeat=dds.repeat)
+    return pwndbg.commands.telescope.telescope(addr, count=int(count), repeat=dds.repeat)
 
 
 da_parser = argparse.ArgumentParser(description="Dump a string at the specified address.")

--- a/pwndbg/commands/windbg.py
+++ b/pwndbg/commands/windbg.py
@@ -311,7 +311,7 @@ dds_parser.add_argument(
 )
 dds_parser.add_argument(
     "count",
-    type=pwndbg.commands.AddressExpr,
+    type=int,
     default=None,
     nargs="?",
     help="The number of pointers to dump.",
@@ -320,7 +320,7 @@ dds_parser.add_argument(
 
 @pwndbg.commands.Command(dds_parser, aliases=["kd", "dps", "dqs"], category=CommandCategory.WINDBG)
 @pwndbg.commands.OnlyWhenRunning
-def dds(addr, count=None):
+def dds(addr: int, count: int | None = None):
     """
     Dump pointers and symbols at the specified address.
     """

--- a/tests/library/dbg/tests/test_windbg.py
+++ b/tests/library/dbg/tests/test_windbg.py
@@ -234,20 +234,22 @@ async def test_windbg_dX_commands(ctrl: Controller) -> None:
         # Ensure the first lines of both are identical
         assert out_default[:3] == out_3
 
-    # Test repeat/Enter behavior by mocking check_repeated to return True
-    out_normal = (await ctrl.execute_and_capture("dds &data 2")).strip().splitlines()
-    await ctrl.execute("pi pwndbg.commands.windbg.dds.check_repeated = lambda *a, **kw: True")
-    try:
-        out_repeated = (await ctrl.execute_and_capture("dds &data 2")).strip().splitlines()
-        # Verify it has different addresses
-        assert out_normal != out_repeated
-        # Verify it dumped consecutive memory regions (e.g. out_repeated starts after out_normal ends)
-        ptrsize = pwndbg.aglib.typeinfo.ptrsize
-        addr_normal_start = int(out_normal[0].split()[1], 16)
-        addr_repeated_start = int(out_repeated[0].split()[1], 16)
-        assert addr_repeated_start == addr_normal_start + 2 * ptrsize
-    finally:
-        await ctrl.execute("pi del pwndbg.commands.windbg.dds.check_repeated")
+    # Test repeat/Enter behavior by mocking check_repeated to return True (only on GDB)
+    is_gdb = "GDB" in type(ctrl).__name__
+    if is_gdb:
+        out_normal = (await ctrl.execute_and_capture("dds &data 2")).strip().splitlines()
+        await ctrl.execute("pi pwndbg.commands.windbg.dds.check_repeated = lambda *a, **kw: True")
+        try:
+            out_repeated = (await ctrl.execute_and_capture("dds &data 2")).strip().splitlines()
+            # Verify it has different addresses
+            assert out_normal != out_repeated
+            # Verify it dumped consecutive memory regions (e.g. out_repeated starts after out_normal ends)
+            ptrsize = pwndbg.aglib.typeinfo.ptrsize
+            addr_normal_start = int(out_normal[0].split()[1], 16)
+            addr_repeated_start = int(out_repeated[0].split()[1], 16)
+            assert addr_repeated_start == addr_normal_start + 2 * ptrsize
+        finally:
+            await ctrl.execute("pi del pwndbg.commands.windbg.dds.check_repeated")
 
 
 @pwndbg_test

--- a/tests/library/dbg/tests/test_windbg.py
+++ b/tests/library/dbg/tests/test_windbg.py
@@ -222,6 +222,18 @@ async def test_windbg_dX_commands(ctrl: Controller) -> None:
         "Perhaps try: db <address> <count> or hexdump <address>\n"
     )
 
+    #################################################
+    #### dds / dps / dqs / kd command tests
+    #################################################
+    for cmd in ("dds", "dps", "dqs", "kd"):
+        # Without count argument (uses default)
+        out_default = (await ctrl.execute_and_capture(f"{cmd} &data")).strip().splitlines()
+        # With count argument
+        out_3 = (await ctrl.execute_and_capture(f"{cmd} &data 3")).strip().splitlines()
+        assert len(out_3) == 3
+        # Ensure the first lines of both are identical
+        assert out_default[:3] == out_3
+
 
 @pwndbg_test
 async def test_windbg_eX_commands(ctrl: Controller) -> None:

--- a/tests/library/dbg/tests/test_windbg.py
+++ b/tests/library/dbg/tests/test_windbg.py
@@ -234,6 +234,21 @@ async def test_windbg_dX_commands(ctrl: Controller) -> None:
         # Ensure the first lines of both are identical
         assert out_default[:3] == out_3
 
+    # Test repeat/Enter behavior by mocking check_repeated to return True
+    out_normal = (await ctrl.execute_and_capture("dds &data 2")).strip().splitlines()
+    await ctrl.execute("pi pwndbg.commands.windbg.dds.check_repeated = lambda *a, **kw: True")
+    try:
+        out_repeated = (await ctrl.execute_and_capture("dds &data 2")).strip().splitlines()
+        # Verify it has different addresses
+        assert out_normal != out_repeated
+        # Verify it dumped consecutive memory regions (e.g. out_repeated starts after out_normal ends)
+        ptrsize = pwndbg.aglib.typeinfo.ptrsize
+        addr_normal_start = int(out_normal[0].split()[1], 16)
+        addr_repeated_start = int(out_repeated[0].split()[1], 16)
+        assert addr_repeated_start == addr_normal_start + 2 * ptrsize
+    finally:
+        await ctrl.execute("pi del pwndbg.commands.windbg.dds.check_repeated")
+
 
 @pwndbg_test
 async def test_windbg_eX_commands(ctrl: Controller) -> None:

--- a/tests/library/dbg/tests/test_windbg.py
+++ b/tests/library/dbg/tests/test_windbg.py
@@ -20,6 +20,7 @@ async def test_windbg_dX_commands(ctrl: Controller) -> None:
     """
     import pwndbg
     import pwndbg.aglib
+    from pwndbg.dbg_mod import DebuggerType
 
     await ctrl.launch(MEMORY_BINARY)
 
@@ -235,7 +236,7 @@ async def test_windbg_dX_commands(ctrl: Controller) -> None:
         assert out_default[:3] == out_3
 
     # Test repeat/Enter behavior by mocking check_repeated to return True (only on GDB)
-    is_gdb = "GDB" in type(ctrl).__name__
+    is_gdb = pwndbg.dbg.name() == DebuggerType.GDB
     if is_gdb:
         out_normal = (await ctrl.execute_and_capture("dds &data 2")).strip().splitlines()
         await ctrl.execute("pi pwndbg.commands.windbg.dds.check_repeated = lambda *a, **kw: True")


### PR DESCRIPTION
### Description

This PR adds an optional `count` parameter to the WinDbg compatibility commands `dds`, `dps`, `dqs`, and `kd` to control the dump size (length).
Currently, these commands only accept a single positional `addr` argument.
Passing an extra parameter (e.g., `dps $rsp 20`) causes GDB to fail with:

```
usage: dps [-h] addr
dps: error: unrecognized arguments: 20
```

With this change:

1. An optional `count` argument is registered (`type=int` based on feedback).
2. If provided, the count is forwarded directly to `pwndbg.commands.telescope.telescope(addr, count=int(count), repeat=dds.repeat)`.
3. Support for command repeats (hitting Enter) is fully preserved by forwarding `repeat=dds.repeat` to `telescope()`.

### Testing

I have added integration tests in `tests/library/dbg/tests/test_windbg.py` verifying that:

• Running `dds/dps/dqs/kd` with a custom count parameter (e.g., `dps &data 3`) returns exactly that number of lines.
• Running without a count parameter defaults to the normal display range.
• Hitting Enter correctly repeats the command.

Resolves #2965 