### PR TITLE
fix(heap-tracker): don't crash when realloc() returns NULL (#3998)

### DIFF
--- a/pwndbg/gdblib/ptmalloc2_tracking.py
+++ b/pwndbg/gdblib/ptmalloc2_tracking.py
@@ -552,8 +552,18 @@ class ReallocExitBreakpoint(gdb.FinishBreakpoint):
         # Figure out what the reallocated pointer is.
         ret_ptr = int(self.return_value)
         if ret_ptr == 0:
-            # No change.
-            malloc = None
+            # realloc() failed to allocate. Per the C standard the original
+            # block is left untouched, so this is a genuine no-op: we must not
+            # free the old pointer or build a chunk from the NULL return. In
+            # particular, get_chunk(0, ...) would read a header at address
+            # 0 - sizeof(void*), which wraps around and throws (see #3998).
+            self.tracker.exit_memory_management()
+            print(
+                f"[*] realloc({self.freed_str}, {self.requested_size}) -> 0x0"
+                " (failed, original allocation unchanged)"
+            )
+            return False
+
         chunk = get_chunk(ret_ptr, self.requested_size)
         malloc = lambda: self.tracker.malloc(chunk)
 

--- a/tests/binaries/host/heap_tracker_realloc_fail.native.c
+++ b/tests/binaries/host/heap_tracker_realloc_fail.native.c
@@ -1,0 +1,27 @@
+/* Exercises the heap tracker (`track-heap enable`) on a realloc() that fails.
+ *
+ * `realloc(p, (size_t)-1)` requests an impossible size, so the allocator
+ * returns NULL. Per the C standard the original block `p` is left untouched
+ * and remains valid, so the final free(p) must succeed.
+ *
+ * Regression test for https://github.com/pwndbg/pwndbg/issues/3998: the tracker
+ * used to call get_chunk() on the NULL return, reading a chunk header at
+ * address 0 - sizeof(void*) and crashing with an uncaught
+ * "Cannot access memory at address 0xfffffffffffffff8".
+ */
+
+#include <stdlib.h>
+
+int main(void) {
+    void *p = malloc(0x20);
+
+    /* Impossible size: realloc() must fail and return NULL, leaving p valid. */
+    void *r = realloc(p, (size_t)-1);
+    if (r != NULL) {
+        /* Not expected, but keep p pointing at the live block either way. */
+        p = r;
+    }
+
+    free(p);
+    return 0;
+}

--- a/tests/library/dbg/tests/test_track_heap_realloc_fail.py
+++ b/tests/library/dbg/tests/test_track_heap_realloc_fail.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import pytest
+
+from ....host import Controller
+from . import get_binary
+from . import launch_to
+from . import pwndbg_test
+
+REFERENCE_BINARY = get_binary("heap_tracker_realloc_fail.native.out")
+
+
+@pwndbg_test
+async def test_track_heap_survives_realloc_failure(ctrl: Controller) -> None:
+    """A realloc() that returns NULL must not crash the tracker (#3998).
+
+    The binary does `realloc(p, (size_t)-1)`, which the allocator cannot satisfy
+    and so returns NULL, leaving the original block valid. The tracker used to
+    feed that NULL through get_chunk(), reading a header at `0 - sizeof(void*)`
+    and raising an uncaught `Cannot access memory at address 0xfffffffffffffff8`.
+    """
+    import pwndbg
+    from pwndbg.dbg_mod import DebuggerType
+
+    if pwndbg.dbg.name() != DebuggerType.GDB:
+        pytest.skip("track-heap hooks a GDB-only event (inferior_call_post)")
+        return
+
+    await launch_to(ctrl, REFERENCE_BINARY, "main")
+
+    await ctrl.execute("track-heap enable")
+    output = await ctrl.execute_and_capture("continue")
+
+    # The failed realloc must not surface as a Python exception / crash.
+    assert "Cannot access memory" not in output
+    assert "Exception" not in output
+    assert "Traceback" not in output
+
+    # It is reported as returning NULL rather than a real chunk...
+    assert "realloc(" in output
+    assert "-> 0x0" in output
+
+    # ...and the tracker is left in a good state: the original block is still
+    # tracked, so the subsequent free() is recognised (not flagged as an
+    # unknown / previously-unseen pointer).
+    assert "free(" in output
+    assert "previously unknown pointer" not in output


### PR DESCRIPTION
Fixes #3998.

### The bug

`track-heap enable` crashes with an uncaught Python exception whenever `realloc()` fails and returns `NULL` (out of memory, or an impossible size). A failed `realloc()` returns `NULL` and, per the C standard, leaves the original allocation untouched — but `ReallocExitBreakpoint.stop()` didn't handle that case:

```python
ret_ptr = int(self.return_value)
if ret_ptr == 0:
    # No change.
    malloc = None
chunk = get_chunk(ret_ptr, self.requested_size)   # runs even when ret_ptr == 0
malloc = lambda: self.tracker.malloc(chunk)        # ...and overwrites malloc = None
```

Two problems:

1. The `malloc = None` branch is dead — it's unconditionally overwritten one line below, so `ret_ptr == 0` was never actually treated specially.
2. `get_chunk(ret_ptr, ...)` reads the chunk header at `ret_ptr - sizeof(void*)`. With `ret_ptr == 0` that's `0 - 8`, which wraps to `0xfffffffffffffff8` and throws `Cannot access memory at address 0xfffffffffffffff8`.

Because the exception escapes before `exit_memory_management()` runs, the tracker is also left flagged as "in progress", so the *next* allocation event is silently dropped — the damage outlives the failed call.

### The fix

Treat a `NULL` return as the no-op it is: skip `get_chunk()`/`free()`/`malloc()`, leave the tracked chunk state untouched (the original block is still live), release the in-progress flag, and report the failed call. This mirrors how `requested_size == 0` is already special-cased on the enter side in `ReallocEnterBreakpoint.stop()`.

### Before / after

Repro from #3998 — `realloc(p, (size_t)-1)` forces a `NULL` return:

**Before**
```
[*] malloc(32) -> 0x5555555592a0, 0x30 bytes real size
Python Exception <class 'pwndbg.dbg_mod.Error'>: Cannot access memory at address 0xfffffffffffffff8
```

**After**
```
[*] malloc(32) -> 0x5555555592a0, 0x30 bytes real size
[*] realloc(0x5555555592a0, 18446744073709551615) -> 0x0 (failed, original allocation unchanged)
[*] free(0x5555555592a0)
```

Note the original pointer's `free()` is now correctly tracked. Before the fix it was never reached, and once it was reached it would have been misreported as a "previously unknown pointer" because the tracker state had been corrupted.

### Tests

- `tests/binaries/host/heap_tracker_realloc_fail.native.c` — reference binary that forces `realloc()` to fail.
- `tests/library/dbg/tests/test_track_heap_realloc_fail.py` — regression test asserting the failed `realloc()` produces no exception and the original block stays tracked. The tracker hooks a GDB-only event, so the test skips under LLDB, following the existing `test_track_heap_symbols.py`.

Verified the test fails before the fix (uncaught exception) and passes after. ruff, `ruff format`, vermin (3.10) and `custom-lint.py` all pass on the changed files.

+ [x] I read the contributing documentation.
+ [x] I am providing a screenshot of the (new feature) / (fixed bug). *(Terminal before/after transcript above — the tracker output is plain text.)*
