### PR TITLE
fix: don't allow `set`ting to invalid colours

### DIFF
--- a/pwndbg/color/theme.py
+++ b/pwndbg/color/theme.py
@@ -8,6 +8,7 @@ import pwndbg.color
 from pwndbg import config
 from pwndbg.lib.config import Parameter
 from pwndbg.lib.config import Scope
+from pwndbg.lib.config import rollback_on_trigger_error
 
 
 class ColorParameter(Parameter):
@@ -17,6 +18,7 @@ class ColorParameter(Parameter):
         super().__init__(*args, **kwargs)
         self.update_color_function()
 
+    @rollback_on_trigger_error
     def update_color_function(self):
         self.color_function = pwndbg.color.generate_color_function(self.value)
 

--- a/pwndbg/gdblib/config.py
+++ b/pwndbg/gdblib/config.py
@@ -88,6 +88,7 @@ class Parameter(gdb.Parameter):
 
     def get_set_string(self) -> str:
         """Handles the GDB `set <param>`"""
+        prev_value = self.param.value
         # GDB will set `self.value` to the user's input
         if self.value is None and CLASS_MAPPING[self.param.param_class] in (
             gdb.PARAM_UINTEGER,
@@ -105,7 +106,12 @@ class Parameter(gdb.Parameter):
             self.param.value = self.value
 
         for trigger in pwndbg.config.triggers[self.param.name]:
-            trigger()
+            try:
+                trigger()
+            except Exception as e:
+                if hasattr(trigger, pwndbg.lib.config.ROLLBACK_ON_ERROR):
+                    self.param.value = prev_value
+                raise e
 
         # No need to print anything if this is set before we get to a prompt,
         # like if we're setting options in .gdbinit

--- a/pwndbg/lib/config.py
+++ b/pwndbg/lib/config.py
@@ -294,3 +294,11 @@ class Config:
         if attr in ("params", "triggers"):
             return super().__setattr__(attr, val)
         raise AttributeError("Use config.<param>.value to set value of a parameter")
+
+
+ROLLBACK_ON_ERROR = "_rollback_on_error"
+
+
+def rollback_on_trigger_error(fn: Callable) -> Callable:
+    setattr(fn, ROLLBACK_ON_ERROR, True)
+    return fn

--- a/pwndbg/lib/config.py
+++ b/pwndbg/lib/config.py
@@ -299,6 +299,6 @@ class Config:
 ROLLBACK_ON_ERROR = "_rollback_on_error"
 
 
-def rollback_on_trigger_error(fn: Callable) -> Callable:
+def rollback_on_trigger_error(fn: Callable[..., Any]) -> Callable[..., Any]:
     setattr(fn, ROLLBACK_ON_ERROR, True)
     return fn

--- a/tests/library/dbg/tests/test_command_config.py
+++ b/tests/library/dbg/tests/test_command_config.py
@@ -52,3 +52,12 @@ async def test_config_filtering_missing(ctrl: Controller):
 
     out = await ctrl.execute_and_capture("config asdasdasdasd")
     assert out == 'No config parameter found with filter "asdasdasdasd"\n'
+
+
+@pwndbg_test
+async def test_set_doesnt_allow_setting_invalid_colors(ctrl: Controller) -> None:
+    await ctrl.execute("set telescope-register-color bld,red")
+    assert "bold,red" in (await ctrl.execute_and_capture("show telescope-register-color"))
+
+    await ctrl.execute("set telescope-register-color foo")
+    assert "bold,red" in (await ctrl.execute_and_capture("show telescope-register-color"))


### PR DESCRIPTION
<!--
    Please make sure to read the linting and testing instructions at
    https://pwndbg.re/dev/contributing/ before creating a PR.
-->

+ [x] I read the contributing documentation.
+ [ ] I am providing a screenshot of the (new feature) / (fixed bug).

---
- would (somewhat) fix #2874

---

- a lot of this is probably in the wrong place (code wise)
- currently only implemented for gdb

