### PR TITLE
kernel: Take flag integer properly from struct slab and struct page

### DIFF
--- a/pwndbg/aglib/kernel/macros.py
+++ b/pwndbg/aglib/kernel/macros.py
@@ -44,6 +44,21 @@ def _arr(x: pwndbg.dbg_mod.Value, n: int) -> pwndbg.dbg_mod.Value:
     return (ptr + n).dereference()
 
 
+def memdesc_flag_or_int(val: pwndbg.dbg_mod.Value) -> int:
+    """
+    Return flag integer value from `val` which is either of type `unsigned long`
+    or `memdesc_flags_t`.
+
+    Use this to read `flags` variable of `struct slab` and `struct page`.
+    """
+    # Since kernel v6.18 the flag integer is tucked away in a struct.
+    # (https://elixir.bootlin.com/linux/v6.18/source/include/linux/mm_types.h#L79)
+    # (https://elixir.bootlin.com/linux/v6.18/source/mm/slab.h#L53)
+    if val.type.has_field("f"):
+        return int(val["f"])
+    return int(val)
+
+
 def compound_head(page: pwndbg.dbg_mod.Value) -> pwndbg.dbg_mod.Value:
     """returns the head page of compound pages"""
     assert page.type.code == pwndbg.dbg_mod.TypeCode.STRUCT and page.type.name_identifier == "page"
@@ -57,17 +72,8 @@ def compound_head(page: pwndbg.dbg_mod.Value) -> pwndbg.dbg_mod.Value:
     pg_head = pg_headty.enum_member("PG_head")
     assert pg_head is not None, "Type 'enum pageflags' not found"
 
-    # Fetch page flags.
-    maybeflags = page["flags"]
-    # Since kernel v6.18 the flag integer is tucked away in a struct.
-    # (https://elixir.bootlin.com/linux/v6.18/source/include/linux/mm_types.h#L79)
-    if maybeflags.type.has_field("f"):
-        flagint: int = int(maybeflags["f"])
-    else:
-        flagint = int(maybeflags)
-
     # https://elixir.bootlin.com/linux/v6.2/source/include/linux/page-flags.h#L212
-    if flagint & (1 << pg_head):
+    if memdesc_flag_or_int(page["flags"]) & (1 << pg_head):
         next_page = _arr(page, 1)
 
         head = next_page["compound_head"]

--- a/pwndbg/aglib/kernel/macros.py
+++ b/pwndbg/aglib/kernel/macros.py
@@ -60,7 +60,7 @@ def compound_head(page: pwndbg.dbg_mod.Value) -> pwndbg.dbg_mod.Value:
     # Fetch page flags.
     maybeflags = page["flags"]
     # Since kernel v6.18 the flag integer is tucked away in a struct.
-    # (https://elixir.bootlin.com/linux/v6.18/source/mm/slab.h#L53)
+    # (https://elixir.bootlin.com/linux/v6.18/source/include/linux/mm_types.h#L79)
     if maybeflags.type.has_field("f"):
         flagint: int = int(maybeflags["f"])
     else:

--- a/pwndbg/aglib/kernel/macros.py
+++ b/pwndbg/aglib/kernel/macros.py
@@ -57,8 +57,17 @@ def compound_head(page: pwndbg.dbg_mod.Value) -> pwndbg.dbg_mod.Value:
     pg_head = pg_headty.enum_member("PG_head")
     assert pg_head is not None, "Type 'enum pageflags' not found"
 
+    # Fetch page flags.
+    maybeflags = page["flags"]
+    # Since kernel v6.18 the flag integer is tucked away in a struct.
+    # (https://elixir.bootlin.com/linux/v6.18/source/mm/slab.h#L53)
+    if maybeflags.type.has_field("f"):
+        flagint: int = int(maybeflags["f"])
+    else:
+        flagint = int(maybeflags)
+
     # https://elixir.bootlin.com/linux/v6.2/source/include/linux/page-flags.h#L212
-    if int(page["flags"]) & (1 << pg_head):
+    if flagint & (1 << pg_head):
         next_page = _arr(page, 1)
 
         head = next_page["compound_head"]

--- a/pwndbg/aglib/kernel/slab.py
+++ b/pwndbg/aglib/kernel/slab.py
@@ -11,6 +11,7 @@ import pwndbg.lib.cache
 from pwndbg.aglib import kernel
 from pwndbg.aglib.kernel.macros import compound_head
 from pwndbg.aglib.kernel.macros import for_each_entry
+from pwndbg.aglib.kernel.macros import memdesc_flag_or_int
 from pwndbg.aglib.kernel.macros import swab
 
 
@@ -183,14 +184,7 @@ class SlabCache:
 
     @property
     def flags(self) -> list[str]:
-        maybeflags = self._slab_cache["flags"]
-        # Since kernel v6.18 the flag integer is tucked away in a struct.
-        # (https://elixir.bootlin.com/linux/v6.18/source/mm/slab.h#L53)
-        if maybeflags.type.has_field("f"):
-            flagint: int = int(maybeflags["f"])
-        else:
-            flagint = int(maybeflags)
-        return get_flags_list(flagint)
+        return get_flags_list(memdesc_flag_or_int(self._slab_cache["flags"]))
 
     @property
     def cpu_cache(self) -> CpuCache | None:

--- a/pwndbg/aglib/kernel/slab.py
+++ b/pwndbg/aglib/kernel/slab.py
@@ -183,7 +183,14 @@ class SlabCache:
 
     @property
     def flags(self) -> list[str]:
-        return get_flags_list(int(self._slab_cache["flags"]))
+        maybeflags = self._slab_cache["flags"]
+        # Since kernel v6.18 the flag integer is tucked away in a struct.
+        # (https://elixir.bootlin.com/linux/v6.18/source/mm/slab.h#L53)
+        if maybeflags.type.has_field("f"):
+            flagint: int = int(maybeflags["f"])
+        else:
+            flagint = int(maybeflags)
+        return get_flags_list(flagint)
 
     @property
     def cpu_cache(self) -> CpuCache | None:

--- a/pwndbg/aglib/kernel/symbol.py
+++ b/pwndbg/aglib/kernel/symbol.py
@@ -166,6 +166,9 @@ typedef struct {
 typedef struct refcount_struct {
 	atomic_t refs;
 } refcount_t;
+typedef struct {
+	unsigned long f;
+} memdesc_flags_t;
 
 struct list_head {
     struct list_head *next, *prev;
@@ -217,7 +220,7 @@ def recover_page_typeinfo() -> str:
 #if KVERSION < KERNEL_VERSION(6, 18, 0)
         unsigned long flags;
 #else
-        struct { unsigned long f; } flags;
+        memdesc_flags_t flags;
 #endif
         union {
             struct {

--- a/pwndbg/aglib/kernel/symbol.py
+++ b/pwndbg/aglib/kernel/symbol.py
@@ -213,8 +213,12 @@ def recover_page_typeinfo() -> str:
     result += "\n".join(f"#define {s}" for s in defs)
     result += COMMON_TYPES
     result += """
-    struct page { // just a simplied page struct with relavent fields
+    struct page { // just a simplied page struct with relevant fields
+#if KVERSION < KERNEL_VERSION(6, 18, 0)
         unsigned long flags;
+#else
+        struct { unsigned long f; } flags;
+#endif
         union {
             struct {
                 union {

--- a/pwndbg/dbg_mod/__init__.py
+++ b/pwndbg/dbg_mod/__init__.py
@@ -875,12 +875,16 @@ class Type:
     def fields(self) -> list[TypeField]:
         """
         List of all fields in this type, if it is a structured type.
+
+        Otherwise, return empty list.
         """
         raise NotImplementedError()
 
     def has_field(self, name: str) -> bool:
         """
         Whether this type has a field with the given name.
+
+        Always returns False for non-structured types.
         """
         # This is a sensible default way to check for a field's existence.
         #

--- a/pwndbg/dbg_mod/gdb/__init__.py
+++ b/pwndbg/dbg_mod/gdb/__init__.py
@@ -1453,7 +1453,13 @@ class GDBType(pwndbg.dbg_mod.Type):
         # For GDB, we can do a little better than the default implementation, as
         # it has a specific convenience function that checks for this condition
         # exactly.
-        return gdb.types.has_field(self.inner, name)
+        try:
+            return gdb.types.has_field(self.inner, name)
+        except TypeError:
+            # GDB throws an exception for stuff that does not resolve to a struct or union
+            # after typedefs have been stripped.
+            # https://git.sr.ht/~sourceware/binutils-gdb/tree/05c660d1d7ca754a9607084e606c263b1fd74a94/item/gdb/python/lib/gdb/types.py#L61
+            return False
 
     @override
     def array(self, count: int) -> pwndbg.dbg_mod.Type:


### PR DESCRIPTION
v6.18: https://elixir.bootlin.com/linux/v6.18/source/mm/slab.h#L53
```c
struct slab {
	memdesc_flags_t flags;
// ...
```
v6.17: https://elixir.bootlin.com/linux/v6.17/source/mm/slab.h
```c
struct slab {
	unsigned long flags;
```
Same for `struct page`.

### Before
<img width="931" height="24" alt="image" src="https://github.com/user-attachments/assets/38cd7cba-aab6-4fdd-a58d-1134ebae0163" />

### After
<img width="481" height="128" alt="image" src="https://github.com/user-attachments/assets/2a1b1d70-66b1-433a-9b2b-07ec5089fc36" />
