### PR TITLE
Do not show args with nearpc command

### DIFF
--- a/pwndbg/aglib/nearpc.py
+++ b/pwndbg/aglib/nearpc.py
@@ -691,7 +691,7 @@ def nearpc(
 
         # For call instructions, attempt to resolve the target and
         # determine the number of arguments.
-        if show_args:
+        if show_args and not linear:
             result.extend(
                 f"{'':>8}{arg}" for arg in pwndbg.arguments.format_args(instruction=instruction)
             )

--- a/tests/library/dbg/tests/test_nearpc.py
+++ b/tests/library/dbg/tests/test_nearpc.py
@@ -129,7 +129,7 @@ async def test_nearpc_opcode_bytes(ctrl: Controller, opcode_bytes: int) -> None:
     await ctrl.execute("nextsyscall")
 
     await ctrl.execute(f"set nearpc-num-opcode-bytes {opcode_bytes}")
-    dis = await ctrl.execute_and_capture("nearpc -t 11")
+    dis = await ctrl.execute_and_capture("emulate -t 11")
     expected = (
         "   0x400080 {} <_start>       mov    eax, 0                 EAX => 0\n"
         "   0x400085 {} <_start+5>     mov    edi, 0x1337            EDI => 0x1337\n"
@@ -158,7 +158,7 @@ async def test_nearpc_opcode_seperator(ctrl: Controller, separator_bytes: int) -
     await ctrl.execute("set nearpc-num-opcode-bytes 5")
     await ctrl.execute(f"set nearpc-opcode-separator-bytes {separator_bytes}")
 
-    dis = await ctrl.execute_and_capture("nearpc -t 11")
+    dis = await ctrl.execute_and_capture("emulate -t 11")
     excepted = (
         "   0x400080 {} <_start>       mov    eax, 0                 EAX => 0\n"
         "   0x400085 {} <_start+5>     mov    edi, 0x1337            EDI => 0x1337\n"

--- a/tests/library/qemu_user/tests/test_aarch64.py
+++ b/tests/library/qemu_user/tests/test_aarch64.py
@@ -879,7 +879,7 @@ def test_aarch64_reference(qemu_start_binary):
 
     # verify call argument are enriched
     gdb.execute("stepuntilasm bl")
-    assembly = gdb.execute("nearpc", to_string=True)
+    assembly = gdb.execute("emulate", to_string=True)
     assert "'Not enough args'" in assembly
 
     gdb.execute("argv", to_string=True)

--- a/tests/library/qemu_user/tests/test_riscv64.py
+++ b/tests/library/qemu_user/tests/test_riscv64.py
@@ -386,7 +386,7 @@ def test_riscv64_reference(qemu_start_binary):
     gdb.execute("stepuntilasm jalr")
 
     # verify call argument are enriched
-    assembly = gdb.execute("nearpc --no-branch", to_string=True)
+    assembly = gdb.execute("emulate", to_string=True)
     assert "'Not enough args'" in assembly
 
     gdb.execute("stepuntilasm c.jalr")


### PR DESCRIPTION
The `nearpc` command is meant for disassembling linear flow of instructions. It is an replacement for gdb `x/20 ADDRESS`. It sometimes showing arguments (if the program PC happens to be sitting on a call) makes for a confusing display sometimes, as it conditionally introduces new rows when disassembling a function, just because the `pc` happens to be there right now.

It still shows arguments on the context disasm and with `emulate` command.

Before:
See screenshot in #4158

After:
<img width="1600" height="521" alt="image" src="https://github.com/user-attachments/assets/dc5272a1-b683-4324-ab4d-6ac1df0a7866" />
