### PR TITLE
fix(got): filter non-ELF pages

### DIFF
--- a/pwndbg/commands/got.py
+++ b/pwndbg/commands/got.py
@@ -190,6 +190,9 @@ def iter_objfiles() -> Iterator[pwndbg.lib.memory.Page]:
         if page.objfile in uniq:
             continue
         if pwndbg.aglib.memory.read(page.start, 4, True) != b"\x7fELF":
+            # FIXME: hacky, should be pulled out to a page.is_disk_backed_elf
+            # and that function should read the file from disk rather than from memory
+            # (and support remote files), related: #3641
             continue
         uniq.add(page.objfile)
         yield page

--- a/pwndbg/commands/got.py
+++ b/pwndbg/commands/got.py
@@ -189,5 +189,7 @@ def iter_objfiles() -> Iterator[pwndbg.lib.memory.Page]:
             continue
         if page.objfile in uniq:
             continue
+        if pwndbg.aglib.memory.read(page.start, 4, True) != b"\x7fELF":
+            continue
         uniq.add(page.objfile)
         yield page


### PR DESCRIPTION
+ [x] I read the contributing documentation.
+ [x] I am providing a screenshot of the (new feature) / (fixed bug).

Use a simple read to probe if the page is actually mapped from an executable rather than a regular file.
https://sourceware.org/git/?p=glibc.git;a=commitdiff;h=b9957a70b82203d91b0659b93cfe8632f954aba3 maps /etc/ld.so.cache into memory, which is not a file, breaking unit test. However, these regular files should not be treated as shared libraries at first.

<img width="1547" height="1185" alt="image" src="https://github.com/user-attachments/assets/4b7f66e6-238b-41d4-acde-66d343b215a9" />

This PR is part of archlinux test fix.

Ref #4050 