### PR TITLE
Fixup order of instruction enhancement for instructions backwards in memory

### DIFF
--- a/pwndbg/aglib/disasm/assistant.py
+++ b/pwndbg/aglib/disasm/assistant.py
@@ -175,6 +175,7 @@ class DisassemblyAssistant:
 
         This is the only public method that should be called on this object externally.
         """
+        instruction.enhanced = True
         # It is assumed that the emulator's pc is at the instruction's address
 
         # There are 3 degrees of emulation:
@@ -1109,6 +1110,7 @@ class DisassemblyAssistant:
 
 
 def basic_enhance(ins: PwndbgInstruction) -> None:
+    ins.enhanced = True
     # Apply syntax highlighting and inline symbol replacement
     # Used in cases were we don't want to do the full enhancement process
     # for performance reasons.

--- a/pwndbg/aglib/disasm/disassembly.py
+++ b/pwndbg/aglib/disasm/disassembly.py
@@ -590,7 +590,7 @@ def enhance_instruction(
     instruction: PwndbgInstruction,
     assistant: DisassemblyAssistant | None = None,
     emu: pwndbg.emu.emulator.Emulator | None = None,
-):
+) -> None:
 
     if instruction.enhanced:
         return

--- a/pwndbg/aglib/disasm/disassembly.py
+++ b/pwndbg/aglib/disasm/disassembly.py
@@ -30,6 +30,7 @@ import pwndbg.lib.cache
 import pwndbg.lib.config
 from pwndbg.aglib.disasm.assistant import DEBUG_ENHANCEMENT
 from pwndbg.aglib.disasm.assistant import DisassemblyAssistant
+from pwndbg.aglib.disasm.instruction import DisassemblySource
 from pwndbg.aglib.disasm.instruction import ManualPwndbgInstruction
 from pwndbg.aglib.disasm.instruction import PwndbgInstruction
 from pwndbg.aglib.disasm.instruction import PwndbgInstructionImpl
@@ -195,7 +196,13 @@ def get_previous_instruction(
         prev_address = get_previous_linear_address_with_heuristic(address)
 
         insn = (
-            one(prev_address, from_cache=use_cache, put_linear_backward_cache=False, linear=linear)
+            one(
+                prev_address,
+                from_cache=use_cache,
+                put_linear_backward_cache=False,
+                linear=linear,
+                enhance=False,
+            )
             if prev_address
             else None
         )
@@ -219,6 +226,7 @@ def get_previous_instruction(
             from_cache=use_cache,
             put_linear_backward_cache=False,
             put_dynamic_backward_cache=False,
+            enhance=False,
         )
 
         return (insn, False) if insn is not None else None
@@ -232,6 +240,7 @@ def get_previous_instruction(
             from_cache=use_cache,
             put_linear_backward_cache=False,
             put_dynamic_backward_cache=False,
+            enhance=False,
         )
         if prev_address
         else None
@@ -576,7 +585,29 @@ def set_visual_split(
         set_ins.split = SplitType.BRANCH_NOT_TAKEN
 
 
-# Return (list of PwndbgInstructions, index in list where instruction.address = passed in address)
+def enhance_instruction(
+    instruction: PwndbgInstruction,
+    assistant: DisassemblyAssistant | None = None,
+    emu: pwndbg.emu.emulator.Emulator | None = None,
+):
+
+    if instruction.enhanced:
+        return
+
+    match instruction.disassembly_source:
+        case DisassemblySource.CAPSTONE:
+            if assistant is None:
+                assistant = (
+                    pwndbg.aglib.disasm.disassembly.get_disassembly_assistant_for_current_arch()
+                )
+            assistant.enhance(instruction, emu)
+
+        case DisassemblySource.DEBUGGER:
+            pwndbg.aglib.disasm.assistant.basic_enhance(instr)
+        case _:
+            raise NotImplementedError("Unknown disassembly source")
+
+
 def near(
     address: int,
     forward_count: int = 1,
@@ -633,47 +664,13 @@ def near(
             raise
 
     # By using the same assistant for all the instructions disassembled in this pass, we can track and share information across the instructions
-    assistant = pwndbg.aglib.disasm.disassembly.get_disassembly_assistant_for_current_arch()
-
-    # Copy register values to the enhancer for use in manual register tracking
-    if assistant.supports_manual_emulation and address == pc:
-        for reg in pwndbg.aglib.regs.current.common:
-            if (reg_value := pwndbg.aglib.regs.read_reg(reg)) is not None:
-                assistant.manual_register_values.write_register(reg, reg_value)
-
-    # Start at the current instruction using emulation if available.
-    current = one(
-        address,
-        emu,
-        put_cache=True,
-        put_linear_backward_cache=disassembling_from_pc,
-        assistant=assistant,
-        linear=linear,
-    )
-
-    if DEBUG_ENHANCEMENT:
-        if emu and not emu.last_step_succeeded:
-            print("Emulator failed at first step")
-
-    if current is None:
-        return ([], -1, -1)
-
-    # A linked list that contains the order of instructions that emulation
-    # determines will run upon uses of the "nexti" command.
-    instruction_sequence_head = instruction_sequence_linked_list_map.get(address)
-
-    if instruction_sequence_head is None:
-        instruction_sequence_head = InstructionSequenceNode(None, current)
-        instruction_sequence_linked_list_map[address] = instruction_sequence_head
-    else:
-        # We re-disassembled the instruction and enhanced it, so save the new value
-        instruction_sequence_head.instruction = current
+    assistant = get_disassembly_assistant_for_current_arch()
 
     insns: list[PwndbgInstruction] = []
 
     # Get previously executed instructions from the cache.
     if DEBUG_ENHANCEMENT:
-        print(f"CACHE START -------------------, {current.address}")
+        print(f"CACHE START -------------------, {address}")
 
     # Keep track of which of the previous instructions were disassembly linearly so we can display them as gray while emulating
     # The assumption is that the instruction list will start with the linear instructions, and then transition to the emulated one
@@ -684,7 +681,7 @@ def near(
         saveptr = InstructionSequenceSavePointer(None)
 
         prev_instruction_fetch = get_previous_instruction(
-            current.address, use_cache=use_cache, linear=linear, saveptr=saveptr
+            address, use_cache=use_cache, linear=linear, saveptr=saveptr
         )
         while prev_instruction_fetch is not None and len(insns) < backward_count:
             insn, was_linear = prev_instruction_fetch
@@ -718,13 +715,56 @@ def near(
         target_instruction_count = len(insns) + forward_count
 
     index_of_current_instruction = len(insns)
-    insns.append(current)
 
     if DEBUG_ENHANCEMENT:
         print("END CACHE -------------------")
 
-    # At this point, we've already added everything *BEFORE* the requested address,
-    # and the instruction at 'address'.
+    # At this point, we seen everything *BEFORE* the requested address.
+    # However, some of them may not have gone through the enhancement process yet
+
+    for instruction in insns:
+        if instruction.enhanced:
+            break
+        enhance_instruction(instruction, assistant, emu)
+
+    # Copy register values to the enhancer for use in manual register tracking
+    if assistant.supports_manual_emulation and address == pc:
+        for reg in pwndbg.aglib.regs.current.common:
+            if (reg_value := pwndbg.aglib.regs.read_reg(reg)) is not None:
+                assistant.manual_register_values.write_register(reg, reg_value)
+
+    # Now, disassemble instruction at `address`
+
+    current = one(
+        address,
+        emu,
+        put_cache=True,
+        put_linear_backward_cache=disassembling_from_pc,
+        assistant=assistant,
+        linear=linear,
+    )
+
+    if DEBUG_ENHANCEMENT:
+        if emu and not emu.last_step_succeeded:
+            print("Emulator failed at first step")
+
+    if current is None:
+        return ([], -1, -1)
+
+    insns.append(current)
+
+    # A linked list that contains the order of instructions that emulation
+    # determines will run upon uses of the "nexti" command.
+    instruction_sequence_head = instruction_sequence_linked_list_map.get(address)
+
+    if instruction_sequence_head is None:
+        # The second parameter usually cannot be None, but we set it later done
+        instruction_sequence_head = InstructionSequenceNode(None, current)
+        instruction_sequence_linked_list_map[address] = instruction_sequence_head
+    else:
+        # We re-disassembled the instruction and enhanced it, so save the new value
+        instruction_sequence_head.instruction = current
+
     # Now, continue forwards.
 
     # A set of all the addresses after the PC that we have disassembled in this pass

--- a/pwndbg/aglib/disasm/disassembly.py
+++ b/pwndbg/aglib/disasm/disassembly.py
@@ -725,7 +725,7 @@ def near(
     for instruction in insns:
         if instruction.enhanced:
             break
-        enhance_instruction(instruction, assistant, emu)
+        enhance_instruction(instruction, assistant)
 
     # Copy register values to the enhancer for use in manual register tracking
     if assistant.supports_manual_emulation and address == pc:

--- a/pwndbg/aglib/disasm/disassembly.py
+++ b/pwndbg/aglib/disasm/disassembly.py
@@ -25,6 +25,7 @@ import pwndbg.aglib.disasm.sparc
 import pwndbg.aglib.disasm.x86
 import pwndbg.aglib.memory
 import pwndbg.aglib.vmmap
+import pwndbg.dbg_mod
 import pwndbg.emu.emulator
 import pwndbg.lib.cache
 import pwndbg.lib.config
@@ -650,7 +651,7 @@ def near(
     if not pwndbg.emu or pwndbg.aglib.arch.name not in pwndbg.emu.emulator.arch_to_UC:
         emulate = False
 
-    emu: pwndbg.emu.emulator.Emulator = None
+    emu: pwndbg.emu.emulator.Emulator | None = None
 
     # Emulate if program pc is at the current instruction - can't emulate at arbitrary places, because we need current
     # processor state to instantiate the emulator.

--- a/pwndbg/aglib/disasm/disassembly.py
+++ b/pwndbg/aglib/disasm/disassembly.py
@@ -758,7 +758,6 @@ def near(
     instruction_sequence_head = instruction_sequence_linked_list_map.get(address)
 
     if instruction_sequence_head is None:
-        # The second parameter usually cannot be None, but we set it later done
         instruction_sequence_head = InstructionSequenceNode(None, current)
         instruction_sequence_linked_list_map[address] = instruction_sequence_head
     else:

--- a/pwndbg/aglib/disasm/instruction.py
+++ b/pwndbg/aglib/disasm/instruction.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import typing
 from collections import defaultdict
 from enum import Enum
+from enum import auto
 from typing import Protocol
 
 import pwnlib
@@ -186,6 +187,11 @@ CAPSTONE_ARCH_MAPPING_STRING = {
 }
 
 
+class DisassemblySource(Enum):
+    CAPSTONE = (auto(),)
+    DEBUGGER = auto()
+
+
 # Interface for enhanced instructions - there are two implementations defined in this file
 class PwndbgInstruction(Protocol):
     cs_insn: CsInsn
@@ -212,6 +218,9 @@ class PwndbgInstruction(Protocol):
     split: SplitType
     emulated: bool
     register_writes: dict[int, int]
+
+    enhanced: bool
+    disassembly_source: DisassemblySource
 
     @property
     def call_like(self) -> bool: ...
@@ -248,6 +257,9 @@ class PwndbgInstruction(Protocol):
 # The information in this class is backed by metadata from Capstone
 class PwndbgInstructionImpl(PwndbgInstruction):
     def __init__(self, cs_insn: CsInsn, padding: int = 6) -> None:
+        self.disassembly_source = DisassemblySource.CAPSTONE
+        self.enhanced = False
+
         self.cs_insn: CsInsn = cs_insn
         """
         The underlying Capstone instruction object.
@@ -728,6 +740,9 @@ class ManualPwndbgInstruction(PwndbgInstruction):
         Instances of this class do not go through the 'enhancement' process due to lacking important information provided by Capstone.
         As a result of this, some of the methods raise NotImplementedError, because if they are called it indicates a bug elsewhere in the codebase.
         """
+        self.disassembly_source = DisassemblySource.DEBUGGER
+        self.enhanced = False
+
         ins: DisassembledInstruction = pwndbg.dbg.selected_inferior().disasm(address)
         asm = ins["asm"].split(maxsplit=1)
 

--- a/tests/library/dbg/tests/test_nearpc.py
+++ b/tests/library/dbg/tests/test_nearpc.py
@@ -384,7 +384,7 @@ async def test_syscall_annotated_on_pc_address(ctrl: Controller) -> None:
     # Enable the heuristic
     await ctrl.execute_and_capture("set heuristic-backwards-disasm on")
 
-    dis = await ctrl.execute_and_capture("nearpc syscall_read_label -n -t 11")
+    dis = await ctrl.execute_and_capture("nearpc $rip-3 -n -t 11")
 
     # Data region location can differ based on the system
     buf_addr = int(pwndbg.aglib.symbol.lookup_symbol_addr("buf"))

--- a/tests/library/dbg/tests/test_nearpc.py
+++ b/tests/library/dbg/tests/test_nearpc.py
@@ -370,3 +370,40 @@ async def test_nearpc_function(ctrl: Controller) -> None:
     dis = await ctrl.execute_and_capture("nearpc -f (char*)break_here+2")
     # no "►" prefix this time cause we switched to the parent frame:
     assert dis == expected_break_here.replace("►", " ")
+
+
+STEPSYSCALL_X64_BINARY = get_binary("stepsyscall.x86-64.out")
+
+
+@pwndbg_test
+async def test_syscall_annotated_on_pc_address(ctrl: Controller) -> None:
+    import pwndbg.aglib
+
+    await ctrl.launch(STEPSYSCALL_X64_BINARY)
+
+    # Enable the heuristic
+    await ctrl.execute_and_capture("set heuristic-backwards-disasm on")
+
+    dis = await ctrl.execute_and_capture("nearpc syscall_read_label -n -t 11")
+
+    # Data region location can differ based on the system
+    buf_addr = int(pwndbg.aglib.symbol.lookup_symbol_addr("buf"))
+
+    expected = (
+        "   0x4000b7 <syscall_write_stderr_label+2>    ret   \n"
+        " \n"
+        "   0x4000b8 <do_read>                         mov    eax, 0          EAX => 0\n"
+        "   0x4000bd <do_read+5>                       mov    edi, 0          EDI => 0\n"
+        f"   0x4000c2 <do_read+10>                      movabs rsi, buf        RSI => 0x{buf_addr:x} (buf)\n"
+        "   0x4000cc <do_read+20>                      mov    edx, 1          EDX => 1\n"
+        " ► 0x4000d1 <syscall_read_label>              syscall <SYS_read>\n"
+        "   0x4000d3 <syscall_read_label+2>            ret   \n"
+        " \n"
+        "   0x4000d4 <_start>                          nop   \n"
+        "   0x4000d5 <_start+1>                        jmp    label1                      <label1>\n"
+        " \n"
+        "   0x4000d7 <_start+3>                        nop   \n"
+        "   0x4000d8 <label1>                          call   write_stdout                <write_stdout>\n"
+    )
+
+    assert dis == expected


### PR DESCRIPTION
This is a minor change in the order we "enhance" instructions will disassembling. Previously, it was done first for the instruction at the PC, then at instructions moving backwards from the program counter, and then from instructions moving forwards from the PC.

Now, we enhance instructions in the original program order. This allows us to take advantage of the feature added in #2963 for these instructions (manually tracking register value propagation), which results in nicer disassembly, mostly visibly seen in syscalls names being annotated.

An example below, is where we do `nearpc` after a syscall instruction.

Before: note that the syscall name is not annotated
<img width="1167" height="505" alt="image" src="https://github.com/user-attachments/assets/7e2b29f5-9ac8-4fe3-8c09-20984053ce62" />

Note that the syscall name is annotated now, since we enhance in order and can propagate the value of `eax` to the syscall instruction.

<img width="1150" height="549" alt="image" src="https://github.com/user-attachments/assets/9c51f797-3a28-49ac-8520-f21399e2631a" />
