### PR TITLE
refactor(exithandlers): cleanup `rich.Table` usage

### DIFF
--- a/pwndbg/commands/exithandlers.py
+++ b/pwndbg/commands/exithandlers.py
@@ -10,6 +10,7 @@ from pwnlib.util.packing import p64
 from pwnlib.util.packing import u32
 from pwnlib.util.packing import u64
 from rich.table import Table
+from rich.text import Text
 
 import pwndbg.aglib
 import pwndbg.aglib.disasm.disassembly
@@ -424,61 +425,94 @@ def _list_tls_dtors(pointer_guard: int, tls_dtor_list: int) -> list[_TlsDtorEntr
 
 
 def _print_exit_handlers(handlers: list[_ExitFunctionEntry]) -> None:
-    table = Table.grid()
-    table.add_column(no_wrap=True)
-    table.add_column(no_wrap=True)
-    table.add_column(no_wrap=True)
+    table = Table.grid(expand=False, padding=(0, 1))
+
+    table.add_column(justify="right", overflow="fold")  # handler address
+    table.add_column(overflow="fold")  # type (e.g. [ef_on (2)] or [ef_cxa (4)])
+    table.add_column(overflow="fold")  # function ptr + symbol (if available)
+    table.add_column(overflow="fold")  # args
+
+    flavor_names = {
+        0: "ef_free",
+        1: "ef_us",
+        2: "ef_on",
+        3: "ef_at",
+        4: "ef_cxa",
+    }
+
+    decomp_stack_vars = pwndbg.dintegration.manager.get_stack_var_dict_all()
+
     for handler in handlers:
-        sections = []
-        match handler.flavor:
-            case 0:
-                flavor_str = "ef_free"
-            case 1:
-                flavor_str = "ef_us"
-            case 2:
-                flavor_str = "ef_on"
-            case 3:
-                flavor_str = "ef_at"
-            case 4:
-                flavor_str = "ef_cxa"
-            case _:
-                flavor_str = "unknown"
-        sections.append(
-            f"{pwndbg.color.memory.get(handler.addr)} \\[{flavor_str} ({handler.flavor})]"
+        flavor_str = flavor_names.get(handler.flavor, "unknown")
+        has_function = flavor_str in {"ef_on", "ef_at", "ef_cxa", "unknown"}
+
+        address_cell = Text.from_ansi(pwndbg.color.memory.get(handler.addr))
+
+        flavor_cell = Text(f"[{flavor_str} ({handler.flavor})]")
+        if has_function:
+            flavor_cell.append(":")
+
+        function_cell = Text()
+        if has_function:
+            function_cell = Text.from_ansi(
+                pwndbg.color.memory.get_address_and_symbol(
+                    handler.fn,
+                    decomp_stack_vars,
+                )
+            )
+
+        argument_cell = Text()
+
+        if flavor_str == "ef_on":
+            argument_cell = Text.from_ansi(f"[arg = {pwndbg.chain.format(handler.arg)}]")
+
+        elif flavor_str in {"ef_cxa", "unknown"}:
+            argument_cell = Text.from_ansi(
+                f"[arg = {pwndbg.chain.format(handler.arg)}, "
+                f"dso_handle = "
+                f"{pwndbg.color.memory.get(handler.dso_handle)}]"
+            )
+
+        table.add_row(
+            address_cell,
+            flavor_cell,
+            function_cell,
+            argument_cell,
         )
-        if flavor_str in {"ef_on", "ef_cxa", "ef_at", "unknown"}:
-            sections[0] += ": "
-            decomp_stack_vars = pwndbg.dintegration.manager.get_stack_var_dict_all()
-            fn_str = pwndbg.color.memory.get_address_and_symbol(handler.fn, decomp_stack_vars)
-            sections.append(fn_str)
-        else:
-            sections.append("")
-        if flavor_str in {"ef_on", "ef_cxa", "unknown"}:
-            detail_string = f" \\[arg = {pwndbg.chain.format(handler.arg)}"
-            if flavor_str in {"ef_cxa", "unknown"}:
-                detail_string += f", dso_handle = {pwndbg.color.memory.get(handler.dso_handle)}]"
-            elif flavor_str == "ef_on":
-                detail_string += "]"
-            sections.append(detail_string)
-        else:
-            sections.append("")
-        table.add_row(*sections)
-    print(pwndbg.rich.rich_to_str(table, width=512))  # effectively disable per-cell truncation
+
+    print(pwndbg.rich.rich_to_str(table))
 
 
 def _print_tls_dtors(dtors: list[_TlsDtorEntry]) -> None:
-    table = Table.grid()
-    table.add_column(no_wrap=True)
-    table.add_column(no_wrap=True)
-    table.add_column(no_wrap=True)
+    table = Table.grid(expand=False, padding=(0, 1))
+
+    table.add_column(justify="right", overflow="fold")  # dtor address
+    table.add_column(overflow="fold")  # function + symbol
+    table.add_column(overflow="fold")  # object and map
+
     decomp_stack_vars = pwndbg.dintegration.manager.get_stack_var_dict_all()
     for dtor in dtors:
-        table.add_row(
-            f"{pwndbg.color.memory.get(dtor.address)}: ",
-            pwndbg.color.memory.get_address_and_symbol(dtor.func, decomp_stack_vars),
-            f" \\[obj = {pwndbg.chain.format(dtor.obj)}, map = {pwndbg.color.memory.get(dtor.map)}]",
+        address_cell = Text.from_ansi(pwndbg.color.memory.get(dtor.address))
+        address_cell.append(":")
+
+        function_cell = Text.from_ansi(
+            pwndbg.color.memory.get_address_and_symbol(
+                dtor.func,
+                decomp_stack_vars,
+            )
         )
-    print(pwndbg.rich.rich_to_str(table, width=512))
+
+        details_cell = Text.from_ansi(
+            f"[obj = {pwndbg.chain.format(dtor.obj)}, map = {pwndbg.color.memory.get(dtor.map)}]"
+        )
+
+        table.add_row(
+            address_cell,
+            function_cell,
+            details_cell,
+        )
+
+    print(pwndbg.rich.rich_to_str(table))
 
 
 parser = argparse.ArgumentParser(description="List currently registered glibc exit handlers.")

--- a/pwndbg/rich.py
+++ b/pwndbg/rich.py
@@ -5,12 +5,22 @@ from io import StringIO
 from rich.console import Console
 from rich.console import RenderableType
 
+from pwndbg.ui import get_window_size
 
-def rich_to_str(renderable: RenderableType, *args, **kwargs) -> str:
+
+def rich_to_str(
+    renderable: RenderableType,
+    **kwargs,
+) -> str:
     """
     Render something with `rich`, to a string.
     """
     with StringIO() as rendered:
-        c = Console(*args, **kwargs, file=rendered)
+        c = Console(
+            file=rendered,
+            width=get_window_size()[1],
+            force_terminal=True,
+            **kwargs,
+        )
         c.print(renderable)
         return rendered.getvalue()


### PR DESCRIPTION
<!--
    Please make sure to read the linting and testing instructions at
    https://pwndbg.re/dev/contributing/ before creating a PR.
-->

+ [x] I read the contributing documentation.
+ [x] I am providing a screenshot of the (new feature) / (fixed bug).

## exithandlers

### before

<img width="1138" height="1029" alt="before" src="https://github.com/user-attachments/assets/dafe7032-8a87-400c-be9d-3daec9eb34e2" />
<img width="851" height="1029" alt="before-2" src="https://github.com/user-attachments/assets/9b4d0e70-242f-4676-b42a-dd00bf9e6f0b" />

### after


<img width="1138" height="1029" alt="after" src="https://github.com/user-attachments/assets/8dad936c-c90b-4c8c-a933-0a99ac95ff44" />
<img width="947" height="1029" alt="after-2" src="https://github.com/user-attachments/assets/9e252b20-b69a-45c0-949f-fa48f1a18f0a" />

## dtors

### before

<img width="1138" height="1029" alt="before-dtors" src="https://github.com/user-attachments/assets/aafaa44e-c6a6-46af-be9a-13cea88722db" />
<img width="851" height="1029" alt="before-dtors-2" src="https://github.com/user-attachments/assets/4daca20f-143b-473a-8f7c-0b4fbade00c4" />



### after


<img width="1138" height="1029" alt="after-dtors" src="https://github.com/user-attachments/assets/a3f2ad2a-07dc-4cae-b59b-23e17c343005" />
<img width="947" height="1029" alt="after-dtors-2" src="https://github.com/user-attachments/assets/c94fa69d-84bc-42b0-b628-4aa917dc9421" />