### PR TITLE
Fix telescope not taking dereference-limit plus showing wrong arrow when deref limit is hit

### DIFF
--- a/pwndbg/chain.py
+++ b/pwndbg/chain.py
@@ -141,9 +141,6 @@ def format(
     else:
         chain = get(value, limit, offset, hard_stop, hard_end, safe_linking=safe_linking) or []
 
-    arrow_left = c.arrow(f" {config_arrow_left} ")
-    arrow_right = c.arrow(f" {config_arrow_right} ")
-
     # Ask the decompiler to resolve stack variables
     stack_vars = pwndbg.dintegration.manager.get_stack_var_dict_all()
 
@@ -172,7 +169,7 @@ def format(
         # This case only applies to lists of length one, because if the list has more than one value, we already know
         # that the second to last value, chain[-2], can be safely dereferenced - how else would chain[-1] exist?
         # In other case where chain[-1] is not a pointer, the argument has no effect.
-        enhanced = pwndbg.enhance.enhance(
+        return pwndbg.enhance.enhance(
             chain[-1],
             code=code,
             attempt_dereference=False,
@@ -181,7 +178,7 @@ def format(
         )
     # We want to enhance the last pointer value. If an offset was used
     # chain failed at that offset, so display that offset.
-    elif len(chain) < limit + 1:
+    if len(chain) < limit + 1:
         pointer_to_enhance = chain[-2] + offset
 
         page = pwndbg.aglib.vmmap.find(pointer_to_enhance)
@@ -211,7 +208,12 @@ def format(
     else:
         enhanced = c.contiguous_marker(f"{config_contiguous}")
 
-    if len(chain) == 1:
-        return enhanced
+    arrow_right = c.arrow(f" {config_arrow_right} ")
 
-    return arrow_right.join(rest) + arrow_left + enhanced
+    # Show left arrow if we finished dereferencing the chain, otherwise, use right arrow
+    if len(chain) <= limit:
+        arrow_last = c.arrow(f" {config_arrow_left} ")
+    else:
+        arrow_last = arrow_right
+
+    return arrow_right.join(rest) + arrow_last + enhanced

--- a/pwndbg/chain.py
+++ b/pwndbg/chain.py
@@ -104,7 +104,7 @@ config_contiguous = theme.add_param(
 
 def format(
     value: int | list[int] | None,
-    limit: int = int(LIMIT),
+    limit: int = LIMIT,
     code: bool = True,
     offset: int = 0,
     hard_stop: int | None = None,

--- a/pwndbg/emu/emulator.py
+++ b/pwndbg/emu/emulator.py
@@ -423,8 +423,6 @@ class Emulator:
     ) -> str:
         # Code is near identical to pwndbg.chain.format, but takes into account reading from
         # the emulator's memory when necessary
-        arrow_left = pwndbg.chain.c.arrow(f" {pwndbg.chain.config_arrow_left} ")
-        arrow_right = pwndbg.chain.c.arrow(f" {pwndbg.chain.config_arrow_right} ")
 
         # Colorize the chain
         rest = []
@@ -444,20 +442,25 @@ class Emulator:
         # Enhance the last entry
         # If there are no pointers (e.g. eax = 0x41414141), then enhance it
         if len(chain) == 1:
-            enhanced = self.telescope_enhance(
+            return self.telescope_enhance(
                 chain[-1], code=True, enhance_string_len=enhance_string_len
             )
-        elif len(chain) < limit + 1:
+        if len(chain) < limit + 1:
             enhanced = self.telescope_enhance(
                 chain[-2], code=True, enhance_string_len=enhance_string_len
             )
         else:
             enhanced = pwndbg.chain.c.contiguous_marker(f"{pwndbg.chain.config_contiguous}")
 
-        if len(chain) == 1:
-            return enhanced
+        arrow_right = pwndbg.chain.c.arrow(f" {pwndbg.chain.config_arrow_right} ")
 
-        return arrow_right.join(rest) + arrow_left + enhanced
+        # Show left arrow if we finished dereferencing the chain, otherwise, use right arrow
+        if len(chain) <= limit:
+            arrow_last = pwndbg.chain.c.arrow(f" {pwndbg.chain.config_arrow_left} ")
+        else:
+            arrow_last = arrow_right
+
+        return arrow_right.join(rest) + arrow_last + enhanced
 
     def telescope_enhance(self, value: int, code: bool = True, enhance_string_len: int = None):
         # Near identical to pwndbg.enhance.enhance, just read from emulator memory

--- a/tests/library/dbg/tests/test_command_telescope.py
+++ b/tests/library/dbg/tests/test_command_telescope.py
@@ -196,3 +196,26 @@ async def test_command_telescope_frame_bp_sp_different_vmmaps(ctrl: Controller) 
         "Cannot display stack frame because base pointer is not on the same page with stack pointer"
         in result_str
     )
+
+
+@pwndbg_test
+async def test_command_telescope_truncated_chain_uses_right_arrow(ctrl: Controller) -> None:
+    """
+    Tests that a deref chain cut off by dereference-limit ends with the right
+    arrow before the contiguous marker, and the left arrow otherwise.
+
+    See https://github.com/pwndbg/pwndbg/issues/4114
+    """
+    await ctrl.launch(get_binary("linked-lists.native.out"))
+
+    # &node_a.next -> node_b -> node_b.value (1, not a pointer, chain ends here)
+    await ctrl.execute("set dereference-limit 2")
+    result_str = await ctrl.execute_and_capture("telescope &node_a.next 1")
+    assert "—▸ ..." in result_str
+    assert "◂—" not in result_str
+
+    # High enough limit that the chain terminates on its own, i.e. is not truncated
+    await ctrl.execute("set dereference-limit 16")
+    result_str = await ctrl.execute_and_capture("telescope &node_a.next 1")
+    assert "..." not in result_str
+    assert "◂—" in result_str


### PR DESCRIPTION
Last link of telescope deref chain was always joined with left arrow, even when chain was cut off by dereference limit and the last element is contiguous marker (`...`).

This was misleading, so changing it so left arrow is used only when whole chain was dereferenced. Otherwise, the right arrow is used.

Applying same fix to the emulator code as well.

Fixes #4114

In addition, the `limit = int(LIMIT)` -> `limit = LIMIT` change in `pwndbg.chain.format` fixes the problem that `telescope ptr` did not apply the dereference limit set via `set dereference-limit 1`.
