### PR TITLE
Fix portable pwndbg-lldb resolving glibc from the host

### DIFF
--- a/nix/bundle/bundle.py
+++ b/nix/bundle/bundle.py
@@ -36,6 +36,14 @@ def eprint(msg: str):
     print(msg, file=sys.stderr)
 
 
+def try_run(args: list[str]) -> str | None:
+    """Like `run`, but returns None instead of bailing out when the command fails."""
+    result = subprocess.run(args, capture_output=True)
+    if result.returncode != 0:
+        return None
+    return result.stdout.decode("utf-8")
+
+
 def run(args: list[str], no_error=False) -> str:
     result = subprocess.run(args, capture_output=True)
     if result.returncode != 0:
@@ -68,12 +76,18 @@ def iter_macho_deps(binary_path: Path) -> typing.Iterator[Path]:
         yield lib_path
 
 
-def iter_elf_deps(binary_path: Path) -> typing.Iterator[Path]:
-    def stripped_strs(strs: typing.Iterable[str]) -> typing.Iterable[str]:
-        return (cleaned for x in strs for cleaned in [x.strip()] if cleaned != "")
+def stripped_strs(strs: typing.Iterable[str]) -> typing.Iterable[str]:
+    return (cleaned for x in strs for cleaned in [x.strip()] if cleaned != "")
 
+
+def parse_rpaths(raw_rpath: str) -> list[str]:
+    # An empty entry means "current working directory" to the loader, drop those.
+    return list(stripped_strs(raw_rpath.split(":")))
+
+
+def iter_elf_deps(binary_path: Path) -> typing.Iterator[Path]:
     def get_rpaths(exe: str) -> typing.Iterable[str]:
-        return stripped_strs(run(["patchelf", "--print-rpath", exe]).split(":"))
+        return parse_rpaths(run(["patchelf", "--print-rpath", exe]))
 
     def resolve_origin(origin: str, paths: typing.Iterable[str]) -> typing.Iterable[str]:
         return (path.replace("$ORIGIN", origin) for path in paths)
@@ -239,6 +253,40 @@ def patch_library_elf(binary_path: Path, root_dst: Path, *, is_exe: bool):
     cleanup_nixrefs(binary_path)
 
 
+def is_elf_exe(path: Path) -> bool:
+    return check_file_type(path) == "ELF" and bool(path.stat().st_mode & stat.S_IXUSR)
+
+
+def patch_venv_exe_rpath_elf(binary_path: Path, root_dst: Path):
+    # Executables shipped inside the venv, e.g.
+    # site-packages/lldb_for_pwndbg/_vendor/bin/lldb, come from prebuilt PyPI
+    # wheels rather than from the Nix store. `bundle_library` has nothing to do
+    # for them, since none of their dependencies live in /nix/store, so they
+    # would otherwise keep resolving libc/libm/... against the *host* instead of
+    # against the glibc we bundle. That breaks as soon as the host is different
+    # from what the wheel was built against.
+    # See https://github.com/pwndbg/pwndbg/issues/4081.
+    #
+    # The rpath is extended, never replaced: lldb ships RUNPATH=$ORIGIN/../lib,
+    # which is how it finds its own libpython_loader_lldb.so and liblldb_stub.so.
+    bundle_lib = '$ORIGIN/' + str(Path(os.path.relpath(root_dst, binary_path.parent)) / 'lib')
+
+    raw_rpath = try_run(["patchelf", "--print-rpath", str(binary_path)])
+    if raw_rpath is None:
+        # Statically linked, e.g. ziglang/zig, so there is no .dynamic section.
+        print(f'SkippingRpath {binary_path.name}, not dynamically linked')
+        return
+
+    rpaths = parse_rpaths(raw_rpath)
+    if bundle_lib in rpaths:
+        # Some wheels, e.g. gdb_for_pwndbg, already ship the right RUNPATH.
+        print(f'SkippingRpath {binary_path.name}, already points at {bundle_lib}')
+        return
+
+    print(f'PatchingRpath {binary_path.name}: {rpaths}+[{bundle_lib}]')
+    run(["patchelf", "--set-rpath", ":".join([*rpaths, bundle_lib]), str(binary_path)])
+
+
 if sys.platform == 'darwin':
     patch_library = patch_library_macho
 else:
@@ -368,6 +416,7 @@ def bundle_library(binary_path: Path, root_dst: Path, *, is_exe: bool, dst_path:
 
 def bundle_python_venv(src_lib_dir: Path, out_lib_dir: Path, root_dst: Path):
     bundle_libs = set()
+    bundle_exes = set()
     for _, files in iter_dir_recursive(src_lib_dir):
         for src_file_path in files:
             # search for so files:
@@ -379,12 +428,26 @@ def bundle_python_venv(src_lib_dir: Path, out_lib_dir: Path, root_dst: Path):
                 '.dylib',
             ))
 
-            real_file = copy_with_symlink_normal(src_file_path, src_lib_dir, out_lib_dir, is_so=is_so)
-            if is_so and real_file:
+            # search for executables shipped by wheels, they have no suffix:
+            # - /gdb_for_pwndbg/_vendor/bin/gdb
+            # - /lldb_for_pwndbg/_vendor/bin/lldb
+            is_exe = not is_so and sys.platform != 'darwin' and is_elf_exe(src_file_path)
+
+            # Both are $ORIGIN-sensitive, so they get the same symlink restriction.
+            real_file = copy_with_symlink_normal(src_file_path, src_lib_dir, out_lib_dir, is_so=is_so or is_exe)
+            if real_file is None:
+                continue
+
+            if is_so:
                 bundle_libs.add(real_file)
+            elif is_exe:
+                bundle_exes.add(real_file)
 
     for file in bundle_libs:
         bundle_library(file, root_dst, is_exe=False)
+
+    for file in bundle_exes:
+        patch_venv_exe_rpath_elf(file, root_dst)
 
 
 def main():

--- a/nix/portable.nix
+++ b/nix/portable.nix
@@ -217,17 +217,6 @@ let
         # writable out
         chmod -R +w $out
 
-        # fix lldb/gdb in bundle
-        ${
-          if pwndbgVenv.stdenv.targetPlatform.isLinux then
-            ''
-              ${pkgsNative.patchelf}/bin/patchelf --set-rpath '$ORIGIN/../../../../../../lib' $out/pwndbg/lib/${python3.libPrefix}/site-packages/gdb_for_pwndbg/_vendor/bin/gdbserver || true
-              ${pkgsNative.patchelf}/bin/patchelf --set-rpath '$ORIGIN/../../../../../../lib' $out/pwndbg/lib/${python3.libPrefix}/site-packages/lldb_for_pwndbg/_vendor/bin/lldb-server || true
-            ''
-          else
-            ""
-        }
-
         # remove unneeded dirs
         rm -rf $out/pwndbg/lib/pkgconfig
         find $out/pwndbg/lib/${python3.libPrefix}/ -type d -name "__pycache__" -exec rm -rf {} +


### PR DESCRIPTION
Fixes #4081.

## Root cause

Two layers.

**1. `nix/bundle/bundle.py` decides what is a binary by filename suffix.** `bundle_python_venv()` only bundles/patches files whose suffix contains `.so`/`.dylib`, so the extensionless executables shipped by the `gdb_for_pwndbg` / `lldb_for_pwndbg` wheels are copied verbatim and never get their RUNPATH rewritten. That is why `nix/portable.nix` had to patch two of them by hand with `patchelf`.

**2. `lldb` was missing from that hand-written list.** Dumping the dynamic sections of the wheels currently pinned in `uv.lock`:

| binary | RUNPATH | NEEDED |
|---|---|---|
| `gdb_for_pwndbg/_vendor/bin/gdb` | `$ORIGIN/../../../../../../lib` | libpython3.13.so.1.0, libm.so.6, libpthread.so.0, libc.so.6, libdl.so.2 |
| `gdb_for_pwndbg/_vendor/bin/gdbserver` | *(empty)* | libm.so.6, libpthread.so.0, libc.so.6, libdl.so.2 |
| `lldb_for_pwndbg/_vendor/bin/lldb` | `$ORIGIN/../lib` | **libpython_loader_lldb.so, liblldb_stub.so**, libm.so.6, libpthread.so.0, libc.so.6, libdl.so.2 |
| `lldb_for_pwndbg/_vendor/bin/lldb-server` | *(empty)* | libm.so.6, libpthread.so.0, libc.so.6, libdl.so.2 |

`gdb` already ships the bundle-relative RUNPATH, and `gdbserver`/`lldb-server` were patched. `lldb` is the odd one out: its RUNPATH is non-empty but only covers `_vendor/lib`, so libc/libm/libpthread/libdl were resolved from the **host** rather than from the glibc shipped inside the bundle. That happened to work on older distros and broke on Ubuntu 26.04:

```
$ pwndbg-lldb
Could not find the LLDB Python Path: b'/usr/local/lib/pwndbg-lldb/lib/python3.13/site-packages/lldb_for_pwndbg/_vendor/bin/lldb: error while loading shared libraries: libm.so.6: cannot open shared object file: No such file or directory'
```

Checking the four `NEEDED` entries against the old RUNPATH in a real `pwndbg-lldb` portable bundle:

```
libpython_loader_lldb.so -> found in $ORIGIN/../lib
liblldb_stub.so          -> found in $ORIGIN/../lib
libm.so.6                -> NOT FOUND -> resolved from HOST
libpthread.so.0          -> NOT FOUND -> resolved from HOST
libc.so.6                -> NOT FOUND -> resolved from HOST
libdl.so.2               -> NOT FOUND -> resolved from HOST
```

## Fix

Handle it in `bundle.py` rather than adding a third hardcoded path to `portable.nix`. Venv-shipped executables are detected by ELF magic plus the executable bit, and the bundle's `lib/` is appended to their rpath, with the offset computed via `os.path.relpath` instead of a hand-counted `../../../../../..`.

Details that matter:

- **Extend, don't replace.** `lldb` must keep `$ORIGIN/../lib` or it can no longer find `libpython_loader_lldb.so` / `liblldb_stub.so`. `--set-rpath` alone would have broken it.
- **Empty rpath entries are dropped** — an empty entry means "current working directory" to the loader, and `gdbserver`'s wheel ships one.
- **Statically linked executables are skipped** — `ziglang/zig` is a prod dependency, is fully static, and has no `.dynamic` section, so `patchelf` fails on it.
- Patching the executable is enough for its whole dependency closure: `ld.so` resolves by SONAME, so once `libc.so.6` and friends are loaded from the bundle via `lldb`'s RUNPATH, `libpython_loader_lldb.so`'s own `libc.so.6`/`libdl.so.2` resolve to the already-loaded objects. No risk of two glibcs in one process.

This subsumes the two `patchelf` lines in `portable.nix`, which are removed.

## Testing

`./lint.sh`, `nixfmt --check` and `nix-instantiate --parse` pass.

@patryk4815 built real `aarch64-linux` portable bundles before and after this change. Both were unpacked and every file compared by SHA-256.

**`pwndbg-lldb` portable** — 35229 files + 1053 symlinks, identical tree structure, identical total apparent size, and **exactly one file differs**:

```
pwndbg/lib/python3.13/site-packages/lldb_for_pwndbg/_vendor/bin/lldb   734920 -> 734920 bytes
```

| binary | before | after |
|---|---|---|
| `_vendor/bin/lldb` | `$ORIGIN/../lib` | `$ORIGIN/../lib:$ORIGIN/../../../../../../lib` |
| `_vendor/bin/lldb-server` | `$ORIGIN/../../../../../../lib` | `$ORIGIN/../../../../../../lib` |
| `_vendor/lib/libpython_loader_lldb.so` | `$ORIGIN` | `$ORIGIN` |
| `ziglang/zig` | *(none)* | *(none)* |

All six `NEEDED` entries of `lldb` now resolve inside the bundle, four of them against the newly added path:

```
libpython_loader_lldb.so -> $ORIGIN/../lib
liblldb_stub.so          -> $ORIGIN/../lib
libm.so.6                -> $ORIGIN/../../../../../../lib   (bundled)
libpthread.so.0          -> $ORIGIN/../../../../../../lib   (bundled)
libc.so.6                -> $ORIGIN/../../../../../../lib   (bundled)
libdl.so.2               -> $ORIGIN/../../../../../../lib   (bundled)
```

**`pwndbg` (GDB) portable** — 35295 files + 1053 symlinks, **byte-for-byte identical**, zero files changed. That is the expected result and confirms the two removed `patchelf` lines were migrated exactly: `gdbserver` comes out with the same `$ORIGIN/../../../../../../lib` it had before, `gdb` is correctly left alone, and `zig` is correctly skipped.

The `.tar.xz` sizes differ slightly between the old and new archives in both directions (GDB `+1.9M`, LLDB `-1.8M`) even where content is identical. That is archive nondeterminism, not content: the tar member order moved (`ziglang/zig` is emitted before `gdb_for_pwndbg/` in one and after in the other), which shifts the xz block boundaries. Total apparent bytes are equal to the byte in both pairs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015LwZJkBgzobzhh2eg4BZR7