### PR TITLE
mypy not catching bad types?

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -79,35 +79,35 @@ jobs:
           filter_mode: nofilter
           fail_on_error: true
 
-      # The PR must not contain more mypy --strict errors than the dev branch does
-      - name: Count mypy --strict errors in PR and dev branch.
+      # The PR must not contain more mypy --strict --strict-optional errors than the dev branch does
+      - name: Count mypy --strict --strict-optional errors in PR and dev branch.
         id: mypy_strict_count
         run: |
           set +e
           # Taken from ./lint.sh
           LINT_FILES="pwndbg pwndbginit tests *.py scripts"
 
-          # Count `mypy --strict` errors on PR branch.
-          uv run --group dev --group lint --group tests --all-extras mypy --strict $LINT_FILES > mypy_pr.txt 2>&1
+          # Count `mypy --strict --strict-optional` errors on PR branch.
+          uv run --group dev --group lint --group tests --all-extras mypy --strict --strict-optional $LINT_FILES > mypy_pr.txt 2>&1
           PR_ERRORS=$(grep -c "error:" mypy_pr.txt || true)
           echo "pr_count=$PR_ERRORS" >> $GITHUB_OUTPUT
-          echo "PR mypy (--strict) errors: $PR_ERRORS"
+          echo "PR mypy (--strict --strict-optional) errors: $PR_ERRORS"
 
-          # Count `mypy --strict` errors on dev branch.
+          # Count `mypy --strict --strict-optional` errors on dev branch.
           git fetch origin dev
           git checkout origin/dev
-          uv run --group dev --group lint --group tests --all-extras mypy --strict $LINT_FILES > mypy_dev.txt 2>&1
+          uv run --group dev --group lint --group tests --all-extras mypy --strict --strict-optional $LINT_FILES > mypy_dev.txt 2>&1
           DEV_ERRORS=$(grep -c "error:" mypy_dev.txt || true)
           echo "dev_count=$DEV_ERRORS" >> $GITHUB_OUTPUT
-          echo "Dev mypy (--strict) errors: $DEV_ERRORS"
+          echo "Dev mypy (--strict --strict-optional) errors: $DEV_ERRORS"
 
           echo "============================="
-          echo "mypy --strict diff:"
+          echo "mypy --strict --strict-optional diff:"
           echo "============================="
           diff mypy_dev.txt mypy_pr.txt
         continue-on-error: true
 
-      - name: Compare mypy --strict error counts
+      - name: Compare mypy --strict --strict-optional error counts
         run: |
           PR_ERRORS=${{ steps.mypy_strict_count.outputs.pr_count }}
           DEV_ERRORS=${{ steps.mypy_strict_count.outputs.dev_count }}
@@ -116,10 +116,10 @@ jobs:
           echo "Dev errors: $DEV_ERRORS"
 
           if [ "$PR_ERRORS" -gt "$DEV_ERRORS" ]; then
-            echo "This PR introduces more \`mypy --strict\` errors than are present on the dev branch."
+            echo "This PR introduces more \`mypy --strict --strict-optional\` errors than are present on the dev branch."
             echo "See the diff in the step above."
-            echo "Ideally, a python type checker (mypy --strict/pyright/ty/pyrefly etc..) should be running in your editor."
+            echo "Ideally, a python type checker (mypy --strict --strict-optional, pyright, ty, pyrefly, etc.) should be running in your editor."
             exit 1
           else
-            echo "This PR does not introduce any more \`mypy --strict\` errors than there are on the dev branch."
+            echo "This PR does not introduce any more \`mypy --strict --strict-optional\` errors than there are on the dev branch."
           fi

--- a/docs/contributing/common-pitfalls.md
+++ b/docs/contributing/common-pitfalls.md
@@ -102,17 +102,17 @@ There are some exceptions to this rule of course, such as `dbg.setup()`, `aglib.
 
 ## Linting and typing
 
-Currently we run a relatively strict lint on PRs. First `./lint.sh` needs to pass, further, you must not increase the number of `mypy --strict` errors as compared to the `dev` branch (see `.github/workflows/lint.sh`).
+Currently we run a relatively strict lint on PRs. First `./lint.sh` needs to pass, further, you must not increase the number of `mypy --strict --strict-optional` errors as compared to the `dev` branch (see `.github/workflows/lint.sh`).
 
 This is done to make sure the codebase does not deteriorate over time. Type errors are often indicative of real bugs.
 
-The easiest way to debug any typing issues is to have a type checker running in your python editor / IDE. It does not necessarily have to be mypy (pyright, ty, pyrefly etc. will also work as they all report similar issues), but mypy will be used as the source of truth for the purposes of our CI. If you are using mypy with your editor, make sure you have passed it the `--strict` flag.
+The easiest way to debug any typing issues is to have a type checker running in your python editor / IDE. It does not necessarily have to be mypy (pyright, ty, pyrefly etc. will also work as they all report similar issues), but mypy will be used as the source of truth for the purposes of our CI. If you are using mypy with your editor, make sure you have passed it the `--strict --strict-optional` flags.
 
-#### mypy and mypy --strict disagree!
+#### mypy and mypy --strict --strict-optional disagree!
 
-First of all, one might question why we run both `mypy` and `mypy --strict` over the codebase, and not just `mypy --strict`. This is done to prevent code changes that fix "trivial" type fixes, but introduce severe type issues. In these cases, our `mypy --strict` CI will pass because the total number of type issues has been reduced, but the `mypy` run will still catch the problem.
+First of all, one might question why we run both `mypy` and `mypy --strict --strict-optional` over the codebase, and not just `mypy --strict --strict-optional`. This is done to prevent code changes that fix "trivial" type fixes, but introduce severe type issues. In these cases, our `mypy --strict --strict-optional` CI will pass because the total number of type issues has been reduced, but the `mypy` run will still catch the problem.
 
-This can however be troublesome in some cases. For instance, there are (rare) situations where you can reasonably add a `# type: ignore[<something>]` comment to a line of code (one such situation is when interfacing with pyelftools which includes a py.typed marker even though the codebase has no types (https://github.com/eliben/pyelftools/pull/611)). It can happen then, that `mypy --strict` requires such a comment, but that `mypy` complains about an "unused type: ignore".
+This can however be troublesome in some cases. For instance, there are (rare) situations where you can reasonably add a `# type: ignore[<something>]` comment to a line of code (one such situation is when interfacing with pyelftools which includes a py.typed marker even though the codebase has no types (https://github.com/eliben/pyelftools/pull/611)). It can happen then, that `mypy --strict --strict-optional` requires such a comment, but that `mypy` complains about an "unused type: ignore".
 
-To fix this, ideally, you fix the source of the typing error and remove the comment. This is most often possible and will appease both `mypy` and `mypy --strict`. If this is not possible, you can often get around the issue by using `cast` as seen here: https://github.com/pwndbg/pwndbg/blob/a35bf70366645b7bbd1359aee6e0caf0958aca87/pwndbg/integration/__init__.py#L182 . If that is also not possible due to the nature of the issue, tell us, and we will figure out what to do together.
 
+To fix this, ideally, you fix the source of the typing error and remove the comment. This is most often possible and will appease both `mypy` and `mypy --strict --strict-optional`. If this is not possible, you can often get around the issue by using `cast` as seen here: https://github.com/pwndbg/pwndbg/blob/a35bf70366645b7bbd1359aee6e0caf0958aca87/pwndbg/integration/__init__.py#L182 . If that is also not possible due to the nature of the issue, tell us, and we will figure out what to do together.

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -24,7 +24,7 @@ The `lint.sh` script runs ruff, shfmt, and vermin. ruff is (mostly) able to auto
     You can find the configuration files for these tools in `pyproject.toml` or by checking the arguments passed inside `lint.sh`.
     You can also run `./lint.sh -fo` to skip vermin and mypy, allowing for a quicker lint.
 
-When submitting a PR, the continuous integration (CI) job defined in `.github/workflows/lint.yml` will verify that running `./lint.sh` succeeds. Furthermore, you must not increase the number of `mypy --strict` errors as compared to the `dev` branch (see `.github/workflows/lint.sh`). Otherwise the job will fail and we won't be able to merge your PR. Make sure to have a type checker (mypy --strict, pyright, ty, pyrefly, ...) running in your python editor / IDE.
+When submitting a PR, the continuous integration (CI) job defined in `.github/workflows/lint.yml` will verify that running `./lint.sh` succeeds. Furthermore, you must not increase the number of `mypy --strict --strict-optional` errors as compared to the `dev` branch (see `.github/workflows/lint.sh`). Otherwise the job will fail and we won't be able to merge your PR. Make sure to have a type checker (mypy --strict --strict-optional, pyright, ty, pyrefly, ...) running in your python editor / IDE.
 
 It is recommended to enable the pre-push git hook to run the lint if you haven't already done so. You may re-run `./setup-dev.sh` to set it.
 ## Running tests


### PR DESCRIPTION
<!--
    Please make sure to read the linting and testing instructions at
    https://pwndbg.re/dev/contributing/ before creating a PR.
-->

+ [x] I read the contributing documentation.
+ [ ] I am providing a screenshot of the (new feature) / (fixed bug).

Use `mypy --strict --strict-optional` for both sides of the PR-vs-dev strict error baseline so new Optional/None incompatibilities are counted without changing the repository-wide mypy configuration. Contributor documentation now describes the same strict baseline mode.

## Verification
`./lint.sh --check` passes, and a focused type-check confirms that passing `None` to a `MemoryMap` parameter is rejected. A full strict-optional run exposes the existing type-error baseline, which remains handled by the unchanged PR-vs-dev count comparison.

Fixes #4115