### PR TITLE
Fix OSError parameter order in get_file

### DIFF
--- a/pwndbg/aglib/file.py
+++ b/pwndbg/aglib/file.py
@@ -88,7 +88,7 @@ def get_file(path: str, try_local_path: bool = False) -> str:
     local_path = path
     if not pwndbg.aglib.remote.is_remote() or pwndbg.aglib.qemu.is_qemu_kernel():
         if not os.path.exists(local_path):
-            raise OSError(f"File '{local_path}' does not exist", errno.ENOENT)
+            raise OSError(errno.ENOENT, f"File '{local_path}' does not exist")
 
         return local_path
 
@@ -103,7 +103,7 @@ def get_file(path: str, try_local_path: bool = False) -> str:
             # This module originally raised this as an OSError.
             raise OSError(e)
     else:
-        raise OSError(f"get_file('{local_path}') is not supported for your target", errno.ENODEV)
+        raise OSError(errno.ENODEV, f"get_file('{local_path}') is not supported for your target")
 
     return local_path
 


### PR DESCRIPTION
Fixes #3404. OSError expects (errno, strerror) instead of (strerror, errno) to correctly set e.errno.

### Before
![Before](https://files.catbox.moe/evk8tv.png)

### After
![After](https://files.catbox.moe/98mpuy.png)