### PR TITLE
gdbinit: inline is_system_installation to avoid early pwndbginit import

### DIFF
--- a/gdbinit.py
+++ b/gdbinit.py
@@ -36,6 +36,24 @@ def fixup_paths(src_root: Path, venv_path: Path):
     sys.exec_prefix = str(venv_path)
 
 
+def is_system_installation(src_root: Path) -> bool:
+    # NOTE: Keep this in sync with `pwndbginit.common.is_system_installation`.
+    # It is intentionally duplicated here so that `gdbinit.py` does not import the
+    # `pwndbginit` package before `fixup_paths()` has corrected `sys.path`. Otherwise,
+    # a system-wide Pwndbg installation (e.g. an Arch `pwndbg` package in the global
+    # site-packages) could shadow the source checkout that is being sourced, leading
+    # to a confusing mix of modules loaded from two different locations. See:
+    # https://github.com/pwndbg/pwndbg/issues/3963
+    #
+    # If pwndbg is installed in `/venv/lib/pythonX.Y/site-packages/pwndbg/`,
+    # the `.pwndbg_root` file will not exist because `src_root` will point to the
+    # `/venv/lib/pythonX.Y/site-packages/` directory, not the original source directory.
+    #
+    # However, if pwndbg is installed in editable mode (our recommended way), this file
+    # will exist, and the condition will be False, allowing auto-update.
+    return not (src_root / ".pwndbg_root").exists()
+
+
 def get_venv_path(src_root: Path):
     venv_path_env = os.environ.get("PWNDBG_VENV_PATH")
     if venv_path_env:
@@ -64,17 +82,10 @@ def main() -> None:
 
     src_root = Path(__file__).parent.resolve()
 
-    skip_venv = False
-    try:
-        # This can fail if Pwndbg is not installed to system site-packages
-        # on our regular virtualenv setup
-        from pwndbginit.common import is_system_installation
-
-        # If Pwndbg is installed by distro package manager, skip virtualenv check
-        if is_system_installation(src_root):
-            skip_venv = True
-    except ImportError:
-        pass
+    # If Pwndbg is installed by a distro package manager, skip the virtualenv check.
+    # `is_system_installation` is inlined (not imported from `pwndbginit`) on purpose so
+    # we don't import the `pwndbginit` package before `fixup_paths()` fixes `sys.path`.
+    skip_venv = is_system_installation(src_root)
 
     if not skip_venv:
         venv_path = get_venv_path(src_root)

--- a/pwndbginit/common.py
+++ b/pwndbginit/common.py
@@ -101,6 +101,11 @@ def update_deps(src_root: Path) -> None:
 
 
 def is_system_installation(src_root: Path) -> bool:
+    # NOTE: This is intentionally duplicated (inlined) in the top-level `gdbinit.py`
+    # so that gdbinit doesn't import the `pwndbginit` package before `fixup_paths()`
+    # corrects `sys.path` (see https://github.com/pwndbg/pwndbg/issues/3963). If you
+    # change the logic here, update `is_system_installation` in `gdbinit.py` too.
+    #
     # If pwndbg is installed in `/venv/lib/pythonX.Y/site-packages/pwndbg/`,
     # the `.pwndbg_root` file will not exist because `src_root` will point to the
     # `/venv/lib/pythonX.Y/site-packages/` directory, not the original source directory


### PR DESCRIPTION
gdbinit.py imported `is_system_installation` from `pwndbginit.common` before `fixup_paths()` corrected `sys.path`. With a system-wide Pwndbg installation (e.g. an Arch `pwndbg` package in the global site-packages), this early import could shadow the source checkout being sourced, mixing modules loaded from two different locations and producing confusing import errors.

Inline `is_system_installation` (a trivial `.pwndbg_root` existence check) so gdbinit.py no longer imports the `pwndbginit` package before sys.path is fixed.

Fixes #3963

<!--
    Please make sure to read the linting and testing instructions at
    https://pwndbg.re/dev/contributing/ before creating a PR.
-->

+ [x] I read the contributing documentation.
+ [ ] I am providing a screenshot of the (new feature) / (fixed bug).
