### PR TITLE
fix(heap): heap command crash on stripped libc without debug info

### DIFF
--- a/pwndbg/aglib/dynamic.py
+++ b/pwndbg/aglib/dynamic.py
@@ -156,7 +156,7 @@ def r_debug_link_map_changed_remove_listener(handler: Callable[..., Any]) -> Non
     R_DEBUG_LINK_MAP_CHANGED_LISTENERS.remove(handler)
 
 
-def link_map_head():
+def link_map_head() -> LinkMapEntry | None:
     """
     Acquires a reference to the head entry of the link map.
     """
@@ -171,6 +171,7 @@ def link_map_head():
 
     if r_map != 0:
         return LinkMapEntry(r_map)
+    return None
 
 
 def link_map():

--- a/pwndbg/aglib/heap/ptmalloc.py
+++ b/pwndbg/aglib/heap/ptmalloc.py
@@ -1513,7 +1513,7 @@ class GlibcMemoryAllocator(pwndbg.aglib.heap.heap.MemoryAllocator, Generic[TheTy
             return self.largebin_index_32_big(sz)
         return self.largebin_index_32(sz)
 
-    def is_initialized(self):
+    def is_initialized(self) -> bool:
         raise NotImplementedError()
 
     def is_statically_linked(self) -> bool:

--- a/pwndbg/commands/__init__.py
+++ b/pwndbg/commands/__init__.py
@@ -18,6 +18,7 @@ from typing_extensions import ParamSpec
 from typing_extensions import override
 
 import pwndbg.aglib
+import pwndbg.aglib.dynamic
 import pwndbg.aglib.heap
 import pwndbg.aglib.kernel
 import pwndbg.aglib.proc
@@ -34,8 +35,14 @@ from pwndbg.aglib.heap.ptmalloc import HeuristicHeap
 from pwndbg.color import message
 from pwndbg.lib import SymbolNotRecoveredError
 from pwndbg.lib import TypeNotRecoveredError
+from pwndbg.libc import LibcNotFound
 
 log = logging.getLogger(__name__)
+
+_HEURISTIC_FALLBACK_WARNING = (
+    "pwndbg will try to resolve the heap symbols via heuristic now since we cannot resolve the heap via the debug symbols.\n"
+    "This might not work in all cases. Use `help set resolve-heap-via-heuristic` for more details.\n"
+)
 
 T = TypeVar("T")
 P = ParamSpec("P")
@@ -882,10 +889,68 @@ def OnlyWithTcache(function: Callable[P, T]) -> Callable[P, T | None]:
 def OnlyWhenHeapIsInitialized(function: Callable[P, T]) -> Callable[P, T | None]:
     @functools.wraps(function)
     def _OnlyWhenHeapIsInitialized(*a: P.args, **kw: P.kwargs) -> T | None:
-        if pwndbg.aglib.heap.current is not None and pwndbg.aglib.heap.current.is_initialized():
-            return function(*a, **kw)
-        log.error(f"{func_name(function)}: Heap is not initialized yet.")
-        return None
+        if pwndbg.aglib.heap.current is None or not pwndbg.aglib.proc.alive():
+            log.error(f"{func_name(function)}: Heap is not initialized yet.")
+            return None
+
+        try:
+            libc_type = pwndbg.libc.which()
+        except LibcNotFound:
+            log.error(f"{func_name(function)}: Heap is not initialized yet.")
+            return None
+
+        # At the dynamic linker's entry point, _r_debug is available but its
+        # link map has not been populated yet. Treat that as "heap not
+        # initialized" instead of misreporting the active libc type.
+        if (
+            libc_type == pwndbg.libc.LibcType.UNKNOWN
+            and pwndbg.dbg.selected_inferior().is_dynamically_linked()
+            and pwndbg.aglib.dynamic.is_dynamic()
+            and pwndbg.aglib.dynamic.link_map_head() is None
+        ):
+            log.error(f"{func_name(function)}: Heap is not initialized yet.")
+            return None
+
+        allocator = _resolve_heap_allocator()
+        if allocator is None:
+            return None
+
+        previous_allocator = pwndbg.aglib.heap.current
+        warn_about_heuristic = isinstance(previous_allocator, DebugSymsHeap) and isinstance(
+            allocator, HeuristicHeap
+        )
+
+        # Some allocator methods read the global `heap.current` (e.g.
+        # Arena.__init__() uses it to fetch malloc_state), so the candidate must
+        # be installed while checking initialization. Restore the previous
+        # allocator if the check fails or raises.
+        is_initialized: bool | None = None
+        if allocator is not previous_allocator:
+            pwndbg.aglib.heap.current = allocator
+        try:
+
+            @functools.wraps(function)
+            def _is_initialized() -> bool:
+                return allocator.is_initialized()
+
+            is_initialized = _try2run_heap_command(_is_initialized)
+        finally:
+            if not is_initialized:
+                pwndbg.aglib.heap.current = previous_allocator
+
+        if is_initialized is None:
+            return None
+        if not is_initialized:
+            log.error(f"{func_name(function)}: Heap is not initialized yet.")
+            return None
+
+        # The candidate is initialized and is already installed as the current
+        # allocator. Print the fallback warning only for the first
+        # DebugSymsHeap -> HeuristicHeap transition.
+        if warn_about_heuristic:
+            log.warning(_HEURISTIC_FALLBACK_WARNING)
+
+        return function(*a, **kw)
 
     return _OnlyWhenHeapIsInitialized
 
@@ -926,75 +991,85 @@ def _try2run_heap_command(function: Callable[P, T], *a: P.args, **kw: P.kwargs) 
     return None
 
 
+def _resolve_heap_allocator() -> GlibcMemoryAllocator[Any, Any] | None:
+    """Return a resolvable heap allocator without mutating global state."""
+    e = log.error
+    w = log.warning
+
+    # Operating under the assumption that the pwndbg/libc/ code can figure out
+    # that we are using glibc with at least as good accuracy as the ptmalloc code.
+    libc_type = pwndbg.libc.which()
+    if libc_type != pwndbg.libc.LibcType.GLIBC:
+        e(f"The currently active libc isn't glibc. It's {libc_type.value}.")
+        return None
+
+    allocator = pwndbg.aglib.heap.current
+    if (
+        isinstance(allocator, HeuristicHeap)
+        and pwndbg.config.resolve_heap_via_heuristic == "auto"
+        and DebugSymsHeap().can_be_resolved()
+    ):
+        # In auto mode, we will try to use the debug symbols if possible
+        return DebugSymsHeap()
+
+    if isinstance(allocator, GlibcMemoryAllocator) and allocator.can_be_resolved():
+        return allocator
+
+    static = not pwndbg.dbg.selected_inferior().is_dynamically_linked()
+    if isinstance(allocator, DebugSymsHeap) and pwndbg.config.resolve_heap_via_heuristic == "auto":
+        # In auto mode, if the debug symbols are not enough, we will try to use the heuristic if possible
+        heuristic_heap = HeuristicHeap()
+        if heuristic_heap.can_be_resolved():
+            return heuristic_heap
+        if static:
+            e(
+                "Can't find GLIBC version required for this command to work since this is a statically linked binary"
+            )
+            w(
+                "Please set the GLIBC version you think the target binary was compiled (using `set glibc <version>` command; e.g. 2.32) and re-run this command."
+            )
+        else:
+            e(
+                "Can't find GLIBC version required for this command to work, maybe is because GLIBC is not loaded yet."
+            )
+            w(
+                "If you believe the GLIBC is loaded or this is a statically linked binary. "
+                "Please set the GLIBC version you think the target binary was compiled (using `set glibc <version>` command; e.g. 2.32) and re-run this command"
+            )
+    elif (
+        isinstance(allocator, DebugSymsHeap) and pwndbg.config.resolve_heap_via_heuristic == "force"
+    ):
+        e(
+            "You are forcing to resolve the heap symbols via heuristic, but we cannot resolve the heap via the debug symbols."
+        )
+        w("Use `set resolve-heap-via-heuristic auto` and re-run this command.")
+    else:
+        # Note: Should not see this error, but just in case
+        e("An unknown error occurred when resolved the heap.")
+        pwndbg.exception.inform_report_issue("An unknown error occurred when resolved the heap")
+    return None
+
+
+def _activate_heap_allocator(allocator: GlibcMemoryAllocator[Any, Any]) -> None:
+    """Make `allocator` the current allocator, warning once on the
+    DebugSymsHeap -> HeuristicHeap fallback."""
+    previous = pwndbg.aglib.heap.current
+    # The initialization guard has already installed the candidate for all
+    # current ptmalloc commands. Keep this warning for standalone uses of
+    # OnlyWithResolvedHeapSyms, preserving that decorator's original behavior.
+    if isinstance(previous, DebugSymsHeap) and isinstance(allocator, HeuristicHeap):
+        log.warning(_HEURISTIC_FALLBACK_WARNING)
+    pwndbg.aglib.heap.current = allocator
+
+
 def OnlyWithResolvedHeapSyms(function: Callable[P, T]) -> Callable[P, T | None]:
     @functools.wraps(function)
     def _OnlyWithResolvedHeapSyms(*a: P.args, **kw: P.kwargs) -> T | None:
-        e = log.error
-        w = log.warning
-
-        # Operating under the assumption that the pwndbg/libc/ code can figure out
-        # that we are using glibc with at least as good accuracy as the ptmalloc code.
-        if pwndbg.libc.which() != pwndbg.libc.LibcType.GLIBC:
-            e(f"The currently active libc isn't glibc. It's {pwndbg.libc.which().value}.")
+        allocator = _resolve_heap_allocator()
+        if allocator is None:
             return None
-
-        if (
-            isinstance(pwndbg.aglib.heap.current, HeuristicHeap)
-            and pwndbg.config.resolve_heap_via_heuristic == "auto"
-            and DebugSymsHeap().can_be_resolved()
-        ):
-            # In auto mode, we will try to use the debug symbols if possible
-            pwndbg.aglib.heap.current = DebugSymsHeap()
-
-        if (
-            pwndbg.aglib.heap.current is not None
-            and isinstance(pwndbg.aglib.heap.current, GlibcMemoryAllocator)
-            and pwndbg.aglib.heap.current.can_be_resolved()
-        ):
-            return _try2run_heap_command(function, *a, **kw)
-
-        static = not pwndbg.dbg.selected_inferior().is_dynamically_linked()
-        if (
-            isinstance(pwndbg.aglib.heap.current, DebugSymsHeap)
-            and pwndbg.config.resolve_heap_via_heuristic == "auto"
-        ):
-            # In auto mode, if the debug symbols are not enough, we will try to use the heuristic if possible
-            heuristic_heap = HeuristicHeap()
-            if heuristic_heap.can_be_resolved():
-                pwndbg.aglib.heap.current = heuristic_heap
-                w(
-                    "pwndbg will try to resolve the heap symbols via heuristic now since we cannot resolve the heap via the debug symbols.\n"
-                    "This might not work in all cases. Use `help set resolve-heap-via-heuristic` for more details.\n"
-                )
-                return _try2run_heap_command(function, *a, **kw)
-            if static:
-                e(
-                    "Can't find GLIBC version required for this command to work since this is a statically linked binary"
-                )
-                w(
-                    "Please set the GLIBC version you think the target binary was compiled (using `set glibc <version>` command; e.g. 2.32) and re-run this command."
-                )
-            else:
-                e(
-                    "Can't find GLIBC version required for this command to work, maybe is because GLIBC is not loaded yet."
-                )
-                w(
-                    "If you believe the GLIBC is loaded or this is a statically linked binary. "
-                    "Please set the GLIBC version you think the target binary was compiled (using `set glibc <version>` command; e.g. 2.32) and re-run this command"
-                )
-        elif (
-            isinstance(pwndbg.aglib.heap.current, DebugSymsHeap)
-            and pwndbg.config.resolve_heap_via_heuristic == "force"
-        ):
-            e(
-                "You are forcing to resolve the heap symbols via heuristic, but we cannot resolve the heap via the debug symbols."
-            )
-            w("Use `set resolve-heap-via-heuristic auto` and re-run this command.")
-        else:
-            # Note: Should not see this error, but just in case
-            e("An unknown error occurred when resolved the heap.")
-            pwndbg.exception.inform_report_issue("An unknown error occurred when resolved the heap")
-        return None
+        _activate_heap_allocator(allocator)
+        return _try2run_heap_command(function, *a, **kw)
 
     return _OnlyWithResolvedHeapSyms
 

--- a/pwndbg/libc/__init__.py
+++ b/pwndbg/libc/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from .dispatch import LibcProvider
 from .dispatch import LibcType
 from .dispatch import LibcURLs
+from .facade import LibcNotFound
 from .facade import addr
 from .facade import filepath
 from .facade import has_debug_info
@@ -18,6 +19,7 @@ from .facade import version
 from .facade import which
 
 __all__ = [
+    "LibcNotFound",
     "LibcProvider",
     "LibcType",
     "LibcURLs",

--- a/tests/library/dbg/tests/test_heap.py
+++ b/tests/library/dbg/tests/test_heap.py
@@ -716,3 +716,159 @@ async def test_heuristic_fail_gracefully(ctrl: Controller, is_multi_threaded: bo
         _test_heuristic_fail_gracefully("global_max_fast")
         _test_heuristic_fail_gracefully("thread_cache")
         _test_heuristic_fail_gracefully("thread_arena")
+
+
+@pwndbg_test
+async def test_heap_at_starti_reports_not_initialized(
+    ctrl: Controller, caplog: pytest.LogCaptureFixture
+) -> None:
+    """At `starti` libc is not loaded yet, so `heap` must report an
+    uninitialized heap instead of misreporting the active libc type."""
+    await ctrl.launch(HEAP_MALLOC_CHUNK)
+    caplog.clear()
+
+    await ctrl.execute("heap")
+
+    assert "Heap is not initialized yet." in caplog.text
+    assert "The currently active libc isn't glibc" not in caplog.text
+
+
+@pwndbg_test
+async def test_heap_guard_commits_allocator_only_after_initialization(
+    ctrl: Controller, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The candidate must be current while checking initialization, but only
+    remain current and warn after successful initialization."""
+    from unittest.mock import PropertyMock
+    from unittest.mock import patch
+
+    import pwndbg.aglib.heap
+    import pwndbg.aglib.symbol
+    from pwndbg.aglib.heap.ptmalloc import Arena
+    from pwndbg.aglib.heap.ptmalloc import DebugSymsHeap
+    from pwndbg.aglib.heap.ptmalloc import HeuristicHeap
+    from pwndbg.commands import OnlyWhenHeapIsInitialized
+    from pwndbg.commands import OnlyWithResolvedHeapSyms
+
+    await ctrl.launch(HEAP_MALLOC_CHUNK)
+    break_at_sym("break_here")
+    await ctrl.cont()
+
+    old_allocator = pwndbg.aglib.heap.current
+    assert isinstance(old_allocator, DebugSymsHeap)
+    main_arena_addr = pwndbg.aglib.symbol.lookup_symbol_addr("main_arena", prefer_static=True)
+    assert main_arena_addr is not None
+
+    initialization_results = iter((False, True, True))
+
+    def is_initialized(allocator: HeuristicHeap) -> bool:
+        # Arena reads malloc_state from the global heap.current. This fails if
+        # the candidate allocator was not installed for the initialization
+        # check.
+        Arena(main_arena_addr)
+        assert pwndbg.aglib.heap.current is allocator
+        return next(initialization_results)
+
+    def command() -> str:
+        return "called"
+
+    wrapper = OnlyWhenHeapIsInitialized(OnlyWithResolvedHeapSyms(command))
+
+    try:
+        with (
+            patch.object(DebugSymsHeap, "can_be_resolved", return_value=False),
+            patch.object(
+                DebugSymsHeap,
+                "malloc_state",
+                new_callable=PropertyMock,
+                return_value=None,
+            ),
+            patch.object(HeuristicHeap, "can_be_resolved", return_value=True),
+            patch.object(
+                HeuristicHeap,
+                "is_initialized",
+                autospec=True,
+                side_effect=is_initialized,
+            ),
+        ):
+            caplog.clear()
+            assert wrapper() is None
+            assert pwndbg.aglib.heap.current is old_allocator
+            assert "pwndbg will try to resolve the heap symbols via heuristic" not in caplog.text
+
+            caplog.clear()
+            assert wrapper() == "called"
+            assert isinstance(pwndbg.aglib.heap.current, HeuristicHeap)
+            assert (
+                caplog.text.count("pwndbg will try to resolve the heap symbols via heuristic") == 1
+            )
+
+            assert wrapper() == "called"
+            assert (
+                caplog.text.count("pwndbg will try to resolve the heap symbols via heuristic") == 1
+            )
+    finally:
+        pwndbg.aglib.heap.current = old_allocator
+
+
+@pwndbg_test
+async def test_heap_guard_keeps_current_on_initialization_error(
+    ctrl: Controller, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Initialization exceptions must be handled by _try2run_heap_command and
+    must not commit the allocator switch."""
+    from unittest.mock import patch
+
+    import pwndbg.aglib.heap
+    import pwndbg.commands.ptmalloc2
+    from pwndbg.aglib.heap.ptmalloc import DebugSymsHeap
+    from pwndbg.aglib.heap.ptmalloc import HeuristicHeap
+    from pwndbg.lib import SymbolNotRecoveredError
+
+    await ctrl.launch(HEAP_MALLOC_CHUNK)
+    break_at_sym("break_here")
+    await ctrl.cont()
+
+    old_allocator = pwndbg.aglib.heap.current
+    old_exception_verbose = pwndbg.config.exception_verbose.value
+    old_exception_debugger = pwndbg.config.exception_debugger.value
+    assert isinstance(old_allocator, DebugSymsHeap)
+    pwndbg.config.exception_verbose.value = False
+    pwndbg.config.exception_debugger.value = False
+
+    try:
+        with (
+            patch.object(DebugSymsHeap, "can_be_resolved", return_value=False),
+            patch.object(
+                DebugSymsHeap,
+                "is_initialized",
+                side_effect=AssertionError("unresolvable DebugSymsHeap was initialized"),
+            ),
+            patch.object(HeuristicHeap, "can_be_resolved", return_value=True),
+            patch.object(
+                HeuristicHeap,
+                "is_initialized",
+                side_effect=SymbolNotRecoveredError("mp_", "test failure"),
+            ),
+        ):
+            caplog.clear()
+            try:
+                pwndbg.commands.ptmalloc2.heap.function()
+            except SymbolNotRecoveredError:
+                pytest.fail("heap initialization escaped the heap command error handler")
+
+            assert "heap: Fail to resolve the symbol: `mp_`" in caplog.text
+            assert "pwndbg will try to resolve the heap symbols via heuristic" not in caplog.text
+            assert pwndbg.aglib.heap.current is old_allocator
+
+            caplog.clear()
+            pwndbg.config.exception_verbose.value = True
+            with pytest.raises(SymbolNotRecoveredError):
+                pwndbg.commands.ptmalloc2.heap.function()
+
+            assert "pwndbg will try to resolve the heap symbols via heuristic" not in caplog.text
+            assert pwndbg.aglib.heap.current is old_allocator
+    finally:
+        pwndbg.aglib.heap.current = old_allocator
+        pwndbg.config.exception_verbose.value = old_exception_verbose
+        pwndbg.config.exception_debugger.value = old_exception_debugger

--- a/tests/library/gdb/tests/test_glibc.py
+++ b/tests/library/gdb/tests/test_glibc.py
@@ -66,6 +66,10 @@ def test_finding_glibc_filepath(start_binary, have_debugging_information):
         assert pwndbg.libc.which() == pwndbg.libc.LibcType.UNKNOWN
         assert pwndbg.libc.filepath().name == "ld-linux-x86-64.so.2"
 
+        heap_output = gdb.execute("heap", to_string=True)
+        assert "The currently active libc isn't glibc. It's unknown." in heap_output
+        assert "Heap is not initialized yet." not in heap_output
+
 
 def test_set_glibc_version(start_binary):
     # Needed for glibc.version() as it requires an alive process.


### PR DESCRIPTION
## Summary

Fixes the `heap` command crash on a stripped libc (glibc >= 2.42), reported in #4076.

## Root cause

### Before glibc 2.42

glibc tracked malloc initialization with a `static` flag in `malloc/malloc.c`
(the `__malloc_initialized` / `__libc_malloc_initialized` symbols). pwndbg's
`DebugSymsHeap.is_initialized()` read that symbol.

### Since glibc 2.42

The flag was **removed entirely** and initialization is now tracked by the
internal `sbrk_base` field of the malloc parameters struct:

- `char *sbrk_base;` field — [`malloc/malloc.c#L1625`](https://elixir.bootlin.com/glibc/glibc-2.44/source/malloc/malloc.c#L1625)
- `static struct malloc_par mp_ = { ... };` — [`malloc/malloc.c#L1651`](https://elixir.bootlin.com/glibc/glibc-2.44/source/malloc/malloc.c#L1651)
- init check — [`malloc/malloc.c#L2349`](https://elixir.bootlin.com/glibc/glibc-2.44/source/malloc/malloc.c#L2349):

```c
if (mp_.sbrk_base == NULL)
    mp_.sbrk_base = brk;   /* first sbrk → malloc is initialized */
```

### The pwndbg bug

PR #3464 replaced the old `assert` with a fallback for the removed symbol:

```python
if addr is None:
    return int(self.mp["sbrk_base"]) != 0
```

but `self.mp` is only resolvable when the libc has **debug info**: `mp_` is a
`static` (non-exported) symbol and the `struct malloc_par` type comes from
debug info. On a stripped libc `self.mp` is `None`, so the `heap` command
crashes with:

```
TypeError: 'NoneType' object is not subscriptable
```

## When the bug triggers

| glibc version | libc debug info | before this fix | after this fix |
|---|---|---|---|
| >= 2.42 (2.42/2.43/2.44) | no (stripped) | :boom: TypeError (the reported bug) | :white_check_mark: works |
| >= 2.42 | yes | :white_check_mark: works (via `sbrk_base`) | :white_check_mark: works |
| < 2.42 (e.g. 2.41) | no (stripped) | :boom: `AssertionError` (pre-#3464) / TypeError | :white_check_mark: works |
| < 2.42 | yes | :white_check_mark: works (via `__malloc_initialized`) | :white_check_mark: works |

So the trigger condition is "stripped libc (no debug info)", which exists
across all glibc versions — 2.42 just removed the symbol and made the crash
path the default.

## Fix

Guard the fallback: when `self.mp is None`, fall back to checking whether the
`[heap]` mapping exists — the same signal `HeuristicHeap.is_initialized()` uses:

```python
if addr is None:
    if self.mp is None:
        return any(page.is_heap for page in pwndbg.aglib.vmmap.get())
    return int(self.mp["sbrk_base"]) != 0
```

## Reproduction

Built glibc 2.41 and 2.44 from source, compiled a small test program
(malloc/free of 0x20 chunks), stripped `libc.so.6` to reproduce the
no-debug-info condition, and ran `heap`:

- **Before**: `heap` crashes with `TypeError: 'NoneType' object is not subscriptable` on glibc 2.44 (stripped)
- **After**: `heap` correctly prints the chunks (allocated + free tcache chunks + top chunk)
- Also verified with and without debug info on glibc 2.41 / 2.43 / 2.44 (see matrix above)
```bash
./.venv/bin/pwndbg .repro/test_program_244g
~/.gdbinit: Skipped loading Pwndbg from `source path/gdbinit.py` - already loaded.
pwndbg: loaded 200 pwndbg commands. Type pwndbg [filter] for a list.
pwndbg: created 12 GDB functions (can be used with print/break). Type help function to see them.
Reading symbols from .repro/test_program_244g...
------- tip of the day (disable with set show-tips off) -------
Pwndbg's hexdump colorizes by byte type and lets you re-run with no args to keep dumping forward
pwndbg> set debuginfod enabled off
pwndbg> start
libcinfo
Temporary breakpoint 1 at 0x1277: file test_program.c, line 15.
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/home/xxx/Global/Dev/pwndbg/.repro/glibc-install/lib/libthread_db.so.1".

Temporary breakpoint 1, main () at test_program.c:15
15          setbuf(stdout, NULL);
LEGEND: STACK | HEAP | CODE | DATA | WX | RODATA
─────────────────────────────────────────────────────────────────────────────────────────────[ REGISTERS / show-flags off / show-compact-regs off ]──────────────────────────────────────────────────────────────────────────────────────────────
 RAX  0x7ffff7faffa8 (environ) —▸ 0x7fffffffd4e0 —▸ 0x7fffffffd8dd ◂— 'USER=xxx'
 RBX  0
 RCX  0x555555557d78 (__do_global_dtors_aux_fini_array_entry) —▸ 0x5555555551e0 (__do_global_dtors_aux) ◂— endbr64
 RDX  0x7fffffffd4e0 —▸ 0x7fffffffd8dd ◂— 'USER=xxx'
 RDI  2
 RSI  0x7fffffffd4c8 —▸ 0x7fffffffd89f ◂— '/home/xxx/Global/Dev/pwndbg/.repro/test_program_244g'
 R8   0x7ffff7fa8840 —▸ 0x7ffff7faa160 ◂— 0
 R9   0x7ffff7faa160 ◂— 0
 R10  0
 R11  0x7ffff7ffcab0 (__pointer_chk_guard_local) ◂— 0x4265a3da0c9c90a8
 R12  2
 R13  0x7ffff7ffd000 (_rtld_local) —▸ 0x7ffff7ffe3c0 —▸ 0x555555554000 ◂— 0x10102464c457f
 R14  0x7fffffffd4e0 —▸ 0x7fffffffd8dd ◂— 'USER=xxx'
 R15  0x555555557d78 (__do_global_dtors_aux_fini_array_entry) —▸ 0x5555555551e0 (__do_global_dtors_aux) ◂— endbr64
 RBP  0x7fffffffd3a0 —▸ 0x7fffffffd4c8 —▸ 0x7fffffffd89f ◂— '/home/xxx/Global/Dev/pwndbg/.repro/test_program_244g'
 RSP  0x7fffffffd370 {a} ◂— 0
 RIP  0x555555555277 (main+12) ◂— mov rax, qword ptr [rip + 0x2d92]
──────────────────────────────────────────────────────────────────────────────────────────────────────[ DISASM / x86-64 / set emulate on ]───────────────────────────────────────────────────────────────────────────────────────────────────────
 ► 0x555555555277 <main+12>    mov    rax, qword ptr [rip + 0x2d92]     RAX, [stdout@GLIBC_2.2.5] => 0x7ffff7fa9740 (_IO_2_1_stdout_) ◂— 0xfbad2084
   0x55555555527e <main+19>    mov    esi, 0                            ESI => 0
   0x555555555283 <main+24>    mov    rdi, rax                          RDI => 0x7ffff7fa9740 (_IO_2_1_stdout_) ◂— 0xfbad2084
   0x555555555286 <main+27>    call   setbuf@plt                  <setbuf@plt>
 
   0x55555555528b <main+32>    call   getpid@plt                  <getpid@plt>
 
   0x555555555290 <main+37>    mov    edx, eax
   0x555555555292 <main+39>    lea    rax, [rip + 0xda1]     RAX => 0x55555555603a ◂— 'PID: %d\n'
   0x555555555299 <main+46>    mov    esi, edx
   0x55555555529b <main+48>    mov    rdi, rax               RDI => 0x55555555603a ◂— 'PID: %d\n'
   0x55555555529e <main+51>    mov    eax, 0                 EAX => 0
   0x5555555552a3 <main+56>    call   printf@plt                  <printf@plt>
────────────────────────────────────────────────────────────────────────────────────────────────────────────────[ SOURCE (CODE) ]────────────────────────────────────────────────────────────────────────────────────────────────────────────────
In file: /home/xxx/Global/Dev/pwndbg/test_program.c:15
    9     getchar();
   10 }
   11 
   12 int main(void)
   13 {
   14     // Disable stdout buffering so output shows up promptly while debugging
 ► 15     setbuf(stdout, NULL);
   16 
   17     printf("PID: %d\n", getpid());
   18 
   19     pause_here("Program start");
   20 
   21     /*
   22      * malloc(0x20)
────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[ STACK ]────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
00:0000│ rsp 0x7fffffffd370 {a} ◂— 0
... ↓        4 skipped
05:0028│-008 0x7fffffffd398 {big} —▸ 0x7fffffffd4c0 ◂— 2
06:0030│ rbp 0x7fffffffd3a0 —▸ 0x7fffffffd4c8 —▸ 0x7fffffffd89f ◂— '/home/xxx/Global/Dev/pwndbg/.repro/test_program_244g'
07:0038│+008 0x7fffffffd3a8 —▸ 0x7ffff7decfad ◂— mov edi, eax
──────────────────────────────────────────────────────────────────────────────────────────────────────────────────[ BACKTRACE ]──────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 ► 0 0x555555555277 main+12
   1 0x7ffff7decfad
   2 0x7ffff7ded0cb __libc_start_main+139
   3 0x555555555165 _start+37
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
pwndbg> libcinfo
libc: glibc
libc version: 2.44
linked: dynamically
URLs:
    project homepage:       https://sourceware.org/glibc/
    read the source:        https://elixir.bootlin.com/glibc/glibc-2.44/source
    download the archive:   https://ftp.gnu.org/gnu/libc/glibc-2.44.tar.gz
    git clone               https://sourceware.org/git/glibc.git
Mappings:
    libc is at:             0x7ffff7dc6000
           /home/xxx/Global/Dev/pwndbg/.repro/glibc-install/lib/libc.so.6
    ld is at:               0x7ffff7fc2000
           /home/xxx/Global/Dev/pwndbg/.repro/glibc-install/lib/ld-linux-x86-64.so.2
Symbolication:
    has exported symbols:  yes
    has internal symbols:  no
    has debug info:        no
pwndbg> break test_program.c:42
Breakpoint 2 at 0x555555555371: file test_program.c, line 42.
pwndbg> continue
Continuing.
PID: 1145416

========== Program start ==========
Press Enter to continue...

a = 0x555555559420
b = 0x555555559450
c = 0x555555559480

Breakpoint 2, main () at test_program.c:42
42          pause_here("After malloc a/b/c");
LEGEND: STACK | HEAP | CODE | DATA | WX | RODATA
─────────────────────────────────────────────────────────────────────────────────────────────[ REGISTERS / show-flags off / show-compact-regs off ]──────────────────────────────────────────────────────────────────────────────────────────────
*RAX  0x555555559480 ◂— 'CCCCCCCC'
 RBX  0
*RCX  0x4343434343434343 ('CCCCCCCC')
*RDX  0x13
*RDI  0x7fffffffd1a0 —▸ 0x7fffffffd1d0 ◂— 'c = 0x555555559480\nUUU'
*RSI  0x7fffffffd1d0 ◂— 'c = 0x555555559480\nUUU'
*R8   0x13
*R9   0
 R10  0
*R11  0x202
 R12  2
 R13  0x7ffff7ffd000 (_rtld_local) —▸ 0x7ffff7ffe3c0 —▸ 0x555555554000 ◂— 0x10102464c457f
 R14  0x7fffffffd4e0 —▸ 0x7fffffffd8dd ◂— 'USER=xxx'
 R15  0x555555557d78 (__do_global_dtors_aux_fini_array_entry) —▸ 0x5555555551e0 (__do_global_dtors_aux) ◂— endbr64
 RBP  0x7fffffffd3a0 —▸ 0x7fffffffd4c8 —▸ 0x7fffffffd89f ◂— '/home/xxx/Global/Dev/pwndbg/.repro/test_program_244g'
 RSP  0x7fffffffd370 {a} —▸ 0x555555559420 ◂— 'AAAAAAAA'
*RIP  0x555555555371 (main+262) ◂— lea rax, [rip + 0xcf1]
──────────────────────────────────────────────────────────────────────────────────────────────────────[ DISASM / x86-64 / set emulate on ]───────────────────────────────────────────────────────────────────────────────────────────────────────
b► 0x555555555371 <main+262>    lea    rax, [rip + 0xcf1]     RAX => 0x555555556069 ◂— 'After malloc a/b/c'
   0x555555555378 <main+269>    mov    rdi, rax               RDI => 0x555555556069 ◂— 'After malloc a/b/c'
   0x55555555537b <main+272>    call   pause_here                  <pause_here>
 
   0x555555555380 <main+277>    mov    rax, qword ptr [rbp - 0x30]
   0x555555555384 <main+281>    mov    rdi, rax
   0x555555555387 <main+284>    call   free@plt                    <free@plt>
 
   0x55555555538c <main+289>    lea    rax, [rip + 0xce9]              RAX => 0x55555555607c ◂— 'After free(a)'
   0x555555555393 <main+296>    mov    rdi, rax                        RDI => 0x55555555607c ◂— 'After free(a)'
   0x555555555396 <main+299>    call   pause_here                  <pause_here>
 
   0x55555555539b <main+304>    mov    rax, qword ptr [rbp - 0x28]
   0x55555555539f <main+308>    mov    rdi, rax
────────────────────────────────────────────────────────────────────────────────────────────────────────────────[ SOURCE (CODE) ]────────────────────────────────────────────────────────────────────────────────────────────────────────────────
In file: /home/xxx/Global/Dev/pwndbg/test_program.c:42
   36     printf("c = %p\n", c);
   37 
   38     strcpy(a, "AAAAAAAA");
   39     strcpy(b, "BBBBBBBB");
   40     strcpy(c, "CCCCCCCC");
   41 
 ► 42     pause_here("After malloc a/b/c");
   43 
   44     /*
   45      * After free(), small chunks usually go into the tcache.
   46      */
   47     free(a);
   48 
   49     pause_here("After free(a)");
────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[ STACK ]────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
00:0000│ rsp 0x7fffffffd370 {a} —▸ 0x555555559420 ◂— 'AAAAAAAA'
01:0008│-028 0x7fffffffd378 {b} —▸ 0x555555559450 ◂— 'BBBBBBBB'
02:0010│-020 0x7fffffffd380 {c} —▸ 0x555555559480 ◂— 'CCCCCCCC'
03:0018│-018 0x7fffffffd388 {d} ◂— 0
04:0020│-010 0x7fffffffd390 {e} ◂— 0
05:0028│-008 0x7fffffffd398 {big} —▸ 0x7fffffffd4c0 ◂— 2
06:0030│ rbp 0x7fffffffd3a0 —▸ 0x7fffffffd4c8 —▸ 0x7fffffffd89f ◂— '/home/xxx/Global/Dev/pwndbg/.repro/test_program_244g'
07:0038│+008 0x7fffffffd3a8 —▸ 0x7ffff7decfad ◂— mov edi, eax
──────────────────────────────────────────────────────────────────────────────────────────────────────────────────[ BACKTRACE ]──────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 ► 0 0x555555555371 main+262
   1 0x7ffff7decfad
   2 0x7ffff7ded0cb __libc_start_main+139
   3 0x555555555165 _start+37
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
pwndbg> heap
pwndbg will try to resolve the heap symbols via heuristic now since we cannot resolve the heap via the debug symbols.
This might not work in all cases. Use `help set resolve-heap-via-heuristic` for more details.

Allocated chunk | PREV_INUSE
Addr: 0x555555559000
Size: 0x410 (with flag bits: 0x411)

Allocated chunk | PREV_INUSE
Addr: 0x555555559410
Size: 0x30 (with flag bits: 0x31)

Allocated chunk | PREV_INUSE
Addr: 0x555555559440
Size: 0x30 (with flag bits: 0x31)

Allocated chunk | PREV_INUSE
Addr: 0x555555559470
Size: 0x30 (with flag bits: 0x31)

Top chunk | PREV_INUSE
Addr: 0x5555555594a0
Size: 0x20b60 (with flag bits: 0x20b61)

pwndbg> 
```
## Testing

- Added regression test `test_is_initialized_without_debug_info` in `tests/library/dbg/tests/test_heap.py`
- Heap test suite: 20 passed, 4 skipped, 0 failed

## Screenshots

<!-- BEFORE: `heap` crash on glibc 2.44 stripped (with `set exception-verbose on`) -->

<!-- AFTER: `heap` works on glibc 2.44 stripped -->

<!-- OPTIONAL: `heap` works on glibc 2.44 with debug info / 2.43 / 2.41 -->

Fixes #4076

---

- [x] I read the contributing documentation.
- [x] I am providing a screenshot of the (fixed bug).