### PR TITLE
Make branch visualization offsets better

### DIFF
--- a/pwndbg/aglib/nearpc.py
+++ b/pwndbg/aglib/nearpc.py
@@ -210,6 +210,8 @@ def preprocess_branch_visualization(
                 if abs(target - instruction.address) < 100:
                     jumps.append(JumpRange(instruction.address, target))
 
+    jumps.sort(key=lambda x: x.max - x.min)
+
     # Of the jumpranges we processed last time, which ones do we keep? Relevant for repeat nearpc
     continued_ranges: set[JumpRange] = set()
 

--- a/tests/library/dbg/tests/test_nearpc.py
+++ b/tests/library/dbg/tests/test_nearpc.py
@@ -330,11 +330,11 @@ async def test_nearpc_branch_visualization(ctrl: Controller) -> None:
         "                                          ││ \n"
         "   0x40008f <B>                           │└>   sub    eax, 1\n"
         "   0x400092 <B+3>                         │     cmp    eax, 0\n"
-        "   0x400095 <B+6>                        ┌──<   jne    C                           <C>\n"
-        "                                         ││  \n"
-        "   0x400097 <B+8>                        ││     nop   \n"
-        "   0x400098 <B+9>                        ││     nop   \n"
-        "   0x400099 <C>                          └└─>   ret   \n"
+        "   0x400095 <B+6>                         │┌<   jne    C                           <C>\n"
+        "                                          ││ \n"
+        "   0x400097 <B+8>                         ││    nop   \n"
+        "   0x400098 <B+9>                         ││    nop   \n"
+        "   0x400099 <C>                           └└>   ret   \n"
     )
 
     assert dis == expected


### PR DESCRIPTION
A small change to branch visualization. If you have two overlapping jumps in the disassembly output, now the shorter jump (which is possibly contained within the larger jump) has it's lines closer to the right side of the disassembly.


Before:
<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/219756f1-da15-4606-8d1d-75e4158206c2" />



After:
<img width="1005" height="766" alt="image" src="https://github.com/user-attachments/assets/224b697d-8b7c-4ade-bd4a-e20be9f62127" />
