### PR TITLE
Fix: Show arrow right for contiguous marker in address chain

### DIFF
--- a/pwndbg/chain.py
+++ b/pwndbg/chain.py
@@ -214,4 +214,7 @@ def format(
     if len(chain) == 1:
         return enhanced
 
+    if len(chain) > limit:
+        return arrow_right.join([*rest, enhanced])
+
     return arrow_right.join(rest) + arrow_left + enhanced

--- a/pwndbg/emu/emulator.py
+++ b/pwndbg/emu/emulator.py
@@ -457,6 +457,9 @@ class Emulator:
         if len(chain) == 1:
             return enhanced
 
+        if len(chain) > limit:
+            return arrow_right.join([*rest, enhanced])
+
         return arrow_right.join(rest) + arrow_left + enhanced
 
     def telescope_enhance(self, value: int, code: bool = True, enhance_string_len: int = None):


### PR DESCRIPTION
Small consistency fix
As mentioned in https://github.com/pwndbg/pwndbg/issues/4114 it makes more sense for the contiguous marker to be preceded by a right arrow ->

<img width="1359" height="113" alt="image" src="https://github.com/user-attachments/assets/233c15a5-11f1-4a65-a981-f82cf2c1473b" />

<img width="718" height="92" alt="image" src="https://github.com/user-attachments/assets/4712944b-1dcc-4129-a980-771e31a8ca97" />

Fixes https://github.com/pwndbg/pwndbg/issues/4114

+ [x] I read the contributing documentation.
+ [x] I am providing a screenshot of the (new feature) / (fixed bug).