### PR TITLE
fix(heap): correct DEFAULT_MP_ tcache_max_bytes for glibc 2.42

### DIFF
--- a/pwndbg/aglib/heap/glibc.py
+++ b/pwndbg/aglib/heap/glibc.py
@@ -2111,6 +2111,36 @@ class HeuristicHeap(
         self._thread_caches[tidx] = result
         return result
 
+    def _find_mp_addr(self) -> int | None:
+        """
+        Find the mp_ struct address by scanning the .data section.
+
+        Returns the absolute address if found, None otherwise.
+        """
+        if self.is_statically_linked():
+            section = pwndbg.aglib.proc.dump_elf_data_section()
+            section_address = pwndbg.aglib.proc.get_section_address_by_name(".data")
+        else:
+            section = pwndbg.libc.section_by_name(".data")
+            section_address = pwndbg.libc.section_address_by_name(".data")
+
+        if section is None or not section_address:
+            return None
+
+        _, _, data = section
+
+        # try to find the default mp_ struct in the .data section
+        found = data.find(bytes(self.struct_module.DEFAULT_MP_))
+        if found == -1 and pwndbg.libc.version() == (2, 42):
+            # Some glibc 2.42 builds (the official 2.42.0 tarball) use
+            # tcache_max_bytes=0x408 instead of 0x411, so fall back to
+            # that value as well.
+            fallback_mp = copy.deepcopy(self.struct_module.DEFAULT_MP_)
+            fallback_mp.tcache_max_bytes = self.struct_module.MAX_TCACHE_SMALL_SIZE
+            found = data.find(bytes(fallback_mp))
+
+        return section_address + found if found != -1 else None
+
     @property
     @override
     def mp(self) -> pwndbg.aglib.heap.glibc_structs.CStruct2GDB:
@@ -2119,19 +2149,7 @@ class HeuristicHeap(
             self._mp_addr = mp_via_symbol
 
         if not self._mp_addr:
-            if self.is_statically_linked():
-                section = pwndbg.aglib.proc.dump_elf_data_section()
-                section_address = pwndbg.aglib.proc.get_section_address_by_name(".data")
-            else:
-                section = pwndbg.libc.section_by_name(".data")
-                section_address = pwndbg.libc.section_address_by_name(".data")
-            if section is not None and section_address:
-                _, _, data = section
-
-                # try to find the default mp_ struct in the .data section
-                found = data.find(bytes(self.struct_module.DEFAULT_MP_))
-                if found != -1:
-                    self._mp_addr = section_address + found
+            self._mp_addr = self._find_mp_addr()
 
         if pwndbg.aglib.memory.is_readable_address(self._mp_addr):
             mps = self.malloc_par


### PR DESCRIPTION
# heuristic mp resolved in pwndbg
there are several small modificaiton between glibc 2.42 and 2.44.

glibc 2.42 use .tcache_max_bytes = tidx2usize(TCACHE_SMALL_BINS-1)， whose valuse is 0x408, but 2.43 switched  MAX_TCACHE_SMALL_SIZE from tidx2usize to tidx2csize and made the initializer inclusive (+1), so the default became 0x411. In pwndbg, we did not change the logic following glibc, we still use 0x411 for every
glibc >= 2.42, so the heuristic .data scan could never match on a stripped vanilla 2.42 and mp_ resolution failed with SymbolNotRecoveredError.

**glibc 2.42  changed the tcache_bins to tcache_small_bins, glibc 2.43 changed the value.**
# 2.42
```c
#if USE_TCACHE
/* We want 64 entries.  This is an arbitrary limit, which tunables can reduce.  */
# define TCACHE_SMALL_BINS		64
# define TCACHE_LARGE_BINS		12 /* Up to 4M chunks */
# define TCACHE_MAX_BINS	(TCACHE_SMALL_BINS + TCACHE_LARGE_BINS)
# define MAX_TCACHE_SMALL_SIZE	tidx2usize (TCACHE_SMALL_BINS-1)

/* Only used to pre-fill the tunables.  */
# define tidx2usize(idx)	(((size_t) idx) * MALLOC_ALIGNMENT + MINSIZE - SIZE_SZ)

/* When "x" is from chunksize().  */
# define csize2tidx(x) (((x) - MINSIZE) / MALLOC_ALIGNMENT)
/* When "x" is a user-provided size.  */
# define usize2tidx(x) csize2tidx (checked_request2size (x))

static struct malloc_par mp_ =
{
  .top_pad = DEFAULT_TOP_PAD,
  .n_mmaps_max = DEFAULT_MMAP_MAX,
  .mmap_threshold = DEFAULT_MMAP_THRESHOLD,
  .trim_threshold = DEFAULT_TRIM_THRESHOLD,
#define NARENAS_FROM_NCORES(n) ((n) * (sizeof (long) == 4 ? 2 : 8))
  .arena_test = NARENAS_FROM_NCORES (1)
#if USE_TCACHE
  ,
  .tcache_count = TCACHE_FILL_COUNT,
  .tcache_small_bins = TCACHE_SMALL_BINS,
  .tcache_max_bytes = MAX_TCACHE_SMALL_SIZE, // !!!! notice
  .tcache_unsorted_limit = 0 /* No limit.  */
#endif
};
```

# 2.43
```c
/* We want 64 entries.  This is an arbitrary limit, which tunables can reduce.  */
# define TCACHE_SMALL_BINS		64
# define TCACHE_LARGE_BINS		12 /* Up to 4M chunks */
# define TCACHE_MAX_BINS	(TCACHE_SMALL_BINS + TCACHE_LARGE_BINS)
# define MAX_TCACHE_SMALL_SIZE	tidx2csize (TCACHE_SMALL_BINS-1)

# define tidx2csize(idx)	(((size_t) idx) * MALLOC_ALIGNMENT + MINSIZE)
# define tidx2usize(idx)	(((size_t) idx) * MALLOC_ALIGNMENT + MINSIZE - SIZE_SZ)

/* When "x" is from chunksize().  */
# define csize2tidx(x) (((x) - MINSIZE) / MALLOC_ALIGNMENT)
/* When "x" is a user-provided size.  */
# define usize2tidx(x) csize2tidx (checked_request2size (x))

static struct malloc_par mp_ =
{
  .top_pad = DEFAULT_TOP_PAD,
  .n_mmaps_max = DEFAULT_MMAP_MAX,
  .mmap_threshold = DEFAULT_MMAP_THRESHOLD,
  .trim_threshold = DEFAULT_TRIM_THRESHOLD,
#define NARENAS_FROM_NCORES(n) ((n) * (sizeof (long) == 4 ? 2 : 8))
  .arena_test = NARENAS_FROM_NCORES (1),
  .thp_mode = malloc_thp_mode_not_supported
#if USE_TCACHE
  ,
  .tcache_count = TCACHE_FILL_COUNT,
  .tcache_small_bins = TCACHE_SMALL_BINS,
  .tcache_max_bytes = MAX_TCACHE_SMALL_SIZE + 1,  // !!!!!! notice
  .tcache_unsorted_limit = 0 /* No limit.  */
#endif
};
```
i think it is necessary to add a extra check