### PR TITLE
fix(heap-tracker): don't crash when realloc() returns NULL

### DIFF
--- a/pwndbg/gdblib/ptmalloc2_tracking.py
+++ b/pwndbg/gdblib/ptmalloc2_tracking.py
@@ -552,8 +552,18 @@ class ReallocExitBreakpoint(gdb.FinishBreakpoint):
         # Figure out what the reallocated pointer is.
         ret_ptr = int(self.return_value)
         if ret_ptr == 0:
-            # No change.
-            malloc = None
+            # realloc() failed to allocate. Per the C standard the original
+            # block is left untouched, so this is a genuine no-op: we must not
+            # free the old pointer or build a chunk from the NULL return. In
+            # particular, get_chunk(0, ...) would read a header at address
+            # 0 - sizeof(void*), which wraps around and throws (see #3998).
+            self.tracker.exit_memory_management()
+            print(
+                f"[*] realloc({self.freed_str}, {self.requested_size}) -> 0x0"
+                " (failed, original allocation unchanged)"
+            )
+            return False
+
         chunk = get_chunk(ret_ptr, self.requested_size)
         malloc = lambda: self.tracker.malloc(chunk)
 

--- a/tests/binaries/host/heap_tracker_realloc_fail.native.c
+++ b/tests/binaries/host/heap_tracker_realloc_fail.native.c
@@ -1,0 +1,27 @@
+/* Exercises the heap tracker (`track-heap enable`) on a realloc() that fails.
+ *
+ * `realloc(p, (size_t)-1)` requests an impossible size, so the allocator
+ * returns NULL. Per the C standard the original block `p` is left untouched
+ * and remains valid, so the final free(p) must succeed.
+ *
+ * Regression test for https://github.com/pwndbg/pwndbg/issues/3998: the tracker
+ * used to call get_chunk() on the NULL return, reading a chunk header at
+ * address 0 - sizeof(void*) and crashing with an uncaught
+ * "Cannot access memory at address 0xfffffffffffffff8".
+ */
+
+#include <stdlib.h>
+
+int main(void) {
+    void *p = malloc(0x20);
+
+    /* Impossible size: realloc() must fail and return NULL, leaving p valid. */
+    void *r = realloc(p, (size_t)-1);
+    if (r != NULL) {
+        /* Not expected, but keep p pointing at the live block either way. */
+        p = r;
+    }
+
+    free(p);
+    return 0;
+}

--- a/tests/library/dbg/tests/test_track_heap_realloc_fail.py
+++ b/tests/library/dbg/tests/test_track_heap_realloc_fail.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import pytest
+
+from ....host import Controller
+from . import get_binary
+from . import launch_to
+from . import pwndbg_test
+
+REFERENCE_BINARY = get_binary("heap_tracker_realloc_fail.native.out")
+
+
+@pwndbg_test
+async def test_track_heap_survives_realloc_failure(ctrl: Controller) -> None:
+    """A realloc() that returns NULL must not crash the tracker (#3998).
+
+    The binary does `realloc(p, (size_t)-1)`, which the allocator cannot satisfy
+    and so returns NULL, leaving the original block valid. The tracker used to
+    feed that NULL through get_chunk(), reading a header at `0 - sizeof(void*)`
+    and raising an uncaught `Cannot access memory at address 0xfffffffffffffff8`.
+    """
+    import pwndbg
+    from pwndbg.dbg_mod import DebuggerType
+
+    if pwndbg.dbg.name() != DebuggerType.GDB:
+        pytest.skip("track-heap hooks a GDB-only event (inferior_call_post)")
+        return
+
+    await launch_to(ctrl, REFERENCE_BINARY, "main")
+
+    await ctrl.execute("track-heap enable")
+    output = await ctrl.execute_and_capture("continue")
+
+    # The failed realloc must not surface as a Python exception / crash.
+    assert "Cannot access memory" not in output
+    assert "Exception" not in output
+    assert "Traceback" not in output
+
+    # It is reported as returning NULL rather than a real chunk...
+    assert "realloc(" in output
+    assert "-> 0x0" in output
+
+    # ...and the tracker is left in a good state: the original block is still
+    # tracked, so the subsequent free() is recognised (not flagged as an
+    # unknown / previously-unseen pointer).
+    assert "free(" in output
+    assert "previously unknown pointer" not in output


### PR DESCRIPTION
Fixes #3998.

`track-heap enable` blows up with an uncaught exception the moment `realloc()` fails and returns NULL. Minimal repro:

```c
void *p = malloc(0x20);
realloc(p, (size_t)-1);   // impossible size, forces a NULL return
free(p);
```

```
pwndbg> entry
pwndbg> track-heap enable
pwndbg> continue
[*] malloc(32) -> 0x5555555592a0, 0x30 bytes real size
Python Exception <class 'pwndbg.dbg_mod.Error'>: Cannot access memory at address 0xfffffffffffffff8
```

The problem is in `ReallocExitBreakpoint.stop()`:

```python
ret_ptr = int(self.return_value)
if ret_ptr == 0:
    # No change.
    malloc = None
chunk = get_chunk(ret_ptr, self.requested_size)
malloc = lambda: self.tracker.malloc(chunk)
```

The `malloc = None` line is dead — the line right under it reassigns `malloc` no matter what `ret_ptr` was. And `get_chunk()` runs unconditionally, so on a NULL return it reads the size field at `ret_ptr - sizeof(void*)`, i.e. `0 - 8` = `0xfffffffffffffff8`, and throws. Worse, it throws before `exit_memory_management()` runs, so the tracker is left mid-operation and quietly ignores every alloc/free that comes after.

A failed `realloc()` is a no-op as far as the standard cares — the old block is left untouched — so that's what I made it do: skip the chunk read, leave the tracked state alone, clear the in-progress flag, and print the failed call. Same shape as the `requested_size == 0` short-circuit that already lives on the enter side.

Same run, after the fix:

```
[*] malloc(32) -> 0x5555555592a0, 0x30 bytes real size
[*] realloc(0x5555555592a0, 18446744073709551615) -> 0x0 (failed, original allocation unchanged)
[*] free(0x5555555592a0)
```

The `free()` of the original pointer lines up now too — before, execution never reached it, and even if it had the tracker state was already corrupted so it'd have been reported as an unknown pointer.

Tests: `test_track_heap_realloc_fail.py` plus a small reference binary that forces the failing realloc. The tracker hangs off a GDB-only event, so the test skips under LLDB, same as `test_track_heap_symbols.py`. Fails before the change, passes after; ruff, `ruff format`, vermin (3.10) and `custom-lint.py` are all clean on the touched files.

+ [x] I read the contributing documentation.
+ [x] I am providing a screenshot of the (new feature) / (fixed bug). *(before/after transcript is above — the tracker output is plain text, so a paste is clearer than a screenshot)*
