### PR TITLE
fix(kernel): label ksighand entries with the correct signal

### DIFF
--- a/pwndbg/commands/kcurrent.py
+++ b/pwndbg/commands/kcurrent.py
@@ -175,8 +175,9 @@ def ksighand(pid: int) -> None:
         if not thread.user_task:
             indent.print(message.warn("not user task"))
             return
-        for i, (handler, flags) in enumerate(thread.sighand):
-            m = pwndbg.aglib.signal.PER_ARCH_SIGNAL_MAPPINGS[pwndbg.aglib.arch.name]
+        m = pwndbg.aglib.signal.PER_ARCH_SIGNAL_MAPPINGS[pwndbg.aglib.arch.name]
+        # `sighand->action` is indexed by `signal - 1`, so entry `i` describes signal `i + 1`
+        for i, (handler, flags) in enumerate(thread.sighand, start=1):
             if i not in m:
                 continue
             name = color.blue(f"{m[i]:<10}")


### PR DESCRIPTION
## Problem

`ksighand` reports every signal handler under the name of the signal **below** it.

The kernel indexes `sighand->action` by `signal - 1` (`t->sighand->action[sig - 1]`), but the command enumerated the array from `0` and looked that index up in `PER_ARCH_SIGNAL_MAPPINGS`, which is keyed by real signal numbers:

```python
for i, (handler, flags) in enumerate(thread.sighand):
    m = pwndbg.aglib.signal.PER_ARCH_SIGNAL_MAPPINGS[pwndbg.aglib.arch.name]
    if i not in m:
        continue
    name = color.blue(f"{m[i]:<10}")
```

Consequences:

* every non-default disposition is attributed to the wrong signal,
* `SIGHUP` (entry `0`) is never printed,
* the row labelled `SIGSYS` actually describes `SIGRTMIN` (signal 32).

The giveaway is that the output shows handlers installed on `SIGKILL` and `SIGSTOP`, which can never be caught or ignored.

## Fix

Enumerate from `1` so entry `i` describes signal `i + 1`. The loop-invariant mapping lookup is also hoisted out of the loop.

## Verification

Tested against a Linux 7.0 aarch64 guest under QEMU (`--debug --nokaslr`, gdbstub + `vmlinux`), with a test process that installs exactly three dispositions — `SIGINT` ignored, `SIGUSR1` and `SIGALRM` handled:

```c
signal(SIGALRM, on_alarm);
signal(SIGUSR1, on_usr1);
signal(SIGINT, SIG_IGN);
```

Before — three wrong labels, two of them impossible:

```
SIGHUP     0x0000000010000000 SIG_IGN
SIGKILL    0x0000000010000000 0x400894 ◂— 0xb9000fe0d10043ff
SIGPIPE    0x0000000010000000 0x400880 ◂— 0xb9000fe0d10043ff
```

After — exactly the three signals the process actually set:

```
SIGINT     0x0000000010000000 SIG_IGN
SIGUSR1    0x0000000010000000 0x400894 ◂— 0xb9000fe0d10043ff
SIGALRM    0x0000000010000000 0x400880 ◂— 0xb9000fe0d10043ff
```

All remaining 28 signals report `SIG_DFL`, as expected.

`ruff check` and `ruff format --check` pass on the touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)