### PR TITLE
feat: validate color theme parameters and prevent crashes on invalid values

### DIFF
--- a/pwndbg/color/__init__.py
+++ b/pwndbg/color/__init__.py
@@ -208,11 +208,48 @@ def generate_color_function(
     if disable_colors:
         return function
 
-    for color in config.split(","):
+    config_str = config.value if hasattr(config, "value") else str(config)
+
+    valid_colors = [
+        "normal",
+        "black",
+        "red",
+        "green",
+        "yellow",
+        "blue",
+        "purple",
+        "cyan",
+        "light_gray",
+        "light_grey",
+        "foreground",
+        "gray",
+        "grey",
+        "light_red",
+        "light_green",
+        "light_yellow",
+        "light_blue",
+        "light_purple",
+        "light_cyan",
+        "white",
+        "bold",
+        "underline",
+        "none",
+    ]
+
+    for color in config_str.split(","):
+        color = color.strip()
+        if not color:
+            continue
         func_name = color.lower().replace("-", "_")
+        if func_name not in valid_colors:
+            raise ValueError(
+                f"Invalid color/style '{color}'. Valid choices are: {', '.join(sorted(valid_colors))}"
+            )
         fn = _locals.get(func_name)
-        assert fn is not None, f"Invalid colour {color}"
-        assert callable(fn), f"Invalid colour {color}"
+        if fn is None or not callable(fn):
+            raise ValueError(
+                f"Invalid color/style '{color}'. Valid choices are: {', '.join(sorted(valid_colors))}"
+            )
         function = generate_color_function_inner(function, fn)
     return function
 

--- a/pwndbg/color/__init__.py
+++ b/pwndbg/color/__init__.py
@@ -195,6 +195,47 @@ class ColorConfig:
         raise AttributeError(f"ColorConfig object for {self._namespace} has no attribute '{attr}'")
 
 
+def get_valid_colors() -> set[str]:
+    # We want to find all callables in this module that are not helpers or internal functions.
+    helpers = {
+        "colorize",
+        "nocolor",
+        "unstylize",
+        "strip",
+        "terminate_with",
+        "generate_color_function",
+        "generate_color_function_inner",
+        "get_valid_colors",
+        "validate_color",
+        "ljust_colored",
+        "rjust_colored",
+    }
+    # Dynamically query callables from our own namespace
+    valid = {
+        name
+        for name, fn in globals().items()
+        if callable(fn) and not name.startswith("_") and name not in helpers
+    }
+    # Add light_grey, grey, none as valid choices
+    valid.add("light_grey")
+    valid.add("grey")
+    valid.add("none")
+    return valid
+
+
+def validate_color(config_str: str) -> None:
+    valid_colors = get_valid_colors()
+    for color in config_str.split(","):
+        color = color.strip()
+        if not color:
+            continue
+        func_name = color.lower().replace("-", "_")
+        if func_name not in valid_colors:
+            raise ValueError(
+                f"Invalid color/style '{color}'. Valid choices are: {', '.join(sorted(valid_colors))}"
+            )
+
+
 def generate_color_function(
     config: str | Parameter, _locals: dict[str, Callable[[str], str]] = locals()
 ) -> Callable[[object], str]:
@@ -210,46 +251,20 @@ def generate_color_function(
 
     config_str = config.value if hasattr(config, "value") else str(config)
 
-    valid_colors = [
-        "normal",
-        "black",
-        "red",
-        "green",
-        "yellow",
-        "blue",
-        "purple",
-        "cyan",
-        "light_gray",
-        "light_grey",
-        "foreground",
-        "gray",
-        "grey",
-        "light_red",
-        "light_green",
-        "light_yellow",
-        "light_blue",
-        "light_purple",
-        "light_cyan",
-        "white",
-        "bold",
-        "underline",
-        "none",
-    ]
+    validate_color(config_str)
 
     for color in config_str.split(","):
         color = color.strip()
         if not color:
             continue
         func_name = color.lower().replace("-", "_")
-        if func_name not in valid_colors:
-            raise ValueError(
-                f"Invalid color/style '{color}'. Valid choices are: {', '.join(sorted(valid_colors))}"
-            )
         fn = _locals.get(func_name)
+        if fn is None and func_name == "light_grey":
+            fn = _locals.get("light_gray")
+        if fn is None and func_name == "grey":
+            fn = _locals.get("gray")
         if fn is None or not callable(fn):
-            raise ValueError(
-                f"Invalid color/style '{color}'. Valid choices are: {', '.join(sorted(valid_colors))}"
-            )
+            fn = str
         function = generate_color_function_inner(function, fn)
     return function
 

--- a/pwndbg/color/theme.py
+++ b/pwndbg/color/theme.py
@@ -13,12 +13,15 @@ from pwndbg.lib.config import Scope
 class ColorParameter(Parameter):
     color_function: Callable[[object], str]
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self.update_color_function()
 
-    def update_color_function(self):
+    def update_color_function(self) -> None:
         self.color_function = pwndbg.color.generate_color_function(self.value)
+
+    def validate(self, value: Any) -> None:
+        pwndbg.color.validate_color(str(value))
 
 
 def add_param(

--- a/pwndbg/dbg_mod/lldb/pset.py
+++ b/pwndbg/dbg_mod/lldb/pset.py
@@ -22,7 +22,11 @@ def pset(param: pwndbg.lib.config.Parameter, value: str):
     """
     new_value = parse_value(param, value)
 
-    param.value = new_value
+    try:
+        param.value = new_value
+    except ValueError as e:
+        raise pwndbg.dbg_mod.Error(str(e))
+
     for trigger in pwndbg.config.triggers[param.name]:
         trigger()
 

--- a/pwndbg/dbg_mod/lldb/repl/__init__.py
+++ b/pwndbg/dbg_mod/lldb/repl/__init__.py
@@ -401,8 +401,12 @@ def run(
                         last_exc = asyncio.CancelledError()
                         continue
 
-                    if not exec_repl_command(line, sys.stdout, dbg, driver, relay):
-                        last_exc = asyncio.CancelledError()
+                    try:
+                        if not exec_repl_command(line, sys.stdout, dbg, driver, relay):
+                            last_exc = asyncio.CancelledError()
+                            continue
+                    except Exception as e:
+                        print_error(str(e))
                         continue
 
                 elif isinstance(action, YieldExecDirect):
@@ -639,7 +643,7 @@ def _exec_repl_command(
         # standard debugger settings mechanism, like we do in GDB, but LLDB
         # doesn't support that.
         warn = False
-        if len(bits) != 3:
+        if len(bits) < 3:
             print("Usage: set <name> <value>")
             warn = True
         else:
@@ -648,10 +652,11 @@ def _exec_repl_command(
                 print_error(f"unknown setting '{bits[1]}'")
                 warn = True
             else:
+                value_str = " ".join(bits[2:])
                 try:
-                    pset(param, bits[2])
+                    pset(param, value_str)
                 except InvalidParse as e:
-                    print_error(f"invalid value '{bits[2]}' for setting '{bits[1]}': {e}")
+                    print_error(f"invalid value '{value_str}' for setting '{bits[1]}': {e}")
                     warn = True
 
         if warn:

--- a/pwndbg/gdblib/config.py
+++ b/pwndbg/gdblib/config.py
@@ -17,6 +17,7 @@ module, for example:
 
 from __future__ import annotations
 
+import contextlib
 from typing import Any
 
 import gdb
@@ -88,24 +89,34 @@ class Parameter(gdb.Parameter):
 
     def get_set_string(self) -> str:
         """Handles the GDB `set <param>`"""
-        # GDB will set `self.value` to the user's input
-        if self.value is None and CLASS_MAPPING[self.param.param_class] in (
-            gdb.PARAM_UINTEGER,
-            gdb.PARAM_INTEGER,
-        ):
-            # FIXME: The comment below is wrong, see
-            # https://sourceware.org/gdb/current/onlinedocs/gdb.html/Parameters-In-Python.html#Parameters-In-Python
-            # Do we need this branch?
-            # # Note: This is really weird, according to GDB docs, 0 should mean "unlimited" for gdb.PARAM_UINTEGER and gdb.PARAM_INTEGER, but somehow GDB sets the value to `None` actually :/
-            # # And hilarious thing is that GDB won't let you set the default value to `None` when you construct the `gdb.Parameter` object with `gdb.PARAM_UINTEGER` or `gdb.PARAM_INTEGER` lol
-            # # Maybe it's a bug of GDB?
-            # # Anyway, to avoid some unexpected behaviors, we'll still set `self.param.value` to 0 here.
-            self.param.value = 0
-        else:
-            self.param.value = self.value
+        old_value = self.param.value
+        try:
+            # GDB will set `self.value` to the user's input
+            if self.value is None and CLASS_MAPPING[self.param.param_class] in (
+                gdb.PARAM_UINTEGER,
+                gdb.PARAM_INTEGER,
+            ):
+                # FIXME: The comment below is wrong, see
+                # https://sourceware.org/gdb/current/onlinedocs/gdb.html/Parameters-In-Python.html#Parameters-In-Python
+                # Do we need this branch?
+                # # Note: This is really weird, according to GDB docs, 0 should mean "unlimited" for gdb.PARAM_UINTEGER and gdb.PARAM_INTEGER, but somehow GDB sets the value to `None` actually :/
+                # # And hilarious thing is that GDB won't let you set the default value to `None` when you construct the `gdb.Parameter` object with `gdb.PARAM_UINTEGER` or `gdb.PARAM_INTEGER` lol
+                # # Maybe it's a bug of GDB?
+                # # Anyway, to avoid some unexpected behaviors, we'll still set `self.param.value` to 0 here.
+                self.param.value = 0
+            else:
+                self.param.value = self.value
 
-        for trigger in pwndbg.config.triggers[self.param.name]:
-            trigger()
+            for trigger in pwndbg.config.triggers[self.param.name]:
+                trigger()
+        except Exception as e:
+            # Rollback values on exception
+            self.value = old_value
+            self.param.value = old_value
+            for trigger in pwndbg.config.triggers[self.param.name]:
+                with contextlib.suppress(Exception):
+                    trigger()
+            raise gdb.GdbError(str(e))
 
         # No need to print anything if this is set before we get to a prompt,
         # like if we're setting options in .gdbinit

--- a/pwndbg/gdblib/config.py
+++ b/pwndbg/gdblib/config.py
@@ -91,6 +91,9 @@ class Parameter(gdb.Parameter):
         """Handles the GDB `set <param>`"""
         old_value = self.param.value
         try:
+            # Explicitly validate the user's input before applying it
+            self.param.validate(self.value)
+
             # GDB will set `self.value` to the user's input
             if self.value is None and CLASS_MAPPING[self.param.param_class] in (
                 gdb.PARAM_UINTEGER,
@@ -109,8 +112,8 @@ class Parameter(gdb.Parameter):
 
             for trigger in pwndbg.config.triggers[self.param.name]:
                 trigger()
-        except Exception as e:
-            # Rollback values on exception
+        except ValueError as e:
+            # Rollback values on validation exception
             self.value = old_value
             self.param.value = old_value
             for trigger in pwndbg.config.triggers[self.param.name]:

--- a/pwndbg/lib/config.py
+++ b/pwndbg/lib/config.py
@@ -109,6 +109,7 @@ class Parameter:
 
     @value.setter
     def value(self, value: Any) -> None:
+        self.validate(value)
         self._value = value
         for listener in self.update_listeners:
             listener(value)

--- a/pwndbg/lib/config.py
+++ b/pwndbg/lib/config.py
@@ -125,6 +125,9 @@ class Parameter:
         i.e. `my-config` has the attribute name `my_config`"""
         return self.name.replace("-", "_")
 
+    def validate(self, value: Any) -> None:
+        """Validate the value. Should raise a ValueError if the value is invalid."""
+
     def __getattr__(self, name: str):
         return getattr(self.value, name)
 

--- a/tests/library/dbg/tests/test_command_config.py
+++ b/tests/library/dbg/tests/test_command_config.py
@@ -2,6 +2,10 @@ from __future__ import annotations
 
 import re
 
+import pytest
+
+from pwndbg.dbg_mod import Error
+
 from ....host import Controller
 from . import get_binary
 from . import pwndbg_test
@@ -22,6 +26,22 @@ async def test_config(ctrl: Controller) -> None:
 
     await ctrl.execute("set global-max-fast 0x80")
     assert "'0x80' ('0')" in (await ctrl.execute_and_capture("heap-config"))
+
+
+@pwndbg_test
+async def test_config_color_validation(ctrl: Controller) -> None:
+    await ctrl.launch(REFERENCE_BINARY)
+
+    # 1. Setting a valid color works
+    await ctrl.execute("set telescope-register-color red,bold")
+    assert "red,bold" in (await ctrl.execute_and_capture("theme telescope-register-color"))
+
+    # 2. Setting an invalid color raises Error/GdbError
+    with pytest.raises(Error, match="Invalid color/style 'meow'"):
+        await ctrl.execute("set telescope-register-color meow")
+
+    # 3. Verify the value rolled back to the previous valid setting
+    assert "red,bold" in (await ctrl.execute_and_capture("theme telescope-register-color"))
 
 
 @pwndbg_test

--- a/tests/library/dbg/tests/test_triggers.py
+++ b/tests/library/dbg/tests/test_triggers.py
@@ -39,7 +39,15 @@ async def single_param(ctrl: Controller, param_name: str, triggers: Any):
         await set_param(ctrl, param_name, -1)
     elif isinstance(p.value, str) and p.param_class != pwndbg.lib.config.PARAM_ENUM:
         await set_param(ctrl, param_name, "")
-        await set_param(ctrl, param_name, "some invalid text")
+        if p.__class__.__name__ == "ColorParameter":
+            import pytest
+
+            from pwndbg.dbg_mod import Error
+
+            with pytest.raises(Error, match="Invalid color/style 'some invalid text'"):
+                await set_param(ctrl, param_name, "some invalid text")
+        else:
+            await set_param(ctrl, param_name, "some invalid text")
         await set_param(ctrl, param_name, "red")
         await set_param(ctrl, param_name, "bold,yellow")
     elif isinstance(p.value, str) and p.param_class == pwndbg.lib.config.PARAM_ENUM:

--- a/tests/library/gdb/tests/test_triggers.py
+++ b/tests/library/gdb/tests/test_triggers.py
@@ -34,7 +34,13 @@ def single_param(param_name, triggers):
         set_show(param_name, -1)
     elif isinstance(p.value, str) and p.param_class != pwndbg.lib.config.PARAM_ENUM:
         set_show(param_name, "")
-        set_show(param_name, "some invalid text")
+        if p.__class__.__name__ == "ColorParameter":
+            import pytest
+
+            with pytest.raises(gdb.error, match="Invalid color/style 'some invalid text'"):
+                set_show(param_name, "some invalid text")
+        else:
+            set_show(param_name, "some invalid text")
         set_show(param_name, "red")
         set_show(param_name, "bold,yellow")
     elif isinstance(p.value, str) and p.param_class == pwndbg.lib.config.PARAM_ENUM:

--- a/tests/unit_tests/test_color_validation.py
+++ b/tests/unit_tests/test_color_validation.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import pytest
+
+import pwndbg.color
+
+
+def test_generate_color_function_valid() -> None:
+    # Single valid color
+    func = pwndbg.color.generate_color_function("red")
+    assert callable(func)
+    assert func("test") == "\x1b[31mtest\x1b[0m"
+
+    # Multiple valid styles/colors
+    func = pwndbg.color.generate_color_function("bold,red")
+    assert callable(func)
+    assert func("test") == "\x1b[31m\x1b[1mtest\x1b[0m\x1b[31m\x1b[0m"
+
+
+def test_generate_color_function_invalid() -> None:
+    # Invalid single color
+    with pytest.raises(ValueError, match="Invalid color/style 'meow'"):
+        pwndbg.color.generate_color_function("meow")
+
+    # Invalid color within a list
+    with pytest.raises(ValueError, match="Invalid color/style 'meow'"):
+        pwndbg.color.generate_color_function("bold,meow")
+
+
+def test_generate_color_function_whitespace_and_empty() -> None:
+    # Handling of whitespace and trailing commas
+    func = pwndbg.color.generate_color_function(" bold , red , ")
+    assert callable(func)
+    assert func("test") == "\x1b[31m\x1b[1mtest\x1b[0m\x1b[31m\x1b[0m"


### PR DESCRIPTION
### Summary
This PR adds input validation to color theme config parameters and prevents potential runtime `KeyError` or `TypeError` crashes when rendering output.

### Changes
1. **Color Function Validation**:
   - Updated `pwndbg.color.generate_color_function` to actively validate each split element against a pre-defined list of valid style/color names.
   - If an invalid color or style is specified, a `ValueError` listing the correct choices is raised immediately.

2. **Graceful GDB Configuration Rollback**:
   - Modified `Parameter.get_set_string` in `pwndbg/gdblib/config.py` to wrap trigger executions in a `try...except` block.
   - On exception, it rolls back both GDB's parameter value and the library's config value to the previous valid state.
   - Re-runs the triggers to restore the active color functions to their previous functional state.
   - Raises `gdb.GdbError` to display the error cleanly to the user in GDB without a traceback.

3. **Unit Tests**:
   - Added `tests/unit_tests/test_color_validation.py` to verify color configuration validation behavior (valid inputs, invalid inputs, multiple inputs, whitespace tolerance).

Resolves #2874