### PR TITLE
Context disasm: target now shown for future ret to unmapped address

### DIFF
--- a/pwndbg/aglib/disasm/aarch64.py
+++ b/pwndbg/aglib/disasm/aarch64.py
@@ -268,7 +268,7 @@ class AArch64DisassemblyAssistant(pwndbg.aglib.disasm.assistant.DisassemblyAssis
         }
 
     @override
-    def _set_annotation_string(self, instruction: PwndbgInstruction, emu: Emulator) -> None:
+    def _set_annotation_string(self, instruction: PwndbgInstruction, emu: Emulator | None) -> None:
         # Dispatch to the correct handler
         if instruction.id in AARCH64_SINGLE_LOAD_INSTRUCTIONS:
             target_reg_size = self._register_width(instruction, instruction.operands[0]) // 8
@@ -344,13 +344,15 @@ class AArch64DisassemblyAssistant(pwndbg.aglib.disasm.assistant.DisassemblyAssis
             instruction.annotation = register_assign(result_operand.str, telescope)
 
     @override
-    def _prepare(self, instruction: PwndbgInstruction, emu: Emulator) -> None:
+    def _prepare(self, instruction: PwndbgInstruction, emu: Emulator | None) -> None:
         if CS_GRP_INT in instruction.groups:
             # https://github.com/capstone-engine/capstone/issues/2630
             instruction.groups.remove(CS_GRP_CALL)
 
     @override
-    def _condition(self, instruction: PwndbgInstruction, emu: Emulator) -> InstructionCondition:
+    def _condition(
+        self, instruction: PwndbgInstruction, emu: Emulator | None
+    ) -> InstructionCondition:
         # In ARM64, only branches have the conditional code in the instruction,
         # as opposed to ARM32 which allows most instructions to be conditional
         if instruction.id == AARCH64_INS_B:
@@ -424,7 +426,7 @@ class AArch64DisassemblyAssistant(pwndbg.aglib.disasm.assistant.DisassemblyAssis
 
     @override
     def _parse_memory(
-        self, instruction: PwndbgInstruction, op: EnhancedOperand, emu: Emulator
+        self, instruction: PwndbgInstruction, op: EnhancedOperand, emu: Emulator | None
     ) -> int | None:
         """
         Parse the `Arm64OpMem` Capstone object to determine the concrete memory address used.

--- a/pwndbg/aglib/disasm/arm.py
+++ b/pwndbg/aglib/disasm/arm.py
@@ -206,7 +206,7 @@ class ArmDisassemblyAssistant(pwndbg.aglib.disasm.assistant.DisassemblyAssistant
         }
 
     @override
-    def _set_annotation_string(self, instruction: PwndbgInstruction, emu: Emulator) -> None:
+    def _set_annotation_string(self, instruction: PwndbgInstruction, emu: Emulator | None) -> None:
         if instruction.id in ARM_SINGLE_LOAD_INSTRUCTIONS:
             read_size = ARM_SINGLE_LOAD_INSTRUCTIONS[instruction.id]
             self._common_load_annotator(
@@ -267,7 +267,7 @@ class ArmDisassemblyAssistant(pwndbg.aglib.disasm.assistant.DisassemblyAssistant
             self.annotation_handlers.get(instruction.id, lambda *a: None)(instruction, emu)
 
     @override
-    def _prepare(self, instruction: PwndbgInstruction, emu: Emulator) -> None:
+    def _prepare(self, instruction: PwndbgInstruction, emu: Emulator | None) -> None:
         if CS_GRP_INT in instruction.groups:
             # https://github.com/capstone-engine/capstone/issues/2630
             instruction.groups.remove(CS_GRP_CALL)
@@ -280,7 +280,9 @@ class ArmDisassemblyAssistant(pwndbg.aglib.disasm.assistant.DisassemblyAssistant
             emu.valid = False
 
     @override
-    def _condition(self, instruction: PwndbgInstruction, emu: Emulator) -> InstructionCondition:
+    def _condition(
+        self, instruction: PwndbgInstruction, emu: Emulator | None
+    ) -> InstructionCondition:
         if ARM_GRP_JUMP in instruction.groups:
             if instruction.id in ARM_CAN_WRITE_TO_PC_INSTRUCTIONS:
                 # Since Capstone V6, instructions that write to the PC are given the jump group.
@@ -347,7 +349,7 @@ class ArmDisassemblyAssistant(pwndbg.aglib.disasm.assistant.DisassemblyAssistant
 
     @override
     def _read_register(
-        self, instruction: PwndbgInstruction, operand_id: int, emu: Emulator
+        self, instruction: PwndbgInstruction, operand_id: int, emu: Emulator | None
     ) -> int | None:
         # When `pc` is referenced in an operand (typically in a memory operand), the value it takes on
         # is `pc_at_instruction + 8`. In Thumb mode, you only add 4 to the instruction address.
@@ -358,7 +360,7 @@ class ArmDisassemblyAssistant(pwndbg.aglib.disasm.assistant.DisassemblyAssistant
 
     @override
     def _parse_memory(
-        self, instruction: PwndbgInstruction, op: EnhancedOperand, emu: Emulator
+        self, instruction: PwndbgInstruction, op: EnhancedOperand, emu: Emulator | None
     ) -> int | None:
         """
         Parse the `ArmOpMem` Capstone object to determine the concrete memory address used.

--- a/pwndbg/aglib/disasm/assistant.py
+++ b/pwndbg/aglib/disasm/assistant.py
@@ -18,12 +18,14 @@ import pwndbg.color.syntax_highlight as H
 import pwndbg.dintegration
 import pwndbg.lib.config
 import pwndbg.lib.disasm.helpers as bit_math
+import pwndbg.lib.pretty_print
 from pwndbg.aglib.disasm.instruction import FORWARD_JUMP_GROUP
 from pwndbg.aglib.disasm.instruction import EnhancedOperand
 from pwndbg.aglib.disasm.instruction import InstructionCondition
 from pwndbg.aglib.disasm.instruction import PwndbgInstruction
 from pwndbg.aglib.disasm.instruction import boolean_to_instruction_condition
 from pwndbg.color import message
+from pwndbg.emu.emulator import EmulatorCrashData
 from pwndbg.lib.arch import PWNDBG_SUPPORTED_ARCHITECTURES_TYPE
 from pwndbg.lib.regs import PseudoEmulatedRegisterFile
 
@@ -88,7 +90,7 @@ pwndbg.config.add_param(
 )
 
 
-def syntax_highlight(ins):
+def syntax_highlight(ins: str):
     return H.syntax_highlight(ins, filename=".asm")
 
 
@@ -157,6 +159,11 @@ class DisassemblyAssistant:
     Otherwise, we use the emulator.
     """
 
+    emu_crash_reason: EmulatorCrashData | None = None
+    """
+    If the emulator stopped while we attempted to step it, this will contain the data for the crash
+    """
+
     def __init__(self, architecture: PWNDBG_SUPPORTED_ARCHITECTURES_TYPE) -> None:
         self.architecture = architecture
         self.manual_register_values = PseudoEmulatedRegisterFile(
@@ -164,7 +171,7 @@ class DisassemblyAssistant:
         )
 
         self.op_handlers: dict[
-            int, Callable[[PwndbgInstruction, EnhancedOperand, Emulator], int | None]
+            int, Callable[[PwndbgInstruction, EnhancedOperand, Emulator | None], int | None]
         ] = {
             CS_OP_IMM: self._parse_immediate,  # Return immediate value
             CS_OP_REG: self._parse_register,  # Return value of register
@@ -191,6 +198,9 @@ class DisassemblyAssistant:
 
         This is the only public method that should be called on this object externally.
         """
+        # Reset this every time we enhance (and thus try to step the emulator)
+        self.emu_crash_reason = None
+
         instruction.enhanced = True
         # It is assumed that the emulator's pc is at the instruction's address
 
@@ -311,11 +321,11 @@ class DisassemblyAssistant:
             print("Done enhancing")
 
     # This is run before enhancement - often used to handle edge case behavior
-    def _prepare(self, instruction: PwndbgInstruction, emu: Emulator) -> None:
+    def _prepare(self, instruction: PwndbgInstruction, emu: Emulator | None) -> None:
         return None
 
     # Subclasses for specific architecture should override this
-    def _set_annotation_string(self, instruction: PwndbgInstruction, emu: Emulator) -> None:
+    def _set_annotation_string(self, instruction: PwndbgInstruction, emu: Emulator | None) -> None:
         """
         The goal of this function is to set the `annotation` field of the instruction,
         which is the string to be printed in a disasm view.
@@ -323,7 +333,7 @@ class DisassemblyAssistant:
         return
 
     def _enhance_operands(
-        self, instruction: PwndbgInstruction, emu: Emulator, jump_emu: Emulator
+        self, instruction: PwndbgInstruction, emu: Emulator | None, jump_emu: Emulator | None
     ) -> bool:
         """
         Enhances the operands by determining values and symbols
@@ -385,10 +395,13 @@ class DisassemblyAssistant:
                     )
 
         # Execute the instruction
-        if jump_emu and None in jump_emu.single_step(instruction=instruction):
-            # This branch is taken if stepping the emulator failed
-            jump_emu = None
-            emu = None
+        if jump_emu:
+            step_attempt = jump_emu.single_step(instruction=instruction)
+            if not step_attempt.success:
+                # This branch is taken if stepping the emulator failed
+                jump_emu = None
+                emu = None
+                self.emu_crash_reason = step_attempt.emulator_crash_data
 
         # Set after_value after single stepping the emulator
         if emu is not None:
@@ -423,7 +436,7 @@ class DisassemblyAssistant:
 
     # Delegates to "read_register", which takes Capstone ID for register.
     def _parse_register(
-        self, instruction: PwndbgInstruction, op: EnhancedOperand, emu: Emulator
+        self, instruction: PwndbgInstruction, op: EnhancedOperand, emu: Emulator | None
     ) -> int | None:
         reg = op.reg
         return self._read_register(instruction, reg, emu)
@@ -431,17 +444,17 @@ class DisassemblyAssistant:
     # Determine memory address of operand (Ex: in x86, mov rax, [rip + 0xd55], would return $rip_after_instruction+0xd55)
     # Subclasses override for specific architectures
     def _parse_memory(
-        self, instruction: PwndbgInstruction, op: EnhancedOperand, emu: Emulator
+        self, instruction: PwndbgInstruction, op: EnhancedOperand, emu: Emulator | None
     ) -> int | None:
         return None
 
     def _parse_immediate(
-        self, instruction: PwndbgInstruction, op: EnhancedOperand, emu: Emulator
+        self, instruction: PwndbgInstruction, op: EnhancedOperand, emu: Emulator | None
     ) -> int | None:
         return op.imm
 
     def _read_register(
-        self, instruction: PwndbgInstruction, operand_id: int, emu: Emulator
+        self, instruction: PwndbgInstruction, operand_id: int, emu: Emulator | None
     ) -> int | None:
         """
         Read value in register. Return None if cannot reason about the value in the register.
@@ -651,7 +664,7 @@ class DisassemblyAssistant:
 
         return None
 
-    def _enhance_syscall(self, instruction: PwndbgInstruction, emu: Emulator) -> None:
+    def _enhance_syscall(self, instruction: PwndbgInstruction, emu: Emulator | None) -> None:
         if CS_GRP_INT not in instruction.groups:
             return
 
@@ -667,7 +680,9 @@ class DisassemblyAssistant:
                 or f"<unk_{instruction.syscall}>"
             )
 
-    def _get_syscall_arch_info(self, instruction) -> tuple[str, str]:
+    def _get_syscall_arch_info(
+        self, instruction: PwndbgInstruction
+    ) -> tuple[str, str] | tuple[None, None]:
         """
         Return tuple of (name of syscall architecture, syscall register name)
 
@@ -677,7 +692,7 @@ class DisassemblyAssistant:
             return (None, None)
         return (pwndbg.aglib.arch.name, pwndbg.aglib.arch.syscall_abi.syscall_register)
 
-    def _enhance_conditional(self, instruction: PwndbgInstruction, emu: Emulator) -> None:
+    def _enhance_conditional(self, instruction: PwndbgInstruction, emu: Emulator | None) -> None:
         """
         Sets the `condition` of the instruction
 
@@ -695,11 +710,13 @@ class DisassemblyAssistant:
         instruction.condition = self._condition(instruction, emu)
 
     # Subclasses should override
-    def _condition(self, instruction: PwndbgInstruction, emu: Emulator) -> InstructionCondition:
+    def _condition(
+        self, instruction: PwndbgInstruction, emu: Emulator | None
+    ) -> InstructionCondition:
         return InstructionCondition.UNCONDITIONAL
 
     def _enhance_next(
-        self, instruction: PwndbgInstruction, emu: Emulator, jump_emu: Emulator
+        self, instruction: PwndbgInstruction, emu: Emulator | None, jump_emu: Emulator | None
     ) -> None:
         """
         Set the `next` and `target` field of the instruction.
@@ -855,7 +872,7 @@ class DisassemblyAssistant:
         return repr(instruction)
 
     # String functions assume the .before_value and .after_value have been set
-    def _immediate_string(self, instruction, operand) -> str:
+    def _immediate_string(self, instruction: PwndbgInstruction, operand: EnhancedOperand) -> str:
         return pwndbg.lib.pretty_print.int_to_string(operand.before_value)
 
     def _register_string(self, instruction: PwndbgInstruction, operand: EnhancedOperand):

--- a/pwndbg/aglib/disasm/disassembly.py
+++ b/pwndbg/aglib/disasm/disassembly.py
@@ -426,7 +426,7 @@ def get_disassembler(cs_info: tuple[int, int]) -> Cs:
 
 def one(
     address: int | None = None,
-    emu: pwndbg.emu.emulator.Emulator = None,
+    emu: pwndbg.emu.emulator.Emulator | None = None,
     enhance: bool = True,
     assistant: DisassemblyAssistant | None = None,
     from_cache: bool = False,

--- a/pwndbg/aglib/disasm/loongarch64.py
+++ b/pwndbg/aglib/disasm/loongarch64.py
@@ -49,7 +49,9 @@ class Loong64DisassemblyAssistant(pwndbg.aglib.disasm.assistant.DisassemblyAssis
         self.annotation_handlers: dict[int, Callable[[PwndbgInstruction, Emulator], None]] = {}
 
     @override
-    def _condition(self, instruction: PwndbgInstruction, emu: Emulator) -> InstructionCondition:
+    def _condition(
+        self, instruction: PwndbgInstruction, emu: Emulator | None
+    ) -> InstructionCondition:
         condition_resolver = CONDITION_RESOLVERS.get(instruction.id)
 
         if condition_resolver is None:

--- a/pwndbg/aglib/disasm/mips.py
+++ b/pwndbg/aglib/disasm/mips.py
@@ -195,7 +195,7 @@ class MipsDisassemblyAssistant(pwndbg.aglib.disasm.assistant.DisassemblyAssistan
         }
 
     @override
-    def _set_annotation_string(self, instruction: PwndbgInstruction, emu: Emulator) -> None:
+    def _set_annotation_string(self, instruction: PwndbgInstruction, emu: Emulator | None) -> None:
         if instruction.id in MIPS_LOAD_INSTRUCTIONS:
             read_size = MIPS_LOAD_INSTRUCTIONS[instruction.id]
 
@@ -247,7 +247,9 @@ class MipsDisassemblyAssistant(pwndbg.aglib.disasm.assistant.DisassemblyAssistan
             )
 
     @override
-    def _condition(self, instruction: PwndbgInstruction, emu: Emulator) -> InstructionCondition:
+    def _condition(
+        self, instruction: PwndbgInstruction, emu: Emulator | None
+    ) -> InstructionCondition:
         condition_resolver = CONDITION_RESOLVERS.get(instruction.id)
 
         if condition_resolver is None:
@@ -286,7 +288,7 @@ class MipsDisassemblyAssistant(pwndbg.aglib.disasm.assistant.DisassemblyAssistan
         self,
         instruction: PwndbgInstruction,
         op: EnhancedOperand,
-        emu: Emulator,
+        emu: Emulator | None,
     ) -> int | None:
         """
         Parse the `MipsOpMem` Capstone object to determine the concrete memory address used.

--- a/pwndbg/aglib/disasm/ppc.py
+++ b/pwndbg/aglib/disasm/ppc.py
@@ -82,7 +82,7 @@ class PowerPCDisassemblyAssistant(pwndbg.aglib.disasm.assistant.DisassemblyAssis
         self.annotation_handlers: dict[int, Callable[[PwndbgInstruction, Emulator], None]] = {}
 
     @override
-    def _prepare(self, instruction: PwndbgInstruction, emu: Emulator) -> None:
+    def _prepare(self, instruction: PwndbgInstruction, emu: Emulator | None) -> None:
         # Prepare is called before emulation.
         # At this point, we want to read the value of the ctr register.
         # This is because branch instructions might mutate ctr within the emulator, which the read_register_name may fetch from
@@ -93,7 +93,9 @@ class PowerPCDisassemblyAssistant(pwndbg.aglib.disasm.assistant.DisassemblyAssis
             self.saved_ctr = self._read_register_name(instruction, "ctr", emu)
 
     @override
-    def _condition(self, instruction: PwndbgInstruction, emu: Emulator) -> InstructionCondition:
+    def _condition(
+        self, instruction: PwndbgInstruction, emu: Emulator | None
+    ) -> InstructionCondition:
         if instruction.id in POWERPC_CONDITIONAL_BRANCHES:
             cr = self._read_register_name(instruction, "cr", emu)
 

--- a/pwndbg/aglib/disasm/riscv.py
+++ b/pwndbg/aglib/disasm/riscv.py
@@ -159,7 +159,7 @@ class RISCVDisassemblyAssistant(pwndbg.aglib.disasm.assistant.DisassemblyAssista
         }
 
     @override
-    def _set_annotation_string(self, instruction: PwndbgInstruction, emu: Emulator) -> None:
+    def _set_annotation_string(self, instruction: PwndbgInstruction, emu: Emulator | None) -> None:
         if instruction.id in RISCV_LOAD_INSTRUCTIONS:
             read_size = RISCV_LOAD_INSTRUCTIONS[instruction.id]
             self._common_load_annotator(
@@ -227,7 +227,9 @@ class RISCVDisassemblyAssistant(pwndbg.aglib.disasm.assistant.DisassemblyAssista
             )
 
     @override
-    def _condition(self, instruction: PwndbgInstruction, emu: Emulator) -> InstructionCondition:
+    def _condition(
+        self, instruction: PwndbgInstruction, emu: Emulator | None
+    ) -> InstructionCondition:
         """
         Checks if the current instruction is a jump that is taken.
         """
@@ -308,7 +310,7 @@ class RISCVDisassemblyAssistant(pwndbg.aglib.disasm.assistant.DisassemblyAssista
 
     @override
     def _parse_memory(
-        self, instruction: PwndbgInstruction, op: EnhancedOperand, emu: Emulator
+        self, instruction: PwndbgInstruction, op: EnhancedOperand, emu: Emulator | None
     ) -> int | None:
         """
         Parse the `RISCVOpMem` Capstone object to determine the concrete memory address used.

--- a/pwndbg/aglib/disasm/sparc.py
+++ b/pwndbg/aglib/disasm/sparc.py
@@ -83,7 +83,9 @@ ICC_CONDITION_RESOLVERS: dict[int, Callable[[int], bool]] = {
 
 class SparcDisassemblyAssistant(pwndbg.aglib.disasm.assistant.DisassemblyAssistant):
     @override
-    def _condition(self, instruction: PwndbgInstruction, emu: Emulator) -> InstructionCondition:
+    def _condition(
+        self, instruction: PwndbgInstruction, emu: Emulator | None
+    ) -> InstructionCondition:
         if instruction.id in SPARC_CONDITIONAL_BRANCHES:
             cc_field = instruction.cs_insn.cc_field
 

--- a/pwndbg/aglib/disasm/x86.py
+++ b/pwndbg/aglib/disasm/x86.py
@@ -19,6 +19,7 @@ from pwndbg.aglib.disasm.instruction import EnhancedOperand
 from pwndbg.aglib.disasm.instruction import InstructionCondition
 from pwndbg.aglib.disasm.instruction import PwndbgInstruction
 from pwndbg.color import message
+from pwndbg.emu.emulator import EmulatorCrashReason
 
 # Emulator currently requires GDB, and we only use it here for type checking.
 if TYPE_CHECKING:
@@ -138,7 +139,7 @@ class X86DisassemblyAssistant(pwndbg.aglib.disasm.assistant.DisassemblyAssistant
         }
 
     @override
-    def _set_annotation_string(self, instruction: PwndbgInstruction, emu: Emulator) -> None:
+    def _set_annotation_string(self, instruction: PwndbgInstruction, emu: Emulator | None) -> None:
         if instruction.id in X86_MATH_INSTRUCTIONS:
             self._common_binary_op_annotator(
                 instruction,
@@ -338,7 +339,7 @@ class X86DisassemblyAssistant(pwndbg.aglib.disasm.assistant.DisassemblyAssistant
         )
 
     @override
-    def _read_register(self, instruction: PwndbgInstruction, operand_id: int, emu: Emulator):
+    def _read_register(self, instruction: PwndbgInstruction, operand_id: int, emu: Emulator | None):
         # operand_id is the ID internal to Capstone
 
         if operand_id == X86_REG_RIP:
@@ -348,7 +349,9 @@ class X86DisassemblyAssistant(pwndbg.aglib.disasm.assistant.DisassemblyAssistant
         return super()._read_register(instruction, operand_id, emu)
 
     @override
-    def _parse_memory(self, instruction: PwndbgInstruction, op: EnhancedOperand, emu: Emulator):
+    def _parse_memory(
+        self, instruction: PwndbgInstruction, op: EnhancedOperand, emu: Emulator | None
+    ):
         # Get memory address (Ex: lea    rax, [rip + 0xd55], this would return $rip+0xd55. Does not dereference)
         if op.mem.segment != 0:
             if op.mem.segment == X86_REG_FS:
@@ -403,8 +406,18 @@ class X86DisassemblyAssistant(pwndbg.aglib.disasm.assistant.DisassemblyAssistant
         if X86_INS_RET != instruction.id or len(instruction.operands) > 1:
             return super()._resolve_target(instruction, emu)
 
+        # From this point on, we are know we are on a `ret` instruction
+
         # Stop disassembling at RET if we won't know where it goes to without emulation
         if not self.can_reason_about_process_state():
+            # If the CPU crashed executing this RET because of an unmapped address while fetching,
+            # then we know it must be because the target address was not mapped
+            if (
+                self.emu_crash_reason is not None
+                and self.emu_crash_reason.emulator_crash_reason
+                == EmulatorCrashReason.UNMAPPED_CPU_FETCH
+            ):
+                return self.emu_crash_reason.fault_address
             return super()._resolve_target(instruction, emu)
 
         # Otherwise, resolve the return on the stack
@@ -418,7 +431,9 @@ class X86DisassemblyAssistant(pwndbg.aglib.disasm.assistant.DisassemblyAssistant
             )
 
     @override
-    def _condition(self, instruction: PwndbgInstruction, emu: Emulator) -> InstructionCondition:
+    def _condition(
+        self, instruction: PwndbgInstruction, emu: Emulator | None
+    ) -> InstructionCondition:
         # JMP is unconditional
         if instruction.id in (X86_INS_JMP, X86_INS_RET, X86_INS_CALL):
             return InstructionCondition.UNCONDITIONAL
@@ -437,7 +452,9 @@ class X86DisassemblyAssistant(pwndbg.aglib.disasm.assistant.DisassemblyAssistant
         return InstructionCondition.TRUE if conditional else InstructionCondition.FALSE
 
     @override
-    def _get_syscall_arch_info(self, instruction: PwndbgInstruction) -> tuple[str, str]:
+    def _get_syscall_arch_info(
+        self, instruction: PwndbgInstruction
+    ) -> tuple[str, str] | tuple[None, None]:
         # Since this class handles both x86 and x86_64, we need to choose the correct
         # syscall arch depending on the instruction being executed.
 

--- a/pwndbg/emu/emulator.py
+++ b/pwndbg/emu/emulator.py
@@ -7,7 +7,9 @@ from __future__ import annotations
 import binascii
 import re
 import string
-from typing import NamedTuple
+from dataclasses import dataclass
+from enum import Enum
+from enum import auto
 
 import capstone6pwndbg as C
 import unicorn as U
@@ -183,7 +185,7 @@ enable_virtual_tlb: dict[PWNDBG_SUPPORTED_ARCHITECTURES_TYPE, bool] = {
 ) = (0, 1, 2, 4, 8, 16, 32, 64, 128)
 
 DEBUG = NO_DEBUG
-# DEBUG = -1 # ALL
+# DEBUG = -1  # ALL
 # DEBUG = DEBUG_EXECUTING | DEBUG_MEM_MAP | DEBUG_MEM_READ
 
 if DEBUG != NO_DEBUG:
@@ -198,6 +200,12 @@ else:
         pass
 
 
+# For debug printing
+DEBUG_MEM_FAULT_TYPE_NAME = {
+    U.UC_MEM_READ_UNMAPPED: "READ_UNMAPPED",
+    U.UC_MEM_WRITE_UNMAPPED: "WRITE_UNMAPPED",
+    U.UC_MEM_FETCH_UNMAPPED: "FETCH_UNMAPPED",
+}
 # Until Unicorn Engine provides full information about the specific instruction
 # being executed for all architectures, we must rely on Capstone to provide
 # that information.
@@ -246,14 +254,56 @@ e.until_jump()
 """
 
 
-class InstructionExecutedResult(NamedTuple):
-    address: int
-    size: int
+class EmulatorCrashReason(Enum):
+    INTERRUPT = (auto(),)
+    UNMAPPED_WRITE = auto()
+    UNMAPPED_READ = auto()
+    UNMAPPED_CPU_FETCH = auto()
+    """
+    This is set whenever the CPU fetches and instruction from unmapped location.
+    """
+
+
+@dataclass
+class EmulatorCrashData:
+    emulator_crash_reason: EmulatorCrashReason
+    fault_address: int
+    fault_written_value: int | None = None
+    """
+    If the fault type is WRITE, then this is set to the value
+    that we attempted to write
+    """
+
+
+@dataclass
+class InstructionExecutedResult:
+    success: bool
+    """
+    Did Unicorn successfully execute the instruction (without segfaulting/interrupt)
+    """
+    address: int | None
+    """
+    The instruction that was attempted
+    """
+    size: int | None
+    """
+    The size of the last instruction attempted
+    """
+    emulator_crash_data: EmulatorCrashData | None = None
 
 
 # Instantiating an instance of `Emulator` will start an instance
 # with a copy of the current processor state.
 class Emulator:
+    last_emulator_crash_data: EmulatorCrashData | None = None
+    """
+    This is set whenever some event that COULD cause a crash occurs.
+
+    For example, on a memory fault, this is set.
+
+    However, it may be benign, since we lazily copy memory into the emulator.
+    """
+
     def __init__(self) -> None:
         self.arch = pwndbg.aglib.arch.name
 
@@ -287,8 +337,10 @@ class Emulator:
         # The address of the last successfully executed instruction using single_step
         self.last_pc: int | None = None
 
+        self.last_emulator_crash_data = None
+
         # (address_successfully_executed, size_of_instruction)
-        self.last_single_step_result = InstructionExecutedResult(None, None)
+        self.last_single_step_result = InstructionExecutedResult(False, None, None)
 
         # Initialize the register state
         for emu_reg in self.reg_set.emulated_regs_order:
@@ -332,7 +384,7 @@ class Emulator:
 
     @property
     def last_step_succeeded(self) -> bool:
-        return None not in self.last_single_step_result
+        return self.last_single_step_result.success
 
     def read_register(self, name: str):
         reg = self.get_reg_enum(name)
@@ -388,7 +440,7 @@ class Emulator:
     # Recursively dereference memory, return list of addresses
     # read_size typically must be either 1, 2, 4, or 8. It dictates the size to read
     # Naturally, if it is less than the pointer size, then only one value would be telescoped
-    def telescope(self, address: int, limit: int, read_size: int = None) -> list[int]:
+    def telescope(self, address: int, limit: int, read_size: int | None = None) -> list[int]:
         read_size = read_size if read_size is not None else pwndbg.aglib.arch.ptrsize
 
         result = [address]
@@ -651,7 +703,7 @@ class Emulator:
 
         return mode
 
-    def map_page(self, page) -> bool:
+    def map_page(self, page: int) -> bool:
         page = pwndbg.lib.memory.page_align(page)
         size = pwndbg.lib.memory.PAGE_SIZE
 
@@ -679,8 +731,33 @@ class Emulator:
 
         return True
 
-    def hook_mem_invalid(self, uc, access, address, size: int, value, user_data) -> bool:
-        debug(DEBUG_MEM_MAP, "# Invalid access at %#x, attempting to map the page", address)
+    def hook_mem_invalid(
+        self, uc, access: int, address: int, size: int, value: int, user_data
+    ) -> bool:
+        debug(
+            DEBUG_MEM_MAP,
+            "# Invalid access at %#x, attempting to map the page. Fault type %s",
+            (address, DEBUG_MEM_FAULT_TYPE_NAME.get(access, access)),
+        )
+
+        if access == U.UC_MEM_FETCH_UNMAPPED:
+            # NOTE: we do NOT use the `address` value
+            # In x86_64, it gets truncated to 52 bytes.
+            # However, for the user, we want to display the full contents
+            # of what is on the stack
+            # We can just read the PC to get this
+            pc = self.pc()
+            self.last_emulator_crash_data = EmulatorCrashData(
+                EmulatorCrashReason.UNMAPPED_CPU_FETCH, pc
+            )
+        elif access == U.UC_MEM_READ_UNMAPPED:
+            self.last_emulator_crash_data = EmulatorCrashData(
+                EmulatorCrashReason.UNMAPPED_READ, address
+            )
+        elif access == U.UC_MEM_WRITE_UNMAPPED:
+            self.last_emulator_crash_data = EmulatorCrashData(
+                EmulatorCrashReason.UNMAPPED_WRITE, address, value
+            )
 
         # Page-align the start address
         start = pwndbg.lib.memory.page_align(address)
@@ -698,12 +775,17 @@ class Emulator:
 
         return True
 
-    def hook_intr(self, uc, intno, user_data) -> None:
+    def hook_intr(self, uc, intno: int, user_data) -> None:
         """
         We never want to emulate through an interrupt.  Just stop.
         """
         debug(DEBUG_INTERRUPT, "Got an interrupt - %d", intno)
         self.valid = False
+
+        self.last_emulator_crash_data = EmulatorCrashData(
+            EmulatorCrashReason.INTERRUPT,
+            None,
+        )
         self.uc.emu_stop()
 
     def get_reg_enum(self, reg: str) -> int | None:
@@ -754,6 +836,14 @@ class Emulator:
         # for the execution of the next instruction. If this `emulate_with_hook` executes multiple instructions
         # which have Thumb mode transitions, Unicorn will internally handle them.
         pc |= self.read_thumb_bit()
+
+        # This is very important!
+        # Otherwise, Unicorn would stop at address 0, the second parameter
+        # of emu_start below.
+        # Setting this cause it to ignore the normal "execute until X" value
+        # And only stop when we tell it to (based on our hooks)
+        self.uc.ctl_exits_enabled(True)
+        self.uc.ctl_set_exits([])
 
         try:
             self.emu_start(pc, 0, count=count)
@@ -837,22 +927,20 @@ class Emulator:
         )
         self.until_syscall_address = address
 
-    def single_step(self, pc=None, instruction: PwndbgInstruction | None = None) -> tuple[int, int]:
-        """Steps one instruction.
-
-        Yields:
-            Each iteration, yields a tuple of (address_just_executed, instruction_size).
-
-            Returns (None, None) upon failure to execute the instruction
+    def single_step(
+        self, pc: int | None = None, instruction: PwndbgInstruction | None = None
+    ) -> InstructionExecutedResult:
+        """
+        Steps one instruction.
         """
 
         # If the emulator has been manually marked as invalid, we should no longer step it
         if not self.valid:
-            return InstructionExecutedResult(None, None)
-
-        self.last_single_step_result = InstructionExecutedResult(None, None)
+            return InstructionExecutedResult(False, None, None)
 
         pc = pc or self.pc()
+
+        self.last_single_step_result = InstructionExecutedResult(False, pc, None)
 
         if instruction is None:
             instruction = pwndbg.aglib.disasm.disassembly.one_raw(pc)
@@ -875,15 +963,24 @@ class Emulator:
         try:
             self.single_step_hook_hit_count = 0
             self.emulate_with_hook(self.single_step_hook_code, count=1)
+
+            # If we hit an interrupt, we set .valid = False
             if not self.valid:
-                return InstructionExecutedResult(None, None)
+                if (
+                    self.last_emulator_crash_data is not None
+                    and self.last_emulator_crash_data.fault_address is None
+                ):
+                    self.last_emulator_crash_data.fault_address = pc
+                return InstructionExecutedResult(False, None, None, self.last_emulator_crash_data)
 
             # If above call does not throw an Exception, we successfully executed the instruction
             self.last_pc = pc
             debug(DEBUG_EXECUTING, "Unicorn now at pc=%#x", self.pc())
         except U.unicorn.UcError:
             debug(DEBUG_EXECUTING, "Emulator failed to execute instruction")
-            self.last_single_step_result = InstructionExecutedResult(None, None)
+            self.last_single_step_result = InstructionExecutedResult(
+                False, None, None, self.last_emulator_crash_data
+            )
 
         return self.last_single_step_result
 
@@ -902,7 +999,9 @@ class Emulator:
         # So we use a counter to ensure the code run only once
         if self.single_step_hook_hit_count == 0:
             debug(DEBUG_EXECUTING, "# single_step: %#-8x", address)
-            self.last_single_step_result = InstructionExecutedResult(address, instruction_size)
+            self.last_single_step_result = InstructionExecutedResult(
+                True, address, instruction_size
+            )
             self.single_step_hook_hit_count += 1
 
     # For debugging

--- a/pwndbg/emu/emulator.py
+++ b/pwndbg/emu/emulator.py
@@ -741,11 +741,10 @@ class Emulator:
         )
 
         if access == U.UC_MEM_FETCH_UNMAPPED:
-            # NOTE: we do NOT use the `address` value
-            # In x86_64, it gets truncated to 52 bytes.
-            # However, for the user, we want to display the full contents
-            # of what is on the stack
-            # We can just read the PC to get this
+            # NOTE: we do NOT use the `address` value. The original address
+            # has been masked with an address mask (such as 52 bits for x86)
+            # However, for the user, we want to display the full contents of original address.
+            # We can just read the PC to get this.
             pc = self.pc()
             self.last_emulator_crash_data = EmulatorCrashData(
                 EmulatorCrashReason.UNMAPPED_CPU_FETCH, pc
@@ -837,11 +836,10 @@ class Emulator:
         # which have Thumb mode transitions, Unicorn will internally handle them.
         pc |= self.read_thumb_bit()
 
-        # This is very important!
-        # Otherwise, Unicorn would stop at address 0, the second parameter
-        # of emu_start below.
-        # Setting this cause it to ignore the normal "execute until X" value
-        # And only stop when we tell it to (based on our hooks)
+        # Tell Unicorn that we want to stop at some explicit exit points, and
+        # then make the list of exit points empty.
+        # This prevents Unicorn from using the "until" argument (second argument below),
+        # which would cause it to always stop before executing at address 0 (which may be mapped!)
         self.uc.ctl_exits_enabled(True)
         self.uc.ctl_set_exits([])
 

--- a/tests/binaries/host/jmp_to_unmapped_page.x86-64.asm
+++ b/tests/binaries/host/jmp_to_unmapped_page.x86-64.asm
@@ -1,0 +1,7 @@
+global _start
+section .text
+
+_start:
+
+mov rax, 0
+jmp rax

--- a/tests/binaries/host/ret_to_unmapped_page.x86-64.asm
+++ b/tests/binaries/host/ret_to_unmapped_page.x86-64.asm
@@ -1,0 +1,8 @@
+global _start
+section .text
+
+_start:
+
+push 0xdeadbeef
+ret
+

--- a/tests/library/dbg/tests/test_disassembly.py
+++ b/tests/library/dbg/tests/test_disassembly.py
@@ -182,3 +182,66 @@ async def test_context_disasm_non_global_cache(ctrl: Controller) -> None:
     )
 
     assert dis_0 == expected_0
+
+
+RET_TO_UNMAPPED_PAGE_BINARY = get_binary("ret_to_unmapped_page.x86-64.out")
+
+
+@pwndbg_test
+async def test_context_disasm_ret_to_unmapped_page(ctrl: Controller) -> None:
+    import pwndbg.aglib
+    import pwndbg.color
+
+    await ctrl.launch(RET_TO_UNMAPPED_PAGE_BINARY)
+
+    dis_0 = await ctrl.execute_and_capture("context disasm")
+    dis_0 = pwndbg.color.strip(dis_0)
+
+    expected_0 = (
+        "LEGEND: STACK | HEAP | CODE | DATA | WX | RODATA\n"
+        "──────────────────────[ DISASM / x86-64 / set emulate on ]──────────────────────\n"
+        " ► 0x400080 <_start>      push   -0x21524111\n"
+        "   0x400085 <_start+5>    ret                                <0xffffffffdeadbeef>\n"
+        "    ↓\n"
+        "\n"
+        "\n"
+        "\n"
+        "\n"
+        "\n"
+        "\n"
+        "\n"
+        "\n"
+        "────────────────────────────────────────────────────────────────────────────────\n"
+    )
+
+    assert dis_0 == expected_0
+
+    # Do not call context disasm after the nearpc
+    await ctrl.step_instruction()
+
+    # With and without emulation, we should determine the same address
+    for emulate_option in ("on", "off"):
+        await ctrl.execute(f"set emulate {emulate_option}")
+
+        dis_1 = await ctrl.execute_and_capture("context disasm")
+        dis_1 = pwndbg.color.strip(dis_1)
+
+        # Remove the header as it varies between the emulation being on or off
+        dis_1 = "\n".join(dis_1.split("\n")[2:])
+
+        expected_1 = (
+            "   0x400080 <_start>      push   -0x21524111\n"
+            " ► 0x400085 <_start+5>    ret                                <0xffffffffdeadbeef>\n"
+            "    ↓\n"
+            "\n"
+            "\n"
+            "\n"
+            "\n"
+            "\n"
+            "\n"
+            "\n"
+            "\n"
+            "────────────────────────────────────────────────────────────────────────────────\n"
+        )
+
+        assert dis_1 == expected_1

--- a/tests/library/dbg/tests/test_disassembly.py
+++ b/tests/library/dbg/tests/test_disassembly.py
@@ -245,3 +245,66 @@ async def test_context_disasm_ret_to_unmapped_page(ctrl: Controller) -> None:
         )
 
         assert dis_1 == expected_1
+
+
+JMP_TO_UNMAPPED_PAGE_BINARY = get_binary("jmp_to_unmapped_page.x86-64.out")
+
+
+@pwndbg_test
+async def test_context_disasm_jmp_to_unmapped_page(ctrl: Controller) -> None:
+    import pwndbg.aglib
+    import pwndbg.color
+
+    await ctrl.launch(JMP_TO_UNMAPPED_PAGE_BINARY)
+
+    dis_0 = await ctrl.execute_and_capture("context disasm")
+    dis_0 = pwndbg.color.strip(dis_0)
+
+    expected_0 = (
+        "LEGEND: STACK | HEAP | CODE | DATA | WX | RODATA\n"
+        "──────────────────────[ DISASM / x86-64 / set emulate on ]──────────────────────\n"
+        " ► 0x400080 <_start>      mov    eax, 0     EAX => 0\n"
+        "   0x400085 <_start+5>    jmp    rax                         <0>\n"
+        "    ↓\n"
+        "\n"
+        "\n"
+        "\n"
+        "\n"
+        "\n"
+        "\n"
+        "\n"
+        "\n"
+        "────────────────────────────────────────────────────────────────────────────────\n"
+    )
+
+    assert dis_0 == expected_0
+
+    # Do not call context disasm after the nearpc
+    await ctrl.step_instruction()
+
+    # With and without emulation, we should determine the same address
+    for emulate_option in ("on", "off"):
+        await ctrl.execute(f"set emulate {emulate_option}")
+
+        dis_1 = await ctrl.execute_and_capture("context disasm")
+        dis_1 = pwndbg.color.strip(dis_1)
+
+        # Remove the header as it varies between the emulation being on or off
+        dis_1 = "\n".join(dis_1.split("\n")[2:])
+
+        expected_1 = (
+            "   0x400080 <_start>      mov    eax, 0     EAX => 0\n"
+            " ► 0x400085 <_start+5>    jmp    rax                         <0>\n"
+            "    ↓\n"
+            "\n"
+            "\n"
+            "\n"
+            "\n"
+            "\n"
+            "\n"
+            "\n"
+            "\n"
+            "────────────────────────────────────────────────────────────────────────────────\n"
+        )
+
+        assert dis_1 == expected_1


### PR DESCRIPTION
While stepping through a ROP chain, I came across an interesting bug: if you were NOT stepped on a ret (it was in the future), and this `ret` caused the program counter to jump to a non-mapped memory address, then a target would not be displayed:

<img width="1242" height="200" alt="image" src="https://github.com/user-attachments/assets/d27c78ad-1e17-4e48-9c5e-7b4f35eaffab" />

Note that the `ret` has no `<target>` marked.

The emulator crashes in this case, and because `ret` is special (the return address is an implicit operand on the stack), we didn't have anything to handle getting the address that faulted in this case.

This PR fixes this by adding a better system that tracks how the Unicorn engine fails to execute an instruction (typically a memory fault), and uses this information to display the `ret to unmapped page`.

I also found some an interesting edge cases in the emulator (that produces strange behavior when jumping to address 0), and added better type annotations around the code that used an emulator object.

After:
<img width="1242" height="200" alt="image" src="https://github.com/user-attachments/assets/1f445ee7-c12f-40e1-9d5f-059cc4182494" />


