### PR TITLE
Small loongarch64 disasm fixes

### DIFF
--- a/pwndbg/aglib/disasm/instruction.py
+++ b/pwndbg/aglib/disasm/instruction.py
@@ -19,6 +19,7 @@ from capstone6pwndbg.aarch64 import AARCH64_INS_BR
 from capstone6pwndbg.arm import ARM_INS_TBB
 from capstone6pwndbg.arm import ARM_INS_TBH
 from capstone6pwndbg.loongarch import LOONGARCH_INS_ALIAS_JR
+from capstone6pwndbg.loongarch import LOONGARCH_INS_ALIAS_RET
 from capstone6pwndbg.loongarch import LOONGARCH_INS_B
 from capstone6pwndbg.loongarch import LOONGARCH_INS_BL
 from capstone6pwndbg.loongarch import LOONGARCH_INS_CALL36
@@ -125,6 +126,7 @@ UNCONDITIONAL_JUMP_INSTRUCTIONS: dict[int, set[int]] = {
         LOONGARCH_INS_JIRL,
         LOONGARCH_INS_ALIAS_JR,
         LOONGARCH_INS_CALL36,
+        LOONGARCH_INS_ALIAS_RET,
     },
 }
 

--- a/pwndbg/aglib/disasm/loongarch64.py
+++ b/pwndbg/aglib/disasm/loongarch64.py
@@ -81,6 +81,6 @@ class Loong64DisassemblyAssistant(pwndbg.aglib.disasm.assistant.DisassemblyAssis
 
         if instruction.id == LOONGARCH_INS_JIRL:
             if (offset_reg := instruction.operands[1].before_value) is not None:
-                return offset_reg + (instruction.operands[2].before_value << 2)
+                return offset_reg + (instruction.operands[2].before_value)
 
         return super()._resolve_target(instruction, emu)


### PR DESCRIPTION
Two fixes bugs in to Loongarch64 disasm I encountered:
- rets were not followed correctly in display, because they where not being categorized as a jump correctly.
- jilr (call instructions) had targets calculated incorrectly.


Ret before:
<img width="1096" height="181" alt="loongarch_fix_before" src="https://github.com/user-attachments/assets/6cf7ed3d-6d85-44d8-8c55-c83feb399d89" />

Ret after:
<img width="1096" height="181" alt="loongarch_fix_after" src="https://github.com/user-attachments/assets/4dcd90c7-9866-4f78-b679-ed08c52e76c5" />
