### PR TITLE
Read from ~/.pwndbg_lldbinit to send commands to lldb process

### DIFF
--- a/pwndbginit/pwndbg_lldb.py
+++ b/pwndbginit/pwndbg_lldb.py
@@ -150,11 +150,18 @@ def main() -> None:
 
     # Prepare the startup commands based on those arguments.
     startup = []
+
+    # load user commands from dotfile
+    dotfile = os.path.expanduser("~/.pwndbg_lldbinit")
+    if os.path.exists(dotfile):
+        with open(dotfile) as f:
+            startup += [line.strip("\n") for line in f]
+
     if args.target:
         # DEVIATION: The LLDB CLI silently ignores any target information passed
         # to it when using either '--attach-name' or '--attach-pid', but Pwndbg
         # unconditionally uses it, with a warning.
-        startup = [f"target create '{args.target}'"]
+        startup.append(f"target create '{args.target}'")
 
     if args.attach_name is not None:
         wait = "--waitfor" if args.wait_for else ""


### PR DESCRIPTION
<!--
    Please make sure to read the linting and testing instructions at
    https://pwndbg.re/dev/contributing/ before creating a PR.
-->

This PR lets LLDB users define a `~/.pwndbg_lldbinit` file, which functions identically to the `~/.lldbinit` file. I added this specifically so I can use `pwndbg-lldb` on an M-series mac for rust code. The rust toolchains provides `lldb_lookup.py` and `lldb_commands`, and adding those to `{.lldbinit,.pwndbg_lldbinit}` makes printed variables legible in lldb.

- I have linted this code before submitting this PR.