### PR TITLE
Handle missing malloc parameters in heap initialization

### DIFF
--- a/pwndbg/aglib/heap/ptmalloc.py
+++ b/pwndbg/aglib/heap/ptmalloc.py
@@ -1695,9 +1695,11 @@ class DebugSymsHeap(GlibcMemoryAllocator[pwndbg.dbg_mod.Type, pwndbg.dbg_mod.Val
         addr = pwndbg.aglib.symbol.lookup_symbol_addr("__libc_malloc_initialized")
         if addr is None:
             addr = pwndbg.aglib.symbol.lookup_symbol_addr("__malloc_initialized")
-        # fallback for GLIBC 2.42 as __malloc_initialized was removed
+        # Fallback for GLIBC 2.42 as __malloc_initialized was removed.
+        # Missing debug symbols can also leave mp_ unavailable.
         if addr is None:
-            return int(self.mp["sbrk_base"]) != 0
+            mp = self.mp
+            return mp is not None and int(mp["sbrk_base"]) != 0
         return pwndbg.aglib.memory.s32(addr) > 0
 
 

--- a/tests/library/dbg/tests/test_heap.py
+++ b/tests/library/dbg/tests/test_heap.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import re
 from typing import Any
+from unittest.mock import patch
 
 import pytest
 
@@ -117,6 +118,20 @@ def generate_expected_malloc_chunk_output(chunks: dict[str, Any]) -> dict[str, A
         ]
 
     return expected
+
+
+@pwndbg_test
+async def test_debug_syms_heap_is_uninitialized_without_symbols_or_mp(
+    ctrl: Controller,
+) -> None:
+    import pwndbg.aglib.symbol
+    from pwndbg.aglib.heap.ptmalloc import DebugSymsHeap
+
+    heap = object.__new__(DebugSymsHeap)
+    heap._mp = None
+
+    with patch.object(pwndbg.aglib.symbol, "lookup_symbol_addr", return_value=None):
+        assert heap.is_initialized() is False
 
 
 @pwndbg_test


### PR DESCRIPTION
## Summary
- treat the heap as uninitialized when malloc initialization symbols and `mp_` metadata are both unavailable
- preserve the existing `sbrk_base` fallback when `mp_` can be resolved
- add a debugger integration regression test for the missing-symbol path

Fixes #3968

## Tests
- debugger integration regression with the LLDB driver (1 passed)
- portable unit suite excluding Linux-only `/proc` and Zig objcopy cases on macOS (36 passed, 1 skipped)
- full `ruff format --check` and `ruff check`
- full Python 3.10 compatibility check with `vermin`
- full custom lint rules
- `mypy` on the touched implementation and test files

- [x] I read the contributing documentation.
- [x] Screenshot not applicable; the failure is an exception path covered by the regression test.