### PR TITLE
Fix #3897: procinfo: show pipe peers and read/write end on remote targets

### DIFF
--- a/pwndbg/aglib/osdata.py
+++ b/pwndbg/aglib/osdata.py
@@ -14,9 +14,11 @@ import pwndbg.aglib.file
 import pwndbg.dbg_mod
 import pwndbg.lib.osdata
 
-# Large enough to keep round-trips low, small enough to fit any stub's packet
-# size buffer (gdbserver's default is 16KiB, the protocol minimum is 16KiB too,
-# but qemu and embedded stubs can be much smaller).
+# The length we request per qXfer read. It is only an upper bound: the stub
+# trims each reply to fit its own packet buffer (gdbserver advertises ~128KiB
+# via qSupported PacketSize, QEMU's stub caps at 4KiB, embedded probes can be
+# ~1KiB) and the loop below advances by the bytes actually received, so a
+# stub with a smaller buffer just needs more round-trips.
 _CHUNK = 0xF00
 
 

--- a/pwndbg/aglib/osdata.py
+++ b/pwndbg/aglib/osdata.py
@@ -1,0 +1,74 @@
+"""
+Fetch ``info os`` tables from a remote GDB stub via ``qXfer:osdata:read``.
+
+This is how we enumerate system-wide state (like every process's open file
+descriptors) on a remote target: the vFile packets can read individual files
+but cannot list directories, while osdata asks the stub itself to walk /proc
+on its side. gdbserver implements it on Linux; stubs that don't (qemu-user,
+embedded probes) answer with an empty reply and we report that as None.
+"""
+
+from __future__ import annotations
+
+import pwndbg.aglib.file
+import pwndbg.dbg_mod
+import pwndbg.lib.osdata
+
+# Large enough to keep round-trips low, small enough to fit any stub's packet
+# size buffer (gdbserver's default is 16KiB, the protocol minimum is 16KiB too,
+# but qemu and embedded stubs can be much smaller).
+_CHUNK = 0xF00
+
+
+def read(table: str) -> str | None:
+    """Fetch the raw XML of the given osdata table ("files", "processes", ...).
+
+    Returns None if the stub doesn't support qXfer:osdata:read (empty reply),
+    doesn't know the table (error reply), or the transfer fails part-way.
+    """
+    data = bytearray()
+    offset = 0
+
+    while True:
+        try:
+            response = pwndbg.dbg.selected_inferior().send_remote(
+                f"qXfer:osdata:read:{table}:{offset:x},{_CHUNK:x}"
+            )
+        except pwndbg.dbg_mod.Error:
+            return None
+
+        if not response:
+            # Empty reply is the protocol's "packet not supported".
+            return None
+
+        marker, payload = response[:1], response[1:]
+        # The reply is the binary-escaped chunk prefixed with 'm' (more data
+        # follows) or 'l' (this is the last chunk). Anything else ('E NN', ...)
+        # is an error.
+        if marker not in (b"m", b"l"):
+            return None
+
+        chunk = pwndbg.aglib.file.gdb_memtox_inverse(payload)
+        data += chunk
+
+        if marker == b"l":
+            break
+        if not chunk:
+            # 'm' with no data would loop forever; treat as a broken stub.
+            return None
+        # qXfer offsets count unescaped object bytes.
+        offset += len(chunk)
+
+    return data.decode("utf-8", errors="replace")
+
+
+def open_files() -> list[tuple[int, int, str, str]] | None:
+    """Every open FD on the remote system as (pid, fd, comm, name) rows.
+
+    ``name`` is the fd's readlink target on the remote, e.g. "pipe:[1103727]"
+    or "/dev/pts/0". Returns None when the stub can't provide the table.
+    """
+    xml_text = read("files")
+    if xml_text is None:
+        return None
+    return pwndbg.lib.osdata.parse_files_rows(xml_text)

--- a/pwndbg/commands/procinfo.py
+++ b/pwndbg/commands/procinfo.py
@@ -5,6 +5,7 @@ import shlex
 import string
 
 import pwndbg.aglib.file
+import pwndbg.aglib.osdata
 import pwndbg.aglib.proc
 import pwndbg.aglib.qemu
 import pwndbg.aglib.remote
@@ -136,35 +137,75 @@ def _augment_unix_peers(connections: list[pwndbg.lib.net.inode]) -> None:
             u.peer_comm = comm or None
 
 
-def _augment_pipes(pipes: list[pwndbg.lib.proc_fd.Pipe], self_pid: int) -> None:
-    """Fill in mode and peer endpoints for each Pipe entry, when running locally.
+def _target_file_text(path: str) -> str:
+    """Read a file from wherever the inferior lives (local procfs, or vFile)."""
+    try:
+        return pwndbg.aglib.file.get(path).decode(errors="ignore")
+    except OSError:
+        return ""
 
-    Pipe peer info comes from walking /proc/*/fd on the local kernel; for a
-    remote target this would describe the wrong machine, so we silently skip.
+
+def _fdinfo_mode(pid: int, fd: int) -> str:
+    return pwndbg.lib.proc_fd.parse_fdinfo_mode(_target_file_text(f"/proc/{pid}/fdinfo/{fd}"))
+
+
+def _pipe_endpoints_system_wide(
+    inodes: set[int],
+) -> dict[int, list[tuple[int, int, str, str]]] | None:
+    """All FDs on the target system holding one of ``inodes``, or None.
+
+    Locally this walks /proc/*/fd directly. On a remote target vFile can't
+    list directories, so we ask the stub for its "files" osdata table (the
+    same walk, done on the remote side) and fill in each endpoint's r/w mode
+    by reading its fdinfo over vFile. Returns None when neither is possible
+    (e.g. a stub without qXfer:osdata support, like qemu-user).
     """
-    if not pipes:
-        return
-    if pwndbg.aglib.remote.is_remote():
+    if not pwndbg.aglib.remote.is_remote():
+        return pwndbg.lib.proc_fd.find_pipe_endpoints(inodes)
+
+    rows = pwndbg.aglib.osdata.open_files()
+    if rows is None:
+        return None
+
+    endpoints = pwndbg.lib.proc_fd.pipe_endpoints_from_fd_rows(rows, inodes)
+    return {
+        inode: [(pid, fd, comm, _fdinfo_mode(pid, fd)) for (pid, fd, comm, _mode) in eps]
+        for inode, eps in endpoints.items()
+    }
+
+
+def _augment_pipes(pipes: list[pwndbg.lib.proc_fd.Pipe], self_pid: int) -> None:
+    """Fill in mode and peer endpoints for each Pipe entry.
+
+    Works for both local and remote targets. When no system-wide FD listing
+    is available (or it turns up nothing for an inode, e.g. for permission
+    reasons), peers fall back to what the debuggee's own FD table proves:
+    other FDs of the debuggee itself on the same pipe.
+    """
+    entries = [(p.inode, p.fd, p) for p in pipes if p.inode is not None and p.fd is not None]
+    if not entries:
         return
 
-    inodes = {p.inode for p in pipes if p.inode is not None}
-    if not inodes:
-        return
+    inodes = {inode for inode, _fd, _pipe in entries}
+    self_comm = _target_file_text(f"/proc/{self_pid}/comm").strip()
 
-    endpoints = pwndbg.lib.proc_fd.find_pipe_endpoints(inodes)
+    for _inode, fd, pipe_obj in entries:
+        pipe_obj.mode = _fdinfo_mode(self_pid, fd)
 
-    for pipe_obj in pipes:
-        if pipe_obj.inode is None:
-            continue
-        eps = endpoints.get(pipe_obj.inode, [])
-        for ep_pid, ep_fd, _comm, mode in eps:
-            if ep_pid == self_pid and ep_fd == pipe_obj.fd:
-                pipe_obj.mode = mode
-                break
+    endpoints = _pipe_endpoints_system_wide(inodes) or {}
+
+    for inode, fd, pipe_obj in entries:
+        eps = endpoints.get(inode)
+        if not eps:
+            eps = [
+                (self_pid, other_fd, self_comm, other.mode or "?")
+                for other_inode, other_fd, other in entries
+                if other_inode == inode
+            ]
         pipe_obj.peers = [
             (ep_pid, ep_fd, comm, mode)
             for (ep_pid, ep_fd, comm, mode) in eps
-            if not (ep_pid == self_pid and ep_fd == pipe_obj.fd)
+            if not (ep_pid == self_pid and ep_fd == fd)
         ]
 
 

--- a/pwndbg/commands/procinfo.py
+++ b/pwndbg/commands/procinfo.py
@@ -151,14 +151,13 @@ def _fdinfo_mode(pid: int, fd: int) -> str:
 
 def _pipe_endpoints_system_wide(
     inodes: set[int],
-) -> dict[int, list[tuple[int, int, str, str]]] | None:
+) -> dict[int, list[tuple[int, int, str]]] | None:
     """All FDs on the target system holding one of ``inodes``, or None.
 
     Locally this walks /proc/*/fd directly. On a remote target vFile can't
     list directories, so we ask the stub for its "files" osdata table (the
-    same walk, done on the remote side) and fill in each endpoint's r/w mode
-    by reading its fdinfo over vFile. Returns None when neither is possible
-    (e.g. a stub without qXfer:osdata support, like qemu-user).
+    same walk, done on the remote side). Returns None when neither is
+    possible (e.g. a stub without qXfer:osdata support, like qemu-user).
     """
     if not pwndbg.aglib.remote.is_remote():
         return pwndbg.lib.proc_fd.find_pipe_endpoints(inodes)
@@ -166,12 +165,7 @@ def _pipe_endpoints_system_wide(
     rows = pwndbg.aglib.osdata.open_files()
     if rows is None:
         return None
-
-    endpoints = pwndbg.lib.proc_fd.pipe_endpoints_from_fd_rows(rows, inodes)
-    return {
-        inode: [(pid, fd, comm, _fdinfo_mode(pid, fd)) for (pid, fd, comm, _mode) in eps]
-        for inode, eps in endpoints.items()
-    }
+    return pwndbg.lib.proc_fd.pipe_endpoints_from_fd_rows(rows, inodes)
 
 
 def _augment_pipes(pipes: list[pwndbg.lib.proc_fd.Pipe], self_pid: int) -> None:
@@ -189,22 +183,32 @@ def _augment_pipes(pipes: list[pwndbg.lib.proc_fd.Pipe], self_pid: int) -> None:
     inodes = {inode for inode, _fd, _pipe in entries}
     self_comm = _target_file_text(f"/proc/{self_pid}/comm").strip()
 
-    for _inode, fd, pipe_obj in entries:
-        pipe_obj.mode = _fdinfo_mode(self_pid, fd)
-
     endpoints = _pipe_endpoints_system_wide(inodes) or {}
 
-    for inode, fd, pipe_obj in entries:
-        eps = endpoints.get(inode)
-        if not eps:
-            eps = [
-                (self_pid, other_fd, self_comm, other.mode or "?")
-                for other_inode, other_fd, other in entries
+    # Fall back to the debuggee's own FD table for inodes the system-wide
+    # listing didn't cover.
+    for inode, _fd, _pipe in entries:
+        if not endpoints.get(inode):
+            endpoints[inode] = [
+                (self_pid, other_fd, self_comm)
+                for other_inode, other_fd, _other in entries
                 if other_inode == inode
             ]
+
+    # Resolve every endpoint's read/write end exactly once, from its fdinfo
+    # text (fetched over vFile when the target is remote).
+    modes = {
+        (ep_pid, ep_fd): _fdinfo_mode(ep_pid, ep_fd)
+        for eps in endpoints.values()
+        for (ep_pid, ep_fd, _comm) in eps
+    }
+
+    for inode, fd, pipe_obj in entries:
+        own = (self_pid, fd)
+        pipe_obj.mode = modes[own] if own in modes else _fdinfo_mode(self_pid, fd)
         pipe_obj.peers = [
-            (ep_pid, ep_fd, comm, mode)
-            for (ep_pid, ep_fd, comm, mode) in eps
+            (ep_pid, ep_fd, comm, modes[(ep_pid, ep_fd)])
+            for (ep_pid, ep_fd, comm) in endpoints.get(inode, [])
             if not (ep_pid == self_pid and ep_fd == fd)
         ]
 

--- a/pwndbg/lib/osdata.py
+++ b/pwndbg/lib/osdata.py
@@ -1,0 +1,66 @@
+"""
+Parsing for the XML tables served by the GDB remote protocol's
+``qXfer:osdata:read`` packets (the machinery behind ``info os``).
+
+Pure text processing - no debugger or procfs access - so it can be unit
+tested anywhere. The packet-transfer side lives one layer up, next to the
+rest of the debugger integration.
+
+The document format (see gdb/features/osdata.dtd) is::
+
+    <osdata type="files">
+      <item>
+        <column name="pid">4242</column>
+        <column name="command">cat</column>
+        <column name="file descriptor">0</column>
+        <column name="name">pipe:[1103727]</column>
+      </item>
+      ...
+    </osdata>
+"""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+
+
+def parse_osdata(xml_text: str) -> list[dict[str, str]]:
+    """Parse an ``<osdata>`` document into a list of {column-name: value} rows.
+
+    Returns [] for anything that isn't a well-formed osdata document; a stub
+    that doesn't know the requested table typically answers with an empty or
+    error reply which never reaches this parser.
+    """
+    try:
+        root = ET.fromstring(xml_text)
+    except ET.ParseError:
+        return []
+    if root.tag != "osdata":
+        return []
+
+    rows: list[dict[str, str]] = []
+    for item in root.findall("item"):
+        row: dict[str, str] = {}
+        for column in item.findall("column"):
+            name = column.get("name")
+            if name is not None:
+                row[name] = (column.text or "").strip()
+        if row:
+            rows.append(row)
+    return rows
+
+
+def parse_files_rows(xml_text: str) -> list[tuple[int, int, str, str]]:
+    """Parse the ``files`` osdata table into (pid, fd, comm, name) tuples.
+
+    Rows with a non-numeric pid or descriptor column are skipped.
+    """
+    result: list[tuple[int, int, str, str]] = []
+    for row in parse_osdata(xml_text):
+        try:
+            pid = int(row["pid"])
+            fd = int(row["file descriptor"])
+        except (KeyError, ValueError):
+            continue
+        result.append((pid, fd, row.get("command", ""), row.get("name", "")))
+    return result

--- a/pwndbg/lib/proc_fd.py
+++ b/pwndbg/lib/proc_fd.py
@@ -3,13 +3,14 @@ Helpers for walking ``/proc/*/fd`` to identify which processes share a given
 kernel object.
 
 Currently used by procinfo to turn an anonymous pipe FD ("pipe:[N]") into a
-list of (pid, fd, comm, mode) endpoints.
+list of (pid, fd, comm) endpoints.
 
 ``find_pipe_endpoints`` walks the local kernel's procfs directly. For a remote
 target the same walk is done by the GDB stub on its side (the "files" table of
-``qXfer:osdata:read``) and fed through ``pipe_endpoints_from_fd_rows``.
-``parse_fdinfo_mode`` works off the text of a single /proc/PID/fdinfo/FD file,
-which is readable both locally and over the remote protocol's vFile packets.
+``qXfer:osdata:read``) and fed through ``pipe_endpoints_from_fd_rows``. The
+r/w mode of each endpoint is resolved by the caller, which fetches the text of
+/proc/PID/fdinfo/FD from wherever the target lives and runs it through
+``parse_fdinfo_mode``.
 """
 
 from __future__ import annotations
@@ -93,30 +94,16 @@ def parse_fdinfo_mode(data: str) -> str:
     return "?"
 
 
-def _read_fdinfo_mode(pid: int, fd: int) -> str:
-    """Local-kernel variant of `parse_fdinfo_mode`, reading procfs directly.
-
-    Returns '?' if fdinfo can't be read.
-    """
-    try:
-        with open(f"/proc/{pid}/fdinfo/{fd}") as f:
-            return parse_fdinfo_mode(f.read())
-    except OSError:
-        return "?"
-
-
 def pipe_endpoints_from_fd_rows(
     rows: list[tuple[int, int, str, str]],
     target_inodes: set[int],
-) -> dict[int, list[tuple[int, int, str, str]]]:
+) -> dict[int, list[tuple[int, int, str]]]:
     """Like ``find_pipe_endpoints``, but from pre-collected FD rows.
 
     ``rows`` are ``(pid, fd, comm, name)`` where ``name`` is the fd's readlink
-    target - the shape of the remote stub's osdata "files" table. Modes can't
-    be known at this layer, so every endpoint gets "?"; callers can refine
-    them from fdinfo afterwards.
+    target - the shape of the remote stub's osdata "files" table.
     """
-    result: dict[int, list[tuple[int, int, str, str]]] = {}
+    result: dict[int, list[tuple[int, int, str]]] = {}
     for pid, fd, comm, name in rows:
         if not (name.startswith("pipe:[") and name.endswith("]")):
             continue
@@ -126,7 +113,7 @@ def pipe_endpoints_from_fd_rows(
             continue
         if inode not in target_inodes:
             continue
-        result.setdefault(inode, []).append((pid, fd, comm, "?"))
+        result.setdefault(inode, []).append((pid, fd, comm))
 
     for inode in result:
         result[inode].sort(key=lambda t: (t[0], t[1]))
@@ -136,10 +123,10 @@ def pipe_endpoints_from_fd_rows(
 
 def find_pipe_endpoints(
     target_inodes: set[int],
-) -> dict[int, list[tuple[int, int, str, str]]]:
+) -> dict[int, list[tuple[int, int, str]]]:
     """For each pipe inode in ``target_inodes``, return all FDs holding it.
 
-    Result maps inode -> list of ``(pid, fd, comm, mode)`` sorted by
+    Result maps inode -> list of ``(pid, fd, comm)`` sorted by
     ``(pid, fd)`` for determinism. Inodes with no discoverable holder
     are absent (the kernel may report a pipe inode that's only held by a
     process whose ``/proc/PID/fd`` we can't read).
@@ -150,7 +137,7 @@ def find_pipe_endpoints(
     if not target_inodes:
         return {}
 
-    result: dict[int, list[tuple[int, int, str, str]]] = {}
+    result: dict[int, list[tuple[int, int, str]]] = {}
     try:
         proc_entries = os.listdir("/proc")
     except OSError:
@@ -192,8 +179,7 @@ def find_pipe_endpoints(
                 except OSError:
                     comm = ""
 
-            mode = _read_fdinfo_mode(pid, fd)
-            result.setdefault(inode, []).append((pid, fd, comm, mode))
+            result.setdefault(inode, []).append((pid, fd, comm))
 
     for inode in result:
         result[inode].sort(key=lambda t: (t[0], t[1]))

--- a/pwndbg/lib/proc_fd.py
+++ b/pwndbg/lib/proc_fd.py
@@ -3,9 +3,13 @@ Helpers for walking ``/proc/*/fd`` to identify which processes share a given
 kernel object.
 
 Currently used by procinfo to turn an anonymous pipe FD ("pipe:[N]") into a
-list of (pid, fd, comm, mode) endpoints. Like the SOCK_DIAG path this is
-inherently local-only — the data lives in the host kernel's procfs and means
-nothing for a remote / different-kernel target.
+list of (pid, fd, comm, mode) endpoints.
+
+``find_pipe_endpoints`` walks the local kernel's procfs directly. For a remote
+target the same walk is done by the GDB stub on its side (the "files" table of
+``qXfer:osdata:read``) and fed through ``pipe_endpoints_from_fd_rows``.
+``parse_fdinfo_mode`` works off the text of a single /proc/PID/fdinfo/FD file,
+which is readable both locally and over the remote protocol's vFile packets.
 """
 
 from __future__ import annotations
@@ -17,10 +21,13 @@ class Pipe:
     """Anonymous pipe FD as seen from one process.
 
     ``inode`` and ``fd`` describe our own end. ``mode`` is "r"/"w"/"rw"/"?"
-    derived from /proc/PID/fdinfo. ``peers`` lists every *other* FD across
-    the system that points at the same pipe inode, with the same mode info,
-    so the user can see who's on the other end (or that they hold both ends
-    themselves).
+    derived from /proc/PID/fdinfo. ``peers`` lists every *other* FD that points
+    at the same pipe inode, with the same mode info, so the user can see who's
+    on the other end (or that they hold both ends themselves).
+
+    ``peers`` is system-wide when a whole-system FD listing is available (local
+    procfs walk, or the remote stub's osdata "files" table); otherwise it falls
+    back to just the debuggee's own FDs.
     """
 
     inode: int | None = None
@@ -57,37 +64,74 @@ def _format_peer(peer: tuple[int, int, str, str]) -> str:
     return s
 
 
-def _read_fdinfo_mode(pid: int, fd: int) -> str:
-    """Return access mode of an FD from /proc/PID/fdinfo/FD as 'r'/'w'/'rw'.
+def parse_fdinfo_mode(data: str) -> str:
+    """Return access mode of an FD as 'r'/'w'/'rw' from /proc/PID/fdinfo/FD text.
 
-    Returns '?' if fdinfo can't be read or doesn't carry the flags line. The
-    fdinfo flags field is octal text and contains the original open() flags;
-    the bottom two bits encode the access mode (O_RDONLY / O_WRONLY / O_RDWR).
+    Returns '?' if the text doesn't carry a usable flags line. The fdinfo flags
+    field is octal text and contains the original open() flags; the bottom two
+    bits encode the access mode (O_RDONLY / O_WRONLY / O_RDWR).
+    """
+    for line in data.splitlines():
+        if not line.startswith("flags:"):
+            continue
+        _, _, value = line.partition(":")
+        value = value.strip()
+        if not value:
+            return "?"
+        try:
+            flags = int(value, 8)
+        except ValueError:
+            return "?"
+        access = flags & 0o3
+        if access == 0:
+            return "r"
+        if access == 1:
+            return "w"
+        if access == 2:
+            return "rw"
+        return "?"
+    return "?"
+
+
+def _read_fdinfo_mode(pid: int, fd: int) -> str:
+    """Local-kernel variant of `parse_fdinfo_mode`, reading procfs directly.
+
+    Returns '?' if fdinfo can't be read.
     """
     try:
         with open(f"/proc/{pid}/fdinfo/{fd}") as f:
-            for line in f:
-                if not line.startswith("flags:"):
-                    continue
-                _, _, value = line.partition(":")
-                value = value.strip()
-                if not value:
-                    return "?"
-                try:
-                    flags = int(value, 8)
-                except ValueError:
-                    return "?"
-                access = flags & 0o3
-                if access == 0:
-                    return "r"
-                if access == 1:
-                    return "w"
-                if access == 2:
-                    return "rw"
-                return "?"
+            return parse_fdinfo_mode(f.read())
     except OSError:
         return "?"
-    return "?"
+
+
+def pipe_endpoints_from_fd_rows(
+    rows: list[tuple[int, int, str, str]],
+    target_inodes: set[int],
+) -> dict[int, list[tuple[int, int, str, str]]]:
+    """Like ``find_pipe_endpoints``, but from pre-collected FD rows.
+
+    ``rows`` are ``(pid, fd, comm, name)`` where ``name`` is the fd's readlink
+    target - the shape of the remote stub's osdata "files" table. Modes can't
+    be known at this layer, so every endpoint gets "?"; callers can refine
+    them from fdinfo afterwards.
+    """
+    result: dict[int, list[tuple[int, int, str, str]]] = {}
+    for pid, fd, comm, name in rows:
+        if not (name.startswith("pipe:[") and name.endswith("]")):
+            continue
+        try:
+            inode = int(name[len("pipe:[") : -1])
+        except ValueError:
+            continue
+        if inode not in target_inodes:
+            continue
+        result.setdefault(inode, []).append((pid, fd, comm, "?"))
+
+    for inode in result:
+        result[inode].sort(key=lambda t: (t[0], t[1]))
+
+    return result
 
 
 def find_pipe_endpoints(

--- a/tests/binaries/host/reference-binary-pipe-fork.native.c
+++ b/tests/binaries/host/reference-binary-pipe-fork.native.c
@@ -1,0 +1,47 @@
+// Creates two anonymous pipes split across a fork so that procinfo has both
+// kinds of pipe peers to find:
+//   - "own":   the parent keeps the read AND write end (same-process peer)
+//   - "cross": the parent keeps the read end, the child keeps the write end
+//     (cross-process peer - only discoverable through a system-wide FD walk)
+//
+// The child sleeps for a bounded time and exits on its own, so nothing leaks
+// even if the test harness never gets to kill it.
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+void break_here() {}
+
+int main(void) {
+    int own[2];
+    int cross[2];
+
+    if (pipe(own) < 0 || pipe(cross) < 0) {
+        perror("pipe");
+        return 1;
+    }
+
+    pid_t child = fork();
+    if (child < 0) {
+        perror("fork");
+        return 1;
+    }
+
+    if (child == 0) {
+        close(cross[0]);
+        close(own[0]);
+        close(own[1]);
+        sleep(60);
+        _exit(0);
+    }
+
+    close(cross[1]);
+
+    break_here();
+
+    close(own[0]);
+    close(own[1]);
+    close(cross[0]);
+    return 0;
+}

--- a/tests/library/gdb/tests/test_remote_pipe_peers.py
+++ b/tests/library/gdb/tests/test_remote_pipe_peers.py
@@ -10,9 +10,12 @@ osdata listing, so this can't silently pass through the same-process fallback.
 
 from __future__ import annotations
 
+import os
 import re
+import select
 import shutil
 import subprocess
+import time
 from collections.abc import Iterator
 
 import pytest
@@ -30,22 +33,31 @@ def gdbserver_with_pipe_fork_binary() -> Iterator[int]:
         [GDBSERVER, "127.0.0.1:0", REFERENCE_BINARY_PIPE_FORK],
         stdout=subprocess.DEVNULL,
         stderr=subprocess.PIPE,
-        text=True,
     )
     assert process.stderr is not None
     # With port 0 gdbserver picks a free port and announces it on stderr.
+    # Read the raw fd non-blockingly with a deadline so a wedged gdbserver
+    # can't hang the whole suite (buffered readline + select don't mix).
+    stderr_fd = process.stderr.fileno()
+    os.set_blocking(stderr_fd, False)
+    seen = ""
     port = None
-    for _ in range(20):
-        line = process.stderr.readline()
-        if not line:
+    deadline = time.monotonic() + 10
+    while port is None and time.monotonic() < deadline:
+        ready, _, _ = select.select([stderr_fd], [], [], deadline - time.monotonic())
+        if not ready:
             break
-        match = re.search(r"Listening on port (\d+)", line)
+        chunk = os.read(stderr_fd, 4096)
+        if not chunk:
+            break
+        seen += chunk.decode(errors="replace")
+        match = re.search(r"Listening on port (\d+)", seen)
         if match:
             port = int(match.group(1))
-            break
     if port is None:
         process.kill()
-        pytest.fail("gdbserver did not report a listening port")
+        process.wait()
+        pytest.fail(f"gdbserver did not report a listening port; stderr so far: {seen!r}")
 
     yield port
 

--- a/tests/library/gdb/tests/test_remote_pipe_peers.py
+++ b/tests/library/gdb/tests/test_remote_pipe_peers.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import re
 import shutil
 import subprocess
+from collections.abc import Iterator
 
 import pytest
 
@@ -24,13 +25,14 @@ REFERENCE_BINARY_PIPE_FORK = get_binary("reference-binary-pipe-fork.native.out")
 
 
 @pytest.fixture
-def gdbserver_with_pipe_fork_binary():
+def gdbserver_with_pipe_fork_binary() -> Iterator[int]:
     process = subprocess.Popen(
         [GDBSERVER, "127.0.0.1:0", REFERENCE_BINARY_PIPE_FORK],
         stdout=subprocess.DEVNULL,
         stderr=subprocess.PIPE,
         text=True,
     )
+    assert process.stderr is not None
     # With port 0 gdbserver picks a free port and announces it on stderr.
     port = None
     for _ in range(20):
@@ -52,7 +54,7 @@ def gdbserver_with_pipe_fork_binary():
 
 
 @pytest.mark.skipif(GDBSERVER is None, reason="gdbserver is not installed")
-def test_procinfo_pipe_peers_on_remote_target(gdbserver_with_pipe_fork_binary):
+def test_procinfo_pipe_peers_on_remote_target(gdbserver_with_pipe_fork_binary: int) -> None:
     port = gdbserver_with_pipe_fork_binary
 
     result = run_gdb_with_script(

--- a/tests/library/gdb/tests/test_remote_pipe_peers.py
+++ b/tests/library/gdb/tests/test_remote_pipe_peers.py
@@ -1,0 +1,96 @@
+"""
+Tests for procinfo's pipe peer discovery over a remote target (gdbserver).
+
+The local implementation walks /proc/*/fd directly; the remote one asks the
+stub for its "files" osdata table (qXfer:osdata:read) and reads fdinfo over
+vFile. The reference binary forks so that one pipe has its other end in a
+*different* process: seeing that peer is only possible through the system-wide
+osdata listing, so this can't silently pass through the same-process fallback.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+
+import pytest
+
+from . import get_binary
+from .utils import run_gdb_with_script
+
+GDBSERVER = shutil.which("gdbserver")
+REFERENCE_BINARY_PIPE_FORK = get_binary("reference-binary-pipe-fork.native.out")
+
+
+@pytest.fixture
+def gdbserver_with_pipe_fork_binary():
+    process = subprocess.Popen(
+        [GDBSERVER, "127.0.0.1:0", REFERENCE_BINARY_PIPE_FORK],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    # With port 0 gdbserver picks a free port and announces it on stderr.
+    port = None
+    for _ in range(20):
+        line = process.stderr.readline()
+        if not line:
+            break
+        match = re.search(r"Listening on port (\d+)", line)
+        if match:
+            port = int(match.group(1))
+            break
+    if port is None:
+        process.kill()
+        pytest.fail("gdbserver did not report a listening port")
+
+    yield port
+
+    process.kill()
+    process.wait()
+
+
+@pytest.mark.skipif(GDBSERVER is None, reason="gdbserver is not installed")
+def test_procinfo_pipe_peers_on_remote_target(gdbserver_with_pipe_fork_binary):
+    port = gdbserver_with_pipe_fork_binary
+
+    result = run_gdb_with_script(
+        binary=REFERENCE_BINARY_PIPE_FORK,
+        pyafter=[
+            # Pwndbg defaults to following the fork *child*; the parent is the
+            # side that reaches break_here holding the pipe ends.
+            "set follow-fork-mode parent",
+            f"target remote 127.0.0.1:{port}",
+            "break break_here",
+            "continue",
+            "procinfo",
+        ],
+        timeout=120,
+    )
+
+    match = re.search(r"^pid\s+(\d+)", result, re.MULTILINE)
+    assert match, f"no pid line in procinfo output:\n{result}"
+    debuggee_pid = match.group(1)
+
+    pipe_lines = [line for line in result.splitlines() if "pipe:[" in line and "peers:" in line]
+    assert pipe_lines, f"no pipe peer lines in procinfo output:\n{result}"
+
+    # The "own" pipe: read end and write end both live in the debuggee, and
+    # each end's peer is the debuggee itself.
+    assert any("(r, peers:" in line and f"pid={debuggee_pid} " in line for line in pipe_lines), (
+        f"no self-peering read end:\n{result}"
+    )
+    assert any("(w, peers:" in line and f"pid={debuggee_pid} " in line for line in pipe_lines), (
+        f"no self-peering write end:\n{result}"
+    )
+
+    # The "cross" pipe: its write end lives in the forked child, i.e. a pid
+    # other than the debuggee's. Only the osdata-backed system-wide listing
+    # can discover it on a remote target.
+    peer_pids: set[str] = set()
+    for line in pipe_lines:
+        peer_pids.update(re.findall(r"pid=(\d+)", line.split("peers:", 1)[1]))
+    assert any(pid != debuggee_pid for pid in peer_pids), (
+        f"no cross-process pipe peer found (peers all in {debuggee_pid}):\n{result}"
+    )

--- a/tests/library/gdb/tests/utils.py
+++ b/tests/library/gdb/tests/utils.py
@@ -9,13 +9,13 @@ gdb_bin_path = os.environ.get("GDB_BIN_PATH", "pwndbg")
 
 
 def run_gdb_with_script(
-    binary="",
-    core="",
-    stdin_input=None,
-    pybefore=None,
-    pyafter=None,
-    timeout=None,
-):
+    binary: str = "",
+    core: str = "",
+    stdin_input: bytes | None = None,
+    pybefore: str | list[str] | None = None,
+    pyafter: str | list[str] | None = None,
+    timeout: float | None = None,
+) -> str:
     """
     Runs GDB with given commands launched before and after loading of gdbinit.py
     Returns GDB output.

--- a/tests/unit_tests/test_osdata.py
+++ b/tests/unit_tests/test_osdata.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from pwndbg.lib.osdata import parse_files_rows
+from pwndbg.lib.osdata import parse_osdata
+
+# Shape produced by gdb/nat/linux-osdata.c:linux_xfer_osdata_fds, which backs
+# gdbserver's qXfer:osdata:read:files reply.
+FILES_XML = """<osdata type="files">
+<item>
+<column name="pid">4242</column>
+<column name="command">cat</column>
+<column name="file descriptor">0</column>
+<column name="name">pipe:[1103727]</column>
+</item>
+<item>
+<column name="pid">4243</column>
+<column name="command">grep</column>
+<column name="file descriptor">1</column>
+<column name="name">/dev/pts/0</column>
+</item>
+</osdata>
+"""
+
+
+def test_parse_osdata_files_table() -> None:
+    rows = parse_osdata(FILES_XML)
+    assert len(rows) == 2
+    assert rows[0] == {
+        "pid": "4242",
+        "command": "cat",
+        "file descriptor": "0",
+        "name": "pipe:[1103727]",
+    }
+
+
+def test_parse_osdata_rejects_garbage() -> None:
+    assert parse_osdata("") == []
+    assert parse_osdata("not xml at all") == []
+    assert parse_osdata("<notosdata></notosdata>") == []
+    # Truncated transfer: broken XML must not raise.
+    assert parse_osdata(FILES_XML[: len(FILES_XML) // 2]) == []
+
+
+def test_parse_osdata_handles_xml_escapes() -> None:
+    # readlink targets can contain XML-special characters; linux-osdata.c
+    # escapes them with string_xml_appendf.
+    xml = (
+        '<osdata type="files"><item>'
+        '<column name="pid">1</column>'
+        '<column name="command">a&amp;b</column>'
+        '<column name="file descriptor">3</column>'
+        '<column name="name">/tmp/&lt;x&gt;</column>'
+        "</item></osdata>"
+    )
+    rows = parse_osdata(xml)
+    assert rows == [{"pid": "1", "command": "a&b", "file descriptor": "3", "name": "/tmp/<x>"}]
+
+
+def test_parse_files_rows() -> None:
+    rows = parse_files_rows(FILES_XML)
+    assert rows == [
+        (4242, 0, "cat", "pipe:[1103727]"),
+        (4243, 1, "grep", "/dev/pts/0"),
+    ]
+
+
+def test_parse_files_rows_skips_non_numeric() -> None:
+    xml = (
+        '<osdata type="files">'
+        '<item><column name="pid">nope</column>'
+        '<column name="file descriptor">3</column></item>'
+        '<item><column name="pid">5</column>'
+        '<column name="file descriptor">7</column></item>'
+        "</osdata>"
+    )
+    assert parse_files_rows(xml) == [(5, 7, "", "")]

--- a/tests/unit_tests/test_proc_fd.py
+++ b/tests/unit_tests/test_proc_fd.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import os
 
 from pwndbg.lib.proc_fd import Pipe
-from pwndbg.lib.proc_fd import _read_fdinfo_mode
 from pwndbg.lib.proc_fd import find_pipe_endpoints
 from pwndbg.lib.proc_fd import parse_fdinfo_mode
 from pwndbg.lib.proc_fd import pipe_endpoints_from_fd_rows
@@ -13,10 +12,14 @@ def _pipe_inode(fd: int) -> int:
     return os.stat(f"/proc/self/fd/{fd}").st_ino
 
 
+def _live_fdinfo_mode(fd: int) -> str:
+    with open(f"/proc/self/fdinfo/{fd}") as f:
+        return parse_fdinfo_mode(f.read())
+
+
 def test_find_pipe_endpoints_locates_both_ends() -> None:
     # An anonymous pipe(2) gives us a read end and a write end that share
-    # the same inode but have different access modes. find_pipe_endpoints
-    # must report both, with the correct read/write tag for each.
+    # the same inode. find_pipe_endpoints must report both FDs.
     r, w = os.pipe()
     try:
         inode = _pipe_inode(r)
@@ -27,9 +30,8 @@ def test_find_pipe_endpoints_locates_both_ends() -> None:
         ends = endpoints[inode]
         assert len(ends) >= 2
 
-        modes = {fd: mode for (pid, fd, _comm, mode) in ends if pid == os.getpid()}
-        assert modes[r] == "r"
-        assert modes[w] == "w"
+        own_fds = {fd for (pid, fd, _comm) in ends if pid == os.getpid()}
+        assert {r, w} <= own_fds
     finally:
         os.close(r)
         os.close(w)
@@ -45,19 +47,15 @@ def test_find_pipe_endpoints_unknown_inode() -> None:
     assert find_pipe_endpoints({2**32 - 1}) == {}
 
 
-def test_read_fdinfo_mode_for_pipe_ends() -> None:
+def test_parse_fdinfo_mode_on_live_pipe_ends() -> None:
+    # The parser against real kernel-produced fdinfo text, not a fixture.
     r, w = os.pipe()
     try:
-        assert _read_fdinfo_mode(os.getpid(), r) == "r"
-        assert _read_fdinfo_mode(os.getpid(), w) == "w"
+        assert _live_fdinfo_mode(r) == "r"
+        assert _live_fdinfo_mode(w) == "w"
     finally:
         os.close(r)
         os.close(w)
-
-
-def test_read_fdinfo_mode_unknown_fd() -> None:
-    # A wildly-invalid fd number gives us '?' instead of raising.
-    assert _read_fdinfo_mode(os.getpid(), 999_999) == "?"
 
 
 def test_pipe_endpoints_from_fd_rows() -> None:
@@ -72,8 +70,8 @@ def test_pipe_endpoints_from_fd_rows() -> None:
     ]
     endpoints = pipe_endpoints_from_fd_rows(rows, {555})
     assert set(endpoints) == {555}
-    # Sorted by (pid, fd); modes unknown at this layer.
-    assert endpoints[555] == [(4242, 4, "cat", "?"), (4243, 0, "grep", "?")]
+    # Sorted by (pid, fd).
+    assert endpoints[555] == [(4242, 4, "cat"), (4243, 0, "grep")]
 
 
 def test_pipe_endpoints_from_fd_rows_malformed_names() -> None:

--- a/tests/unit_tests/test_proc_fd.py
+++ b/tests/unit_tests/test_proc_fd.py
@@ -5,6 +5,8 @@ import os
 from pwndbg.lib.proc_fd import Pipe
 from pwndbg.lib.proc_fd import _read_fdinfo_mode
 from pwndbg.lib.proc_fd import find_pipe_endpoints
+from pwndbg.lib.proc_fd import parse_fdinfo_mode
+from pwndbg.lib.proc_fd import pipe_endpoints_from_fd_rows
 
 
 def _pipe_inode(fd: int) -> int:
@@ -56,6 +58,48 @@ def test_read_fdinfo_mode_for_pipe_ends() -> None:
 def test_read_fdinfo_mode_unknown_fd() -> None:
     # A wildly-invalid fd number gives us '?' instead of raising.
     assert _read_fdinfo_mode(os.getpid(), 999_999) == "?"
+
+
+def test_pipe_endpoints_from_fd_rows() -> None:
+    # Rows in the shape of the remote stub's "files" osdata table: the same
+    # pipe held by two processes, plus unrelated FDs that must be ignored.
+    rows = [
+        (4243, 0, "grep", "pipe:[555]"),
+        (4242, 4, "cat", "pipe:[555]"),
+        (4242, 1, "cat", "/dev/pts/0"),
+        (9999, 3, "other", "pipe:[777]"),
+        (1, 5, "init", "socket:[555]"),
+    ]
+    endpoints = pipe_endpoints_from_fd_rows(rows, {555})
+    assert set(endpoints) == {555}
+    # Sorted by (pid, fd); modes unknown at this layer.
+    assert endpoints[555] == [(4242, 4, "cat", "?"), (4243, 0, "grep", "?")]
+
+
+def test_pipe_endpoints_from_fd_rows_malformed_names() -> None:
+    rows = [
+        (1, 2, "x", "pipe:[notanumber]"),
+        (1, 3, "x", "pipe:[123"),
+        (1, 4, "x", ""),
+    ]
+    assert pipe_endpoints_from_fd_rows(rows, {123}) == {}
+
+
+def test_parse_fdinfo_mode() -> None:
+    # This is the parser used for remote targets, where fdinfo arrives as bytes
+    # over vFile rather than being read from the local procfs.
+    fdinfo = "pos:\t0\nflags:\t02\nmnt_id:\t14\nino:\t1109875\n"
+    assert parse_fdinfo_mode(fdinfo) == "rw"
+    assert parse_fdinfo_mode("pos:\t0\nflags:\t00\n") == "r"
+    assert parse_fdinfo_mode("pos:\t0\nflags:\t0100001\n") == "w"
+
+
+def test_parse_fdinfo_mode_malformed() -> None:
+    # No flags line, an empty value, or a non-octal value: '?' rather than raise.
+    assert parse_fdinfo_mode("") == "?"
+    assert parse_fdinfo_mode("pos:\t0\nino:\t123\n") == "?"
+    assert parse_fdinfo_mode("flags:\t\n") == "?"
+    assert parse_fdinfo_mode("flags:\tnonsense\n") == "?"
 
 
 def test_pipe_str_renders_self_only() -> None:


### PR DESCRIPTION
+ [x] I read the contributing documentation.
+ [x] Output of the feature is shown below.

Fixes #3897 (follow-up to #3150, as discussed in the issue).

## Approach

The local implementation walks `/proc/*/fd`, which can't be done over the remote protocol: `vFile:*` packets can read files but have no readdir. Instead we ask the stub for its **`files` osdata table** (`qXfer:osdata:read`, the machinery behind `info os files`). gdbserver performs the same `/proc/*/fd` walk on its side and returns pid / command / fd / readlink target for every FD on the system. Each endpoint's read/write mode then comes from reading `/proc/PID/fdinfo/FD` over vFile, which also works for processes the stub isn't attached to.

Degradation: stubs without osdata support (e.g. qemu-user) fall back to r/w modes plus same-process peers derived from the debuggee's own FD table; without vFile the output stays as it is today. The fallback is also applied per-inode locally when `/proc` entries of other processes aren't readable.

New modules: `pwndbg/lib/osdata.py` (pure osdata XML parsing, unit-testable anywhere) and `pwndbg/aglib/osdata.py` (chunked qXfer transfer via `send_remote`).

## Output over `target remote` (gdbserver, x86-64)

```
fd[3]      pipe:[92005] (r, peers: pid=13190 'pipetest' fd=4 w)
fd[4]      pipe:[92005] (w, peers: pid=13190 'pipetest' fd=3 r)
fd[5]      pipe:[92006] (r, peers: pid=13203 'pipetest' fd=6 w)
```

pid 13203 is a forked child the debugger is not attached to; the cross-process case works, including its r/w mode.

## Testcase (as requested in the issue)

`tests/library/gdb/tests/test_remote_pipe_peers.py` plus a new `reference-binary-pipe-fork.native.c`: the binary forks so one pipe's write end lives in a different process, which the same-process fallback cannot discover, so the test only passes if the osdata path genuinely works. It skips when gdbserver isn't installed.

## Tested

- Unit tests for the XML/fdinfo parsers (malformed input, truncation, escapes)
- New gdbserver testcase passes; the existing local `test_command_procinfo_pipe` still passes (no local regression)
- Verified live against gdbserver (x86-64) and qemu-user 8.2 (osdata-less fallback path, no crash, modes still resolved via vFile)
- `./lint.sh` clean including mypy

@k4lizen since Android debugging was your original use case, trying this branch against your remote target would be the perfect real-world validation. Everything degrades gracefully if the stub lacks a capability.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>