### PR TITLE
Disassembly fixes for instructions seen multiple times

### DIFF
--- a/pwndbg/aglib/disasm/assistant.py
+++ b/pwndbg/aglib/disasm/assistant.py
@@ -529,11 +529,9 @@ class DisassemblyAssistant:
         The list that the function returns is guaranteed have len >= 1
         """
 
-        can_read_process_state = self.can_reason_about_process_state()
-
         if emu:
             return emu.telescope(address, limit, read_size=read_size)
-        if can_read_process_state:
+        if self.can_reason_about_process_state():
             # Can reason about memory in this case.
 
             if read_size is not None and read_size < pwndbg.aglib.arch.ptrsize:

--- a/pwndbg/aglib/disasm/assistant.py
+++ b/pwndbg/aglib/disasm/assistant.py
@@ -146,6 +146,12 @@ class DisassemblyAssistant:
     supports_manual_emulation = False
     """This feature relies on the Capstone .regs_access() features that not all architectures have reliable support for"""
 
+    _can_reason_about_process_state: bool = False
+    """
+    While enhancing an instruction, will we allow it to read from the current process state to read registers.
+    This is only true in one case: when enhancing the instruction that the CPU is currently paused on!
+    """
+
     def __init__(self, architecture: PWNDBG_SUPPORTED_ARCHITECTURES_TYPE) -> None:
         self.architecture = architecture
         self.manual_register_values = PseudoEmulatedRegisterFile(
@@ -169,7 +175,12 @@ class DisassemblyAssistant:
             CS_OP_MEM: self._memory_string,
         }
 
-    def enhance(self, instruction: PwndbgInstruction, emu: Emulator = None) -> None:
+    def enhance(
+        self,
+        instruction: PwndbgInstruction,
+        current_cpu_instruction: bool,
+        emu: Emulator | None = None,
+    ) -> None:
         """
         Enhance the instruction - resolving branch targets, conditionals, and adding annotations
 
@@ -177,6 +188,8 @@ class DisassemblyAssistant:
         """
         instruction.enhanced = True
         # It is assumed that the emulator's pc is at the instruction's address
+
+        self._can_reason_about_process_state = current_cpu_instruction
 
         # There are 3 degrees of emulation:
         # 1. No emulation at all. In this case, the `emu` parameter should be None
@@ -394,14 +407,14 @@ class DisassemblyAssistant:
 
         return jump_emu is not None
 
-    def can_reason_about_process_state(self, instruction: PwndbgInstruction) -> bool:
+    def can_reason_about_process_state(self) -> bool:
         """
         Determine if the program counter of the process equals the address of the instruction being enhanced.
         If so, it means we can safely reason and read from registers and memory to enhance values that
         we can add to the annotation string. This becomes relevent when NOT emulating, and is meant to
         allow more details when the PC is at the instruction being enhanced
         """
-        return instruction.address == pwndbg.aglib.regs.pc
+        return self._can_reason_about_process_state
 
     # Delegates to "read_register", which takes Capstone ID for register.
     def _parse_register(
@@ -446,7 +459,7 @@ class DisassemblyAssistant:
             if DEBUG_ENHANCEMENT:
                 print(f"Register in emulation returned {regname}={hex(value)}")
             return value
-        if self.can_reason_about_process_state(instruction):
+        if self.can_reason_about_process_state():
             # When instruction address == pc, we can reason about all registers.
             # The values will just reflect values prior to executing the instruction, instead of after,
             # which is relevent if we are writing to this register.
@@ -516,7 +529,7 @@ class DisassemblyAssistant:
         The list that the function returns is guaranteed have len >= 1
         """
 
-        can_read_process_state = self.can_reason_about_process_state(instruction)
+        can_read_process_state = self.can_reason_about_process_state()
 
         if emu:
             return emu.telescope(address, limit, read_size=read_size)

--- a/pwndbg/aglib/disasm/assistant.py
+++ b/pwndbg/aglib/disasm/assistant.py
@@ -148,8 +148,13 @@ class DisassemblyAssistant:
 
     _can_reason_about_process_state: bool = False
     """
-    While enhancing an instruction, will we allow it to read from the current process state to read registers.
+    While enhancing an instruction, will we be allowed to read from the current process state to read registers / memory
+    that could provide more context on what the instruction does?
+
+    For example, if the instruction is `LOAD R9, [RAX]`, can we read the register RAX and dereference it?
+
     This is only true in one case: when enhancing the instruction that the CPU is currently paused on!
+    Otherwise, we use the emulator.
     """
 
     def __init__(self, architecture: PWNDBG_SUPPORTED_ARCHITECTURES_TYPE) -> None:

--- a/pwndbg/aglib/disasm/disassembly.py
+++ b/pwndbg/aglib/disasm/disassembly.py
@@ -31,6 +31,7 @@ import pwndbg.lib.cache
 import pwndbg.lib.config
 from pwndbg.aglib.disasm.assistant import DEBUG_ENHANCEMENT
 from pwndbg.aglib.disasm.assistant import DisassemblyAssistant
+from pwndbg.aglib.disasm.instruction import CacheSource
 from pwndbg.aglib.disasm.instruction import DisassemblySource
 from pwndbg.aglib.disasm.instruction import ManualPwndbgInstruction
 from pwndbg.aglib.disasm.instruction import PwndbgInstruction
@@ -203,10 +204,14 @@ def get_previous_instruction(
                 put_linear_backward_cache=False,
                 linear=linear,
                 enhance=False,
+                current_cpu_instruction=False,
             )
             if prev_address
             else None
         )
+
+        if insn:
+            insn.cache_source = CacheSource.CACHE_LINEAR
 
         return (insn, True) if insn is not None else None
 
@@ -217,6 +222,8 @@ def get_previous_instruction(
         prev_node = sequence_node.previous
         saveptr.node = prev_node
         if prev_node is not None:
+            prev_node.instruction.cache_source = CacheSource.LINKED_LIST_DYNAMIC
+
             return (prev_node.instruction, False)
 
     prev_address = dynamic_backward_address_cache[address]
@@ -228,7 +235,11 @@ def get_previous_instruction(
             put_linear_backward_cache=False,
             put_dynamic_backward_cache=False,
             enhance=False,
+            current_cpu_instruction=False,
         )
+
+        if insn:
+            insn.cache_source = CacheSource.FALLBACK_DYNAMIC
 
         return (insn, False) if insn is not None else None
 
@@ -242,10 +253,14 @@ def get_previous_instruction(
             put_linear_backward_cache=False,
             put_dynamic_backward_cache=False,
             enhance=False,
+            current_cpu_instruction=False,
         )
         if prev_address
         else None
     )
+
+    if insn:
+        insn.cache_source = CacheSource.CACHE_LINEAR
 
     return (insn, True) if insn is not None else None
 
@@ -389,13 +404,27 @@ def one(
     put_linear_backward_cache: bool = True,
     put_dynamic_backward_cache: bool = True,
     linear: bool = False,
+    current_cpu_instruction: bool | None = None,
+    previously_seen_addresses: set[int] | None = None,
 ) -> PwndbgInstruction | None:
     """
     Return None on failure to fetch an instruction
+
+
+    current_cpu_instruction:
+        If True, it means we already know this instruction is the one the CPU is paused on/
+        If False, we know it's not (even if it shares the same instruction address as the one the CPU is paused on.
+            This can happen during emulation in loops, for example).
+        If set to None (default), it simply checks if instruction.address == program counter.
+            In most contexts, this is desirable, when we want to do the "best effort enhancing" at a given moment,
+            or where the caller doesn't know if we are at the program counter or not.
     """
 
     if address is None:
         address = pwndbg.aglib.regs.pc
+
+    if current_cpu_instruction is None:
+        current_cpu_instruction = address == pwndbg.aglib.regs.pc
 
     if not pwndbg.aglib.memory.peek(address):
         return None
@@ -406,7 +435,13 @@ def one(
             return cached
 
     if (
-        insn := get_one_instruction(address, emu, enhance=enhance, assistant=assistant)
+        insn := get_one_instruction(
+            address,
+            emu,
+            enhance=enhance,
+            assistant=assistant,
+            current_cpu_instruction=current_cpu_instruction,
+        )
     ) is not None:
         if put_cache:
             computed_instruction_cache[address] = insn
@@ -415,7 +450,11 @@ def one(
             linear_backward_address_cache[insn.address + insn.size] = insn.address
 
         if put_dynamic_backward_cache and not linear:
-            dynamic_backward_address_cache[insn.next] = insn.address
+            # TODO: this check is bad What about next insn.....
+            if previously_seen_addresses is None or (
+                insn.next not in previously_seen_addresses and insn.next != insn.address
+            ):
+                dynamic_backward_address_cache[insn.next] = insn.address
         return insn
 
     return None
@@ -469,6 +508,7 @@ def get_one_instruction(
     enhance: bool = True,
     assistant: DisassemblyAssistant | None = None,
     padding: int = 6,
+    current_cpu_instruction: bool = False,
 ) -> PwndbgInstruction | None:
     """
     If passed an emulator, this will pass it to the DisassemblyAssistant which will
@@ -488,10 +528,8 @@ def get_one_instruction(
 
         if enhance:
             if assistant is None:
-                assistant = (
-                    pwndbg.aglib.disasm.disassembly.get_disassembly_assistant_for_current_arch()
-                )
-            assistant.enhance(pwn_ins, emu)
+                assistant = get_disassembly_assistant_for_current_arch()
+            assistant.enhance(pwn_ins, current_cpu_instruction=current_cpu_instruction, emu=emu)
 
         return pwn_ins
 
@@ -590,6 +628,7 @@ def enhance_instruction(
     instruction: PwndbgInstruction,
     assistant: DisassemblyAssistant | None = None,
     emu: pwndbg.emu.emulator.Emulator | None = None,
+    current_cpu_instruction: bool = False,
 ) -> None:
 
     if instruction.enhanced:
@@ -598,10 +637,8 @@ def enhance_instruction(
     match instruction.disassembly_source:
         case DisassemblySource.CAPSTONE:
             if assistant is None:
-                assistant = (
-                    pwndbg.aglib.disasm.disassembly.get_disassembly_assistant_for_current_arch()
-                )
-            assistant.enhance(instruction, emu)
+                assistant = get_disassembly_assistant_for_current_arch()
+            assistant.enhance(instruction, current_cpu_instruction=current_cpu_instruction, emu=emu)
 
         case DisassemblySource.DEBUGGER:
             pwndbg.aglib.disasm.assistant.basic_enhance(instr)
@@ -668,6 +705,7 @@ def near(
     assistant = get_disassembly_assistant_for_current_arch()
 
     insns: list[PwndbgInstruction] = []
+    addresses: set[int] = set()
 
     # Get previously executed instructions from the cache.
     if DEBUG_ENHANCEMENT:
@@ -701,6 +739,7 @@ def near(
             if insn.jump_like and insn.split == SplitType.NO_SPLIT and not insn.causes_branch_delay:
                 insn.split = SplitType.BRANCH_NOT_TAKEN
             insns.append(insn)
+            addresses.add(insn.address)
 
             prev_instruction_fetch = get_previous_instruction(
                 insn.address,
@@ -743,6 +782,8 @@ def near(
         put_linear_backward_cache=disassembling_from_pc,
         assistant=assistant,
         linear=linear,
+        current_cpu_instruction=disassembling_from_pc,
+        previously_seen_addresses=addresses,
     )
 
     if DEBUG_ENHANCEMENT:
@@ -827,6 +868,8 @@ def near(
                     put_linear_backward_cache=populate_backward_linear_cache,
                     put_cache=True,
                     linear=linear,
+                    previously_seen_addresses=addresses,
+                    current_cpu_instruction=False,
                 )
 
                 # There might not be a valid instruction at the branch delay slot
@@ -893,6 +936,8 @@ def near(
             put_linear_backward_cache=populate_backward_linear_cache,
             assistant=assistant,
             linear=linear,
+            previously_seen_addresses=addresses,
+            current_cpu_instruction=False,
         )
 
         if insn:

--- a/pwndbg/aglib/disasm/disassembly.py
+++ b/pwndbg/aglib/disasm/disassembly.py
@@ -719,13 +719,16 @@ def near(
     if show_prev_insns:
         saveptr = InstructionSequenceSavePointer(None)
 
+        linear_prev_fetch = linear
         prev_instruction_fetch = get_previous_instruction(
-            address, use_cache=use_cache, linear=linear, saveptr=saveptr
+            address, use_cache=use_cache, linear=linear_prev_fetch, saveptr=saveptr
         )
         while prev_instruction_fetch is not None and len(insns) < backward_count:
             insn, was_linear = prev_instruction_fetch
 
             if was_linear:
+                # Once one instruction has been linear, we cannot go back to dynamic caching method
+                linear_prev_fetch = True
                 count_backwards_linear += 1
                 if (
                     max_backwards_linear_count is not None
@@ -744,7 +747,7 @@ def near(
             prev_instruction_fetch = get_previous_instruction(
                 insn.address,
                 use_cache=use_cache,
-                linear=linear,
+                linear=linear_prev_fetch,
                 saveptr=saveptr,
             )
         insns.reverse()
@@ -794,6 +797,7 @@ def near(
         return ([], -1, -1)
 
     insns.append(current)
+    addresses.add(current.address)
 
     # A linked list that contains the order of instructions that emulation
     # determines will run upon uses of the "nexti" command.
@@ -877,6 +881,7 @@ def near(
                     break
 
                 insns.append(split_insn)
+                addresses.add(split_insn.address)
 
                 ### Start manually handling caching related to delay slots
                 next_addresses_cache.add(split_insn.address)
@@ -951,6 +956,7 @@ def near(
                 instruction_sequence_linked_list_map[target] = instruction_sequence_head
 
             insns.append(insn)
+            addresses.add(insn.address)
 
     # Remove repeated instructions at the end of disassembly.
     # Always ensure we display the current and *next* instruction,

--- a/pwndbg/aglib/disasm/instruction.py
+++ b/pwndbg/aglib/disasm/instruction.py
@@ -192,6 +192,17 @@ class DisassemblySource(Enum):
     DEBUGGER = auto()
 
 
+# This is used for debugging issues in the disassembly display when instructions behind
+# the program counter are unexpectedly appearing
+class CacheSource(Enum):
+    LINKED_LIST_DYNAMIC = "L"
+    FALLBACK_DYNAMIC = "F"
+    CACHE_LINEAR = "C"
+    HEURISTIC_LINEAR = "H"
+
+    NOT_FROM_CACHE = ""
+
+
 # Interface for enhanced instructions - there are two implementations defined in this file
 class PwndbgInstruction(Protocol):
     cs_insn: CsInsn
@@ -221,6 +232,8 @@ class PwndbgInstruction(Protocol):
 
     enhanced: bool
     disassembly_source: DisassemblySource
+
+    cache_source: CacheSource
 
     @property
     def call_like(self) -> bool: ...
@@ -443,6 +456,12 @@ class PwndbgInstructionImpl(PwndbgInstruction):
         """
         Mapping of Capstone register id to integer value. During enhancement, we might manually determine
         that an instruction writes some value to a register, and this is stored here.
+        """
+
+        self.cache_source = CacheSource.NOT_FROM_CACHE
+        """
+        This is purely for debugging.
+        This may change during the lifetime of this instruction, as this value is set during the latest time this instruction was displayed.
         """
 
     @property
@@ -792,6 +811,8 @@ class ManualPwndbgInstruction(PwndbgInstruction):
         self.emulated = False
 
         self.register_writes = {}
+
+        self.cache_source = CacheSource.NOT_FROM_CACHE
 
     @property
     def bytes(self) -> bytearray:

--- a/pwndbg/aglib/disasm/instruction.py
+++ b/pwndbg/aglib/disasm/instruction.py
@@ -198,7 +198,6 @@ class CacheSource(Enum):
     LINKED_LIST_DYNAMIC = "L"
     FALLBACK_DYNAMIC = "F"
     CACHE_LINEAR = "C"
-    HEURISTIC_LINEAR = "H"
 
     NOT_FROM_CACHE = ""
 

--- a/pwndbg/aglib/disasm/x86.py
+++ b/pwndbg/aglib/disasm/x86.py
@@ -248,7 +248,6 @@ class X86DisassemblyAssistant(pwndbg.aglib.disasm.assistant.DisassemblyAssistant
             )
 
     def handle_pop(self, instruction: PwndbgInstruction, emu: Emulator) -> None:
-        pc_is_at_instruction = self.can_reason_about_process_state(instruction)
 
         if len(instruction.operands) != 1:
             return
@@ -266,7 +265,7 @@ class X86DisassemblyAssistant(pwndbg.aglib.disasm.assistant.DisassemblyAssistant
                         pwndbg.dintegration.manager.get_stack_var_dict_all(),
                     ),
                 )
-            elif pc_is_at_instruction:
+            elif self.can_reason_about_process_state():
                 # Attempt to read from the top of the stack
                 try:
                     value = pwndbg.aglib.memory.read_pointer_width(pwndbg.aglib.regs.sp)
@@ -389,7 +388,7 @@ class X86DisassemblyAssistant(pwndbg.aglib.disasm.assistant.DisassemblyAssistant
             return super()._resolve_target(instruction, emu)
 
         # Stop disassembling at RET if we won't know where it goes to without emulation
-        if instruction.address != pwndbg.aglib.regs.pc:
+        if not self.can_reason_about_process_state():
             return super()._resolve_target(instruction, emu)
 
         # Otherwise, resolve the return on the stack

--- a/pwndbg/color/disasm.py
+++ b/pwndbg/color/disasm.py
@@ -29,6 +29,8 @@ config_branch_off = theme.add_param(
     "disasm-branch-off", "✘", "marker for branches that will NOT be taken"
 )
 
+DEBUG_CACHE = False
+
 
 def one_instruction(ins: PwndbgInstruction, linear: bool) -> str:
     """
@@ -60,6 +62,8 @@ def one_instruction(ins: PwndbgInstruction, linear: bool) -> str:
     else:
         asm = f"  {asm}"
 
+    if DEBUG_CACHE:
+        asm = f"{ins.cache_source.value} {asm}"
     return asm
 
 

--- a/pwndbg/commands/branch.py
+++ b/pwndbg/commands/branch.py
@@ -28,7 +28,7 @@ class BreakOnConditionalBranch(pwndbg.gdblib.bpoint.Breakpoint):
         # where previously it was not. The enhancement process will figure out if all the conditions
         # this branch requires in order to be taken have been met.
         assistant = pwndbg.aglib.disasm.disassembly.get_disassembly_assistant_for_current_arch()
-        assistant.enhance(self.instruction)
+        assistant.enhance(self.instruction, current_cpu_instruction=True)
         condition_met = self.instruction.is_conditional_jump_taken
 
         return condition_met == self.taken

--- a/tests/binaries/host/nextret_to_double_ret_chain.x86-64.asm
+++ b/tests/binaries/host/nextret_to_double_ret_chain.x86-64.asm
@@ -1,0 +1,29 @@
+global _start
+
+; This program essentially does "ROP" on itself
+; It constructs a double "ret", and does so in a way such that
+; the first ret causes the program counter to not change (it rets back to itself)
+
+_start:
+times 32 nop
+
+rop_setup:
+mov rax, self_ret
+mov [rsp], rax
+mov rax, nop_sled
+mov [rsp + 8], rax
+
+one_before_self_ret:
+nop
+
+; When this ret executes, it will jump back to itself!
+self_ret:
+nop
+ret
+
+nop_sled:
+times 32 nop
+
+mov     edi, 0
+mov     eax, 60
+syscall

--- a/tests/binaries/host/rop_32x_ret.x86-64.asm
+++ b/tests/binaries/host/rop_32x_ret.x86-64.asm
@@ -1,0 +1,26 @@
+global _start
+
+CHAIN_LEN   equ 32
+
+section .text
+
+_start:
+    sub     rsp, CHAIN_LEN * 8
+    call    gadget_setup
+    ud2
+
+gadget_setup:
+    mov     rdi, rsp
+    mov     rax, self_ret
+    mov     rcx, CHAIN_LEN - 1
+    rep     stosq
+    mov     rax, nop_sled
+    stosq
+self_ret:
+    ret
+
+nop_sled:
+    times 64 nop
+    mov     edi, 0
+    mov     eax, 60
+    syscall

--- a/tests/binaries/host/rop_duplicate_ret.x86-64.asm
+++ b/tests/binaries/host/rop_duplicate_ret.x86-64.asm
@@ -1,0 +1,31 @@
+global _start
+
+; This program essentially does "ROP" on itself
+; It constructs a double "ret", and does so in a way such that
+; the first ret causes the program counter to not change (it rets back to itself)
+
+_start:
+sub rsp, 16
+call rop_setup
+ud2
+times 32 nop
+
+rop_setup:
+mov rax, self_ret
+mov [rsp], rax
+mov rax, nop_sled
+mov [rsp + 8], rax
+
+one_before_self_ret:
+nop
+
+; When this ret executes, it will jump back to itself!
+self_ret:
+ret
+
+nop_sled:
+times 32 nop
+
+mov     edi, 0
+mov     eax, 60
+syscall

--- a/tests/binaries/host/rop_duplicate_ret_variant_2.x86-64.asm
+++ b/tests/binaries/host/rop_duplicate_ret_variant_2.x86-64.asm
@@ -1,0 +1,32 @@
+global _start
+
+; This program essentially does "ROP" on itself
+; It constructs a double "ret", and does so in a way such that
+; the first ret causes the program counter to not change (it rets back to itself)
+
+_start:
+sub rsp, 16
+call rop_setup
+ud2
+times 32 nop
+
+rop_setup:
+mov rax, self_ret
+mov [rsp], rax
+mov rax, nop_sled
+mov [rsp + 8], rax
+
+one_before_self_ret:
+nop
+
+; When this ret executes, it will jump back to itself!
+self_ret:
+nop
+ret
+
+nop_sled:
+times 32 nop
+
+mov     edi, 0
+mov     eax, 60
+syscall

--- a/tests/library/dbg/tests/test_emulate.py
+++ b/tests/library/dbg/tests/test_emulate.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from ....host import Controller
+from . import break_at_sym
 from . import get_binary
 from . import pwndbg_test
 
@@ -277,3 +278,174 @@ async def test_backwards_linear_cache_misaligned_disasm(ctrl: Controller) -> Non
         "   0x4000ee                           add    byte ptr [rax], al\n"
     )
     assert dis_2 == expected_2
+
+
+DOUBLE_RET_ROP_CHAIN_BINARY = get_binary("rop_duplicate_ret.x86-64.out")
+
+
+@pwndbg_test
+async def test_emulate_double_ret_chain_with_leadup(ctrl: Controller) -> None:
+    """
+    This makes sure we handle the check for allowing to read from current process state during enhancement correctly.
+
+    This test involves a double "ret" to the same "ret" instruction in memory (two instructions, at the same address executed back to back!)
+    We should treat allow enhancement for the current `ret` (the one the CPU PC is on) to read from memory, and not future ones that we emulate through.
+    """
+
+    # Do not allow the disassembly section to run to populate the caches automatically
+    await ctrl.execute_and_capture("set context-sections ''")
+
+    await ctrl.launch(DOUBLE_RET_ROP_CHAIN_BINARY)
+
+    break_at_sym("one_before_self_ret")
+
+    await ctrl.cont()
+
+    dis_0 = await ctrl.execute_and_capture("context disasm")
+
+    expected_0 = (
+        "LEGEND: STACK | HEAP | CODE | DATA | WX | RODATA\n"
+        "──────────────────────[ DISASM / x86-64 / set emulate on ]──────────────────────\n"
+        "b► 0x4000c8 <one_before_self_ret>    nop   \n"
+        "   0x4000c9 <self_ret>               ret                                <self_ret>\n"
+        "    ↓\n"
+        "   0x4000c9 <self_ret>               ret                                <nop_sled>\n"
+        "    ↓\n"
+        "   0x4000ca <nop_sled>               nop   \n"
+        "   0x4000cb <nop_sled+1>             nop   \n"
+        "   0x4000cc <nop_sled+2>             nop   \n"
+        "   0x4000cd <nop_sled+3>             nop   \n"
+        "   0x4000ce <nop_sled+4>             nop   \n"
+        "   0x4000cf <nop_sled+5>             nop   \n"
+        "   0x4000d0 <nop_sled+6>             nop   \n"
+        "   0x4000d1 <nop_sled+7>             nop   \n"
+        "────────────────────────────────────────────────────────────────────────────────\n"
+    )
+
+    assert dis_0 == expected_0
+
+    await ctrl.step_instruction()
+
+    dis_1 = await ctrl.execute_and_capture("context disasm")
+
+    expected_1 = (
+        "LEGEND: STACK | HEAP | CODE | DATA | WX | RODATA\n"
+        "──────────────────────[ DISASM / x86-64 / set emulate on ]──────────────────────\n"
+        "b+ 0x4000c8 <one_before_self_ret>    nop   \n"
+        " ► 0x4000c9 <self_ret>               ret                                <self_ret>\n"
+        "    ↓\n"
+        "   0x4000c9 <self_ret>               ret                                <nop_sled>\n"
+        "    ↓\n"
+        "   0x4000ca <nop_sled>               nop   \n"
+        "   0x4000cb <nop_sled+1>             nop   \n"
+        "   0x4000cc <nop_sled+2>             nop   \n"
+        "   0x4000cd <nop_sled+3>             nop   \n"
+        "   0x4000ce <nop_sled+4>             nop   \n"
+        "   0x4000cf <nop_sled+5>             nop   \n"
+        "   0x4000d0 <nop_sled+6>             nop   \n"
+        "   0x4000d1 <nop_sled+7>             nop   \n"
+        "────────────────────────────────────────────────────────────────────────────────\n"
+    )
+
+    assert dis_1 == expected_1
+
+    await ctrl.step_instruction()
+
+    dis_2 = await ctrl.execute_and_capture("context disasm")
+
+    expected_2 = (
+        "LEGEND: STACK | HEAP | CODE | DATA | WX | RODATA\n"
+        "──────────────────────[ DISASM / x86-64 / set emulate on ]──────────────────────\n"
+        "b+ 0x4000c8 <one_before_self_ret>    nop   \n"
+        "   0x4000c9 <self_ret>               ret                                <self_ret>\n"
+        "    ↓\n"
+        " ► 0x4000c9 <self_ret>               ret                                <nop_sled>\n"
+        "    ↓\n"
+        "   0x4000ca <nop_sled>               nop   \n"
+        "   0x4000cb <nop_sled+1>             nop   \n"
+        "   0x4000cc <nop_sled+2>             nop   \n"
+        "   0x4000cd <nop_sled+3>             nop   \n"
+        "   0x4000ce <nop_sled+4>             nop   \n"
+        "   0x4000cf <nop_sled+5>             nop   \n"
+        "   0x4000d0 <nop_sled+6>             nop   \n"
+        "   0x4000d1 <nop_sled+7>             nop   \n"
+        "────────────────────────────────────────────────────────────────────────────────\n"
+    )
+
+    assert dis_2 == expected_2
+
+
+@pwndbg_test
+async def test_emulate_double_ret_chain(ctrl: Controller) -> None:
+    """
+    Similar to the above test, except we go directly to the first ret (we don't know the instruction flow into it)
+
+    If this fails with the result show a bunch of ret instructions before the ret we are on (where there should be none),
+    it means that while handling the current pc's ret, we are corrupting the cache, affecting how we pull instructions from "backwards"
+    (it may be writing "this ret comes back the next ret" (which is at the same), which is a fact that pollutes pulling values from "behind" us).
+    """
+
+    # Do not allow the disassembly section to run to populate the caches automatically
+    await ctrl.execute_and_capture("set context-sections ''")
+
+    await ctrl.launch(DOUBLE_RET_ROP_CHAIN_BINARY)
+
+    break_at_sym("self_ret")
+
+    await ctrl.cont()
+
+    dis_0 = await ctrl.execute_and_capture("context disasm")
+
+    expected_0 = (
+        "LEGEND: STACK | HEAP | CODE | DATA | WX | RODATA\n"
+        "──────────────────────[ DISASM / x86-64 / set emulate on ]──────────────────────\n"
+        "b► 0x4000c9 <self_ret>      ret                                <self_ret>\n"
+        "    ↓\n"
+        "b+ 0x4000c9 <self_ret>      ret                                <nop_sled>\n"
+        "    ↓\n"
+        "   0x4000ca <nop_sled>      nop   \n"
+        "   0x4000cb <nop_sled+1>    nop   \n"
+        "   0x4000cc <nop_sled+2>    nop   \n"
+        "   0x4000cd <nop_sled+3>    nop   \n"
+        "   0x4000ce <nop_sled+4>    nop   \n"
+        "   0x4000cf <nop_sled+5>    nop   \n"
+        "   0x4000d0 <nop_sled+6>    nop   \n"
+        "   0x4000d1 <nop_sled+7>    nop   \n"
+        "   0x4000d2 <nop_sled+8>    nop   \n"
+        "────────────────────────────────────────────────────────────────────────────────\n"
+    )
+
+    assert dis_0 == expected_0
+
+    await ctrl.step_instruction()
+
+    # This second check requires we are careful about our caching!
+    # Having two of the same instruction, if a cache is keyed off of only the
+    # instruction address, can cause the remembered control flow to be incorrect
+    # for a given instance of the instruction at that address.
+    dis_1 = await ctrl.execute_and_capture("context disasm")
+
+    expected_1 = (
+        "LEGEND: STACK | HEAP | CODE | DATA | WX | RODATA\n"
+        "──────────────────────[ DISASM / x86-64 / set emulate on ]──────────────────────\n"
+        "b+ 0x4000c9 <self_ret>      ret                                <self_ret>\n"
+        "    ↓\n"
+        "b► 0x4000c9 <self_ret>      ret                                <nop_sled>\n"
+        "    ↓\n"
+        "   0x4000ca <nop_sled>      nop   \n"
+        "   0x4000cb <nop_sled+1>    nop   \n"
+        "   0x4000cc <nop_sled+2>    nop   \n"
+        "   0x4000cd <nop_sled+3>    nop   \n"
+        "   0x4000ce <nop_sled+4>    nop   \n"
+        "   0x4000cf <nop_sled+5>    nop   \n"
+        "   0x4000d0 <nop_sled+6>    nop   \n"
+        "   0x4000d1 <nop_sled+7>    nop   \n"
+        "   0x4000d2 <nop_sled+8>    nop   \n"
+        "────────────────────────────────────────────────────────────────────────────────\n"
+    )
+
+    assert dis_1 == expected_1
+
+    # TODO and TO FIX:
+    # What if run ctx disasm twice here
+    # --- make it be stateful: current_state, next_state

--- a/tests/library/dbg/tests/test_emulate.py
+++ b/tests/library/dbg/tests/test_emulate.py
@@ -281,6 +281,7 @@ async def test_backwards_linear_cache_misaligned_disasm(ctrl: Controller) -> Non
 
 
 DOUBLE_RET_ROP_CHAIN_BINARY = get_binary("rop_duplicate_ret.x86-64.out")
+DOUBLE_RET_ROP_CHAIN_BINARY_VARIANT_2 = get_binary("rop_duplicate_ret_variant_2.x86-64.out")
 
 
 @pwndbg_test
@@ -446,6 +447,150 @@ async def test_emulate_double_ret_chain(ctrl: Controller) -> None:
 
     assert dis_1 == expected_1
 
-    # TODO and TO FIX:
-    # What if run ctx disasm twice here
-    # --- make it be stateful: current_state, next_state
+
+@pwndbg_test
+async def test_emulate_double_ret_chain_variant_2(ctrl: Controller) -> None:
+    """
+    Even if the gadgets are multiple instructions long, we shouldn't backfill history incorrectly.
+    """
+
+    # Do not allow the disassembly section to run to populate the caches automatically
+    await ctrl.execute_and_capture("set context-sections ''")
+
+    await ctrl.launch(DOUBLE_RET_ROP_CHAIN_BINARY_VARIANT_2)
+
+    break_at_sym("self_ret")
+
+    await ctrl.cont()
+
+    # We want to end up on self_ret+1
+    await ctrl.step_instruction()
+
+    dis_0 = await ctrl.execute_and_capture("context disasm")
+
+    expected_0 = (
+        "LEGEND: STACK | HEAP | CODE | DATA | WX | RODATA\n"
+        "──────────────────────[ DISASM / x86-64 / set emulate on ]──────────────────────\n"
+        " ► 0x4000ca <self_ret+1>    ret                                <self_ret>\n"
+        "    ↓\n"
+        "b+ 0x4000c9 <self_ret>      nop   \n"
+        "   0x4000ca <self_ret+1>    ret                                <nop_sled>\n"
+        "    ↓\n"
+        "   0x4000cb <nop_sled>      nop   \n"
+        "   0x4000cc <nop_sled+1>    nop   \n"
+        "   0x4000cd <nop_sled+2>    nop   \n"
+        "   0x4000ce <nop_sled+3>    nop   \n"
+        "   0x4000cf <nop_sled+4>    nop   \n"
+        "   0x4000d0 <nop_sled+5>    nop   \n"
+        "   0x4000d1 <nop_sled+6>    nop   \n"
+        "   0x4000d2 <nop_sled+7>    nop   \n"
+        "────────────────────────────────────────────────────────────────────────────────\n"
+    )
+
+    assert dis_0 == expected_0
+
+    await ctrl.step_instruction()
+
+    # This second check requires we are careful about our caching!
+    # Having two of the same instruction, if a cache is keyed off of only the
+    # instruction address, can cause the remembered control flow to be incorrect
+    # for a given instance of the instruction at that address.
+    dis_1 = await ctrl.execute_and_capture("context disasm")
+
+    expected_1 = (
+        "LEGEND: STACK | HEAP | CODE | DATA | WX | RODATA\n"
+        "──────────────────────[ DISASM / x86-64 / set emulate on ]──────────────────────\n"
+        "   0x4000ca <self_ret+1>    ret                                <self_ret>\n"
+        "    ↓\n"
+        "b► 0x4000c9 <self_ret>      nop   \n"
+        "   0x4000ca <self_ret+1>    ret                                <nop_sled>\n"
+        "    ↓\n"
+        "   0x4000cb <nop_sled>      nop   \n"
+        "   0x4000cc <nop_sled+1>    nop   \n"
+        "   0x4000cd <nop_sled+2>    nop   \n"
+        "   0x4000ce <nop_sled+3>    nop   \n"
+        "   0x4000cf <nop_sled+4>    nop   \n"
+        "   0x4000d0 <nop_sled+5>    nop   \n"
+        "   0x4000d1 <nop_sled+6>    nop   \n"
+        "   0x4000d2 <nop_sled+7>    nop   \n"
+        "────────────────────────────────────────────────────────────────────────────────\n"
+    )
+
+    assert dis_1 == expected_1
+
+
+@pwndbg_test
+async def test_emulate_double_ret_chain_variant_2_dynamic_cache_test(ctrl: Controller) -> None:
+    """
+    Once we go back in history to "linear" instructions, don't allow it to go back to dynamic fetching.
+    """
+
+    # Do not allow the disassembly section to run to populate the caches automatically
+
+    await ctrl.launch(DOUBLE_RET_ROP_CHAIN_BINARY_VARIANT_2)
+
+    await ctrl.execute_and_capture("set context-sections ''")
+
+    await ctrl.execute_and_capture("set context-disasm-back-linear-lines 1")
+
+    break_at_sym("self_ret")
+
+    await ctrl.cont()
+
+    # We want to end up on self_ret+1
+    await ctrl.step_instruction()
+
+    dis_0 = await ctrl.execute_and_capture("context disasm")
+
+    expected_0 = (
+        "LEGEND: STACK | HEAP | CODE | DATA | WX | RODATA\n"
+        "──────────────────────[ DISASM / x86-64 / set emulate on ]──────────────────────\n"
+        " ► 0x4000ca <self_ret+1>    ret                                <self_ret>\n"
+        "    ↓\n"
+        "b+ 0x4000c9 <self_ret>      nop   \n"
+        "   0x4000ca <self_ret+1>    ret                                <nop_sled>\n"
+        "    ↓\n"
+        "   0x4000cb <nop_sled>      nop   \n"
+        "   0x4000cc <nop_sled+1>    nop   \n"
+        "   0x4000cd <nop_sled+2>    nop   \n"
+        "   0x4000ce <nop_sled+3>    nop   \n"
+        "   0x4000cf <nop_sled+4>    nop   \n"
+        "   0x4000d0 <nop_sled+5>    nop   \n"
+        "   0x4000d1 <nop_sled+6>    nop   \n"
+        "   0x4000d2 <nop_sled+7>    nop   \n"
+        "────────────────────────────────────────────────────────────────────────────────\n"
+    )
+
+    assert dis_0 == expected_0
+
+    await ctrl.step_instruction()
+
+    # This second check requires we are careful about our caching!
+    # Having two of the same instruction, if a cache is keyed off of only the
+    # instruction address, can cause the remembered control flow to be incorrect
+    # for a given instance of the instruction at that address.
+    dis_1 = await ctrl.execute_and_capture("context disasm")
+
+    # The nop has backfilled due to "context-disasm-back-linear-lines" being 1.
+    # While disassembing in the first `ctx disasm`, we discovered that this instruction is behind the ret.
+    # But it does not backfill more than that
+    expected_1 = (
+        "LEGEND: STACK | HEAP | CODE | DATA | WX | RODATA\n"
+        "──────────────────────[ DISASM / x86-64 / set emulate on ]──────────────────────\n"
+        "b+ 0x4000c9 <self_ret>      nop   \n"
+        "   0x4000ca <self_ret+1>    ret                                <self_ret>\n"
+        "    ↓\n"
+        "b► 0x4000c9 <self_ret>      nop   \n"
+        "   0x4000ca <self_ret+1>    ret                                <nop_sled>\n"
+        "    ↓\n"
+        "   0x4000cb <nop_sled>      nop   \n"
+        "   0x4000cc <nop_sled+1>    nop   \n"
+        "   0x4000cd <nop_sled+2>    nop   \n"
+        "   0x4000ce <nop_sled+3>    nop   \n"
+        "   0x4000cf <nop_sled+4>    nop   \n"
+        "   0x4000d0 <nop_sled+5>    nop   \n"
+        "   0x4000d1 <nop_sled+6>    nop   \n"
+        "────────────────────────────────────────────────────────────────────────────────\n"
+    )
+
+    assert dis_1 == expected_1

--- a/tests/library/dbg/tests/test_emulate.py
+++ b/tests/library/dbg/tests/test_emulate.py
@@ -375,6 +375,32 @@ async def test_emulate_double_ret_chain_with_leadup(ctrl: Controller) -> None:
         "────────────────────────────────────────────────────────────────────────────────\n"
     )
 
+    # LLDB does not support single stepping when the subsequent instructions are at the same PC
+    # See: https://reviews.llvm.org/D81810
+    # Therefore, we modify what we are checking for LLDB (it steps an additional instruction)
+    import pwndbg
+    from pwndbg.dbg_mod import DebuggerType
+
+    if pwndbg.dbg.name() == DebuggerType.LLDB:
+        expected_2 = (
+            "LEGEND: STACK | HEAP | CODE | DATA | WX | RODATA\n"
+            "──────────────────────[ DISASM / x86-64 / set emulate on ]──────────────────────\n"
+            "b+ 0x4000c8 <one_before_self_ret>    nop   \n"
+            "   0x4000c9 <self_ret>               ret                                <self_ret>\n"
+            "    ↓\n"
+            "   0x4000c9 <self_ret>               ret                                <nop_sled>\n"
+            "    ↓\n"
+            " ► 0x4000ca <nop_sled>               nop   \n"
+            "   0x4000cb <nop_sled+1>             nop   \n"
+            "   0x4000cc <nop_sled+2>             nop   \n"
+            "   0x4000cd <nop_sled+3>             nop   \n"
+            "   0x4000ce <nop_sled+4>             nop   \n"
+            "   0x4000cf <nop_sled+5>             nop   \n"
+            "   0x4000d0 <nop_sled+6>             nop   \n"
+            "   0x4000d1 <nop_sled+7>             nop   \n"
+            "────────────────────────────────────────────────────────────────────────────────\n"
+        )
+
     assert dis_2 == expected_2
 
 
@@ -447,6 +473,32 @@ async def test_emulate_double_ret_chain(ctrl: Controller) -> None:
         "   0x4000d2 <nop_sled+8>    nop   \n"
         "────────────────────────────────────────────────────────────────────────────────\n"
     )
+
+    # LLDB does not support single stepping when the subsequent instructions are at the same PC
+    # See: https://reviews.llvm.org/D81810
+    # Therefore, we modify what we are checking for LLDB (it steps an additional instruction)
+    import pwndbg
+    from pwndbg.dbg_mod import DebuggerType
+
+    if pwndbg.dbg.name() == DebuggerType.LLDB:
+        expected_1 = (
+            "LEGEND: STACK | HEAP | CODE | DATA | WX | RODATA\n"
+            "──────────────────────[ DISASM / x86-64 / set emulate on ]──────────────────────\n"
+            "b+ 0x4000c9 <self_ret>      ret                                <self_ret>\n"
+            "    ↓\n"
+            "b+ 0x4000c9 <self_ret>      ret                                <nop_sled>\n"
+            "    ↓\n"
+            " ► 0x4000ca <nop_sled>      nop   \n"
+            "   0x4000cb <nop_sled+1>    nop   \n"
+            "   0x4000cc <nop_sled+2>    nop   \n"
+            "   0x4000cd <nop_sled+3>    nop   \n"
+            "   0x4000ce <nop_sled+4>    nop   \n"
+            "   0x4000cf <nop_sled+5>    nop   \n"
+            "   0x4000d0 <nop_sled+6>    nop   \n"
+            "   0x4000d1 <nop_sled+7>    nop   \n"
+            "   0x4000d2 <nop_sled+8>    nop   \n"
+            "────────────────────────────────────────────────────────────────────────────────\n"
+        )
 
     assert dis_1 == expected_1
 

--- a/tests/library/dbg/tests/test_emulate.py
+++ b/tests/library/dbg/tests/test_emulate.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from ....host import Controller
 from . import break_at_sym
 from . import get_binary
@@ -418,6 +420,7 @@ async def test_emulate_double_ret_chain(ctrl: Controller) -> None:
 
     assert dis_0 == expected_0
 
+    # TODO: why is LLDB stepping more than one instruction here?
     await ctrl.step_instruction()
 
     # This second check requires we are careful about our caching!
@@ -524,6 +527,7 @@ async def test_emulate_double_ret_chain_variant_2_dynamic_cache_test(ctrl: Contr
     """
     Once we go back in history to "linear" instructions, don't allow it to go back to dynamic fetching.
     """
+    import pwndbg.color
 
     # Do not allow the disassembly section to run to populate the caches automatically
 
@@ -571,6 +575,8 @@ async def test_emulate_double_ret_chain_variant_2_dynamic_cache_test(ctrl: Contr
     # for a given instance of the instruction at that address.
     dis_1 = await ctrl.execute_and_capture("context disasm")
 
+    dis_1 = pwndbg.color.strip(dis_1)
+
     # The nop has backfilled due to "context-disasm-back-linear-lines" being 1.
     # While disassembing in the first `ctx disasm`, we discovered that this instruction is behind the ret.
     # But it does not backfill more than that
@@ -594,3 +600,48 @@ async def test_emulate_double_ret_chain_variant_2_dynamic_cache_test(ctrl: Contr
     )
 
     assert dis_1 == expected_1
+
+
+NEXTRET_TO_DOUBLE_RET_BINARY = get_binary("nextret_to_double_ret_chain.x86-64.out")
+
+
+@pytest.mark.xfail(
+    reason="TODO: FIX THIS. The dynamic flow of instructions is incorrect here. The history of instructions from where nextret stops is backfilled incorrectly. The fallback dynamic caching method is at fault"
+)
+@pwndbg_test
+async def test_emulate_nextret_to_double_ret(ctrl: Controller) -> None:
+    """
+    Make sure caching works correctly on nextret (and it's family of commands) when ending on
+    a "same instruction seen twice" scenario
+    """
+
+    await ctrl.launch(NEXTRET_TO_DOUBLE_RET_BINARY)
+
+    await ctrl.execute("nextret")
+
+    dis = await ctrl.execute_and_capture("context disasm")
+
+    # TODO: THIS IS THE CURRENT OUTPUT. IT IS INCORRECT. This should not be happening, but with current cache system it is!
+    # The ret at the PC (noted by ►) should not have a bunch of rets before it! This is flaw of our caching system
+    expected = (
+        "LEGEND: STACK | HEAP | CODE | DATA | WX | RODATA\n"
+        "──────────────────────[ DISASM / x86-64 / set emulate on ]──────────────────────\n"
+        "   0x4000be <self_ret>      nop   \n"
+        "   0x4000bf <self_ret+1>    ret                                <self_ret>\n"
+        "    ↓\n"
+        "   0x4000be <self_ret>      nop   \n"
+        "   0x4000bf <self_ret+1>    ret                                <self_ret>\n"
+        "    ↓\n"
+        "   0x4000be <self_ret>      nop   \n"
+        " ► 0x4000bf <self_ret+1>    ret                                <self_ret>\n"
+        "    ↓\n"
+        "   0x4000be <self_ret>      nop   \n"
+        "   0x4000bf <self_ret+1>    ret                                <nop_sled>\n"
+        "    ↓\n"
+        "   0x4000c0 <nop_sled>      nop   \n"
+        "   0x4000c1 <nop_sled+1>    nop   \n"
+        "   0x4000c2 <nop_sled+2>    nop   \n"
+        "────────────────────────────────────────────────────────────────────────────────\n"
+    )
+
+    assert dis == expected


### PR DESCRIPTION
tl;dr caching is hard, and this will be the first of a couple more fixes to how we track the emulated flow of instructions.


I came across a bug in handling x86 `RET` that resulted in the disassembly incorrectly following the emulated flow of instructions. This occurs when the same `ret` instruction is executed multiple times in the future flow of instructions, which is not too uncommon in long ROP chains and happens in retsleds, where you have back to back ret  gadgets.

This resulted in broken disassembly while the CPU was paused on this instruction.

Basically, we previously had a check for `instruction.address == pwndbg.aglib.regs.pc`, which signaled that we are currently paused on this instruction and thus can read process state during enhancement (because the current register set/memory is the state that the `RET` instruction will access when it runs). This is an incorrect assumption, because during disassembly, we may encounter the same instruction address in the future multiple times due to loops / ROP. This is now handled correctly.

I added tests for this.

Double `ret` instruction before (note that the first `ret` causes program counter to jump back to the same instruction address, to execute another ret):
<img width="2006" height="482" alt="double_ret_did_not_used_to_work" src="https://github.com/user-attachments/assets/a34f9f02-6686-45aa-86c2-719f859e3775" />

After:
<img width="2009" height="558" alt="double_ret_works_now" src="https://github.com/user-attachments/assets/d713fb4a-0270-4828-875f-542757496f8b" />


Other case (we breakpoint at the first ret and continue there. Then we step 1 instruction):

Before, history would be backfilled with a bunch of rets, which was incorrect
<img width="1481" height="713" alt="xuntil_xret_and_step_before" src="https://github.com/user-attachments/assets/6cc5fc5f-5063-4ab5-bb4d-fc19b1919dbb" />

After:
<img width="2086" height="713" alt="xuntil_xret_and_step_works" src="https://github.com/user-attachments/assets/5819dc4d-c10b-42ae-a027-ec7d2f354562" />



However, while making tests for this, I encountered other quirks which mess with how we track the flow of instructions due a multi-leveled caching system, which will require larger changes.

Future changes include:
1.  Currently, every call to display disassembled code goes through one function, `near()`, which is used for too many purposes and has outgrown it's use cases (at least 4: context disasm with emulation, without emulation, nearpc command, and emulate command). This function computes an in-place mutation of the cache state, which is bad. This messes with the caching (ie when running `nearpc`, this modifies state that affects the `ctx disasm` display!). This will be fixed.
2. Even more tests for the disassembly system, across the multiple arches Pwndbg supports.




