### PR TITLE
fix(objc): replace assert False with typing_extensions.assert_never (#4024)

### DIFF
--- a/pwndbg/aglib/objc.py
+++ b/pwndbg/aglib/objc.py
@@ -14,6 +14,7 @@ from collections.abc import Generator
 from typing import Generic
 from typing import TypeVar
 
+from typing_extensions import assert_never
 from typing_extensions import override
 
 import pwndbg
@@ -552,11 +553,9 @@ class Class(Object):
                 return ro_or_rw_ext.ro()
             if isinstance(ro_or_rw_ext, _ClassRoPtr):
                 return ro_or_rw_ext
-            # FIXME: Should be `typing.assert_never`, needs Python 3.11
-            assert False
+            assert_never(ro_or_rw_ext)
         else:
-            # FIXME: Should be `typing.assert_never`, needs Python 3.11
-            assert False
+            assert_never(data)
 
     def _rw_ext(self) -> _ClassRwExtPtr | None:
         data = self._data_bits().data()
@@ -568,11 +567,9 @@ class Class(Object):
                 return ro_or_rw_ext
             if isinstance(ro_or_rw_ext, _ClassRoPtr):
                 return None
-            # FIXME: Should be `typing.assert_never`, needs Python 3.11
-            assert False
+            assert_never(ro_or_rw_ext)
         else:
-            # FIXME: Should be `typing.assert_never`, needs Python 3.11
-            assert False
+            assert_never(data)
 
     @property
     def superclass(self) -> Class | None:


### PR DESCRIPTION
Closes #4024.

This PR resolves the `FIXME` comments in `pwndbg/aglib/objc.py` by replacing `assert False` with `typing_extensions.assert_never`. Since `typing-extensions>=4.15.0` is already a dependency of `pwndbg`, we can safely use `assert_never` for exhaustive type checking without needing to wait for Python 3.10 support to be dropped in favor of `typing.assert_never`.

### Changes
- Imported `assert_never` from `typing_extensions`.
- Replaced `assert False` with `assert_never(ro_or_rw_ext)` and `assert_never(data)` in the Objective-C class parsing logic to properly ensure exhaustive type checking for class structures.
