### PR TITLE
Remove hardcoded tcache dereference limit

### DIFF
--- a/pwndbg/commands/ptmalloc2.py
+++ b/pwndbg/commands/ptmalloc2.py
@@ -94,17 +94,9 @@ def format_bin(bins: Bins, verbose: bool = False, offset: int | None = None) -> 
         if not verbose and (chain_fd == [0] and not count) and not is_chain_corrupted:
             continue
 
-        if bins_type == BinType.TCACHE:
-            limit = 8
-            if count <= 7:
-                limit = count + 1
-            formatted_chain = pwndbg.chain.format(
-                chain_fd[0], offset=offset, limit=limit, safe_linking=safe_lnk
-            )
-        else:
-            formatted_chain = pwndbg.chain.format(
-                chain_fd[0], limit=heap_chain_limit, offset=offset, safe_linking=safe_lnk
-            )
+        formatted_chain = pwndbg.chain.format(
+            chain_fd[0], limit=heap_chain_limit, offset=offset, safe_linking=safe_lnk
+        )
 
         if isinstance(size, int):
             if bins_type == BinType.LARGE:

--- a/tests/library/dbg/tests/test_heap_bins.py
+++ b/tests/library/dbg/tests/test_heap_bins.py
@@ -205,6 +205,38 @@ async def test_heap_bins(ctrl: Controller) -> None:
 
 
 @pwndbg_test
+async def test_tcache_bins_respects_heap_dereference_limit(ctrl: Controller) -> None:
+    """Ensure tcache rendering uses heap-dereference-limit for chains longer than seven."""
+    import pwndbg.aglib.heap
+    from pwndbg.aglib.heap.ptmalloc import GlibcMemoryAllocator
+
+    await ctrl.execute("set context-output /dev/null")
+    await ctrl.launch(BINARY, env={"GLIBC_TUNABLES": "glibc.malloc.tcache_count=16"})
+
+    # Free 11 chunks into one tcache bin
+    break_at_sym("breakpoint")
+    await ctrl.cont()
+    await ctrl.cont()
+    await ctrl.cont()
+
+    assert isinstance(pwndbg.aglib.heap.current, GlibcMemoryAllocator)
+    allocator = pwndbg.aglib.heap.current
+
+    await ctrl.execute("set heap-dereference-limit 12")
+
+    bins = allocator.tcachebins()
+    assert bins is not None
+    tcache_bin = bins.bins[allocator._request2size(0x20)]
+    assert tcache_bin.count == 11
+    assert len(tcache_bin.fd_chain) == 12
+    assert tcache_bin.fd_chain[-1] == 0
+
+    output = await ctrl.execute_and_capture("bins")
+    for address in tcache_bin.fd_chain[:-1]:
+        assert hex(address) in output
+
+
+@pwndbg_test
 async def test_heap_bins_2_43(ctrl: Controller) -> None:
     """
     Tests pwndbg.aglib.heap bins commands (Only for glibc 2.43+ targets)

--- a/tests/library/dbg/tests/test_heap_bins.py
+++ b/tests/library/dbg/tests/test_heap_bins.py
@@ -211,6 +211,8 @@ async def test_tcache_bins_respects_heap_dereference_limit(ctrl: Controller) -> 
     from pwndbg.aglib.heap.ptmalloc import GlibcMemoryAllocator
 
     await ctrl.execute("set context-output /dev/null")
+    # Glibc 2.43 changed tcache binsize to 16.
+    # GLIBC_TUNABLES allows for testing that on the standard binary
     await ctrl.launch(BINARY, env={"GLIBC_TUNABLES": "glibc.malloc.tcache_count=16"})
 
     # Free 11 chunks into one tcache bin


### PR DESCRIPTION
Small change (glibc 2.43 heap)

PR #650 introduced a separate limit for tcache bins because heap-dereference-limit defaulted to 5 while tcache bins could contain up to 7 entries.

glibc 2.43 increased the default tcache bin length to 16, so tcache rendering should probably follow the configured deref-limit instead of using its own hardcoded limit.

Also add a regression test for tcache bins with more than 8 entries.

<img width="2940" height="378" alt="image" src="https://github.com/user-attachments/assets/d1a5bb9b-6608-4ba2-8939-a32fca97ac32" />

+ [x] I read the contributing documentation.
+ [x] I am providing a screenshot of the (new feature) / (fixed bug).
