### PR TITLE
tests.yml caching

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,6 +48,12 @@ jobs:
         with:
           nix_path: nixpkgs=channel:nixos-unstable
 
+      - name: Cache jemalloc build
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/pwndbg
+          key: ${{ runner.os }}-jemalloc-${{ hashFiles('setup-dev.sh') }}
+
       - name: Install dependencies
         run: |
           ./setup-dev.sh --install-only
@@ -84,14 +90,6 @@ jobs:
         run: |
           ./tests.sh --nix -d gdb -g cross-arch-user
 
-      - name: Set up cache for QEMU images
-        if: matrix.type == 'qemu-system-tests'
-        id: qemu-cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ./tests/library/qemu-system/kimages
-          key: ${{ matrix.os }}-cache-qemu-images
-
       - name: Download QEMU images
         if: matrix.type == 'qemu-system-tests'
         run: |
@@ -112,23 +110,22 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - name: Cache for pip
+      - name: Cache uv downloads
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: ~/.cache/pip
-          key: ${{ matrix.os }}-cache-pip
+          path: ~/.cache/uv
+          key: ${{ runner.os }}-uv-${{ hashFiles('uv.lock') }}
+
+      - name: Cache jemalloc build
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/pwndbg
+          key: ${{ runner.os }}-jemalloc-${{ hashFiles('setup-dev.sh') }}
 
       - name: Setup pwndbg
         run: |
           ./setup.sh
           ./setup-dev.sh
-
-      - name: Set up cache for QEMU images
-        id: qemu-cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ./tests/library/qemu-system/kimages
-          key: ${{ matrix.os }}-cache-qemu-images
 
       - name: Download images
         run: |

--- a/setup-dev.sh
+++ b/setup-dev.sh
@@ -177,10 +177,14 @@ install_dnf() {
 }
 
 install_jemalloc() {
+    JEMALLOC_STAGE="${HOME}/.cache/pwndbg/jemalloc"
 
     # Check if jemalloc is already installed
     if command -v jemalloc-config &> /dev/null; then
         echo "Jemalloc already installed. Skipping build and install."
+    elif [ -n "${GITHUB_ACTIONS}" ] && [ -d "${JEMALLOC_STAGE}" ]; then
+        echo "Installing jemalloc from cached build at ${JEMALLOC_STAGE}..."
+        sudo cp -a "${JEMALLOC_STAGE}/." /
     else
         echo "Jemalloc not found in system. Downloading, configuring, building, and installing..."
 
@@ -231,7 +235,12 @@ install_jemalloc() {
         # libstdc++ (e.g. Arch's GCC), and pwndbg's tests don't use it, so disable it.
         ./configure --disable-cxx
         make
-        sudo make install
+        if [ -n "${GITHUB_ACTIONS}" ]; then
+            make install DESTDIR="${JEMALLOC_STAGE}"
+            sudo cp -a "${JEMALLOC_STAGE}/." /
+        else
+            sudo make install
+        fi
         popd
 
         echo "Jemalloc installation complete."


### PR DESCRIPTION
+ [x] I read the contributing documentation.
+ [x] I am providing a screenshot of the (new feature) / (fixed bug).

just adds some caching for jemalloc and deps

and removes the qemu images caching - it was actually broken before, so i fixed it, but it's actually slower to restore the cache (18s) than it is to just download the 1.6 GB because the CDN is just that much faster ig, so i just removed it altogether

<img width="486" height="252" alt="chrome_112fRc4Mjw" src="https://github.com/user-attachments/assets/50237009-a1a0-4cda-9c03-86cc73df3fed" />

I'll do the pytest rewrite next, then the parallelization, and I should be able to get the qemu system tests to run in times similar to the Docker tests after that. The goal is around 8-9 minutes for the full pipeline of all tests on a pr.