### PR TITLE
Add callstack_iter() and callstack_symbols_iter() to aglib.stack

### DIFF
--- a/pwndbg/aglib/stack.py
+++ b/pwndbg/aglib/stack.py
@@ -7,10 +7,13 @@ binaries do things to remap the stack (e.g. pwnies' postit).
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+
 import pwndbg
 import pwndbg.aglib
 import pwndbg.aglib.elf
 import pwndbg.aglib.memory
+import pwndbg.aglib.symbol
 import pwndbg.aglib.vmmap
 import pwndbg.aglib.vmmap_custom
 import pwndbg.lib.cache
@@ -179,19 +182,42 @@ def _fetch_via_exploration() -> dict[int, pwndbg.lib.memory.Page]:
     return stacks
 
 
-def callstack() -> list[int]:
+def callstack_iter() -> Iterator[int]:
     """
-    Return the address of the return address for the current frame.
+    Yield the program counter of each frame of the current call stack, starting
+    at the innermost (selected) frame and walking towards the outermost one.
+
+    Frames whose program counter is not readable memory are skipped.
+
+    Prefer this over `callstack()` when the whole call stack is not needed, as
+    frames are only walked as they are consumed.
     """
     frame = pwndbg.dbg.selected_frame()
-    addresses = []
     while frame:
         addr = frame.pc()
         if pwndbg.aglib.memory.is_readable_address(addr):
-            addresses.append(addr)
+            yield addr
         frame = frame.parent()
 
-    return addresses
+
+def callstack_symbols_iter() -> Iterator[tuple[int, str | None]]:
+    """
+    Same as `callstack_iter()`, but yield `(program counter, symbol)` pairs.
+
+    The symbol is `None` when the address cannot be resolved to one.
+    """
+    for addr in callstack_iter():
+        yield addr, pwndbg.aglib.symbol.resolve_addr(addr)
+
+
+def callstack() -> list[int]:
+    """
+    Return the program counter of each frame of the current call stack, starting
+    at the innermost (selected) frame and walking towards the outermost one.
+
+    Frames whose program counter is not readable memory are skipped.
+    """
+    return list(callstack_iter())
 
 
 @pwndbg.lib.cache.cache_until("stop", "start")

--- a/tests/library/dbg/tests/test_callstack.py
+++ b/tests/library/dbg/tests/test_callstack.py
@@ -1,11 +1,21 @@
 from __future__ import annotations
 
+import inspect
+import itertools
+
 from ....host import Controller
 from . import get_binary
 from . import launch_to
 from . import pwndbg_test
 
 REFERENCE_BINARY = get_binary("reference-binary.native.out")
+
+
+def _symbol_names(pairs: list[tuple[int, str | None]]) -> list[str]:
+    """
+    Strip the `+offset` suffix off resolved symbols, dropping unresolved ones.
+    """
+    return [symbol.split("+")[0] for _, symbol in pairs if symbol is not None]
 
 
 @pwndbg_test
@@ -19,3 +29,49 @@ async def test_callstack_readable(ctrl: Controller) -> None:
 
     assert len(addresses) > 0
     assert all(pwndbg.aglib.memory.is_readable_address(address) for address in addresses)
+
+
+@pwndbg_test
+async def test_callstack_symbols(ctrl: Controller) -> None:
+    import pwndbg.aglib.stack
+
+    await launch_to(ctrl, REFERENCE_BINARY, "break_here")
+
+    pairs = list(pwndbg.aglib.stack.callstack_symbols_iter())
+    names = _symbol_names(pairs)
+
+    # The binary calls break_here() from main(), so both must show up, innermost first.
+    assert names[0] == "break_here"
+    assert "main" in names
+    assert names.index("main") > names.index("break_here")
+
+    # The addresses must be the ones callstack() reports, in the same order.
+    assert [address for address, _ in pairs] == pwndbg.aglib.stack.callstack()
+
+
+@pwndbg_test
+async def test_callstack_iter_matches_callstack(ctrl: Controller) -> None:
+    import pwndbg.aglib.stack
+
+    await launch_to(ctrl, REFERENCE_BINARY, "break_here")
+
+    assert list(pwndbg.aglib.stack.callstack_iter()) == pwndbg.aglib.stack.callstack()
+
+
+@pwndbg_test
+async def test_callstack_iter_is_lazy(ctrl: Controller) -> None:
+    import pwndbg.aglib.stack
+
+    await launch_to(ctrl, REFERENCE_BINARY, "break_here")
+
+    # There is more than one frame, so a partial consumer must be able to stop early.
+    assert len(pwndbg.aglib.stack.callstack()) > 1
+
+    frames = pwndbg.aglib.stack.callstack_iter()
+    assert inspect.isgenerator(frames)
+
+    first = list(itertools.islice(frames, 1))
+
+    assert first == pwndbg.aglib.stack.callstack()[:1]
+    # The generator is only suspended, not exhausted: the outer frames were never walked.
+    assert inspect.getgeneratorstate(frames) == inspect.GEN_SUSPENDED


### PR DESCRIPTION
Refs #2837 — covers items 1-3. See the open questions below for 4 and 5.

### What changed

- `callstack_iter()` — generator yielding each frame's program counter, innermost first, skipping unreadable ones. Frames are walked as they are consumed.
- `callstack_symbols_iter()` — the same walk, yielding `(pc, symbol)` pairs (item 2).
- `callstack()` keeps its `list[int]` return type and is now a thin wrapper over `callstack_iter()`, per your review comment on #2839.
- Docstrings for all three (item 3). The old `callstack()` docstring said it returned "the address of the return address for the current frame", which described neither the return value nor the fact that unreadable frames are skipped.

Symbols resolve through `pwndbg.aglib.symbol.resolve_addr` so the module stays debugger-agnostic — the earlier attempt in #2839 reached for `pwndbg.gdblib.symbol` and broke under LLDB with `ModuleNotFoundError: No module named 'gdb'`.

### Tests

On #2839 you noted the existing tests "are not great; we probably want to assert specific symbols here". `tests/library/dbg/tests/test_callstack.py` now asserts that `break_here` is the innermost frame and that `main` appears after it, that `callstack_iter()` and `callstack()` agree, and that a partial consumer leaves the generator suspended rather than exhausted.

```
./tests.sh -d gdb  -g dbg                 143 passed, 86 skipped, 0 failed
./tests.sh -d lldb -g dbg test_callstack     4 passed
```

`mypy --strict` error count is unchanged against `dev` (1607 on both).

### Open questions (items 4 and 5)

Neither is in this PR — happy to follow up in either direction.

1. **`retaddr`** does `value in addresses` and then `del addresses[:index]`, so it needs the whole remaining list at every stack slot. A lazy iterator buys it nothing there, so I left it on `callstack()`. Switch it anyway for consistency?
2. **`context_backtrace`** walks children as well as parents, windows output by `backtrace-lines`, and compares frame identity to mark the active frame, so it can't consume a flat list of PCs. Sharing code with it would mean a frame-level iterator rather than the PC-level one this issue describes. Worth a separate change?

### Checklist

+ [x] I read the contributing documentation.
+ [ ] I am providing a screenshot of the (new feature) / (fixed bug) — there is no user-visible change here, this is an internal `aglib` API addition, so there is nothing to screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)