### PR TITLE
Fix GDB internally calling malloc while we iterate stack symbols, causing crash

### DIFF
--- a/pwndbg/dbg_mod/gdb/__init__.py
+++ b/pwndbg/dbg_mod/gdb/__init__.py
@@ -126,6 +126,9 @@ def _get_frame_stack_variables(frame: gdb.Frame) -> tuple[tuple[int, int, str], 
             try:
                 value = sym.value(frame)
 
+                # If a variable is optimized out, it surely has no memory location
+                # This check also prevents GDB from calling `malloc` within the inferior process
+                # which can cause a crash. See https://github.com/pwndbg/pwndbg/pull/4112
                 if value.is_optimized_out:
                     continue
 

--- a/pwndbg/dbg_mod/gdb/__init__.py
+++ b/pwndbg/dbg_mod/gdb/__init__.py
@@ -125,6 +125,10 @@ def _get_frame_stack_variables(frame: gdb.Frame) -> tuple[tuple[int, int, str], 
 
             try:
                 value = sym.value(frame)
+
+                if value.is_optimized_out:
+                    continue
+
                 # value.address can be None
                 # https://sourceware.org/gdb/current/onlinedocs/gdb.html/Values-From-Inferior.html#Values-From-Inferior:~:text=Variable%3A%20Value%2Eaddress
                 # https://sourceware.org/bugzilla/show_bug.cgi?id=33860


### PR DESCRIPTION
While stepping through the early instructions of a binary compiled by Zig, I came across a bug where upon entering a function, GDB would suddenly seemingly jump to a completely unrelated function and segfault.

We are here:
<img width="2992" height="454" alt="image" src="https://github.com/user-attachments/assets/ec6a8233-ce24-467a-a0fe-0ea9210b5f14" />

Then `si`, and it suddenly crashes here:
<img width="2992" height="454" alt="image" src="https://github.com/user-attachments/assets/6d060c5e-c838-4963-a34a-83c7f1f39476" />

At the moment of the crash, if we do `bt`, we can see how it got here:
<img width="2631" height="1221" alt="image" src="https://github.com/user-attachments/assets/f04ef45d-b253-429e-be54-f0a9dc0ccb0d" />


Turns out that while we are iterating stack variables in a stack frame for the purposes of displaying variables names (associated with an address), we unknowingly may cause GDB internally to invoke `malloc` within the inferior process. It calls malloc within the process for reasons described below, but it segfaults within malloc almost immediately, since the library hasn't been initialized yet. The malloc implementation assumes that things like thread local memory (FS register) have been setup.

The root cause of this bug starts around here. While displaying integers and pointers to the display, we "enhance" them. One way we do so is to see if the pointer is to a local variable, so we can display the local variable name. Upon entering a new frame, we iterate all symbols in it in this function:

https://github.com/pwndbg/pwndbg/blob/2267f2eb102c53552900129224873481995654da/pwndbg/dbg_mod/gdb/__init__.py#L121-L141

One of the checks in this function is:
```python
if value.address is None:
    continue
```
This `.address` lookup, in certain cases, will cause GDB to invoke malloc in the process. This Python attribute lookup invokes a function in GDB, [valpy_get_address](https://sourceware.org/git/?p=binutils-gdb.git;a=blob;f=gdb/python/py-value.c;h=5d8fab90c04c4b5c98d9efc60700ac5f503138d2;hb=refs/heads/gdb-17-branch#l402). 

This function will try to resolve the address of the variable in question, calling [value_coerce_to_target](https://sourceware.org/git/?p=binutils-gdb.git;a=blob;f=gdb/valops.c;h=85d69fb11f27e283a8a400ae0205df022c8499d2;hb=refs/heads/gdb-17-branch#l1467) for some variable types.

If the variable type pass [this check](https://sourceware.org/git/?p=binutils-gdb.git;a=blob;f=gdb/valops.c;h=85d69fb11f27e283a8a400ae0205df022c8499d2;hb=refs/heads/gdb-17-branch#l1439) (it's an array or string that is an `lvalue`, basically an object that is not backed by memory of any kind currently)

If this is the case, it internally calls [value_allocate_space_in_inferior](https://sourceware.org/git/?p=binutils-gdb.git;a=blob;f=gdb/valops.c;h=85d69fb11f27e283a8a400ae0205df022c8499d2;hb=refs/heads/gdb-17-branch#l165), which calls malloc within the inferior process!
```c
struct value *
value_allocate_space_in_inferior (int len)
{
struct objfile *objf;
struct value *val = find_function_in_inferior ("malloc", &objf);
struct gdbarch *gdbarch = objf->arch ();
struct value *blocklen;
...
```
Presumably it is doing this to be able to actually return an address for the variable in question (after placing a value into it). It is basically "constructing" a location that the variable can be referenced at.

But now this calls `malloc` within the inferior, but the libc library has not been setup yet! So the `FS` register as not be set to the thread local memory region yet, and it crashes when it is referenced.

<img width="3033" height="481" alt="image" src="https://github.com/user-attachments/assets/4a8aa354-6d5b-4c9d-b69a-f77e87791753" />

This then results in a segfault and stops the program.

This PR fixes this by checking if the variable is optimized out (meaning it definitely has no memory location) before calling `value.address`, which could invoke this long chain that calls `malloc` under the hood.



# Replicate
To replicate the issue (which crashes without this PR), you can:

Running with zig version `0.16.0`
// repro.zig file
```
pub fn main() !void {
}
```
```sh
# Build
zig build-exe repro.zig -lc -target x86_64-linux -O ReleaseSafe

# Debug it
gdb ./repro

# Within gdb, run `starti`, then `si` around 30 times until you get to the memset. Step into the memset and observe the crash.
```


If this is ever encountered in other contexts, you can also fix this bug by setting this gdb setting:
```sh
set may-call-functions off
```
This disables GDB calling functions in the inferior in any case.