### PR TITLE
print error on register read if it is non-standard

### DIFF
--- a/pwndbg/dbg_mod/gdb/__init__.py
+++ b/pwndbg/dbg_mod/gdb/__init__.py
@@ -158,10 +158,17 @@ class GDBRegisters(pwndbg.dbg_mod.Registers):
     def by_name(self, name: str) -> pwndbg.dbg_mod.Value | None:
         try:
             return GDBValue(self.frame.inner.read_register(name))
-        except (gdb.error, ValueError):
-            # GDB throws an exception if the name is unknown, we just return
-            # None when that is the case.
-            pass
+        except ValueError as e:
+            if "Bad register" in str(e):
+                # GDB throws a ValueError exception if the name is unknown, we just return
+                # None when that is the case.
+                return None
+            # Otherwise some weird shenanigents might be going on, so we print the message
+            # as well.
+            err_str: str = str(e)
+        except gdb.error as e:
+            err_str = str(e)
+        print(message.error(f"gdb register read error: {err_str}"))
         return None
 
 


### PR DESCRIPTION
+ [x] I read the contributing documentation.
+ [x] I am providing a screenshot of the (new feature) / (fixed bug).

### Before

<img width="979" height="73" alt="image" src="https://github.com/user-attachments/assets/6efe4b62-f314-4ff5-9377-4e86d6b0b9a5" />

### After

<img width="1279" height="88" alt="image" src="https://github.com/user-attachments/assets/fd6cb9e8-c696-4053-be40-a0fa722b1885" />

