### PR TITLE
Improved heap command output.

### DIFF
--- a/pwndbg/commands/ptmalloc2.py
+++ b/pwndbg/commands/ptmalloc2.py
@@ -248,7 +248,7 @@ def heap(
         while chunk is not None:
             if should_stop(chunk.address):
                 break
-            malloc_chunk(chunk.address, verbose=verbose, simple=simple)
+            malloc_chunk(chunk.address, verbose=verbose, simple=simple, compact=True)
             printed_chunks += 1
             chunk = chunk.next_chunk()
         return
@@ -263,7 +263,7 @@ def heap(
     for chunk in h:
         if should_stop(chunk.address):
             break
-        malloc_chunk(chunk.address, verbose=verbose, simple=simple)
+        malloc_chunk(chunk.address, verbose=verbose, simple=simple, compact=True)
         printed_chunks += 1
 
 
@@ -526,6 +526,7 @@ def malloc_chunk(
     simple: bool = False,
     next: int = 0,
     dump: bool = False,
+    compact: bool = False,
 ) -> None:
     """Print a malloc_chunk struct's contents."""
     allocator = pwndbg.aglib.heap.current
@@ -536,7 +537,8 @@ def malloc_chunk(
     headers_to_print: list[str] = []  # both state (free/allocated) and flags
     fields_to_print: set[str] = set()  # in addition to addr and size
     out_fields = f"Addr: {mem_color.get(chunk.address)}\n"
-
+    if compact:
+        out_fields += f"Data: {mem_color.get(chunk.address + 2 * pwndbg.aglib.arch.ptrsize)}\n"
     if fake:
         headers_to_print.append(message.on("Fake chunk"))
         verbose = True  # print all fields for fake chunks
@@ -584,6 +586,7 @@ def malloc_chunk(
     else:
         out_fields += f"Size: 0x{chunk.real_size:02x} (with flag bits: 0x{chunk.size:02x})\n"
 
+    chunk_headers = headers_to_print.copy()
     prev_inuse, is_mmapped, non_main_arena = allocator.chunk_flags(chunk.size)
     if prev_inuse:
         headers_to_print.append(message.hint("PREV_INUSE"))
@@ -593,6 +596,8 @@ def malloc_chunk(
         headers_to_print.append(message.hint("NON_MAIN_ARENA"))
 
     fields_ordered = ["prev_size", "size", "fd", "bk", "fd_nextsize", "bk_nextsize"]
+    flags_to_print = headers_to_print[len(chunk_headers) :]
+
     for field_to_print in fields_ordered:
         if field_to_print not in fields_to_print:
             continue
@@ -606,7 +611,14 @@ def malloc_chunk(
                 message.system(field_to_print) + f": 0x{getattr(chunk, field_to_print):02x}\n"
             )
 
-    print(" | ".join(headers_to_print) + "\n" + out_fields)
+    if compact:
+        chunk_type = " | ".join(chunk_headers)
+        flags = ", ".join(flags_to_print)
+        fields = out_fields.rstrip("\n").replace("\n", " | ")
+
+        print(f"{chunk_type} | {fields} | Flags: {flags}")
+    else:
+        print(" | ".join(headers_to_print) + "\n" + out_fields)
 
     if dump:
         print(ctx_color.banner("hexdump"))

--- a/tests/library/dbg/tests/test_heap.py
+++ b/tests/library/dbg/tests/test_heap.py
@@ -15,13 +15,13 @@ HEAP_MALLOC_CHUNK = get_binary("heap_malloc_chunk.native.out")
 HEAP_MALLOC_CHUNK_DUMP = get_binary("heap_malloc_chunk_dump.native.out")
 HEAP_GLIBC2_43 = get_binary("heap_glibc2.43.native.out")
 
-ADDR_RE = re.compile(r"^Addr: (0x[0-9a-f]+)$")
+ADDR_RE = re.compile(r"\bAddr: (0x[0-9a-f]+)\b")
 
 
 def extract_chunk_addrs(output: str) -> list[int]:
     chunk_addrs: list[int] = []
     for line in output.splitlines():
-        match = ADDR_RE.match(line)
+        match = ADDR_RE.search(line)
         if match:
             chunk_addrs.append(int(match.group(1), 16))
     return chunk_addrs
@@ -117,6 +117,23 @@ def generate_expected_malloc_chunk_output(chunks: dict[str, Any]) -> dict[str, A
         ]
 
     return expected
+
+
+@pwndbg_test
+async def test_heap_command_compact_output(ctrl: Controller) -> None:
+    from pwndbg import color
+
+    await launch_to(ctrl, HEAP_MALLOC_CHUNK, "break_here")
+
+    output = color.strip(await ctrl.execute_and_capture("heap allocated_chunk --count 1"))
+    lines = output.splitlines()
+
+    assert len(lines) == 1
+    assert "Allocated chunk" in lines[0]
+    assert "Addr: " in lines[0]
+    assert "Data: " in lines[0]
+    assert "Size: " in lines[0]
+    assert "Flags: " in lines[0]
 
 
 @pwndbg_test


### PR DESCRIPTION
#3805 

Changes `heap` output so that each chunk is displayed on a single line. Related commands such as `hi` and `malloc-chunk` retain their existing output, since issue only specified `heap`.

1. Adds the chunk data address to compact output (default just outputs base address)
2. Separates chunk type and chunk flags for readability
3. Keeps existing `malloc-chunk` output unchanged.
4. `Flags: ` output is left blank to explicitly show that no flags are set if that's the case.
5. Updates heap address extraction tests for the new format
6. Adds a regression test for single line heap output.

+ [X] I read the contributing documentation.
+ [X] I am providing a screenshot of the (new feature) / (fixed bug).

<img width="1862" height="555" alt="image" src="https://github.com/user-attachments/assets/9cc7d0c0-fccb-4b60-b8ff-b75fe2dd1499" />
