### PR TITLE
Fix certain arm instructions branch resolution logic being incorrect

### DIFF
--- a/pwndbg/aglib/disasm/arm.py
+++ b/pwndbg/aglib/disasm/arm.py
@@ -315,7 +315,7 @@ class ArmDisassemblyAssistant(pwndbg.aglib.disasm.assistant.DisassemblyAssistant
         if instruction.jump_like and instruction.id == ARM_INS_LDR:
             # This is one we could potentially handle manually while stepped on it
             if len(instruction.operands) == 2 and (
-                (branch_target := instruction.operands[1].before_value) is not None
+                (branch_target := instruction.operands[1].before_value_resolved) is not None
             ):
                 target = branch_target
         elif instruction.id not in ARM_CAN_WRITE_TO_PC_INSTRUCTIONS:

--- a/pwndbg/aglib/disasm/arm.py
+++ b/pwndbg/aglib/disasm/arm.py
@@ -310,7 +310,18 @@ class ArmDisassemblyAssistant(pwndbg.aglib.disasm.assistant.DisassemblyAssistant
 
     @override
     def _resolve_target(self, instruction: PwndbgInstruction, emu: Emulator | None):
-        target = super()._resolve_target(instruction, emu)
+
+        target: int | None = None
+        if instruction.id in ARM_CAN_WRITE_TO_PC_INSTRUCTIONS:
+            # The default target resolver does not apply to these instructions, since `pc` is an explicit operand,
+            # but it's not being read from.
+            if len(instruction.operands) == 2:
+                right_operand = instruction.operands[1]
+                if right_operand.before_value is not None:
+                    target = right_operand.before_value
+        else:
+            target = super()._resolve_target(instruction, emu)
+
         if target is not None:
             # On interworking branches - branches that can enable Thumb mode - the target of a jump
             # has the least significant bit set to 1. This is not actually written to the PC

--- a/pwndbg/aglib/disasm/arm.py
+++ b/pwndbg/aglib/disasm/arm.py
@@ -312,14 +312,14 @@ class ArmDisassemblyAssistant(pwndbg.aglib.disasm.assistant.DisassemblyAssistant
     def _resolve_target(self, instruction: PwndbgInstruction, emu: Emulator | None):
 
         target: int | None = None
-        if instruction.id in ARM_CAN_WRITE_TO_PC_INSTRUCTIONS:
-            # The default target resolver does not apply to these instructions, since `pc` is an explicit operand,
-            # but it's not being read from.
-            if len(instruction.operands) == 2:
-                right_operand = instruction.operands[1]
-                if right_operand.before_value is not None:
-                    target = right_operand.before_value
-        else:
+        if instruction.jump_like and instruction.id == ARM_INS_LDR:
+            # This is one we could potentially handle manually while stepped on it
+            if len(instruction.operands) == 2 and (
+                (branch_target := instruction.operands[1].before_value) is not None
+            ):
+                target = branch_target
+        elif instruction.id not in ARM_CAN_WRITE_TO_PC_INSTRUCTIONS:
+            # For the instructions in the list guarding this branch, the default resolver cannot determine the branch target
             target = super()._resolve_target(instruction, emu)
 
         if target is not None:

--- a/pwndbg/aglib/disasm/assistant.py
+++ b/pwndbg/aglib/disasm/assistant.py
@@ -514,7 +514,7 @@ class DisassemblyAssistant:
         if operand.type == CS_OP_MEM:
             # Assume that we are reading ptrsize - subclasses should override this function
             # to provide a more specific value if needed
-            self._read_memory(value, pwndbg.aglib.arch.ptrsize, instruction, emu)
+            return self._read_memory(value, pwndbg.aglib.arch.ptrsize, instruction, emu)
 
         return None
 

--- a/pwndbg/aglib/disasm/instruction.py
+++ b/pwndbg/aglib/disasm/instruction.py
@@ -748,10 +748,10 @@ class EnhancedOperand:
         )
 
         if isinstance(self.cs_op, X86Op):
-            info += (
-                f", size={self.cs_op.size}, "
-                f"access={CS_AC.get(self.cs_op.access, self.cs_op.access)}]"
-            )
+            info += f", size={self.cs_op.size}"
+
+        if hasattr(self.cs_op, "access"):
+            info += f", access={CS_AC.get(self.cs_op.access, self.cs_op.access)}]"
 
         return f"[{info}]"
 

--- a/pwndbg/aglib/disasm/instruction.py
+++ b/pwndbg/aglib/disasm/instruction.py
@@ -742,8 +742,8 @@ class EnhancedOperand:
     def __repr__(self) -> str:
         info = (
             f"'{self.str}': Symbol: {self.symbol}, "
-            f"Before: {hex(self.before_value) if self.before_value is not None else None}, "
-            f"After: {hex(self.after_value) if self.after_value is not None else None}, "
+            f"Before: {hex(self.before_value) if self.before_value is not None else None}: resolved: {hex(self.before_value_resolved) if self.before_value_resolved is not None else None}, "
+            f"After: {hex(self.after_value) if self.after_value is not None else None}, resolved: {hex(self.after_value_resolved) if self.after_value_resolved is not None else None}, "
             f"type={CS_OP.get(self.type, self.type)}"
         )
 


### PR DESCRIPTION
While working on #4122, I was looking at `plt` tables to ARM, and saw there was a bug in how the jump target is determined for certain `ARM` instructions that explicitly write to the program counter.

In ARM, a bunch of general purpose instructions support writing directly to the `pc`: https://support.arm.com/documentation/ddi0406/cb/Application-Level-Architecture/Application-Level-Programmers--Model/ARM-core-registers/Writing-to-the-PC?lang=en

The code didn't take these instructions into account in the correct way when calculating jump targets, and instead used a default jump handler to resolve their addresses, which was incorrect when disassembling them in a static context.


Before: as visualized with the arrows, the branches appear to be going to nearby addresses, but this is incorrect. For all these branches, we don't know statically what the address is.
<img width="1275" height="747" alt="image" src="https://github.com/user-attachments/assets/3c73c2d7-c325-4113-b827-cc0b30b76aa4" />


After (no branch target indicated, since we don't know any of them with statically):
<img width="1276" height="750" alt="image" src="https://github.com/user-attachments/assets/17330051-1547-42d6-9745-47f3aab8dc64" />
