### PR TITLE
Set default debuginfod timeouts

### DIFF
--- a/pwndbg/dbg_mod/gdb/__init__.py
+++ b/pwndbg/dbg_mod/gdb/__init__.py
@@ -1769,7 +1769,7 @@ class GDB(pwndbg.dbg_mod.Debugger):
 
         self._load_gdbinit()
 
-        # show_hint must be called after loading ~/.gdbinit, this order allow disabling show_hint
+        # show_hint must be called after loading ~/.gdbinit, this order allows disabling show_hint
         prompt.show_hint()
 
     @override

--- a/pwndbginit/common.py
+++ b/pwndbginit/common.py
@@ -145,7 +145,7 @@ def set_debuginfod_timeouts() -> None:
     stall for a while.
 
     This is a double-problem because GDB / gnu libdebuginfod does not
-    serve a Ctrl-C during this time.
+    serve a Ctrl-C during this time. See #4079 for extra info.
 
     Set more sane values if the user did not already touch them.
     """

--- a/pwndbginit/common.py
+++ b/pwndbginit/common.py
@@ -130,9 +130,28 @@ def skip_autoupdate(src_root: Path) -> bool:
     return False
 
 
-def verify_venv():
+def verify_venv() -> None:
     src_root = Path(__file__).parent.parent.resolve()
     if skip_autoupdate(src_root):
         return
 
     update_deps(src_root)
+
+
+def set_debuginfod_timeouts() -> None:
+    """
+    The default value for DEBUGINFOD_TIMEOUT is 90 seconds. Since
+    https://debuginfod.ubuntu.com/ is often broken, the download can
+    stall for a while.
+
+    This is a double-problem because GDB / gnu libdebuginfod does not
+    serve a Ctrl-C during this time.
+
+    Set more sane values if the user did not already touch them.
+    """
+    if "DEBUGINFOD_TIMEOUT" not in os.environ:
+        # default is 90
+        os.environ["DEBUGINFOD_TIMEOUT"] = "5"
+    if "DEBUGINFOD_RETRY_LIMIT" not in os.environ:
+        # default is 2
+        os.environ["DEBUGINFOD_RETRY_LIMIT"] = "0"

--- a/pwndbginit/gdbinit.py
+++ b/pwndbginit/gdbinit.py
@@ -10,6 +10,7 @@ import traceback
 import gdb
 
 from pwndbginit import gdbpatches  # noqa: F401
+from pwndbginit.common import set_debuginfod_timeouts
 from pwndbginit.common import verify_venv
 
 
@@ -50,6 +51,7 @@ def main() -> None:
 
     check_doubleload()
     verify_venv()
+    set_debuginfod_timeouts()
 
     # Force UTF-8 encoding (to_string=True to skip output appearing to the user)
     try:

--- a/pwndbginit/lldbinit.py
+++ b/pwndbginit/lldbinit.py
@@ -7,22 +7,28 @@ import time
 
 import lldb
 
+from pwndbginit.common import set_debuginfod_timeouts
 from pwndbginit.common import verify_venv
 
 
-def main(debugger: lldb.SBDebugger, lldb_version: tuple[int, ...], debug: bool = False) -> None:
+def check_doubleload() -> None:
     if "pwndbg" in sys.modules:
         print("Detected double-loading of Pwndbg.")
         print("This should not happen. Please report this issue if you're not sure how to fix it.")
         sys.exit(1)
 
-    verify_venv()
+
+def main(debugger: lldb.SBDebugger, lldb_version: tuple[int, ...], debug: bool = False) -> None:
     profiler = cProfile.Profile()
 
     start_time = None
     if os.environ.get("PWNDBG_PROFILE") == "1":
         start_time = time.time()
         profiler.enable()
+
+    check_doubleload()
+    verify_venv()
+    set_debuginfod_timeouts()
 
     import pwndbg  # noqa: F811
     import pwndbg.dbg_mod.lldb


### PR DESCRIPTION
There are currently two bugs we have to deal with:
+ https://debuginfod.ubuntu.com/ sometimes just does not return a response, and we're stuck waiting for debug info for 90 seconds
+ GDB + libdebuginfod have a bug where during this time, a progress bar is not shown and Ctrl-C is not passed through, causing you to have to kill the process

The Ctrl-C bug is not present in our implementation of debuginfod: https://github.com/pwndbg/debuginfod-zig/ but not all users use our GDB (which statically links debuginfod-zig), and even if they do having to Ctrl-C manually sucks.

The ubuntu bug is reported here: https://bugs.launchpad.net/ubuntu-debuginfod/+bug/2163016 , but it has been going on for quite a few months now. The GDB issue tracker https://sourceware.org/bugzilla/ is currently down so I can't check it.

An easy fix that will work for all pwndbg users is setting a lower timeout limit (DEBUGINFOD_TIMEOUT) by default. This needs to be done before libdebuginfod is first queried, so we do it in pwndbginit/  to be sure.

Since https://debuginfod.pwndbg.re queries https://debuginfod.ubuntu.com/ , it suffers from the same problem. Ideally it should not stall for so long just because ubuntu stalls for so long, and should sever the connection earlier (e.g. after 5 seconds). Implementing the fix here as well allows us to recommend https://debuginfod.pwndbg.re/ even to people not using pwndbg.

### Repro

To test the fix we run a dummy unresponsive """debuginfod""" server in one terminal
```bash
socat TCP-LISTEN:45678,bind=127.0.0.1,reuseaddr,fork EXEC:'sleep 120'
```
And try to query with a clean debuginfod cache from another terminal:
```bash
cache_dir=$(mktemp -d /tmp/pwndbg-debuginfod-test.XXXXXX)

env -u DEBUGINFOD_TIMEOUT -u DEBUGINFOD_RETRY_LIMIT \
  DEBUGINFOD_CACHE_PATH="$cache_dir" \
  gdb -q -nx -batch \
    -ex 'source /path/to/gdbinit.py' \
    -ex 'python import os; print("timeout =", os.environ.get("DEBUGINFOD_TIMEOUT")); print("retry =", os.environ.get("DEBUGINFOD_RETRY_LIMIT"))' \
    -ex 'set debuginfod urls http://127.0.0.1:45678/' \
    -ex 'set debuginfod enabled on' \
    -ex 'file /bin/sh' \
    -ex quit
```
If you run this on `dev` it will stall for 90 seconds. If you run this on this branch it will stall for 5.

In both you can reproduce the Ctrl-C not being passed through as well.

Note that `set debuginfod enabled ask` does not help the issue.

To reproduce the fact that ubuntu is stalling in particular you can run with
```bash
    -ex 'set debuginfod urls https://debuginfod.ubuntu.com' \
```
instead of
```bash
    -ex 'set debuginfod urls http://127.0.0.1:45678/' \
```
, and don't forget to re-run the `cache_dir=$(mktemp -d /tmp/pwndbg-debuginfod-test.XXXXXX)` so you get a fresh cache.

You can also compare the response debuginfod times like so:
```bash
bid=$(openssl rand -hex 20)

for host in \
  debuginfod.archlinux.org \
  debuginfod.fedoraproject.org \
  debuginfod.elfutils.org \
  debuginfod.opensuse.org \
  debuginfod.debian.net \
  debuginfod.ubuntu.com
do
  echo "=== $host ==="
  curl --http1.1 -sS \
    --connect-timeout 5 \
    --max-time 12 \
    -o /dev/null \
    -w 'HTTP=%{http_code} bytes=%{size_download} total=%{time_total}s\n' \
    "https://$host/buildid/$bid/debuginfo"
done
```

The issue is also present in LLDB. Relevant issue: https://github.com/llvm/llvm-project/issues/216629 .