### PR TITLE
lldb: Don't crash the REPL on a malformed command line

### DIFF
--- a/pwndbg/dbg_mod/lldb/__init__.py
+++ b/pwndbg/dbg_mod/lldb/__init__.py
@@ -7,7 +7,6 @@ import functools
 import os
 import random
 import re
-import shlex
 import sys
 from asyncio import CancelledError
 from collections.abc import Awaitable
@@ -32,6 +31,7 @@ import pwndbg.dbg_mod
 import pwndbg.lib.cache
 import pwndbg.lib.memory
 import pwndbg.lib.path
+import pwndbg.lib.strings
 from pwndbg.color import message
 from pwndbg.dbg_mod import EventHandlerPriority
 from pwndbg.dbg_mod import selection
@@ -2293,7 +2293,7 @@ class LLDB(pwndbg.dbg_mod.Debugger):
 
     @override
     def lex_args(self, command_line: str) -> list[str]:
-        return shlex.split(command_line)
+        return pwndbg.lib.strings.lex_args(command_line)
 
     def _any_inferior(self) -> LLDBProcess:
         """

--- a/pwndbg/lib/strings.py
+++ b/pwndbg/lib/strings.py
@@ -1,8 +1,41 @@
 from __future__ import annotations
 
 import re
+import shlex
 
 
 def strip_colors(text):
     """Remove all ANSI color codes from the text"""
     return re.sub(r"\x1b[^m]*m", "", text)
+
+
+def lex_args(command_line: str) -> list[str]:
+    """
+    Split a command line into arguments, the way a POSIX shell would.
+
+    Unlike `shlex.split`, this never raises on a malformed command line. A
+    trailing backslash or an unterminated quote simply yields the incomplete
+    argument the lexer had accumulated when it ran out of input, which is what
+    GDB's `string_to_argv` does.
+    """
+    lexer = shlex.shlex(command_line, posix=True)
+    lexer.whitespace_split = True
+    # Command lines have no comments, `#` is just an ordinary character.
+    lexer.commenters = ""
+
+    args: list[str] = []
+    while True:
+        try:
+            arg = lexer.get_token()
+        except ValueError:
+            # The input ended in the middle of an escape sequence or of a
+            # quoted string. Keep whatever came before it.
+            if lexer.token:
+                args.append(lexer.token)
+            break
+
+        if arg is None:
+            break
+        args.append(arg)
+
+    return args

--- a/tests/unit_tests/test_lex_args.py
+++ b/tests/unit_tests/test_lex_args.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import pytest
+
+from pwndbg.lib.strings import lex_args
+
+
+@pytest.mark.parametrize(
+    ("command_line", "expected"),
+    (
+        # Ordinary command lines.
+        ("", []),
+        ("   ", []),
+        ("nearpc", ["nearpc"]),
+        ("nearpc -f 10", ["nearpc", "-f", "10"]),
+        ("telescope $rsp+8", ["telescope", "$rsp+8"]),
+        # Quoting and escaping, same as `shlex.split`.
+        ('search -s "a b"', ["search", "-s", "a b"]),
+        ("search -s 'a b'", ["search", "-s", "a b"]),
+        ("break foo\\ bar", ["break", "foo bar"]),
+        ("break foo\\\\bar", ["break", "foo\\bar"]),
+        # `#` is not a comment on a command line.
+        ("p a # b", ["p", "a", "#", "b"]),
+    ),
+)
+def test_lex_args(command_line, expected):
+    assert lex_args(command_line) == expected
+
+
+@pytest.mark.parametrize(
+    ("command_line", "expected"),
+    (
+        # A trailing backslash makes `shlex.split` raise "No escaped
+        # character". GDB's `string_to_argv` keeps the incomplete argument
+        # instead, and so do we. See #4130.
+        ("nearpc -f\\", ["nearpc", "-f"]),
+        ("nearpc\\", ["nearpc"]),
+        ("\\", []),
+        # Likewise for an unterminated quote, which makes `shlex.split` raise
+        # "No closing quotation".
+        ('search -s "a b', ["search", "-s", "a b"]),
+        ("search -s 'a b", ["search", "-s", "a b"]),
+        ('search -s "', ["search", "-s"]),
+    ),
+)
+def test_lex_args_is_lenient(command_line, expected):
+    assert lex_args(command_line) == expected


### PR DESCRIPTION
`LLDB.lex_args` used `shlex.split`, which raises `ValueError` on a command line ending in a backslash ("No escaped character") or with an unterminated quote ("No closing quotation"). `Command.invoke` only catches `TypeError` and `DebuggerError`, so the `ValueError` escaped into the LLDB command handler, got stashed in `_exception_relay` and was re-raised by `relay_exceptions` as a `DebuggerError`, tearing down the whole REPL:

    pwndbg-lldb> nearpc -f\
    ...
    pwndbg.dbg_mod.DebuggerError: No escaped character

GDB's `string_to_argv` is lenient here — it yields the incomplete argument instead of failing — so `nearpc -f\` just runs as `nearpc -f` under GDB. Add `pwndbg.lib.strings.lex_args`, which drives `shlex` directly and, on an unterminated escape or quote, keeps the token the lexer had accumulated. This matches GDB for every case checked against it, so a typo no longer kills the session and the two backends agree.

Fixes #4130


<!--
    Please make sure to read the linting and testing instructions at
    https://pwndbg.re/dev/contributing/ before creating a PR.
-->

+ [ ] I read the contributing documentation.
+ [ ] I am providing a screenshot of the (new feature) / (fixed bug).
