### PR TITLE
Fix invalid SLUB object warning for kfree(0)

### DIFF
--- a/pwndbg/commands/kmem_trace.py
+++ b/pwndbg/commands/kmem_trace.py
@@ -103,6 +103,8 @@ class KmemTracepointsData:
 
         if cache is not None:
             result = self._format_kmem_tracepoint_output(prefix, cache.name, "obj", objaddr)
+        elif objaddr == 0:
+            result = self._format_kmem_tracepoint_output(prefix, "NULL", "obj", objaddr)
         self.add_result(result)
 
     def format_page_kmem_tracepoint_output(


### PR DESCRIPTION
Fixes #3816. A kfree(0) is a valid no-op, this avoids printing a warning for it.

### Before
<img width="3129" height="642" alt="genuine_before" src="https://github.com/user-attachments/assets/43b2803c-e845-482e-b8b9-1ddde5c70108" />

### After
<img width="3129" height="642" alt="genuine_after" src="https://github.com/user-attachments/assets/feed95ec-b899-48c2-9f1f-537c5230d64b" />