### PR TITLE
Workaround GDB crash don't catch signal on exit, don't show signal on breakpoints, move signal context down

### DIFF
--- a/docs/configuration/config.md
+++ b/docs/configuration/config.md
@@ -303,7 +303,7 @@ Which context sections are displayed (controls order).
 
 
 
-**Default:** 'last_signal regs disasm code ghidra stack backtrace expressions threads heap_tracker'  
+**Default:** 'regs disasm code ghidra stack backtrace expressions threads heap_tracker last_signal'  
 
 ----------
 

--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -43,6 +43,7 @@ import pwndbg.dbg_mod
 import pwndbg.dintegration
 import pwndbg.lib.cache
 import pwndbg.lib.config
+import pwndbg.lib.tips
 import pwndbg.rich
 import pwndbg.ui
 from pwndbg.aglib.arch_mod import get_thumb_mode_string
@@ -175,7 +176,7 @@ config_output = pwndbg.config.add_param(
 )
 config_context_sections = pwndbg.config.add_param(
     "context-sections",
-    "last_signal regs disasm code ghidra stack backtrace expressions threads heap_tracker",
+    "regs disasm code ghidra stack backtrace expressions threads heap_tracker last_signal",
     "which context sections are displayed (controls order)",
 )
 config_max_threads_display = pwndbg.config.add_param(
@@ -1740,8 +1741,12 @@ def context_threads(
 
 
 @pwndbg.dbg.event_handler(EventType.STOP, EventHandlerPriority.SAVE_SIGNAL)
-@pwndbg.dbg.event_handler(EventType.EXIT, EventHandlerPriority.SAVE_SIGNAL)
 def save_signal() -> None:
+    # We can't do this on EventType.CONTINUE because of #3683
+    # We can't do this on EventType.EXIT because of
+    #  https://sourceware.org/bugzilla/show_bug.cgi?id=34047
+    # But we don't really care about those anyway, at least for GDB, because
+    # the signal information only changes on gdb.SignalEvent which is a subclass of gdb.StopEvent .
     global last_signal
     last_signal = result = []
 
@@ -1757,7 +1762,11 @@ def save_signal() -> None:
     if not process:
         return
 
-    if not (process.stopped_with_signal() or process.stopped_at_breakpoint()):
+    # We don't show signal on breakpoints (process.stopped_at_breakpoint()) because
+    # it clutters the context.
+    # process.stopped_with_signal() does return non-breakpoint caused SIGTRAPs
+    # (e.g. a non-debugger-inserted int3 instruction).
+    if not (process.stopped_with_signal()):
         return
 
     signal = pwndbg.aglib.signal.get_last_signal()
@@ -1773,9 +1782,7 @@ def save_signal() -> None:
                 msg += desc_long
         except pwndbg.dbg_mod.Error:
             pass
-    elif signal == "SIGTRAP":
-        result.append(message.breakpoint(f"Breakpoint hit at {pwndbg.aglib.regs.pc:#x}"))
-        return
+
     result.append(message.signal(msg))
 
 

--- a/pwndbg/dbg_mod/__init__.py
+++ b/pwndbg/dbg_mod/__init__.py
@@ -1150,7 +1150,11 @@ class EventType(Enum):
 
     EXIT = 2
     """This event is fired after the process being debugged has been
-    detached from or has finished executing."""
+    detached from or has finished executing.
+
+    You're not allowed to call `info program` in GDB during this.
+    https://sourceware.org/bugzilla/show_bug.cgi?id=34047
+    """
 
     MEMORY_CHANGED = 3
     """This event is fired when the user interactively makes changes to the memory

--- a/pwndbg/dbg_mod/gdb/__init__.py
+++ b/pwndbg/dbg_mod/gdb/__init__.py
@@ -636,10 +636,12 @@ class GDBProcess(pwndbg.dbg_mod.Process):
 
     @override
     def stopped_with_signal(self) -> bool:
+        # FIXME: `info program` is hacky (#3976)
         return "It stopped with signal " in gdb.execute("info program", to_string=True)
 
     @override
     def stopped_at_breakpoint(self) -> bool:
+        # FIXME: `info program` is hacky (#3976)
         gdb_prog: str = gdb.execute("info program", to_string=True)
         # The first happens when e.g. running start
         # ("It stopped at a breakpoint that has since been deleted.")

--- a/tests/library/dbg/tests/test_context_commands.py
+++ b/tests/library/dbg/tests/test_context_commands.py
@@ -525,7 +525,7 @@ async def test_context_all_sections_flag(ctrl: Controller) -> None:
 
     # Now use -a flag. It should capture all sections regardless of config
     all_out = await ctrl.execute_and_capture("context -a")
-    expected_all = ["REGISTERS", "DISASM", "STACK", "BACKTRACE", "SOURCE (CODE)", "LAST SIGNAL"]
+    expected_all = ["REGISTERS", "DISASM", "STACK", "BACKTRACE", "SOURCE (CODE)"]
     all_sections = extract_context_sections(all_out)
     assert all_sections == expected_all
 

--- a/tests/library/dbg/tests/test_context_commands.py
+++ b/tests/library/dbg/tests/test_context_commands.py
@@ -95,7 +95,7 @@ async def test_empty_context_sections(ctrl: Controller, sections: str) -> None:
 
     # Sanity checkdefault_ctx_sects
     default_ctx_sects = (
-        "last_signal regs disasm code ghidra stack backtrace expressions threads heap_tracker"
+        "regs disasm code ghidra stack backtrace expressions threads heap_tracker last_signal"
     )
     assert pwndbg.config.context_sections.value == default_ctx_sects
     assert (await ctrl.execute_and_capture("context")) != ""


### PR DESCRIPTION
I can confirm that after these changes, we do not trigger this assert in GDB (the second one).

https://sourceware.org/bugzilla/show_bug.cgi?id=34047

last_signal should be the last context section because it's important and when its on top, it can often be out of view when the terminal height is too short to show it, causing confusion on why the process doesn't want to continue running etc.

But when we do that, having it on the bottom for every breakpoint is too eager imo, so I'm just removing the breakpoint print.

Related: https://github.com/pwndbg/pwndbg/issues/3976 , https://github.com/pwndbg/pwndbg/pull/3684