### PR TITLE
Resolve function boundaries in the absence of debugging symbols

### DIFF
--- a/pwndbg/aglib/symbol.py
+++ b/pwndbg/aglib/symbol.py
@@ -9,6 +9,7 @@ import pwndbg.aglib.memory
 import pwndbg.dbg_mod
 import pwndbg.dintegration
 import pwndbg.lib.cache
+from pwndbg.dbg_mod import EventType
 from pwndbg.dbg_mod import SymbolLookupType
 
 
@@ -117,6 +118,14 @@ def resolve_addr(addr: int) -> str | None:
     return pwndbg.dintegration.manager.symbol_at_address(addr)
 
 
+set_existing_ranges: set[tuple[int, int]] = set()
+
+
+@pwndbg.dbg.event_handler(EventType.NEW_MODULE)
+def _clear_set_existing_ranges() -> None:
+    set_existing_ranges.clear()
+
+
 @pwndbg.lib.cache.cache_until("objfile")
 def resolve_function_boundaries(addr: int) -> tuple[int, int] | None:
     """
@@ -128,4 +137,13 @@ def resolve_function_boundaries(addr: int) -> tuple[int, int] | None:
     """
     assert addr >= 0, "address must be positive"
 
-    return pwndbg.dbg.selected_inferior().get_function_boundaries(addr)
+    for cached_range in set_existing_ranges:
+        if cached_range[0] <= addr < cached_range[1]:
+            return cached_range
+
+    fn_range = pwndbg.dbg.selected_inferior().get_function_boundaries(addr)
+
+    if fn_range is not None:
+        set_existing_ranges.add(fn_range)
+
+    return fn_range

--- a/pwndbg/aglib/symbol.py
+++ b/pwndbg/aglib/symbol.py
@@ -141,10 +141,15 @@ def resolve_function_boundaries(addr: int) -> tuple[int, int] | None:
     """
     assert addr >= 0, "address must be positive"
 
+    # Binary search for the range which has the highest start which is <= addr,
+    # and out of those, we pick the one with the highest end.
+    # Does not find a match for some overlapping ranges (e.g. addr=150, set_existing_ranges=[(100,200), (148,149)])
+    # but this should almost never happen, and getting a cache miss is still fine correctness-wise.
     i = bisect_right(set_existing_ranges, addr, key=lambda _range: _range[0]) - 1
-    if i >= 0 and addr <= set_existing_ranges[i][1]:
+    if i >= 0 and addr < set_existing_ranges[i][1]:
         return set_existing_ranges[i]
 
+    # Invokes GDBs `disass` which might be slow.
     fn_range = pwndbg.dbg.selected_inferior().get_function_boundaries(addr)
 
     if fn_range is not None:

--- a/pwndbg/aglib/symbol.py
+++ b/pwndbg/aglib/symbol.py
@@ -5,10 +5,14 @@ vice-versa.
 
 from __future__ import annotations
 
+from bisect import bisect_right
+from bisect import insort
+
 import pwndbg.aglib.memory
 import pwndbg.dbg_mod
 import pwndbg.dintegration
 import pwndbg.lib.cache
+from pwndbg.dbg_mod import EventHandlerPriority
 from pwndbg.dbg_mod import EventType
 from pwndbg.dbg_mod import SymbolLookupType
 
@@ -118,15 +122,15 @@ def resolve_addr(addr: int) -> str | None:
     return pwndbg.dintegration.manager.symbol_at_address(addr)
 
 
-set_existing_ranges: set[tuple[int, int]] = set()
+set_existing_ranges: list[tuple[int, int]] = []
 
 
-@pwndbg.dbg.event_handler(EventType.NEW_MODULE)
+@pwndbg.dbg.event_handler(EventType.START, priority=EventHandlerPriority.CACHE_CLEAR)
+@pwndbg.dbg.event_handler(EventType.EXIT, priority=EventHandlerPriority.CACHE_CLEAR)
 def _clear_set_existing_ranges() -> None:
     set_existing_ranges.clear()
 
 
-@pwndbg.lib.cache.cache_until("objfile")
 def resolve_function_boundaries(addr: int) -> tuple[int, int] | None:
     """
     Return the function start and end address for a function that
@@ -137,13 +141,13 @@ def resolve_function_boundaries(addr: int) -> tuple[int, int] | None:
     """
     assert addr >= 0, "address must be positive"
 
-    for cached_range in set_existing_ranges:
-        if cached_range[0] <= addr < cached_range[1]:
-            return cached_range
+    i = bisect_right(set_existing_ranges, addr, key=lambda _range: _range[0]) - 1
+    if i >= 0 and addr <= set_existing_ranges[i][1]:
+        return set_existing_ranges[i]
 
     fn_range = pwndbg.dbg.selected_inferior().get_function_boundaries(addr)
 
     if fn_range is not None:
-        set_existing_ranges.add(fn_range)
+        insort(set_existing_ranges, fn_range)
 
     return fn_range

--- a/pwndbg/dbg_mod/__init__.py
+++ b/pwndbg/dbg_mod/__init__.py
@@ -597,6 +597,8 @@ class Process:
         Return the function start and end address for a function that
         contains address `addr`.
 
+        Might be slow (for GDB it invokes 'disass'), cache the results.
+
         Returns:
         - tuple[int, int] | None: [start, end) of function block if found (end address is exclusive)
         """

--- a/pwndbg/dbg_mod/gdb/__init__.py
+++ b/pwndbg/dbg_mod/gdb/__init__.py
@@ -158,10 +158,17 @@ class GDBRegisters(pwndbg.dbg_mod.Registers):
     def by_name(self, name: str) -> pwndbg.dbg_mod.Value | None:
         try:
             return GDBValue(self.frame.inner.read_register(name))
-        except (gdb.error, ValueError):
-            # GDB throws an exception if the name is unknown, we just return
-            # None when that is the case.
-            pass
+        except ValueError as e:
+            if "Bad register" in str(e):
+                # GDB throws a ValueError exception if the name is unknown, we just return
+                # None when that is the case.
+                return None
+            # Otherwise some weird shenanigents might be going on, so we print the message
+            # as well.
+            err_str: str = str(e)
+        except gdb.error as e:
+            err_str = str(e)
+        print(message.error(f"gdb register read error: {err_str}"))
         return None
 
 

--- a/pwndbg/dbg_mod/gdb/__init__.py
+++ b/pwndbg/dbg_mod/gdb/__init__.py
@@ -626,8 +626,11 @@ def run_disassemble_for_function_boundaries(address: int) -> list[tuple[int, int
     This allows us to disassemble the entire function correctly, as we can start the disassembly of the final instruction (it will still be within the range returned by this function)
     """
 
-    disass_output: str = gdb.execute(f"disassemble {address}", to_string=True)
-
+    try:
+        disass_output: str = gdb.execute(f"disassemble {address}", to_string=True)
+    except gdb.error:
+        # This throws an error if GDB is unable to find the function boundaries
+        return None
     # There two ways the `disass` commands prints output:
     #
     # 1. If there are multiple ranges, it includes "Address range" in the output

--- a/pwndbg/dbg_mod/gdb/__init__.py
+++ b/pwndbg/dbg_mod/gdb/__init__.py
@@ -620,14 +620,15 @@ def run_disassemble_for_function_boundaries(address: int) -> list[tuple[int, int
     """
     Returns list of tuples representing [start,end) of the addresses that make up this function.
 
-    Note that the `end` address is exclusive of the start of the last instruction. It is guaranteed to be at least `address of last instruction` + 1.
-    It gets fully accurate end address in the that `address` is in a function with multiple address ranges.
+    Note that the `end` address is exclusive in terms of the function range, or `1 + the address of the last instruction`.
 
-    This allows us to disassemble the entire function correctly, as we can start the disassembly of the final instruction (it will still be within the range returned by this function)
+    While this means the final address may be slightly inaccurate, in practice this doesn't matter, as we use the range returned by this
+    function to disassemble functions manually ourselves. Since the end address is at least +1 the address of the last instruction, while disassembling
+    manually we will disassemble the last instruction correctly (since we can start the disassembly of the final instruction, as it's address will still be within the range returned by this function)
     """
 
     try:
-        disass_output: str = gdb.execute(f"disassemble {address}", to_string=True)
+        disass_output: str = gdb.execute(f"disassemble {hex(address)}", to_string=True)
     except gdb.error:
         # This throws an error if GDB is unable to find the function boundaries
         return None
@@ -1036,6 +1037,7 @@ class GDBProcess(pwndbg.dbg_mod.Process):
         # of debugging symbols (using symbol sizes if available, then falling back to using the order symbols in memory to determine boundaries)
         # These methods are internally used to determine the these methods are not exposed to the Python API
         # So, we use this hacky method to get function boundaries.
+        # See https://github.com/pwndbg/pwndbg/issues/3908 for more details
 
         ranges = run_disassemble_for_function_boundaries(address)
 

--- a/pwndbg/dbg_mod/gdb/__init__.py
+++ b/pwndbg/dbg_mod/gdb/__init__.py
@@ -623,7 +623,7 @@ def run_disassemble_for_function_boundaries(address: int) -> list[tuple[int, int
     Note that the `end` address is exclusive of the start of the last instruction. It is guaranteed to be at least `address of last instruction` + 1.
     It gets fully accurate end address in the that `address` is in a function with multiple address ranges.
 
-    This allows us to disassemble the entire function correctly, as we only stop disassemble if we are outside of the range returned by this address.
+    This allows us to disassemble the entire function correctly, as we can start the disassembly of the final instruction (it will still be within the range returned by this function)
     """
 
     disass_output: str = gdb.execute(f"disassemble {address}", to_string=True)

--- a/pwndbg/dbg_mod/gdb/__init__.py
+++ b/pwndbg/dbg_mod/gdb/__init__.py
@@ -610,68 +610,80 @@ class GDBStopPoint(pwndbg.dbg_mod.StopPoint):
 RANGE_RE = re.compile(r"^Address range (0x[0-9a-f]+) to (0x[0-9a-f]+):", re.MULTILINE)
 
 # Matches lines like:
-# => 0x0000000000401080 <+0>:	jmp    QWORD PTR [rip+0x2fba]        # 0x404040 <time@got[plt]>
+# => 0x00007ffff7fd13f0 <+0>:	f3 0f 1e fa        	endbr64
 # or
-#    0x0000000000401086 <+6>:	push   0x5
-INSN_RE = re.compile(r"^\s*(?:=>)?\s*(0x[0-9a-f]+)\s*(?:<[^>]*>)?:", re.MULTILINE)
+#    0x00007ffff7fd13f4 <+4>:	55                 	push   rbp
+INSN_RE = re.compile(r"^\s*(?:=>)?\s*(0x[0-9a-f]+)\s*(?:<[^>]*>)?:\t([0-9a-f ]+?)\t", re.MULTILINE)
 
 
 def run_disassemble_for_function_boundaries(address: int) -> list[tuple[int, int]] | None:
     """
     Returns list of tuples representing [start,end) of the addresses that make up this function.
-
-    Note that the `end` address is exclusive in terms of the function range, or `1 + the address of the last instruction`.
-
-    While this means the final address may be slightly inaccurate, in practice this doesn't matter, as we use the range returned by this
-    function to disassemble functions manually ourselves. Since the end address is at least +1 the address of the last instruction, while disassembling
-    manually we will disassemble the last instruction correctly (since we can start the disassembly of the final instruction, as it's address will still be within the range returned by this function)
     """
 
     try:
-        disass_output: str = gdb.execute(f"disassemble {hex(address)}", to_string=True)
+        disass_output: str = gdb.execute(f"disassemble /r {hex(address)}", to_string=True)
     except gdb.error:
         # This throws an error if GDB is unable to find the function boundaries
         return None
-    # There two ways the `disass` commands prints output:
+
+    # There two ways the `disassemble /r` commands prints output:
+    #
+    # Note that you must add the `/r` flag, as it includes the hexcodes for the bytes
+    # This allows us to get the length of the last instruction, so we can know the end boundary
     #
     # 1. If there are multiple ranges, it includes "Address range" in the output
     #
-    # > disass
+    # > disass /r
     # Dump of assembler code for function _dl_fixup:
     # Address range 0x7ffff7fd13f0 to 0x7ffff7fd1693:
-    # => 0x00007ffff7fd13f0 <+0>:	endbr64
-    #    0x00007ffff7fd13f4 <+4>:	push   rbp
-    #    0x00007ffff7fd13f5 <+5>:	xor    edx,edx
-    # ...
-    #    0x00007ffff7fd168a <+666>:	mov    QWORD PTR [rbp-0x38],rax
-    #    0x00007ffff7fd168e <+670>:	jmp    0x7ffff7fd154f <_dl_fixup+351 at dl-runtime.c:133>
+    # => 0x00007ffff7fd13f0 <+0>:	f3 0f 1e fa        	endbr64
+    #    0x00007ffff7fd13f4 <+4>:	55                 	push   rbp
+    #    0x00007ffff7fd13f5 <+5>:	31 d2              	xor    edx,edx
+    #    0x00007ffff7fd13fc <+12>:	41 56              	push   r14
+    #    0x00007ffff7fd168e <+670>:	e9 bc fe ff ff     	jmp    0x7ffff7fd154f <_dl_fixup+351 at dl-runtime.c:133>
     # Address range 0x7ffff7fbf677 to 0x7ffff7fbf696:
-    #    0x00007ffff7fbf677 <-73081>:	lea    rcx,[rip+0x31702]        # 0x7ffff7ff0d80 <__PRETTY_FUNCTION__.1>
-    #    0x00007ffff7fbf67e <-73074>:	mov    edx,0x3f
-    # ...
+    #    0x00007ffff7fbf677 <-73081>:	48 8d 0d 02 17 03 00	lea    rcx,[rip+0x31702]        # 0x7ffff7ff0d80 <__PRETTY_FUNCTION__.1>
+    #    0x00007ffff7fbf67e <-73074>:	ba 3f 00 00 00     	mov    edx,0x3f
+    #    0x00007ffff7fbf683 <-73069>:	48 8d 35 56 ec 02 00	lea    rsi,[rip+0x2ec56]        # 0x7ffff7fee2e0
+    #    0x00007ffff7fbf68a <-73062>:	48 8d 3d b7 16 03 00	lea    rdi,[rip+0x316b7]        # 0x7ffff7ff0d48
+    #    0x00007ffff7fbf691 <-73055>:	e8 70 02 00 00     	call   0x7ffff7fbf906 <__GI___assert_fail at dl-minimal.c:182>
+    # End of assembler dump.
     #
     # 2. It omits "Address range" if these is only one address range for the function
     #
-    # > disass
+    # > disass /r
+    # pwndbg> disass /r
     # Dump of assembler code for function time@plt:
-    # => 0x0000000000401080 <+0>:	jmp    QWORD PTR [rip+0x2fba]        # 0x404040 <time@got[plt]>
-    #    0x0000000000401086 <+6>:	push   0x5
-    #    0x000000000040108b <+11>:	jmp    0x401020
+    # => 0x0000000000401080 <+0>:	ff 25 ba 2f 00 00  	jmp    QWORD PTR [rip+0x2fba]        # 0x404040 <time@got[plt]>
+    #    0x0000000000401086 <+6>:	68 05 00 00 00     	push   0x5
+    #    0x000000000040108b <+11>:	e9 90 ff ff ff     	jmp    0x401020
     # End of assembler dump.
     #
     #
     # Additionally, if you disass at a random address, the output is:
-    # > disass
+    # > disass /r
     # No function contains specified address.
 
     multiple_ranges = [(int(a, 16), int(b, 16)) for a, b in RANGE_RE.findall(disass_output)]
     if multiple_ranges:
         return multiple_ranges
 
-    addresses = [int(a, 16) for a in INSN_RE.findall(disass_output)]
-    if not addresses:
+    output_rows: list[tuple[str, str]] = INSN_RE.findall(disass_output)
+    if not output_rows:
         return None
-    return [(addresses[0], addresses[-1] + 1)]
+
+    # Example:
+    # output_rows == [('0x00007ffff7fdf860', '48 89 e7           '), ('0x00007ffff7fdf863', 'e8 a8 0c 00 00     ')]
+    start = int(output_rows[0][0], 16)
+
+    last_addr, last_bytes = output_rows[-1]
+    end = int(last_addr, 16)
+
+    # Given the number of the hex byte codes, get the length of the final instruction
+    last_instruction_length = len(last_bytes.replace(" ", "")) // 2
+
+    return [(start, end + last_instruction_length)]
 
 
 class GDBProcess(pwndbg.dbg_mod.Process):

--- a/pwndbg/dbg_mod/gdb/__init__.py
+++ b/pwndbg/dbg_mod/gdb/__init__.py
@@ -615,7 +615,7 @@ RANGE_RE = re.compile(r"^Address range (0x[0-9a-f]+) to (0x[0-9a-f]+):", re.MULT
 #    0x0000000000401086 <+6>:	push   0x5
 INSN_RE = re.compile(r"^\s*(?:=>)?\s*(0x[0-9a-f]+)\s*(?:<[^>]*>)?:", re.MULTILINE)
 
-
+@pwndbg.lib.cache.cache_until("objfile")
 def run_disassemble_for_function_boundaries(address: int) -> list[tuple[int, int]] | None:
     """
     Returns list of tuples representing [start,end) of the addresses that make up this function.

--- a/pwndbg/dbg_mod/gdb/__init__.py
+++ b/pwndbg/dbg_mod/gdb/__init__.py
@@ -605,6 +605,69 @@ class GDBStopPoint(pwndbg.dbg_mod.StopPoint):
             self.inner.delete()
 
 
+# Matches a line like:
+# Address range 0x7ffff7fd13f0 to 0x7ffff7fd1693:
+RANGE_RE = re.compile(r"^Address range (0x[0-9a-f]+) to (0x[0-9a-f]+):", re.MULTILINE)
+
+# Matches lines like:
+# => 0x0000000000401080 <+0>:	jmp    QWORD PTR [rip+0x2fba]        # 0x404040 <time@got[plt]>
+# or
+#    0x0000000000401086 <+6>:	push   0x5
+INSN_RE = re.compile(r"^\s*(?:=>)?\s*(0x[0-9a-f]+)\s*(?:<[^>]*>)?:", re.MULTILINE)
+
+
+def run_disassemble_for_function_boundaries(address: int) -> list[tuple[int, int]] | None:
+    """
+    Returns list of tuples representing [start,end) of the addresses that make up this function.
+
+    Note that the `end` address is exclusive of the start of the last instruction. It is `address of last instruction` + 1.
+    This allows us to disassemble it, as we only stop disassemble if we are outside of the range returned by this address.
+    """
+
+    disass_output: str = gdb.execute(f"disassemble {address}", to_string=True)
+
+    # There two ways the `disass` commands prints output:
+    #
+    # 1. If there are multiple ranges, it includes "Address range" in the output
+    #
+    # > disass
+    # Dump of assembler code for function _dl_fixup:
+    # Address range 0x7ffff7fd13f0 to 0x7ffff7fd1693:
+    # => 0x00007ffff7fd13f0 <+0>:	endbr64
+    #    0x00007ffff7fd13f4 <+4>:	push   rbp
+    #    0x00007ffff7fd13f5 <+5>:	xor    edx,edx
+    # ...
+    #    0x00007ffff7fd168a <+666>:	mov    QWORD PTR [rbp-0x38],rax
+    #    0x00007ffff7fd168e <+670>:	jmp    0x7ffff7fd154f <_dl_fixup+351 at dl-runtime.c:133>
+    # Address range 0x7ffff7fbf677 to 0x7ffff7fbf696:
+    #    0x00007ffff7fbf677 <-73081>:	lea    rcx,[rip+0x31702]        # 0x7ffff7ff0d80 <__PRETTY_FUNCTION__.1>
+    #    0x00007ffff7fbf67e <-73074>:	mov    edx,0x3f
+    # ...
+    #
+    # 2. It omits "Address range" if these is only one address range for the function
+    #
+    # > disass
+    # Dump of assembler code for function time@plt:
+    # => 0x0000000000401080 <+0>:	jmp    QWORD PTR [rip+0x2fba]        # 0x404040 <time@got[plt]>
+    #    0x0000000000401086 <+6>:	push   0x5
+    #    0x000000000040108b <+11>:	jmp    0x401020
+    # End of assembler dump.
+    #
+    #
+    # Additionally, if you disass at a random address, the output is:
+    # > disass
+    # No function contains specified address.
+
+    multiple_ranges = [(int(a, 16), int(b, 16)) for a, b in RANGE_RE.findall(disass_output)]
+    if multiple_ranges:
+        return multiple_ranges
+
+    addresses = [int(a, 16) for a in INSN_RE.findall(disass_output)]
+    if not addresses:
+        return None
+    return [(addresses[0], addresses[-1] + 1)]
+
+
 class GDBProcess(pwndbg.dbg_mod.Process):
     # Operations that change the internal state of GDB are generally not allowed
     # during breakpoint stop handles. Because the Pwndbg Debugger-agnostic API
@@ -963,14 +1026,18 @@ class GDBProcess(pwndbg.dbg_mod.Process):
 
     @override
     def get_function_boundaries(self, address: int) -> tuple[int, int] | None:
-        block = gdb.block_for_pc(address)
 
-        if block is not None:
-            # Find the top-level function that this block resides in
-            while block.superblock is not None and block.superblock.function is not None:
-                block = block.superblock
+        # While GDB internally has multiple ways of determine function boundaries in the absence
+        # of debugging symbols (using symbol sizes if available, then falling back to using the order symbols in memory to determine boundaries)
+        # These methods are internally used to determine the these methods are not exposed to the Python API
+        # So, we use this hacky method to get function boundaries.
 
-            return block.start, block.end
+        ranges = run_disassemble_for_function_boundaries(address)
+
+        if ranges is not None:
+            for start_block, end_block in ranges:
+                if start_block <= address < end_block:
+                    return start_block, end_block
 
         return None
 

--- a/pwndbg/dbg_mod/gdb/__init__.py
+++ b/pwndbg/dbg_mod/gdb/__init__.py
@@ -616,7 +616,6 @@ RANGE_RE = re.compile(r"^Address range (0x[0-9a-f]+) to (0x[0-9a-f]+):", re.MULT
 INSN_RE = re.compile(r"^\s*(?:=>)?\s*(0x[0-9a-f]+)\s*(?:<[^>]*>)?:", re.MULTILINE)
 
 
-@pwndbg.lib.cache.cache_until("objfile")
 def run_disassemble_for_function_boundaries(address: int) -> list[tuple[int, int]] | None:
     """
     Returns list of tuples representing [start,end) of the addresses that make up this function.

--- a/pwndbg/dbg_mod/gdb/__init__.py
+++ b/pwndbg/dbg_mod/gdb/__init__.py
@@ -620,8 +620,10 @@ def run_disassemble_for_function_boundaries(address: int) -> list[tuple[int, int
     """
     Returns list of tuples representing [start,end) of the addresses that make up this function.
 
-    Note that the `end` address is exclusive of the start of the last instruction. It is `address of last instruction` + 1.
-    This allows us to disassemble it, as we only stop disassemble if we are outside of the range returned by this address.
+    Note that the `end` address is exclusive of the start of the last instruction. It is guaranteed to be at least `address of last instruction` + 1.
+    It gets fully accurate end address in the that `address` is in a function with multiple address ranges.
+
+    This allows us to disassemble the entire function correctly, as we only stop disassemble if we are outside of the range returned by this address.
     """
 
     disass_output: str = gdb.execute(f"disassemble {address}", to_string=True)

--- a/pwndbg/dbg_mod/gdb/__init__.py
+++ b/pwndbg/dbg_mod/gdb/__init__.py
@@ -615,6 +615,7 @@ RANGE_RE = re.compile(r"^Address range (0x[0-9a-f]+) to (0x[0-9a-f]+):", re.MULT
 #    0x0000000000401086 <+6>:	push   0x5
 INSN_RE = re.compile(r"^\s*(?:=>)?\s*(0x[0-9a-f]+)\s*(?:<[^>]*>)?:", re.MULTILINE)
 
+
 @pwndbg.lib.cache.cache_until("objfile")
 def run_disassemble_for_function_boundaries(address: int) -> list[tuple[int, int]] | None:
     """

--- a/pwndbg/dbg_mod/lldb/__init__.py
+++ b/pwndbg/dbg_mod/lldb/__init__.py
@@ -1647,10 +1647,33 @@ class LLDBProcess(pwndbg.dbg_mod.Process):
         if not addr.IsValid():
             return None
 
-        func = addr.GetFunction()
-        if func.IsValid():
-            start: int = func.GetStartAddress().GetLoadAddress(self.target)
-            end: int = func.GetEndAddress().GetLoadAddress(self.target)
+        ctx = self.target.ResolveSymbolContextForAddress(addr, lldb.eSymbolContextEverything)
+
+        # Function boundaries can have multiple address ranges (for example, _dl_fixup is broken up into multiple blocks)
+        # LLDB can give us access to these blocks, and we return the block that the input address is within
+        if ctx.IsValid():
+            block = ctx.GetBlock()
+            while block.IsValid() and block.GetParent().IsValid():
+                block = block.GetParent()
+
+            ranges = [
+                (
+                    block.GetRangeStartAddress(i).GetLoadAddress(self.target),
+                    block.GetRangeEndAddress(i).GetLoadAddress(self.target),
+                )
+                for i in range(block.GetNumRanges())
+            ]
+
+            for start_block, end_block in ranges:
+                if start_block <= address < end_block:
+                    return start_block, end_block
+
+        # Fallback to finding the symbol that contains this address, and use it to determine the start/end of this function
+        sym = ctx.GetSymbol()
+        if sym.IsValid():
+            start: int = sym.GetStartAddress().GetLoadAddress(self.target)
+            end: int = sym.GetEndAddress().GetLoadAddress(self.target)
+
             return start, end
 
         return None

--- a/pwndbg/dbg_mod/lldb/__init__.py
+++ b/pwndbg/dbg_mod/lldb/__init__.py
@@ -1656,13 +1656,22 @@ class LLDBProcess(pwndbg.dbg_mod.Process):
             while block.IsValid() and block.GetParent().IsValid():
                 block = block.GetParent()
 
-            ranges = [
-                (
-                    block.GetRangeStartAddress(i).GetLoadAddress(self.target),
-                    block.GetRangeEndAddress(i).GetLoadAddress(self.target),
-                )
-                for i in range(block.GetNumRanges())
-            ]
+            ranges: list[tuple[int, int]] = []
+            for i in range(block.GetNumRanges()):
+                start_sb_address = block.GetRangeStartAddress(i)
+                end_sb_address = block.GetRangeEndAddress(i)
+
+                if start_sb_address.IsValid() and end_sb_address.IsValid():
+                    start = start_sb_address.GetLoadAddress(self.target)
+                    end = end_sb_address.GetLoadAddress(self.target)
+
+                    if lldb.LLDB_INVALID_ADDRESS not in (start, end):
+                        ranges.append(
+                            (
+                                start,
+                                end,
+                            )
+                        )
 
             for start_block, end_block in ranges:
                 if start_block <= address < end_block:
@@ -1671,10 +1680,15 @@ class LLDBProcess(pwndbg.dbg_mod.Process):
         # Fallback to finding the symbol that contains this address, and use it to determine the start/end of this function
         sym = ctx.GetSymbol()
         if sym.IsValid():
-            start: int = sym.GetStartAddress().GetLoadAddress(self.target)
-            end: int = sym.GetEndAddress().GetLoadAddress(self.target)
+            start_sb_address = sym.GetStartAddress()
+            end_sb_address = sym.GetEndAddress()
 
-            return start, end
+            if start_sb_address.IsValid() and end_sb_address.IsValid():
+                start = start_sb_address.GetLoadAddress(self.target)
+                end = end_sb_address.GetLoadAddress(self.target)
+
+                if lldb.LLDB_INVALID_ADDRESS not in (start, end):
+                    return start, end
 
         return None
 


### PR DESCRIPTION
Resolves #3908

This implements a way to get the function boundaries of the function which an address is within in the absence of debugging symbols. This is currently used for `nearpc -f`, making our nearpc command now work the same way as the debugger native `disassemble` commands.

When debug symbols are absent, the underlying debugger needs to do a little more work to determine function boundaries. At a high level, they use the symbol information (if they have symbol_start address, and symbol_end address) to determine the boundaries, and as a fallback, if the symbol size is unknown, they find the next symbol contiguously in memory, and treat it as the end of the current symbol. This is how the builtin `disass` does it.

Turns out LLDB already exposes a way for us to get function boundaries such that we get the same info as the built-in `disass`.

For GDB, no such API is exposed. To implement fetching function boundary, in this PR, we call the GDB command `disassemble`, which internally gets the the function boundaries. It's a bit hacky, but we parse the output of `disassemble` to get the boundaries. This guarantees that whenever someone could use `disass`, they could instead use `nearpc -f`, and take advantage of all of our additional disassembly features.

Other methods of determining function boundaries were considered (all of them were hacky ways involving querying symbols), but for this use case, calling `disass` guarantees we get the function boundary correct to the same extent that GDB already does.


<img width="1723" height="256" alt="lldb" src="https://github.com/user-attachments/assets/d1fba7de-aefe-4d0e-b0bf-61e3979a1afb" />

Note that some functions, such as `_dl_fixup` that I came across while testing this, have more than one contiguous block of addresses that define the function. While querying the function boundary, we get all the ranges, and then return the range within with the input address sits.

<img width="1723" height="568" alt="lldb_libc_function" src="https://github.com/user-attachments/assets/2ff8f665-f2f5-416a-9a49-3d9cfcd94aa3" />
