### PR TITLE
Fix checkmark/x for certain aarch64 conditional instructions

### DIFF
--- a/pwndbg/aglib/disasm/aarch64.py
+++ b/pwndbg/aglib/disasm/aarch64.py
@@ -359,8 +359,9 @@ class AArch64DisassemblyAssistant(pwndbg.aglib.disasm.assistant.DisassemblyAssis
                 instruction.declare_is_unconditional_jump = True
             else:
                 flags = super()._read_register_name(instruction, "cpsr", emu)
-                if flags is not None:
-                    return resolve_condition(instruction.cs_insn.cc, flags)
+                if flags is None:
+                    return InstructionCondition.UNDETERMINED_CONDITIONAL
+                return resolve_condition(instruction.cs_insn.cc, flags)
 
         elif instruction.id == AARCH64_INS_CBNZ:
             op_val = instruction.operands[0].before_value
@@ -398,8 +399,10 @@ class AArch64DisassemblyAssistant(pwndbg.aglib.disasm.assistant.DisassemblyAssis
             # for all conditional select instructions
             flags = self._read_register_name(instruction, "cpsr", emu)
 
-            if flags is not None:
-                return resolve_condition(instruction.cs_insn.cc, flags)
+            if flags is None:
+                return InstructionCondition.UNDETERMINED_CONDITIONAL
+
+            return resolve_condition(instruction.cs_insn.cc, flags)
 
         return super()._condition(instruction, emu)
 

--- a/pwndbg/aglib/disasm/aarch64.py
+++ b/pwndbg/aglib/disasm/aarch64.py
@@ -364,11 +364,15 @@ class AArch64DisassemblyAssistant(pwndbg.aglib.disasm.assistant.DisassemblyAssis
 
         elif instruction.id == AARCH64_INS_CBNZ:
             op_val = instruction.operands[0].before_value
-            return boolean_to_instruction_condition(op_val is not None and op_val != 0)
+            if op_val is None:
+                return InstructionCondition.UNDETERMINED_CONDITIONAL
+            return boolean_to_instruction_condition(op_val != 0)
 
         elif instruction.id == AARCH64_INS_CBZ:
             op_val = instruction.operands[0].before_value
-            return boolean_to_instruction_condition(op_val is not None and op_val == 0)
+            if op_val is None:
+                return InstructionCondition.UNDETERMINED_CONDITIONAL
+            return boolean_to_instruction_condition(op_val == 0)
 
         elif instruction.id == AARCH64_INS_TBNZ:
             op_val, bit = (
@@ -376,8 +380,9 @@ class AArch64DisassemblyAssistant(pwndbg.aglib.disasm.assistant.DisassemblyAssis
                 instruction.operands[1].before_value,
             )
 
-            if op_val is not None and bit is not None:
-                return boolean_to_instruction_condition(bool((op_val >> bit) & 1))
+            if op_val is None or bit is None:
+                return InstructionCondition.UNDETERMINED_CONDITIONAL
+            return boolean_to_instruction_condition(bool((op_val >> bit) & 1))
 
         elif instruction.id == AARCH64_INS_TBZ:
             op_val, bit = (
@@ -385,8 +390,9 @@ class AArch64DisassemblyAssistant(pwndbg.aglib.disasm.assistant.DisassemblyAssis
                 instruction.operands[1].before_value,
             )
 
-            if op_val is not None and bit is not None:
-                return boolean_to_instruction_condition(not ((op_val >> bit) & 1))
+            if op_val is None or bit is None:
+                return InstructionCondition.UNDETERMINED_CONDITIONAL
+            return boolean_to_instruction_condition(not ((op_val >> bit) & 1))
         elif instruction.id in CONDITIONAL_SELECT_INSTRUCTIONS:
             # Capstone places the condition to be satisfied in the `cc` field of the instruction
             # for all conditional select instructions

--- a/pwndbg/aglib/disasm/instruction.py
+++ b/pwndbg/aglib/disasm/instruction.py
@@ -13,9 +13,11 @@ from capstone6pwndbg import *  # noqa: F403
 from capstone6pwndbg import CS_AC
 from capstone6pwndbg import CS_GRP
 from capstone6pwndbg import CS_OP
+from capstone6pwndbg.aarch64 import AARCH64_INS_ALIAS_RET
 from capstone6pwndbg.aarch64 import AARCH64_INS_BL
 from capstone6pwndbg.aarch64 import AARCH64_INS_BLR
 from capstone6pwndbg.aarch64 import AARCH64_INS_BR
+from capstone6pwndbg.aarch64 import AARCH64_INS_RET
 from capstone6pwndbg.arm import ARM_INS_TBB
 from capstone6pwndbg.arm import ARM_INS_TBH
 from capstone6pwndbg.loongarch import LOONGARCH_INS_ALIAS_JR
@@ -95,7 +97,13 @@ UNCONDITIONAL_JUMP_INSTRUCTIONS: dict[int, set[int]] = {
         ARM_INS_TBB,
         ARM_INS_TBH,
     },
-    CS_ARCH_AARCH64: {AARCH64_INS_BL, AARCH64_INS_BLR, AARCH64_INS_BR},
+    CS_ARCH_AARCH64: {
+        AARCH64_INS_BL,
+        AARCH64_INS_BLR,
+        AARCH64_INS_BR,
+        AARCH64_INS_RET,
+        AARCH64_INS_ALIAS_RET,
+    },
     CS_ARCH_RISCV: {
         RISCV_INS_ALIAS_RET,
         RISCV_INS_JALR,


### PR DESCRIPTION
The checkmark/x that is marked for branches/conditional instructions was incorrect for certain AArch64 conditional instructions which we don't know the results of yet (because they are after a function call, which we do not emulate through).

These instructions should be marked with a question mark, but instead were defaulting to an `X`.

Before:
<img width="2764" height="1241" alt="image" src="https://github.com/user-attachments/assets/535b70fb-5d36-4909-b5e0-09d392a39944" />


After:
<img width="2764" height="1108" alt="image" src="https://github.com/user-attachments/assets/f593dc21-2c36-4755-b7c4-fb37ebb479b8" />
