### PR TITLE
In context disasm, do not go backwards linearly above the current function

### DIFF
--- a/pwndbg/aglib/disasm/disassembly.py
+++ b/pwndbg/aglib/disasm/disassembly.py
@@ -744,17 +744,17 @@ def near(
     if instruction_flow_cache is not None:
         instruction_flow_cache.copy_current_instruction_flow_to_next()
 
-    function_boundaries: tuple[int, int] | None = None
-    if emulate:
-        # Only bother computing this when emulating
-        function_boundaries = pwndbg.aglib.symbol.resolve_function_boundaries(address)
-
     # Keep track of which of the previous instructions were disassembly linearly so we can display them as gray while emulating
     # The assumption is that the instruction list will start with the linear instructions, and then transition to the emulated one
     index_of_last_linearly_disassembled_instruction = -1
 
     count_backwards_linear = 0
     if show_prev_insns:
+        function_boundaries: tuple[int, int] | None = None
+        if emulate:
+            # Only bother computing this when emulating
+            function_boundaries = pwndbg.aglib.symbol.resolve_function_boundaries(address)
+
         saveptr = InstructionSequenceSavePointer(None)
 
         linear_prev_fetch = linear

--- a/pwndbg/aglib/disasm/disassembly.py
+++ b/pwndbg/aglib/disasm/disassembly.py
@@ -24,6 +24,7 @@ import pwndbg.aglib.disasm.riscv
 import pwndbg.aglib.disasm.sparc
 import pwndbg.aglib.disasm.x86
 import pwndbg.aglib.memory
+import pwndbg.aglib.symbol
 import pwndbg.aglib.vmmap
 import pwndbg.dbg_mod
 import pwndbg.emu.emulator
@@ -743,6 +744,11 @@ def near(
     if instruction_flow_cache is not None:
         instruction_flow_cache.copy_current_instruction_flow_to_next()
 
+    function_boundaries: tuple[int, int] | None = None
+    if emulate:
+        # Only bother computing this when emulating
+        function_boundaries = pwndbg.aglib.symbol.resolve_function_boundaries(address)
+
     # Keep track of which of the previous instructions were disassembly linearly so we can display them as gray while emulating
     # The assumption is that the instruction list will start with the linear instructions, and then transition to the emulated one
     index_of_last_linearly_disassembled_instruction = -1
@@ -773,6 +779,11 @@ def near(
                 dynamic_max_type = CacheSource.FALLBACK_DYNAMIC
 
             if cache_type == CacheSource.CACHE_LINEAR:
+                if emulate and function_boundaries is not None:
+                    # Do not disassemble backwards linearly outside of the current function boundaries
+                    if not (function_boundaries[0] <= insn.address < function_boundaries[1]):
+                        break
+
                 # Once one instruction has been linear, we cannot go back to dynamic caching method
                 linear_prev_fetch = True
                 count_backwards_linear += 1


### PR DESCRIPTION
Addresses #4088.

#3898 introduced a way to "disassemble backwards" in memory. This is great for `nearpc`, however in the context disasm display, it can get confusing, such as when stepping into a function (we will display instructions from before the first instruction of the function, which is irrelevant)

This cleans things up by disallowing disassembling backwards beyond the current function when disassembling for the context display.

Before (starting `gdb ls`), first time context is printed:
<img width="1552" height="277" alt="image" src="https://github.com/user-attachments/assets/2a08d5cb-0712-480b-a917-bb26cae63466" />


After:
<img width="1281" height="264" alt="image" src="https://github.com/user-attachments/assets/0e58a7e3-636f-4a8f-8062-97caee9fcfb2" />

It will still go backwards within a function, which is nice, such as when doing `catch syscall`, or breaking at a breakpoint.
<img width="1467" height="186" alt="image" src="https://github.com/user-attachments/assets/a395a861-f2aa-4ee4-8e21-6d275c9693bd" />


<img width="1353" height="392" alt="image" src="https://github.com/user-attachments/assets/7ae7d49b-d2ad-4a3e-9ad7-3b064862a520" />
