### PR TITLE
Align exithandlers output

### DIFF
--- a/pwndbg/commands/exithandlers.py
+++ b/pwndbg/commands/exithandlers.py
@@ -9,6 +9,7 @@ from pwnlib.util.packing import p32
 from pwnlib.util.packing import p64
 from pwnlib.util.packing import u32
 from pwnlib.util.packing import u64
+from rich.table import Table
 
 import pwndbg.aglib
 import pwndbg.aglib.disasm.disassembly
@@ -23,6 +24,7 @@ import pwndbg.commands
 import pwndbg.dintegration
 import pwndbg.emu.emulator
 import pwndbg.libc
+import pwndbg.rich
 from pwndbg.color import blue
 from pwndbg.color import message
 from pwndbg.dbg_mod import Value
@@ -35,35 +37,6 @@ class _ExitFunctionEntry:
     fn: int
     arg: int
     dso_handle: int
-
-    def __str__(self) -> str:
-        match self.flavor:
-            case 0:
-                flavor_str = "ef_free"
-            case 1:
-                flavor_str = "ef_us"
-            case 2:
-                flavor_str = "ef_on"
-            case 3:
-                flavor_str = "ef_at"
-            case 4:
-                flavor_str = "ef_cxa"
-            case _:
-                flavor_str = "unknown"
-
-        string = f"{pwndbg.color.memory.get(self.addr)} [{flavor_str} ({self.flavor})]"
-        if flavor_str in {"ef_on", "ef_cxa", "ef_at", "unknown"}:
-            decomp_stack_vars = pwndbg.dintegration.manager.get_stack_var_dict_all()
-            fn_str = pwndbg.color.memory.get_address_and_symbol(self.fn, decomp_stack_vars)
-            string += f": {fn_str}"
-        if flavor_str in {"ef_on", "ef_cxa", "unknown"}:
-            string += f" [arg = {pwndbg.chain.format(self.arg)}"
-        if flavor_str in {"ef_cxa", "unknown"}:
-            string += f", dso_handle = {pwndbg.color.memory.get(self.dso_handle)}]"
-        elif flavor_str == "ef_on":
-            string += "]"
-
-        return string
 
     @staticmethod
     def read(addr: int, pointer_guard: int) -> _ExitFunctionEntry:
@@ -458,6 +431,49 @@ def _list_tls_dtors(pointer_guard: int, tls_dtor_list: int) -> list[_TlsDtorEntr
     return dtors
 
 
+def _print_exit_handlers(handlers: list[_ExitFunctionEntry]):
+    table = Table.grid(expand=False)
+    table.add_column()
+    table.add_column()
+    table.add_column()
+    for handler in handlers:
+        sections = []
+        match handler.flavor:
+            case 0:
+                flavor_str = "ef_free"
+            case 1:
+                flavor_str = "ef_us"
+            case 2:
+                flavor_str = "ef_on"
+            case 3:
+                flavor_str = "ef_at"
+            case 4:
+                flavor_str = "ef_cxa"
+            case _:
+                flavor_str = "unknown"
+        sections.append(
+            f"{pwndbg.color.memory.get(handler.addr)} \\[{flavor_str} ({handler.flavor})]"
+        )
+        if flavor_str in {"ef_on", "ef_cxa", "ef_at", "unknown"}:
+            sections[0] += ": "
+            decomp_stack_vars = pwndbg.dintegration.manager.get_stack_var_dict_all()
+            fn_str = pwndbg.color.memory.get_address_and_symbol(handler.fn, decomp_stack_vars)
+            sections.append(fn_str)
+        else:
+            sections.append("")
+        if flavor_str in {"ef_on", "ef_cxa", "unknown"}:
+            detail_string = f" \\[arg = {pwndbg.chain.format(handler.arg)}"
+            if flavor_str in {"ef_cxa", "unknown"}:
+                detail_string += f", dso_handle = {pwndbg.color.memory.get(handler.dso_handle)}]"
+            elif flavor_str == "ef_on":
+                detail_string += "]"
+            sections.append(detail_string)
+        else:
+            sections.append("")
+        table.add_row(*sections)
+        print(pwndbg.rich.rich_to_str(table))
+
+
 parser = argparse.ArgumentParser(description="List currently registered glibc exit handlers.")
 
 
@@ -508,8 +524,7 @@ def exithandlers() -> None:
             print("No __exit_funcs handlers registered.")
             return
         print("Registered __exit_funcs handlers:")
-        for entry in exit_handlers:
-            print(str(entry))
+        _print_exit_handlers(exit_handlers)
 
     # Fetch and print tls dtors if we can.
     print()

--- a/pwndbg/commands/exithandlers.py
+++ b/pwndbg/commands/exithandlers.py
@@ -463,7 +463,7 @@ def _print_exit_handlers(handlers: list[_ExitFunctionEntry]) -> None:
         else:
             sections.append("")
         table.add_row(*sections)
-    print(pwndbg.rich.rich_to_str(table))
+    print(pwndbg.rich.rich_to_str(table, width=512))  # effectively disable per-cell truncation
 
 
 def _print_tls_dtors(dtors: list[_TlsDtorEntry]) -> None:
@@ -478,7 +478,7 @@ def _print_tls_dtors(dtors: list[_TlsDtorEntry]) -> None:
             pwndbg.color.memory.get_address_and_symbol(dtor.func, decomp_stack_vars),
             f" \\[obj = {pwndbg.chain.format(dtor.obj)}, map = {pwndbg.color.memory.get(dtor.map)}]",
         )
-    print(pwndbg.rich.rich_to_str(table))
+    print(pwndbg.rich.rich_to_str(table, width=512))
 
 
 parser = argparse.ArgumentParser(description="List currently registered glibc exit handlers.")

--- a/pwndbg/commands/exithandlers.py
+++ b/pwndbg/commands/exithandlers.py
@@ -103,14 +103,6 @@ class _TlsDtorEntry:
     map: int
     next: int
 
-    def __str__(self) -> str:
-        decomp_stack_vars = pwndbg.dintegration.manager.get_stack_var_dict_all()
-        string = f"{pwndbg.color.memory.get(self.address)}: "
-        string += pwndbg.color.memory.get_address_and_symbol(self.func, decomp_stack_vars)
-        string += f" [obj = {pwndbg.chain.format(self.obj)}"
-        string += f", map = {pwndbg.color.memory.get(self.map)}]"
-        return string
-
     @staticmethod
     def read(addr: int, pointer_guard: int) -> _TlsDtorEntry:
         # https://elixir.bootlin.com/glibc/glibc-2.43/source/stdlib/cxa_thread_atexit_impl.c#L82
@@ -432,7 +424,7 @@ def _list_tls_dtors(pointer_guard: int, tls_dtor_list: int) -> list[_TlsDtorEntr
 
 
 def _print_exit_handlers(handlers: list[_ExitFunctionEntry]):
-    table = Table.grid(expand=False)
+    table = Table.grid()
     table.add_column()
     table.add_column()
     table.add_column()
@@ -471,7 +463,22 @@ def _print_exit_handlers(handlers: list[_ExitFunctionEntry]):
         else:
             sections.append("")
         table.add_row(*sections)
-        print(pwndbg.rich.rich_to_str(table))
+    print(pwndbg.rich.rich_to_str(table))
+
+
+def _print_tls_dtors(dtors: list[_TlsDtorEntry]):
+    table = Table.grid()
+    table.add_column()
+    table.add_column()
+    table.add_column()
+    decomp_stack_vars = pwndbg.dintegration.manager.get_stack_var_dict_all()
+    for dtor in dtors:
+        table.add_row(
+            f"{pwndbg.color.memory.get(dtor.address)}: ",
+            pwndbg.color.memory.get_address_and_symbol(dtor.func, decomp_stack_vars),
+            f" \\[obj = {pwndbg.chain.format(dtor.obj)}, map = {pwndbg.color.memory.get(dtor.map)}]",
+        )
+    print(pwndbg.rich.rich_to_str(table))
 
 
 parser = argparse.ArgumentParser(description="List currently registered glibc exit handlers.")
@@ -534,5 +541,6 @@ def exithandlers() -> None:
             print("No tls_dtor handlers registered.")
         else:
             print("Registered tls_dtor handlers:")
-            for dtor in tls_dtors:
-                print(str(dtor))
+            _print_tls_dtors(tls_dtors)
+            # for dtor in tls_dtors:
+            #     print(str(dtor))

--- a/pwndbg/commands/exithandlers.py
+++ b/pwndbg/commands/exithandlers.py
@@ -425,9 +425,9 @@ def _list_tls_dtors(pointer_guard: int, tls_dtor_list: int) -> list[_TlsDtorEntr
 
 def _print_exit_handlers(handlers: list[_ExitFunctionEntry]) -> None:
     table = Table.grid()
-    table.add_column()
-    table.add_column()
-    table.add_column()
+    table.add_column(no_wrap=True)
+    table.add_column(no_wrap=True)
+    table.add_column(no_wrap=True)
     for handler in handlers:
         sections = []
         match handler.flavor:
@@ -468,9 +468,9 @@ def _print_exit_handlers(handlers: list[_ExitFunctionEntry]) -> None:
 
 def _print_tls_dtors(dtors: list[_TlsDtorEntry]) -> None:
     table = Table.grid()
-    table.add_column()
-    table.add_column()
-    table.add_column()
+    table.add_column(no_wrap=True)
+    table.add_column(no_wrap=True)
+    table.add_column(no_wrap=True)
     decomp_stack_vars = pwndbg.dintegration.manager.get_stack_var_dict_all()
     for dtor in dtors:
         table.add_row(

--- a/pwndbg/commands/exithandlers.py
+++ b/pwndbg/commands/exithandlers.py
@@ -542,5 +542,3 @@ def exithandlers() -> None:
         else:
             print("Registered tls_dtor handlers:")
             _print_tls_dtors(tls_dtors)
-            # for dtor in tls_dtors:
-            #     print(str(dtor))

--- a/pwndbg/commands/exithandlers.py
+++ b/pwndbg/commands/exithandlers.py
@@ -423,7 +423,7 @@ def _list_tls_dtors(pointer_guard: int, tls_dtor_list: int) -> list[_TlsDtorEntr
     return dtors
 
 
-def _print_exit_handlers(handlers: list[_ExitFunctionEntry]):
+def _print_exit_handlers(handlers: list[_ExitFunctionEntry]) -> None:
     table = Table.grid()
     table.add_column()
     table.add_column()
@@ -466,7 +466,7 @@ def _print_exit_handlers(handlers: list[_ExitFunctionEntry]):
     print(pwndbg.rich.rich_to_str(table))
 
 
-def _print_tls_dtors(dtors: list[_TlsDtorEntry]):
+def _print_tls_dtors(dtors: list[_TlsDtorEntry]) -> None:
     table = Table.grid()
     table.add_column()
     table.add_column()

--- a/tests/library/dbg/tests/test_command_exithandlers.py
+++ b/tests/library/dbg/tests/test_command_exithandlers.py
@@ -46,7 +46,7 @@ async def test_command_exithandlers(ctrl: Controller) -> None:
     exit_funcs_start = out_lines.index("Registered __exit_funcs handlers:")
     system_entry = out_lines[exit_funcs_start + 1]
     deadbeef_cxa_entry = out_lines[exit_funcs_start + 2]
-    assert out_lines[exit_funcs_start + 3] == dl_fini_handler_line
+    assert out_lines[exit_funcs_start + 3].strip() == dl_fini_handler_line.strip()
     assert "[ef_on (2)]" in system_entry
     assert "'/bin/whoami'" in system_entry  # arg chain
     assert (

--- a/tests/library/dbg/tests/test_command_exithandlers.py
+++ b/tests/library/dbg/tests/test_command_exithandlers.py
@@ -24,7 +24,7 @@ async def test_command_exithandlers(ctrl: Controller) -> None:
     assert "Registered __exit_funcs handlers:" in out_lines
     dl_fini_handler_line = out_lines[out_lines.index("Registered __exit_funcs handlers:") + 1]
     assert "[ef_cxa (4)]" in dl_fini_handler_line
-    dl_fini_entry_addr_and_symbol = dl_fini_handler_line.split(": ")[1].split(" [")[0]
+    dl_fini_entry_addr_and_symbol = dl_fini_handler_line.split(":")[1].split("[")[0].strip()
     if (
         "(_dl_fini)" in dl_fini_entry_addr_and_symbol
         and (dl_fini_real_addr := pwndbg.aglib.symbol.lookup_symbol("_dl_fini")) is not None


### PR DESCRIPTION
<!--
    Please make sure to read the linting and testing instructions at
    https://pwndbg.re/dev/contributing/ before creating a PR.
-->

+ [X] I read the contributing documentation.
+ [X] I am providing a screenshot of the (new feature) / (fixed bug).

This is a very small PR to address https://github.com/pwndbg/pwndbg/pull/3973#discussion_r3415518378. It aligns the symbol addr/name and [details] for the listed exithandlers using a rich Table.grid. Makes it look slightly prettier :)

<img width="2276" height="682" alt="Screenshot From 2026-06-25 21-08-51" src="https://github.com/user-attachments/assets/99d6db25-ac04-4f35-bc49-efa08402595a" />

