### PR TITLE
chore(deps): bump capstone6pwndbg to 8.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [{ name = "Dominik 'disconnect3d' Czarnota", email = "dominik.b.czarno
 requires-python = ">=3.10, <4"
 readme = "README.md"
 dependencies = [
-    "capstone6pwndbg==6.0.0a9",
+    "capstone6pwndbg==8.0.0",
     "unicorn>=2.1.4,<3",
     "pwntools>=4.14.1,<5",
     "sortedcontainers>=2.4.0,<3",

--- a/uv.lock
+++ b/uv.lock
@@ -164,22 +164,22 @@ wheels = [
 
 [[package]]
 name = "capstone6pwndbg"
-version = "6.0.0a9"
+version = "8.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2e/08/40d233bd656b6f2b1e7b1f74941653be9b8d8ac86df961e535c89a555491/capstone6pwndbg-6.0.0a9.tar.gz", hash = "sha256:d865ae69940dda1a595460dcdb250e6652b699a80dfdcf2f0b8f40c08645d853", size = 5693698, upload-time = "2026-05-12T21:08:38.967Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c5/ee/c18b862ad6b254e6c2fdd6f6a9ed3e465dccc9617beb655500963c1f774f/capstone6pwndbg-8.0.0.tar.gz", hash = "sha256:8ba12480ba09562bd1cec5e714d851ce5490c2559939df7717622c9a6f4756de", size = 5710290, upload-time = "2026-08-27T21:50:31.112Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3c/a8/7d160300f2c6a111e819223470cdb43eacdd6344769511b8fe7d36b827da/capstone6pwndbg-6.0.0a9-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:5661ef710fcb9f2c961b74b9acd297fe2fa9d808dd43b04a44cca20f89633cf7", size = 2071227, upload-time = "2026-05-12T21:13:00.379Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/2e/974702ed91e353c2413b493ca94f4a38ce3617d2e5ed389d4fb34a276511/capstone6pwndbg-6.0.0a9-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:57cae16033f67c7648006524577a08b2530e067d7bafe905118fc662da147a67", size = 2240950, upload-time = "2026-05-12T21:14:07.582Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/a9/71a278a66a9926775141e4b7e1a8ea93eb549cfbf8bd28fa65b3e0735675/capstone6pwndbg-6.0.0a9-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7555211dfb7299ab40517734bc331499b9dc800601e9446977a96bb11f659c5a", size = 2492674, upload-time = "2026-05-12T21:11:16.675Z" },
-    { url = "https://files.pythonhosted.org/packages/78/7c/701c72dba0a3c12631d1d65ba08737cb2dbb5aec24a91c227b45f43f1fe6/capstone6pwndbg-6.0.0a9-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1591880fdf4d47414ab5a4b214ac01a6cf67c48d240ebc8e4b1bc2107f1d21d8", size = 2547302, upload-time = "2026-05-12T21:10:54.906Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/f8/b13799f055eeb5fbcab3663cfe3ae270399963d77889bbc66f5daed46d88/capstone6pwndbg-6.0.0a9-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:932ac5514598af4c39c5284b1592e209ffab00c0990d75695cc86f3ab78874e4", size = 2497699, upload-time = "2026-05-12T21:11:17.973Z" },
-    { url = "https://files.pythonhosted.org/packages/95/64/812f3362476e55a9acd7e05d360eef65e878c29660fe8d5138ee7a78ee2e/capstone6pwndbg-6.0.0a9-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:cc902451ebe33be6b3dfd40d8a62c406afa70aa02b545b3174da0f137ca105b4", size = 2549807, upload-time = "2026-05-12T21:10:56.602Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/8e/d03c1fe1cfcbcfc5b63453565fb8d3e81aacfcfc567c4566bb0c9bd96f61/capstone6pwndbg-6.0.0a9-cp38-abi3-macosx_10_9_x86_64.whl", hash = "sha256:333682235899fbc32b2c943cbd2c12f9910536ae842ae02c541d80c62309f6a3", size = 2070953, upload-time = "2026-05-12T21:13:01.754Z" },
-    { url = "https://files.pythonhosted.org/packages/64/b1/458e83bb7a0178a3ba9be4a44170dbbbe885132ecf3a34915a694daf9e1a/capstone6pwndbg-6.0.0a9-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:ce896e8f79bc6417810a2db8d1eaebd5bd73af4352ea6ef2412972190e21f1a7", size = 2240680, upload-time = "2026-05-12T21:14:08.891Z" },
-    { url = "https://files.pythonhosted.org/packages/39/77/f727da9c24a35ea50e57d224b6367fcda6fe6677f2cdec598161862e9c85/capstone6pwndbg-6.0.0a9-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e74a44590205ad19101fc82f874efdc3ca7f004079d647397e744e7ba1a73652", size = 2492420, upload-time = "2026-05-12T21:11:19.799Z" },
-    { url = "https://files.pythonhosted.org/packages/15/08/cd655525054321d310407de4e70cebaed3facef4752b455bedf681d6ddb0/capstone6pwndbg-6.0.0a9-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8ec9536375bafb69fafaf0ed175f20c58a47971b68c6f2e285cf25154e8b459b", size = 2547049, upload-time = "2026-05-12T21:10:58.135Z" },
-    { url = "https://files.pythonhosted.org/packages/24/0e/02adf7791e538f8b1f1a0bcb669a3a7f23d7fca6dee0c485e6e0a46fbd15/capstone6pwndbg-6.0.0a9-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:03ea4e82b5d5eb9efee5def422b3098edee7525496d9b77fa626578f51df1508", size = 2497445, upload-time = "2026-05-12T21:11:21.612Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/92/ac8d095920861650c1494f45600fee08435038a2891d99a0b43281fe3010/capstone6pwndbg-6.0.0a9-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:fad4f94f884c5d53fcfb541cfea8501124d216a6b7b2617595a855e58433204e", size = 2549555, upload-time = "2026-05-12T21:10:59.355Z" },
+    { url = "https://files.pythonhosted.org/packages/63/de/27c65cb104b35659f1f9ecc913c62982618b4fcb80c9052bf14b208108e8/capstone6pwndbg-8.0.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:489e6bb0364da45dd5a6976cece0ad731ae7deed9241c0fb318781ff7ae10578", size = 2079474, upload-time = "2026-08-27T21:55:07.975Z" },
+    { url = "https://files.pythonhosted.org/packages/92/4a/824ef2f5b0bb92ec1833427d78784b81229be86c84dc15d60cb10bb2ad18/capstone6pwndbg-8.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:187de6c73de7d1bb17896a4ae948cd92ab5952102918fcd808e8a3c122607bae", size = 2243729, upload-time = "2026-08-27T21:58:07.87Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/27/d324ab52a3eb30074f0ea376186fa6d11f601b6c01bac3b5f8fb4ab02d1b/capstone6pwndbg-8.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9ec2a8da80032cb3581295790109b1af7d95849ef3fb45c462a0c418ea494d8f", size = 2499389, upload-time = "2026-08-27T21:52:36.926Z" },
+    { url = "https://files.pythonhosted.org/packages/70/2e/b91a5f26d28b51db4e5fb5fe619ad6988bb5d2d65e088ac457c3bf246267/capstone6pwndbg-8.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:038903623c7f44f3d7bab93b27c522723e4b4d315a21dda5aa728b2ce96540cd", size = 2553926, upload-time = "2026-08-27T21:53:06.56Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/bf/6fc8da792de2b06813f44f590a65c704acdb837c97340f17280f49ccca3d/capstone6pwndbg-8.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4c87e69d54a44160a6012c809375eee3d1cd907958eecbb631abc30e1d5add93", size = 2504973, upload-time = "2026-08-27T21:52:38.269Z" },
+    { url = "https://files.pythonhosted.org/packages/78/85/f4eb47236c141b211a605f3ffb484a1f72fab50cb67579c6adb595d55a12/capstone6pwndbg-8.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ae04929f8ac27eac657525ea1a17030d8b568bdc3bb1dd5448b9b54f1cbe3d93", size = 2554728, upload-time = "2026-08-27T21:53:08.042Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/7a/5ddb0b8af36c3367ec43652eb2c724fb3f5f88afbc38571fffc3278a4f4e/capstone6pwndbg-8.0.0-cp38-abi3-macosx_10_9_x86_64.whl", hash = "sha256:359e4c8bcc0eea26e5469517606ab5c057de546545291cb9e360834a74d49dab", size = 2079208, upload-time = "2026-08-27T21:55:09.277Z" },
+    { url = "https://files.pythonhosted.org/packages/46/0e/83874d5e8912b574d06680c29571a2ca5706bbd3698eb0bd86d3e0b56698/capstone6pwndbg-8.0.0-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:c765e6bb8aaeaadb8b07dfcdd2b952ea5474767bbd0109e6d8c8a12329743a35", size = 2243462, upload-time = "2026-08-27T21:58:09.028Z" },
+    { url = "https://files.pythonhosted.org/packages/98/2e/26592fd32c0291df11fe6a1f5e05b0e7bd7a0ec52349cb9524bace6a34cf/capstone6pwndbg-8.0.0-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0c64072bf8c4e32e9fd762cca78299ffb0b76e103194b32661276f3ee9f97ff3", size = 2499138, upload-time = "2026-08-27T21:52:39.635Z" },
+    { url = "https://files.pythonhosted.org/packages/09/a5/97c8d4d68ee788000224f7f52c3f1fc9990df4ec69931f57e3c0803720e4/capstone6pwndbg-8.0.0-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6b87170c7a62aa36723b28bffbd02c9aab8a08ebf6897414cc73adc280d02172", size = 2553678, upload-time = "2026-08-27T21:53:09.474Z" },
+    { url = "https://files.pythonhosted.org/packages/69/7d/4e909015f6fa5a144fd5b826263c59321d7df409fc8eedefdee715061839/capstone6pwndbg-8.0.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:4f254cc43942df0bcacfba722bd9b3eba36f375a4da1ae0cc9b1a42652cf8132", size = 2504725, upload-time = "2026-08-27T21:52:40.776Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/f9/6179f190fe390fb7a748642dfb649a26fee526cb563de4de2c1fbb4045fd/capstone6pwndbg-8.0.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5c72cad8babfb58a01db7d8d13fce6ba1ae7f14105d1cb52cb8d5a442c092be3", size = 2554478, upload-time = "2026-08-27T21:53:10.789Z" },
 ]
 
 [[package]]
@@ -564,7 +564,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -874,17 +874,17 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_machine == 'loongarch64' and sys_platform == 'linux'",
 ]
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "decorator" },
-    { name = "exceptiongroup", marker = "python_full_version != '3.11'" },
-    { name = "jedi" },
-    { name = "matplotlib-inline" },
-    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit" },
-    { name = "pygments" },
-    { name = "stack-data" },
-    { name = "traitlets" },
-    { name = "typing-extensions" },
+    { name = "colorama", marker = "python_full_version < '3.12' and sys_platform == 'win32'" },
+    { name = "decorator", marker = "python_full_version < '3.12'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "jedi", marker = "python_full_version < '3.12'" },
+    { name = "matplotlib-inline", marker = "python_full_version < '3.12'" },
+    { name = "pexpect", marker = "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit", marker = "python_full_version < '3.12'" },
+    { name = "pygments", marker = "python_full_version < '3.12'" },
+    { name = "stack-data", marker = "python_full_version < '3.12'" },
+    { name = "traitlets", marker = "python_full_version < '3.12'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/40/18/f8598d287006885e7136451fdea0755af4ebcbfe342836f24deefaed1164/ipython-8.39.0.tar.gz", hash = "sha256:4110ae96012c379b8b6db898a07e186c40a2a1ef5d57a7fa83166047d9da7624", size = 5513971, upload-time = "2026-03-27T10:02:13.94Z" }
 wheels = [
@@ -906,17 +906,17 @@ resolution-markers = [
     "(python_full_version == '3.12.*' and platform_machine != 'arm64' and platform_machine != 'loongarch64' and platform_machine != 'x86_64') or (python_full_version == '3.12.*' and platform_machine != 'arm64' and platform_machine != 'x86_64' and sys_platform != 'linux')",
 ]
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "decorator" },
-    { name = "ipython-pygments-lexers" },
-    { name = "jedi" },
-    { name = "matplotlib-inline" },
-    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit" },
-    { name = "psutil", marker = "sys_platform != 'cygwin' and sys_platform != 'emscripten'" },
-    { name = "pygments" },
-    { name = "stack-data" },
-    { name = "traitlets" },
+    { name = "colorama", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
+    { name = "decorator", marker = "python_full_version >= '3.12'" },
+    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.12'" },
+    { name = "jedi", marker = "python_full_version >= '3.12'" },
+    { name = "matplotlib-inline", marker = "python_full_version >= '3.12'" },
+    { name = "pexpect", marker = "python_full_version >= '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit", marker = "python_full_version >= '3.12'" },
+    { name = "psutil", marker = "python_full_version >= '3.12' and sys_platform != 'cygwin' and sys_platform != 'emscripten'" },
+    { name = "pygments", marker = "python_full_version >= '3.12'" },
+    { name = "stack-data", marker = "python_full_version >= '3.12'" },
+    { name = "traitlets", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/53/59/165d3b4d75cc34add3122c4417ecb229085140ac573103c223cd01dde96f/ipython-9.15.0.tar.gz", hash = "sha256:da2819ce2aa83135257df830660b1176d986c3d2876db24df01974fa955b2756", size = 4442580, upload-time = "2026-06-26T11:03:35.913Z" }
 wheels = [
@@ -928,7 +928,7 @@ name = "ipython-pygments-lexers"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pygments" },
+    { name = "pygments", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
 wheels = [
@@ -985,7 +985,7 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_machine == 'loongarch64' and sys_platform == 'linux'",
 ]
 dependencies = [
-    { name = "packaging" },
+    { name = "packaging", marker = "platform_machine != 'arm64' and platform_machine != 'x86_64'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/34/49/6090a131d84b22c6aae13b1853092028b060fd17da1af87c0e42ad69d50f/jpype1-1.6.0.tar.gz", hash = "sha256:2d46b2a14f8f0e6f17d8aa22b4fc3a64b2790851ebf1409ad79a37c698fd6e9a", size = 1057888, upload-time = "2025-07-07T14:04:11.244Z" }
 wheels = [
@@ -1025,7 +1025,7 @@ resolution-markers = [
     "(python_full_version < '3.11' and platform_machine == 'arm64') or (python_full_version < '3.11' and platform_machine == 'x86_64')",
 ]
 dependencies = [
-    { name = "packaging" },
+    { name = "packaging", marker = "platform_machine == 'arm64' or platform_machine == 'x86_64'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/48/a2/5d27e81d24eef64668bf702bfe0e091cc48388b4666f36e025243eb9d827/jpype1-1.7.1.tar.gz", hash = "sha256:3cd88838dc3d2d546f7eaeadaaff864e590010c15f2b6a44b6f37e60796a14b2", size = 783791, upload-time = "2026-05-06T23:55:10.664Z" }
 wheels = [
@@ -1943,7 +1943,7 @@ tests = [
 
 [package.metadata]
 requires-dist = [
-    { name = "capstone6pwndbg", specifier = "==6.0.0a9" },
+    { name = "capstone6pwndbg", specifier = "==8.0.0" },
     { name = "decomp2dbg", specifier = "==3.14.1" },
     { name = "gdb-for-pwndbg", marker = "platform_machine == 'loongarch64' and sys_platform == 'linux' and extra == 'gdb'", specifier = "==17.2.0.post5", index = "https://mirrors.loong64.com/pypi/simple" },
     { name = "gdb-for-pwndbg", marker = "(platform_machine != 'loongarch64' and extra == 'gdb') or (sys_platform != 'linux' and extra == 'gdb')", specifier = "==17.2.0.post5" },


### PR DESCRIPTION
Bumps `capstone6pwndbg` from `6.0.0a9` to `8.0.0`, moving off a pre-release pin onto a stable one.

The underlying Capstone library version is unchanged (`cs_version() == (6, 0, 1536)`), and the Python API changes are limited to architectures pwndbg does not use:

- **Additive only** for pwndbg's archs: new `CS_MODE_M68K_*` constants, `CS_MODE_RISCV_VENTANA` / `CS_MODE_RISCV_XVENTANACONDOPS`, and `CS_OPT_SYNTAX_AARCH64_EXPLICIT_WIDE_IMM`.
- `alpha` / `alpha_const`: constants renamed `Alpha_*` -> `ALPHA_*`.
- `m68k` / `m68k_const`: instruction enum values renumbered.

Neither Alpha nor m68k is referenced anywhere in pwndbg.

### Verification

- Diffed the full exported API surface of both versions across every submodule — the only removed/changed names are the `alpha` and `m68k` ones above. Every symbol pwndbg imports from `capstone6pwndbg` still resolves.
- Diffed disassembly output (address, mnemonic, `op_str`, groups, size, operand types + access) between the two versions across x86/x86-64, ARM/Thumb, AArch64, MIPS32/64, RISC-V 32/64, PPC32/64, SPARC/SPARCv9, SystemZ, LoongArch64 and BPF — byte-for-byte identical.
- `./lint.sh` and `./unit-tests.sh` pass (the only failures on my machine are pre-existing macOS-specific ones: `/proc`-based tests in `test_proc_fd.py`/`test_sock_diag.py` and the `socket.AF_NETLINK` mypy error, all present on `dev` too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015LwZJkBgzobzhh2eg4BZR7