### PR TITLE
nextproginstr bug fix

### DIFF
--- a/pwndbg/aglib/next.py
+++ b/pwndbg/aglib/next.py
@@ -24,22 +24,24 @@ from pwndbg.dbg_mod import BreakpointLocation
 interrupts = {CS_GRP_INT}
 
 
-def next_int(address=None, honor_current_branch=False):
+def next_int(address: int | None = None, honor_current_branch: bool = False):
     """
-    If there is a syscall in the current basic black,
-    return the instruction of the one closest to $PC.
+    Start at `address`, disassembling forwards to find the next syscall.
+    If there is a branch before the syscall, return None.
 
     If honor_current_branch is True, then if the address is already a branch, return None.
 
     If no interrupt exists or a jump is in the way, return None.
     """
     if address is None:
-        ins = pwndbg.aglib.disasm.disassembly.one(pwndbg.aglib.regs.pc)
-        if not ins:
-            return None
-        if honor_current_branch and ins.jump_like:
-            return None
-        address = ins.next
+        address = pwndbg.aglib.regs.pc
+
+    ins = pwndbg.aglib.disasm.disassembly.one(address)
+    if not ins:
+        return None
+    if honor_current_branch and ins.jump_like:
+        return None
+    address = ins.next
 
     ins = pwndbg.aglib.disasm.disassembly.one(address)
     while ins:
@@ -52,21 +54,25 @@ def next_int(address=None, honor_current_branch=False):
     return None
 
 
-def next_branch(address=None, including_current=False) -> PwndbgInstruction | None:
+def next_branch(
+    address: int | None = None, including_current: bool = False
+) -> PwndbgInstruction | None:
     """
-    Return the next branch instruction that the process will encounter with repeated usage of the "nexti" command.
+    Starting at `address`, return the next branch instruction that the process will encounter with repeated usage of the "nexti" command.
 
     If including_current == True, then if the instruction at the address is already a branch, return it.
 
     Returns the next branch instruction, or None if cannot disassemble anymore.
     """
     if address is None:
-        ins = pwndbg.aglib.disasm.disassembly.one(pwndbg.aglib.regs.pc)
-        if not ins:
-            return None
-        if including_current and ins.jump_like:
-            return ins
-        address = ins.next
+        address = pwndbg.aglib.regs.pc
+
+    ins = pwndbg.aglib.disasm.disassembly.one(address)
+    if not ins:
+        return None
+    if including_current and ins.jump_like:
+        return ins
+    address = ins.next
 
     ins = pwndbg.aglib.disasm.disassembly.one(address)
     while ins:
@@ -215,25 +221,26 @@ async def break_next_call(ec: pwndbg.dbg_mod.ExecutionController, symbol_regex=N
             return ins
 
 
-async def break_next_ret(
-    ec: pwndbg.dbg_mod.ExecutionController, address=None, including_current: bool = False
-):
+async def break_next_ret(ec: pwndbg.dbg_mod.ExecutionController, including_current: bool = False):
     """
     If including_current == True, do not step in case we are currently on a ret
     """
+
+    if including_current:
+        ins = pwndbg.aglib.disasm.disassembly.one(pwndbg.aglib.regs.pc)
+        if not ins:
+            return None
+        if CS_GRP_RET in ins.groups:
+            return ins
+
     while pwndbg.aglib.proc.alive():
         # Break on signal as it may be a segfault
         if pwndbg.aglib.proc.stopped_with_signal():
             return None
 
-        if including_current:
-            ins = pwndbg.aglib.disasm.disassembly.one(pwndbg.aglib.regs.pc)
-            if not ins:
-                return None
-            if CS_GRP_RET in ins.groups:
-                return ins
-
-        ins = await break_next_branch(ec, address)
+        # 'rets' are assumed to be a subset of branches
+        # Keep stepping between branches, until one of them is a ret
+        ins = await break_next_branch(ec)
 
         if not ins:
             break

--- a/pwndbg/aglib/next.py
+++ b/pwndbg/aglib/next.py
@@ -215,11 +215,21 @@ async def break_next_call(ec: pwndbg.dbg_mod.ExecutionController, symbol_regex=N
             return ins
 
 
-async def break_next_ret(ec: pwndbg.dbg_mod.ExecutionController, address=None):
+async def break_next_ret(
+    ec: pwndbg.dbg_mod.ExecutionController, address=None, including_current: bool = False
+):
+    """
+    If including_current == True, do not step in case we are currently on a ret
+    """
     while pwndbg.aglib.proc.alive():
         # Break on signal as it may be a segfault
         if pwndbg.aglib.proc.stopped_with_signal():
             return None
+
+        if including_current:
+            ins = pwndbg.aglib.disasm.disassembly.one(pwndbg.aglib.regs.pc)
+            if CS_GRP_RET in ins.groups:
+                return ins
 
         ins = await break_next_branch(ec, address)
 
@@ -300,7 +310,7 @@ async def break_on_program_code(ec: pwndbg.dbg_mod.ExecutionController) -> bool:
         if pwndbg.aglib.proc.stopped_with_signal():
             return False
 
-        await break_next_ret(ec)
+        await break_next_ret(ec, including_current=True)
         await ec.single_step()
 
         for start, end in binary_exec_page_ranges:

--- a/pwndbg/aglib/next.py
+++ b/pwndbg/aglib/next.py
@@ -228,6 +228,8 @@ async def break_next_ret(
 
         if including_current:
             ins = pwndbg.aglib.disasm.disassembly.one(pwndbg.aglib.regs.pc)
+            if not ins:
+                return None
             if CS_GRP_RET in ins.groups:
                 return ins
 

--- a/pwndbg/commands/next.py
+++ b/pwndbg/commands/next.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 import argparse
 from collections.abc import Callable
 
+from capstone6pwndbg import CS_GRP_RET
+
 import pwndbg.aglib.next
 import pwndbg.aglib.proc
 import pwndbg.commands
@@ -78,15 +80,17 @@ async def _stepret(ec: pwndbg.dbg_mod.ExecutionController):
     """
     Execution controller for the `stepret` command.
     """
-    while (
-        pwndbg.aglib.proc.alive()
-        and not (await pwndbg.aglib.next.break_next_ret(ec))
-        and (await pwndbg.aglib.next.break_next_branch(ec))
+    first = True
+    while pwndbg.aglib.proc.alive() and (
+        ins := await pwndbg.aglib.next.break_next_branch(ec, including_current=True)
     ):
+        # If we are already on a RET when starting this command, we skip
+        if not first and CS_GRP_RET in ins.groups:
+            break
+        first = False
         # Here we are e.g. on a CALL instruction (temporarily breakpointed by `break_next_branch`)
         # We need to step so that we take this branch instead of ignoring it
         await ec.single_step()
-        continue
 
 
 @pwndbg.commands.Command(

--- a/pwndbg/commands/next.py
+++ b/pwndbg/commands/next.py
@@ -80,14 +80,16 @@ async def _stepret(ec: pwndbg.dbg_mod.ExecutionController):
     """
     Execution controller for the `stepret` command.
     """
-    first = True
+
+    # We may be starting on a ret. This prevents us from just sitting on the ret
+    if pwndbg.aglib.proc.alive():
+        await ec.single_step()
+
     while pwndbg.aglib.proc.alive() and (
         ins := await pwndbg.aglib.next.break_next_branch(ec, including_current=True)
     ):
-        # If we are already on a RET when starting this command, we skip
-        if not first and CS_GRP_RET in ins.groups:
+        if CS_GRP_RET in ins.groups:
             break
-        first = False
         # Here we are e.g. on a CALL instruction (temporarily breakpointed by `break_next_branch`)
         # We need to step so that we take this branch instead of ignoring it
         await ec.single_step()

--- a/tests/library/dbg/tests/test_commands_next.py
+++ b/tests/library/dbg/tests/test_commands_next.py
@@ -56,6 +56,31 @@ async def test_command_nextproginstr(ctrl: Controller) -> None:
     assert out == "The pc is already at the binary objfile code. Not stepping.\n"
 
 
+@pwndbg_test
+async def test_command_nextproginstr_at_ret(ctrl: Controller) -> None:
+    """
+    Assuming we are currently at a "ret" instruction, nextproginstruction should still work
+    """
+    import pwndbg.aglib
+    import pwndbg.aglib.proc
+    import pwndbg.aglib.vmmap
+
+    await launch_to(ctrl, REFERENCE_BINARY, "main")
+    main_page = pwndbg.aglib.vmmap.find(pwndbg.aglib.regs.pc)
+
+    break_at_sym("puts")
+    await ctrl.cont()
+
+    # Sanity check that we are in libc
+    assert "libc" in pwndbg.aglib.vmmap.find(pwndbg.aglib.regs.pc).objfile
+
+    await ctrl.execute("nextret")
+
+    # Execute nextproginstr and see if we came back to the same vmmap page
+    await ctrl.execute("nextproginstr")
+    assert pwndbg.aglib.regs.pc in main_page
+
+
 @pytest.mark.parametrize("command", NEXT_COMMANDS)
 @pwndbg_test
 async def test_next_command_doesnt_freeze_crashed_binary(ctrl: Controller, command: str) -> None:


### PR DESCRIPTION
I came across a bug where if we are currently on a `ret` instruction, then `nextproginstr` does not work. This was a small logic bug (explained in a comment below), which is now fixed + a test added.