### PR TITLE
slab: fix slab info consistency

### DIFF
--- a/pwndbg/commands/slab.py
+++ b/pwndbg/commands/slab.py
@@ -225,16 +225,12 @@ def print_node_cache(node_cache: NodeCache, verbose: bool) -> None:
     )
     # https://elixir.bootlin.com/linux/v6.13/source/mm/slub.c#L3140
     indent.print(
-        f"{indent.prefix('kmem_cache_node')} @ {indent.addr_hex(address)} [NUMA node {node}, nr_partial/min_partial: {indent.aux_hex(nr_partial)}/{indent.aux_hex(min_partial)}]:"
+        f"{indent.prefix('kmem_cache_node')} @ {indent.addr_hex(address)} [NUMA node {node}]:"
     )
     with indent:
         partial_slabs = node_cache.partial_slabs
-        if not partial_slabs:
-            indent.print("Partial Slabs: (none)")
-            return
-
         indent.print(
-            f"{indent.prefix('Partial Slabs')} [nr_partial: {indent.aux_hex(len(partial_slabs))}]"
+            f"{indent.prefix('Partial Slabs')} [nr_partial/min_partial: {indent.aux_hex(nr_partial)}/{indent.aux_hex(min_partial)}]"
         )
         with indent:
             for slab in partial_slabs:

--- a/pwndbg/commands/slab.py
+++ b/pwndbg/commands/slab.py
@@ -131,7 +131,7 @@ def freelist_desc(freelist: Freelist) -> str:
 
 def print_slab(slab: Slab, verbose: bool) -> None:
     indent.print(
-        f"- {indent.prefix('Slab')} @ {indent.addr_hex(slab.virt_address)} [{indent.aux_hex(slab.slab_address)}]:"
+        f"- {indent.prefix('Slab')} @ {indent.addr_hex(slab.slab_address)} [{indent.aux_hex(slab.virt_address)}]:"
     )
 
     with indent:

--- a/pwndbg/commands/slab.py
+++ b/pwndbg/commands/slab.py
@@ -229,6 +229,10 @@ def print_node_cache(node_cache: NodeCache, verbose: bool) -> None:
     )
     with indent:
         partial_slabs = node_cache.partial_slabs
+        if not partial_slabs:
+            indent.print("Partial Slabs: (none)")
+            return
+
         indent.print(
             f"{indent.prefix('Partial Slabs')} [nr_partial/min_partial: {indent.aux_hex(nr_partial)}/{indent.aux_hex(min_partial)}]"
         )


### PR DESCRIPTION
Small cleanup of the `slab info` command output:

1. `Slab @` now shows the `struct slab` address (with the data/virt address moved to brackets), making it consistent with the other @ lines (`Slab Cache @`, `kmem_cache_cpu @`, `kmem_cache_node @`), which all print the address of their kernel struct.
2. Move `nr_partial/min_partial` from the `kmem_cache_node` header to the Partial Slabs line, where they more naturally describe the partial list and we can avoid duplicate `nr_partial` output.

<img width="433" height="196" alt="image" src="https://github.com/user-attachments/assets/18928569-926c-42e1-ae14-4ce00092a5c1" />
<img width="399" height="156" alt="image" src="https://github.com/user-attachments/assets/76cdcfa6-7f0f-4188-ba90-5e4db3da5945" />


No functional changes — output formatting only.