### PR TITLE
docs: fix spelling of occurred and separate

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -123,7 +123,7 @@ nix shell github:pwndbg/pwndbg#pwndbg-lldb
 ```
 
 ## Manually install the Portable Version
-You can download a portable release on the [Pwndbg releases page](https://github.com/pwndbg/pwndbg/releases). There are seperate releases for GDB and LLDB. Use the first table to pick the appropriate download for your system architecture. You can then unpack the archive with:
+You can download a portable release on the [Pwndbg releases page](https://github.com/pwndbg/pwndbg/releases). There are separate releases for GDB and LLDB. Use the first table to pick the appropriate download for your system architecture. You can then unpack the archive with:
 ```{.bash .copy}
 tar -v -xf <archive-name>
 ```

--- a/pwndbg/lib/err.py
+++ b/pwndbg/lib/err.py
@@ -12,7 +12,7 @@ from enum import Enum
 
 class ErrorCode(Enum):
     """
-    Describes which error occured.
+    Describes which error occurred.
 
     Feel free to add a new one.
     """


### PR DESCRIPTION
## Summary
- Fix typos: occurred and separate in documentation.

## Test plan
- [x] Docs-only change; no code behavior change.