### PR TITLE
fix(lldb): implement history tracking to support command repeat

### DIFF
--- a/pwndbg/dbg_mod/lldb/__init__.py
+++ b/pwndbg/dbg_mod/lldb/__init__.py
@@ -2219,7 +2219,7 @@ class LLDB(pwndbg.dbg_mod.Debugger):
                         "Execution state mismatch on command handler"
                     )
 
-            def get_repeat_command(self, command):
+            def get_repeat_command(self, command: str) -> str:
                 return f"{name} {command}" if command else name
 
         # LLDB is very particular with the object paths it will accept. It is at

--- a/pwndbg/dbg_mod/lldb/__init__.py
+++ b/pwndbg/dbg_mod/lldb/__init__.py
@@ -2128,6 +2128,8 @@ class LLDB(pwndbg.dbg_mod.Debugger):
         self._exception_relay = None
         self.lldb_python_state_callback = _default_lldb_python_state_callback
         self.should_suspend_ctx = False
+        self._history_list = []
+        self._history_index = 0
 
         import pwndbg
 
@@ -2217,6 +2219,9 @@ class LLDB(pwndbg.dbg_mod.Debugger):
                         "Execution state mismatch on command handler"
                     )
 
+            def get_repeat_command(self, command):
+                return f"{name} {command}" if command else name
+
         # LLDB is very particular with the object paths it will accept. It is at
         # its happiest when its pulling objects straight off the module that was
         # first imported with `command script import`, so, we install the class
@@ -2237,9 +2242,7 @@ class LLDB(pwndbg.dbg_mod.Debugger):
 
     @override
     def history(self, last: int = 10) -> list[tuple[int, str]]:
-        # Figure out a way to retrieve history later.
-        # Just need to parse the result of `self.inner.HandleCommand("history")`
-        return []
+        return self._history_list[-last:]
 
     @override
     def commands(self) -> list[str]:

--- a/pwndbg/dbg_mod/lldb/repl/__init__.py
+++ b/pwndbg/dbg_mod/lldb/repl/__init__.py
@@ -392,6 +392,8 @@ def run(
                         # If the input is empty (i.e., 'Enter'), use the previous command
                         if line:
                             last_command = line
+                            dbg._history_index += 1
+                            dbg._history_list.append((dbg._history_index, line))
                         else:
                             line = last_command
                     except EOFError:


### PR DESCRIPTION
On the LLDB backend, command repeating (pressing `Enter` on an empty line to repeat the last command) was completely broken. This happened because `LLDB.history()` was hardcoded to return an empty list `[]`, which prevented `check_repeated()` from tracking command history. As a result, commands like `nearpc` (and `u`) could never repeat or advance to the next instruction block.

This PR fixes this by:
1. Tracking interactive command history in our custom REPL loop and returning it via `LLDB.history()`.
2. Implementing `get_repeat_command()` on the dynamic LLDB command handler class so LLDB knows to repeat the command.

Tested in the Docker container with `nearpc` and verified it now correctly repeats and advances on empty `Enter` inputs.

Fixes #1374 (for LLDB)
Related #2095

+ [x] I read the contributing documentation.
+ [ ] I am providing a screenshot of the (new feature) / (fixed bug).
