### PR TITLE
Decouple string length from debugger settings

### DIFF
--- a/pwndbg/aglib/strings.py
+++ b/pwndbg/aglib/strings.py
@@ -14,18 +14,7 @@ import pwndbg.aglib.memory
 import pwndbg.dbg_mod
 from pwndbg.lib.memory import Page
 
-length = 15
-
-
-def update_length() -> None:
-    r"""
-    Unfortunately there's not a better way to get at this info.
-
-    >>> gdb.execute('show print elements', from_tty=False, to_string=True)
-    'Limit on string chars or array elements to print is 21.\n'
-    """
-    global length
-    length = pwndbg.dbg.string_limit()
+length = 200
 
 
 def get(address: int, maxlen: int | None = None, maxread: int | None = None) -> str | None:

--- a/pwndbg/dbg_mod/__init__.py
+++ b/pwndbg/dbg_mod/__init__.py
@@ -1396,12 +1396,6 @@ class Debugger:
         """
         raise NotImplementedError()
 
-    def string_limit(self) -> int:
-        """
-        The maximum size of a string.
-        """
-        raise NotImplementedError()
-
     def addrsz(self, address: Any) -> str:
         """
         Format the given address value.

--- a/pwndbg/dbg_mod/gdb/__init__.py
+++ b/pwndbg/dbg_mod/gdb/__init__.py
@@ -2047,15 +2047,6 @@ class GDB(pwndbg.dbg_mod.Debugger):
         return literal
 
     @override
-    def string_limit(self) -> int:
-        message = gdb.execute("show print elements", from_tty=False, to_string=True)
-        message = message.split("\n")[0].split()[-1]
-        message = message.strip(".")
-        if message == "unlimited":
-            return 0
-        return int(message)
-
-    @override
     def addrsz(self, address: Any) -> str:
         address = int(address) & pwndbg.aglib.arch.ptrmask
         return f"%#{2 * pwndbg.aglib.arch.ptrsize}x" % address

--- a/pwndbg/dbg_mod/gdb/hooks.py
+++ b/pwndbg/dbg_mod/gdb/hooks.py
@@ -8,7 +8,6 @@ import pwndbg
 import pwndbg.aglib.arch_mod
 import pwndbg.aglib.file
 import pwndbg.aglib.memory
-import pwndbg.aglib.strings
 import pwndbg.aglib.typeinfo
 import pwndbg.dbg_mod
 import pwndbg.gdblib.events
@@ -90,7 +89,6 @@ def on_start() -> None:
 
 @pwndbg.dbg.event_handler(EventType.STOP)
 def on_stop() -> None:
-    pwndbg.aglib.strings.update_length()
     pwndbg.dbg_mod.number_of_stops_since_birth += 1
 
 

--- a/pwndbg/dbg_mod/lldb/__init__.py
+++ b/pwndbg/dbg_mod/lldb/__init__.py
@@ -2536,10 +2536,6 @@ class LLDB(pwndbg.dbg_mod.Debugger):
         return literal
 
     @override
-    def string_limit(self) -> int:
-        return 200
-
-    @override
     def get_cmd_window_size(self) -> tuple[int, int]:
         return None, None
 

--- a/pwndbg/dbg_mod/lldb/hooks.py
+++ b/pwndbg/dbg_mod/lldb/hooks.py
@@ -9,7 +9,6 @@ import pwndbg.aglib.arch_mod
 import pwndbg.aglib.file
 import pwndbg.aglib.kernel
 import pwndbg.aglib.memory
-import pwndbg.aglib.strings
 import pwndbg.aglib.typeinfo
 import pwndbg.dbg_mod
 import pwndbg.lib.cache
@@ -47,7 +46,6 @@ def on_start() -> None:
 
 @pwndbg.dbg.event_handler(EventType.STOP)
 def on_stop() -> None:
-    pwndbg.aglib.strings.update_length()
     pwndbg.dbg_mod.number_of_stops_since_birth += 1
 
 

--- a/tests/library/gdb/tests/test_command_telescope.py
+++ b/tests/library/gdb/tests/test_command_telescope.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import re
+from collections.abc import Callable
 
 import gdb
+import pytest
 
 import pwndbg.aglib
 import pwndbg.aglib.memory
@@ -66,6 +68,20 @@ def test_command_telescope_n_records(start_binary):
     gdb.execute("entry")
     result = gdb.execute(f"telescope $rsp {n}", to_string=True).strip().splitlines()
     assert len(result) == n
+
+
+@pytest.mark.parametrize("elements", ("0", "unlimited"))
+def test_command_telescope_with_unlimited_print_elements(
+    start_binary: Callable[..., None], elements: str
+) -> None:
+    start_binary(TELESCOPE_BINARY)
+
+    gdb.execute(f"set print elements {elements}")
+    gdb.execute("stepi")
+
+    result = gdb.execute("telescope $rsp 2", to_string=True).strip().splitlines()
+    assert len(result) == 2
+    assert pwndbg.aglib.proc.exe() in result[1]
 
 
 def test_telescope_command_with_address_as_count(start_binary):


### PR DESCRIPTION
Fixes #4110

## Problem

GDB treats both `set print elements 0` and `set print elements unlimited` as an unlimited display setting. Pwndbg copied that value into its internal string-read length on every stop. The resulting zero-length memory read raised `ValueError: Argument 'count' should be greater than zero` during string enhancement.

## Change

Use Pwndbg's existing 200-byte limit independently of debugger display settings. Remove the obsolete `Debugger.string_limit()` interface, its GDB and LLDB implementations, and the per-stop refresh hooks.

The regression test covers both accepted GDB spellings, forces a stop so the old refresh path runs, and verifies that `telescope` still enhances the executable path.

## Verification

- `docker compose run --rm ubuntu24.04-mount ./tests.sh -d gdb -g gdb -v test_command_telescope_with_unlimited_print_elements`
- `docker compose run --rm ubuntu24.04-mount ./tests.sh -d gdb -g gdb -v test_command_telescope`
- `./lint.sh`
- Manual batch-mode reproduction against `dev` at `51e94b37a`

+ [x] I read the contributing documentation.
+ [ ] I am providing a screenshot of the fixed bug. The failure is non-visual; the traceback and regression test cover it instead.