### PR TITLE
Fix nextret when it can encounter a loop

### DIFF
--- a/pwndbg/aglib/next.py
+++ b/pwndbg/aglib/next.py
@@ -57,6 +57,8 @@ def next_branch(address=None, including_current=False) -> PwndbgInstruction | No
     Return the next branch instruction that the process will encounter with repeated usage of the "nexti" command.
 
     If including_current == True, then if the instruction at the address is already a branch, return it.
+    
+    Returns the next branch instruction, or None if cannot disassemble anymore.
     """
     if address is None:
         ins = pwndbg.aglib.disasm.disassembly.one(pwndbg.aglib.regs.pc)
@@ -131,7 +133,7 @@ async def break_next_branch(
     inf = pwndbg.dbg.selected_inferior()
     # If the branch we found was not at the current program counter, we should step to it.
     # Otherwise, return the current instruction.
-    if ins.address != pwndbg.aglib.regs.pc:
+    if not including_current or ins.address != pwndbg.aglib.regs.pc:
         with inf.break_at(BreakpointLocation(ins.address), internal=True) as bp:
             await ec.cont(bp)
     return ins

--- a/pwndbg/aglib/next.py
+++ b/pwndbg/aglib/next.py
@@ -57,7 +57,7 @@ def next_branch(address=None, including_current=False) -> PwndbgInstruction | No
     Return the next branch instruction that the process will encounter with repeated usage of the "nexti" command.
 
     If including_current == True, then if the instruction at the address is already a branch, return it.
-    
+
     Returns the next branch instruction, or None if cannot disassemble anymore.
     """
     if address is None:

--- a/tests/binaries/host/loop_instruction_ending_in_ret.x86-64.asm
+++ b/tests/binaries/host/loop_instruction_ending_in_ret.x86-64.asm
@@ -1,0 +1,24 @@
+global _start
+
+_start:
+nop
+nop
+xor ecx, ecx
+
+
+loop:
+    inc ecx
+    cmp ecx, 4
+    jl loop
+
+times 32 nop
+
+middle_of_nops:
+times 32 nop
+
+end_of_nops:
+ret
+
+; These bytes don't decode to anything, making the test easier as the disassembly is cut off here
+db 0xFF, 0xFF
+

--- a/tests/library/dbg/tests/test_commands_next.py
+++ b/tests/library/dbg/tests/test_commands_next.py
@@ -70,3 +70,25 @@ async def test_next_command_doesnt_freeze_crashed_binary(ctrl: Controller, comma
 
     # This should not halt/freeze the program
     await ctrl.execute(command)
+
+LOOP_BINARY = get_binary("loop_instruction_ending_in_ret.x86-64.out")
+
+@pwndbg_test
+async def test_nextret_loop(ctrl: Controller) -> None:
+    """
+    Test nextret on a program that will encounter an loop
+    """
+
+    import pwndbg.aglib.disasm.disassembly
+    from capstone6pwndbg.x86 import X86_INS_RET
+
+    await ctrl.launch(LOOP_BINARY)
+
+    await ctrl.execute("nextret")
+
+    current_instruction = pwndbg.aglib.disasm.disassembly.one()
+
+    assert current_instruction.id == X86_INS_RET
+
+
+

--- a/tests/library/dbg/tests/test_commands_next.py
+++ b/tests/library/dbg/tests/test_commands_next.py
@@ -87,6 +87,10 @@ async def test_nextret_loop(ctrl: Controller) -> None:
 
     await ctrl.launch(LOOP_BINARY)
 
+    # WORKAROUND FOR LLDB BUG: https://github.com/pwndbg/pwndbg/issues/4097
+    # Need to step once so that nextret works
+    await ctrl.step_instruction()
+
     await ctrl.execute("nextret")
 
     current_instruction = pwndbg.aglib.disasm.disassembly.one()

--- a/tests/library/dbg/tests/test_commands_next.py
+++ b/tests/library/dbg/tests/test_commands_next.py
@@ -71,7 +71,9 @@ async def test_next_command_doesnt_freeze_crashed_binary(ctrl: Controller, comma
     # This should not halt/freeze the program
     await ctrl.execute(command)
 
+
 LOOP_BINARY = get_binary("loop_instruction_ending_in_ret.x86-64.out")
+
 
 @pwndbg_test
 async def test_nextret_loop(ctrl: Controller) -> None:
@@ -79,8 +81,9 @@ async def test_nextret_loop(ctrl: Controller) -> None:
     Test nextret on a program that will encounter an loop
     """
 
-    import pwndbg.aglib.disasm.disassembly
     from capstone6pwndbg.x86 import X86_INS_RET
+
+    import pwndbg.aglib.disasm.disassembly
 
     await ctrl.launch(LOOP_BINARY)
 
@@ -89,6 +92,3 @@ async def test_nextret_loop(ctrl: Controller) -> None:
     current_instruction = pwndbg.aglib.disasm.disassembly.one()
 
     assert current_instruction.id == X86_INS_RET
-
-
-


### PR DESCRIPTION
#2884 introduced a subtle bug that caused nextret to get stuck on certain types of loops.

If you had a binary like the following, where a sequence the instruction in the loop ends in the branch, that can either fall through or not, and there were no intermediate branches, nextret would get stuck forever.

```
xor ecx, ecx

loop:
    inc ecx
    cmp ecx, 4
    jl loop
ret

```

This is fixed and a test, and I added a test for it