### PR TITLE
chore: cleanup `pwndbg.hexdump`

### DIFF
--- a/pwndbg/aglib/file.py
+++ b/pwndbg/aglib/file.py
@@ -268,7 +268,7 @@ def gdb_memtox_inverse(data: bytes) -> bytes:
             buffer.append(b)
         i += 1
 
-    return buffer
+    return bytes(buffer)
 
 
 def vfile_pread(fd: int, size: int, offset: int) -> tuple[int, bytes]:

--- a/pwndbg/aglib/ipi_helpers.py
+++ b/pwndbg/aglib/ipi_helpers.py
@@ -33,7 +33,7 @@ def hd(addr: int, count: int = 0x40) -> None:
         hd(0x400000, 0x100)
     """
     data = pwndbg.aglib.memory.read(addr, count)
-    for line in pwndbg.hexdump.hexdump(bytes(data), address=addr, count=count):
+    for line in pwndbg.hexdump.hexdump(bytes(data), address=addr):
         print(line)
 
 

--- a/pwndbg/commands/windbg.py
+++ b/pwndbg/commands/windbg.py
@@ -6,15 +6,18 @@ from __future__ import annotations
 
 import argparse
 import codecs
+import math
 from itertools import chain
 
 import pwndbg.aglib
 import pwndbg.aglib.memory
 import pwndbg.aglib.strings
 import pwndbg.aglib.symbol
+import pwndbg.aglib.typeinfo
 import pwndbg.commands
 import pwndbg.commands.hexdump
 import pwndbg.commands.next
+import pwndbg.dbg_mod
 from pwndbg.commands import CommandCategory
 
 if pwndbg.dbg.is_gdblib_available():
@@ -22,15 +25,60 @@ if pwndbg.dbg.is_gdblib_available():
 
 
 def enhex(size, value):
-    value = value & ((1 << 8 * size) - 1)
+    value &= (1 << 8 * size) - 1
     x = f"{abs(value):x}"
     x = x.rjust(size * 2, "0")
     return x
 
 
-# `pwndbg.hexdump` imports `enhex` from this module, so we have to import it
-# after it's been defined in order to avoid circular import errors.
-import pwndbg.hexdump
+def hexdump_windbg(
+    address: int = 0,
+    size: int = 0,
+    count: int = 0,
+    repeat: bool = False,
+):
+
+    # Traditionally, windbg will display 16 bytes of data per line.
+    values = []
+
+    if repeat:
+        count = getattr(hexdump_windbg, "last_count", count)
+        address = getattr(hexdump_windbg, "last_address", address)
+    else:
+        address = int(address) & pwndbg.aglib.arch.ptrmask
+        count = int(count)
+
+    size_type = pwndbg.aglib.typeinfo.get_type(size)
+
+    for i in range(count):
+        try:
+            gval = pwndbg.aglib.memory.get_typed_pointer_value(size_type, address + i * size)
+            values.append(int(gval))
+        except pwndbg.dbg_mod.Error:
+            break
+
+    if not values:
+        print("Could not access the provided address")
+        return
+
+    n_rows = int(math.ceil(count * size / 16.0))
+    row_sz = 16 // size
+    rows = [values[i * row_sz : (i + 1) * row_sz] for i in range(n_rows)]
+    lines = []
+
+    for i, row in enumerate(rows):
+        if not row:
+            continue
+        line = [enhex(pwndbg.aglib.arch.ptrsize, address + (i * 16)), "   "]
+        for value in row:
+            line.append(enhex(size, value))
+        lines.append(" ".join(line))
+
+    hexdump_windbg.last_count = count  # type: ignore[attr-defined]
+    hexdump_windbg.last_address = address + len(rows) * 16  # type: ignore[attr-defined]
+
+    yield lines
+
 
 parser = argparse.ArgumentParser(description="Starting at the specified address, dump N bytes.")
 parser.add_argument(
@@ -149,11 +197,7 @@ def dX(size, address, count, to_string=False, repeat=False):
     """
 
     lines = list(
-        chain.from_iterable(
-            pwndbg.hexdump.hexdump(
-                data=None, size=size, count=count, address=address, repeat=repeat, dX_call=True
-            )
-        )
+        chain.from_iterable(hexdump_windbg(size=size, count=count, address=address, repeat=repeat))
     )
 
     if not to_string and lines:

--- a/pwndbg/hexdump.py
+++ b/pwndbg/hexdump.py
@@ -4,19 +4,13 @@ Hexdump implementation, ~= stolen from pwntools.
 
 from __future__ import annotations
 
-import math
 import string
 
 import pwnlib.util.lists
 
 import pwndbg
-import pwndbg.aglib
-import pwndbg.aglib.memory
-import pwndbg.aglib.typeinfo
 import pwndbg.color.hexdump as H
-import pwndbg.dbg_mod
 from pwndbg.color import theme
-from pwndbg.commands.windbg import enhex
 
 color_scheme = None
 printable = None
@@ -79,119 +73,72 @@ def hexdump(
     flip_group_endianness: bool = False,
     skip: bool = True,
     offset: int = 0,
-    size: int = 0,
-    count: int = 0,
-    repeat: bool = False,
-    dX_call: bool = False,
 ):
-    if not dX_call:
-        if not color_scheme or not printable:
-            load_color_scheme()
+    if not color_scheme or not printable:
+        load_color_scheme()
 
-        # If there's nothing to print, just print the offset and address and return
-        if not data:
-            yield H.offset(f"+{offset:04x} ") + H.address(f"{address:#08x}  ")
+    # If there's nothing to print, just print the offset and address and return
+    if not data:
+        yield H.offset(f"+{offset:04x} ") + H.address(f"{address:#08x}  ")
 
-            # Don't allow iterating over this generator again
-            return
+        # Don't allow iterating over this generator again
+        return
 
-        data = list(bytearray(data))
+    data = list(bytearray(data))
 
-        # Hexdump lines to skip_lines values and yields:
-        #
-        # <init: skip_lines = -1>
-        # line AAAA     => skip_lines =  0   => yield "AAAA"
-        # line AAAA     => skip_lines =  1   => <continue>
-        # line AAAA     => skip_lines = -1   => yield "skipped ..." + "AAAA"
-        # line BBBB     => skip_lines = -1   => yield "BBBB"
-        skip_lines = -1
+    # Hexdump lines to skip_lines values and yields:
+    #
+    # <init: skip_lines = -1>
+    # line AAAA     => skip_lines =  0   => yield "AAAA"
+    # line AAAA     => skip_lines =  1   => <continue>
+    # line AAAA     => skip_lines = -1   => yield "skipped ..." + "AAAA"
+    # line BBBB     => skip_lines = -1   => yield "BBBB"
+    skip_lines = -1
 
-        config_separator_str = H.separator(str(config_separator))
-        config_byte_separator_str = str(config_byte_separator)
+    config_separator_str = H.separator(str(config_separator))
+    config_byte_separator_str = str(config_byte_separator)
 
-        groupped = groupby(width, data, fill=-1)
-        before_last_idx = len(groupped) - 2
+    groupped = groupby(width, data, fill=-1)
+    before_last_idx = len(groupped) - 2
 
-        for i, line in enumerate(groupped):
-            # Handle skipping of identical lines (see skip_lines comment above)
-            if skip:
-                # Count lines to be skipped by checking next/future line
-                if i <= before_last_idx and line == groupped[i + 1]:
-                    skip_lines += 1
+    for i, line in enumerate(groupped):
+        # Handle skipping of identical lines (see skip_lines comment above)
+        if skip:
+            # Count lines to be skipped by checking next/future line
+            if i <= before_last_idx and line == groupped[i + 1]:
+                skip_lines += 1
 
-                    # Since we count from -1 then 0 means we are on first line
-                    # We want to yield that line, so we do not continue on that counter
-                    if skip_lines != 0:
-                        continue
+                # Since we count from -1 then 0 means we are on first line
+                # We want to yield that line, so we do not continue on that counter
+                if skip_lines != 0:
+                    continue
 
-                elif skip_lines > 0:
-                    out = f"... ↓            skipped {skip_lines} identical lines ({skip_lines * width} bytes)"
-                    skip_lines = -1
-                    yield out
-                    # Fallthrough (do not continue) so we yield the current line too
+            elif skip_lines > 0:
+                out = f"... ↓            skipped {skip_lines} identical lines ({skip_lines * width} bytes)"
+                skip_lines = -1
+                yield out
+                # Fallthrough (do not continue) so we yield the current line too
 
-            increment = i * width
-            hexline = [
-                H.offset(f"+{offset + increment:04x} "),
-                H.address(f"{address + increment:#08x}  "),
-            ]
+        increment = i * width
+        hexline = [
+            H.offset(f"+{offset + increment:04x} "),
+            H.address(f"{address + increment:#08x}  "),
+        ]
 
-            for group in groupby(group_width, line):
-                group = reversed(group) if flip_group_endianness else group
-                for idx, char in enumerate(group):
-                    if flip_group_endianness and idx == group_width - 1:
-                        hexline.append(H.highlight_group_lsb(color_scheme[char]))
-                    else:
-                        hexline.append(color_scheme[char])
-                    hexline.append(config_byte_separator_str)
-                hexline.append(" ")
+        for group in groupby(group_width, line):
+            group = reversed(group) if flip_group_endianness else group
+            for idx, char in enumerate(group):
+                if flip_group_endianness and idx == group_width - 1:
+                    hexline.append(H.highlight_group_lsb(color_scheme[char]))
+                else:
+                    hexline.append(color_scheme[char])
+                hexline.append(config_byte_separator_str)
+            hexline.append(" ")
 
+        hexline.append(config_separator_str)
+        for group in groupby(group_width, line):
+            for char in group:
+                hexline.append(printable[char])
             hexline.append(config_separator_str)
-            for group in groupby(group_width, line):
-                for char in group:
-                    hexline.append(printable[char])
-                hexline.append(config_separator_str)
 
-            yield "".join(hexline)
-
-    else:
-        # Traditionally, windbg will display 16 bytes of data per line.
-        values = []
-
-        if repeat:
-            count = hexdump.last_count
-            address = hexdump.last_address
-        else:
-            address = int(address) & pwndbg.aglib.arch.ptrmask
-            count = int(count)
-
-        size_type = pwndbg.aglib.typeinfo.get_type(size)
-
-        for i in range(count):
-            try:
-                gval = pwndbg.aglib.memory.get_typed_pointer_value(size_type, address + i * size)
-                values.append(int(gval))
-            except pwndbg.dbg_mod.Error:
-                break
-
-        if not values:
-            print("Could not access the provided address")
-            return
-
-        n_rows = int(math.ceil(count * size / 16.0))
-        row_sz = 16 // size
-        rows = [values[i * row_sz : (i + 1) * row_sz] for i in range(n_rows)]
-        lines = []
-
-        for i, row in enumerate(rows):
-            if not row:
-                continue
-            line = [enhex(pwndbg.aglib.arch.ptrsize, address + (i * 16)), "   "]
-            for value in row:
-                line.append(enhex(size, value))
-            lines.append(" ".join(line))
-
-        hexdump.last_count = count
-        hexdump.last_address = address + len(rows) * 16
-
-        yield lines
+        yield "".join(hexline)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -270,7 +270,6 @@ module = [
     "pwndbg.gdblib.got",
     "pwndbg.gdblib.ptmalloc2_tracking",
     "pwndbg.aglib.heap.*",
-    "pwndbg.hexdump",
     "pwndbg.ui",
     "pwndbg.wrappers.*",
 ]


### PR DESCRIPTION
`dX_call` is only ever used once, and not coupled to `hexdump` at all really

therefore it should **not** be in the top level `pwndbg.hexdump` but rather, in the one place it's actually used; which is `pwndbg.commands.windbg`

<!--
    Please make sure to read the linting and testing instructions at
    https://pwndbg.re/dev/contributing/ before creating a PR.
-->

+ [x] I read the contributing documentation.
+ [ ] I am providing a screenshot of the (new feature) / (fixed bug).
